### PR TITLE
fix(test): use pgrep for cross-platform child process lookup

### DIFF
--- a/cmd/gosx/dev_test.go
+++ b/cmd/gosx/dev_test.go
@@ -165,7 +165,7 @@ func waitForChildProcess(parentPID int, timeout time.Duration) (int, error) {
 	deadline := time.Now().Add(timeout)
 	parent := strconv.Itoa(parentPID)
 	for time.Now().Before(deadline) {
-		out, err := exec.Command("ps", "-o", "pid=", "--ppid", parent).Output()
+		out, err := exec.Command("pgrep", "-P", parent).Output()
 		if err == nil {
 			fields := strings.Fields(string(out))
 			for _, field := range fields {


### PR DESCRIPTION
## Summary
- `TestKillProcessTreeStopsChildProcess` fails on macOS because `ps --ppid` is a Linux-only flag
- Replaced with `pgrep -P` which works on both Linux and macOS
- Test now passes on darwin (verified on macOS 15 / arm64)

## Before
```
=== RUN   TestKillProcessTreeStopsChildProcess
    dev_test.go:143: i/o timeout
--- FAIL: TestKillProcessTreeStopsChildProcess (2.02s)
```

## After
```
=== RUN   TestKillProcessTreeStopsChildProcess
--- PASS: TestKillProcessTreeStopsChildProcess (0.04s)
```

## Test plan
- [x] `go test ./cmd/gosx/... -run TestKillProcessTreeStopsChildProcess -v` passes on macOS
- [ ] Verify `pgrep -P` works on Linux CI (standard on all major distros)