### PR TITLE
migrate(dashboard): convert server pages to file-routed .gsx

### DIFF
--- a/examples/dashboard/app/layout.gsx
+++ b/examples/dashboard/app/layout.gsx
@@ -1,0 +1,21 @@
+package app
+
+func Layout() Node {
+	return <div class="layout">
+		<aside class="sidebar">
+			<h2>GoSX Dashboard</h2>
+			<nav>
+				<a href="/" data-gosx-link>Home</a>
+				<a href="/users" data-gosx-link>Users</a>
+				<a href="/users/new" data-gosx-link>New User</a>
+				<a href="/counter" data-gosx-link>Counter</a>
+				<a href="/kitchen-sink" data-gosx-link>Kitchen Sink</a>
+				<a href="/settings" data-gosx-link>Settings</a>
+			</nav>
+		</aside>
+		<main class="main">
+			<Slot />
+			<div class="footer">GoSX — Server rendered</div>
+		</main>
+	</div>
+}

--- a/examples/dashboard/app/page.gsx
+++ b/examples/dashboard/app/page.gsx
@@ -1,0 +1,44 @@
+package app
+
+func Page() Node {
+	return <div>
+		<h1>Dashboard</h1>
+		<div class="grid">
+			<div class="card">
+				<h3>Users</h3>
+				<div class="stat">{data.users}</div>
+			</div>
+			<div class="card">
+				<h3>Active</h3>
+				<div class="stat">{data.active}</div>
+			</div>
+			<div class="card">
+				<h3>Revenue</h3>
+				<div class="stat">{data.revenue}</div>
+			</div>
+			<div class="card">
+				<h3>Growth</h3>
+				<div class="stat">{data.growth}</div>
+			</div>
+		</div>
+		<div class="card">
+			<h3>Recent Activity</h3>
+			<table>
+				<thead>
+					<tr>
+						<th>User</th>
+						<th>Action</th>
+						<th>When</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr><td>Alice</td><td>Created account</td><td>2 min ago</td></tr>
+					<tr><td>Bob</td><td>Updated profile</td><td>15 min ago</td></tr>
+					<tr><td>Carol</td><td>Uploaded document</td><td>1 hour ago</td></tr>
+					<tr><td>Dave</td><td>Changed settings</td><td>3 hours ago</td></tr>
+					<tr><td>Eve</td><td>Logged in</td><td>5 hours ago</td></tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+}

--- a/examples/dashboard/app/page.server.go
+++ b/examples/dashboard/app/page.server.go
@@ -1,0 +1,22 @@
+package app
+
+import (
+	"github.com/odvcencio/gosx/route"
+	"github.com/odvcencio/gosx/server"
+)
+
+func init() {
+	route.MustRegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]string{
+				"users":   "1,247",
+				"active":  "892",
+				"revenue": "$48,290",
+				"growth":  "+12.5%",
+			}, nil
+		},
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: "Dashboard"}, nil
+		},
+	})
+}

--- a/examples/dashboard/app/settings/page.gsx
+++ b/examples/dashboard/app/settings/page.gsx
@@ -1,0 +1,30 @@
+package settings
+
+func Page() Node {
+	return <div>
+		<h1>Settings</h1>
+		<div class="card">
+			<h3>Application Settings</h3>
+			<form method="post" action={actionPath("saveSettings")}>
+				<input type="hidden" name="csrf_token" value={csrf.token}></input>
+				<div class="form-group">
+					<label>Site Name</label>
+					<input type="text" name="siteName" value="GoSX Dashboard"></input>
+				</div>
+				<div class="form-group">
+					<label>Theme</label>
+					<select name="theme">
+						<option value="light">Light</option>
+						<option value="dark">Dark</option>
+					</select>
+				</div>
+				<div class="form-group">
+					<label>Items per page</label>
+					<input type="number" name="pageSize" value="25" min="10" max="100"></input>
+				</div>
+				<p class="form-status">{action.message}</p>
+				<button type="submit" class="btn btn-primary">Save Settings</button>
+			</form>
+		</div>
+	</div>
+}

--- a/examples/dashboard/app/settings/page.server.go
+++ b/examples/dashboard/app/settings/page.server.go
@@ -1,0 +1,20 @@
+package settings
+
+import (
+	"github.com/odvcencio/gosx/action"
+	"github.com/odvcencio/gosx/route"
+	"github.com/odvcencio/gosx/server"
+)
+
+func init() {
+	route.MustRegisterFileModuleHere(route.FileModuleOptions{
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: "Settings"}, nil
+		},
+		Actions: route.FileActions{
+			"saveSettings": func(ctx *action.Context) error {
+				return ctx.Success("Settings saved.", nil)
+			},
+		},
+	})
+}

--- a/examples/dashboard/app/users/new/page.gsx
+++ b/examples/dashboard/app/users/new/page.gsx
@@ -1,0 +1,33 @@
+package new
+
+func Page() Node {
+	return <div>
+		<h1>New User</h1>
+		<div class="card">
+			<form method="post" action={actionPath("createUser")}>
+				<input type="hidden" name="csrf_token" value={csrf.token}></input>
+				<div class="form-group">
+					<label>Name</label>
+					<input type="text" name="name" placeholder="Full name" value={actions.createUser.values.name}></input>
+					<p class="form-error">{actions.createUser.fieldErrors.name}</p>
+				</div>
+				<div class="form-group">
+					<label>Email</label>
+					<input type="email" name="email" placeholder="email@example.com" value={actions.createUser.values.email}></input>
+					<p class="form-error">{actions.createUser.fieldErrors.email}</p>
+				</div>
+				<div class="form-group">
+					<label>Role</label>
+					<select name="role">
+						<option value="viewer">Viewer</option>
+						<option value="editor">Editor</option>
+						<option value="admin">Admin</option>
+					</select>
+				</div>
+				<p class="form-status">{action.message}</p>
+				<button type="submit" class="btn btn-primary">Create User</button>
+				<a href="/users" data-gosx-link class="btn btn-cancel">Cancel</a>
+			</form>
+		</div>
+	</div>
+}

--- a/examples/dashboard/app/users/new/page.server.go
+++ b/examples/dashboard/app/users/new/page.server.go
@@ -1,0 +1,34 @@
+package new
+
+import (
+	"strings"
+
+	"github.com/odvcencio/gosx/action"
+	"github.com/odvcencio/gosx/route"
+	"github.com/odvcencio/gosx/server"
+)
+
+func init() {
+	route.MustRegisterFileModuleHere(route.FileModuleOptions{
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: "New User"}, nil
+		},
+		Actions: route.FileActions{
+			"createUser": func(ctx *action.Context) error {
+				name := strings.TrimSpace(ctx.FormData["name"])
+				email := strings.TrimSpace(ctx.FormData["email"])
+				fieldErrors := map[string]string{}
+				if name == "" {
+					fieldErrors["name"] = "Name is required."
+				}
+				if email == "" {
+					fieldErrors["email"] = "Email is required."
+				}
+				if len(fieldErrors) > 0 {
+					return action.Validation("Please correct the highlighted fields.", fieldErrors, ctx.FormData)
+				}
+				return ctx.Success("User created.", nil)
+			},
+		},
+	})
+}

--- a/examples/dashboard/app/users/page.gsx
+++ b/examples/dashboard/app/users/page.gsx
@@ -1,0 +1,35 @@
+package users
+
+func Page() Node {
+	return <div>
+		<h1>Users</h1>
+		<div class="search-bar">
+			<form method="get" action="/users" class="search-form">
+				<input type="text" name="q" placeholder="Search users..." value={data.query}></input>
+				<button type="submit" class="btn btn-primary">Search</button>
+			</form>
+			<a href="/users/new" class="btn btn-primary">+ New User</a>
+		</div>
+		<div class="card">
+			<table>
+				<thead>
+					<tr>
+						<th>Name</th>
+						<th>Email</th>
+						<th>Role</th>
+						<th>Status</th>
+						<th>Actions</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr><td>Alice Johnson</td><td>alice@example.com</td><td>Admin</td><td><span class="badge badge-active">Active</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+					<tr><td>Bob Smith</td><td>bob@example.com</td><td>Editor</td><td><span class="badge badge-active">Active</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+					<tr><td>Carol Williams</td><td>carol@example.com</td><td>Viewer</td><td><span class="badge badge-inactive">Inactive</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+					<tr><td>Dave Brown</td><td>dave@example.com</td><td>Editor</td><td><span class="badge badge-active">Active</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+					<tr><td>Eve Davis</td><td>eve@example.com</td><td>Admin</td><td><span class="badge badge-active">Active</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+					<tr><td>Frank Miller</td><td>frank@example.com</td><td>Viewer</td><td><span class="badge badge-inactive">Inactive</span></td><td><button class="btn btn-danger btn-sm">Delete</button></td></tr>
+				</tbody>
+			</table>
+		</div>
+	</div>
+}

--- a/examples/dashboard/app/users/page.server.go
+++ b/examples/dashboard/app/users/page.server.go
@@ -1,0 +1,19 @@
+package users
+
+import (
+	"github.com/odvcencio/gosx/route"
+	"github.com/odvcencio/gosx/server"
+)
+
+func init() {
+	route.MustRegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]string{
+				"query": ctx.Query("q"),
+			}, nil
+		},
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: "Users"}, nil
+		},
+	})
+}

--- a/examples/dashboard/modules/modules.go
+++ b/examples/dashboard/modules/modules.go
@@ -1,0 +1,8 @@
+package modules
+
+import (
+	_ "github.com/odvcencio/gosx/examples/dashboard/app"
+	_ "github.com/odvcencio/gosx/examples/dashboard/app/settings"
+	_ "github.com/odvcencio/gosx/examples/dashboard/app/users"
+	_ "github.com/odvcencio/gosx/examples/dashboard/app/users/new"
+)


### PR DESCRIPTION
## Summary
Migrates the dashboard example's server-rendered pages from programmatic `gosx.El()` trees to file-routed `.gsx` pages. This directly addresses the punchlist item:

> Replace remaining app-facing `gosx.El(...)` trees in `blog.go`, `dashboard.go`, `editor.go`, and `pages.go`

## What changed
- **`app/layout.gsx`** — shared sidebar + main content layout (replaces `Layout()` + `Sidebar()` + `Footer()`)
- **`app/page.gsx`** — home page with stat cards and activity table (replaces `HomePage()` + `StatCard()` + `ActivityTable()`)
- **`app/users/page.gsx`** — user list with search form (replaces `UsersPage()`)
- **`app/users/new/page.gsx`** — user creation form with CSRF + validation (replaces `NewUserPage()`)
- **`app/settings/page.gsx`** — settings form (replaces `SettingsPage()`)
- **`modules/modules.go`** — auto-registration for file modules

## What's NOT in this PR
Island pages (`/counter`, `/kitchen-sink`) remain as programmatic Go. These need the island renderer wired through the file-route system, which is tracked separately as a migration blocker:

> File-routed `.gsx` rendering still evaluates IR directly instead of executing arbitrary Go component bodies automatically

## Test plan
- [ ] `go build ./examples/dashboard` compiles
- [ ] Server-rendered pages render correctly at `/`, `/users`, `/users/new`, `/settings`
- [ ] Form actions work (create user validation, settings save)
- [ ] Navigation links work between pages