### PR TITLE
add(server): MountApp for mounting child GoSX apps at a path prefix

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -19,6 +19,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -335,11 +336,11 @@ func (a *App) Mount(pattern string, handler http.Handler) {
 	}
 }
 
-// MountApp mounts a child GoSX App at a path prefix. The child app's handler
-// is wrapped with http.StripPrefix so routes registered on the child (which
-// are rooted at "/") receive requests with the prefix removed. Requests to the
-// bare prefix without a trailing slash are redirected to prefix+"/" by the
-// underlying http.ServeMux.
+// MountApp mounts a child GoSX App at a path prefix. For non-root prefixes,
+// the child app's handler is wrapped with http.StripPrefix so routes
+// registered on the child (which are rooted at "/") receive requests with the
+// prefix removed. Requests to the bare prefix without a trailing slash are
+// redirected to prefix+"/" by the underlying http.ServeMux.
 //
 // Example:
 //
@@ -356,7 +357,37 @@ func (a *App) MountApp(prefix string, child *App) {
 		return
 	}
 	prefix = "/" + strings.Trim(prefix, "/")
-	a.Mount(prefix+"/", http.StripPrefix(prefix, child.Build()))
+
+	var (
+		cached  atomic.Value
+		buildMu sync.Mutex
+	)
+	loadChild := func() http.Handler {
+		handler, ok := cached.Load().(http.Handler)
+		if ok {
+			return handler
+		}
+		buildMu.Lock()
+		defer buildMu.Unlock()
+		handler, ok = cached.Load().(http.Handler)
+		if !ok {
+			handler = child.Build()
+			if prefix != "/" {
+				handler = http.StripPrefix(prefix, handler)
+			}
+			cached.Store(handler)
+		}
+		return handler
+	}
+	lazy := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		loadChild().ServeHTTP(w, r)
+	})
+
+	pattern := prefix
+	if pattern != "/" {
+		pattern += "/"
+	}
+	a.Mount(pattern, lazy)
 }
 
 // EnableGzip adds gzip compression middleware. It compresses all responses

--- a/server/server.go
+++ b/server/server.go
@@ -335,6 +335,30 @@ func (a *App) Mount(pattern string, handler http.Handler) {
 	}
 }
 
+// MountApp mounts a child GoSX App at a path prefix. The child app's handler
+// is wrapped with http.StripPrefix so routes registered on the child (which
+// are rooted at "/") receive requests with the prefix removed. Requests to the
+// bare prefix without a trailing slash are redirected to prefix+"/" by the
+// underlying http.ServeMux.
+//
+// Example:
+//
+//	parent := server.New()
+//	child := server.New()
+//	// ... configure child routes ...
+//	parent.MountApp("/cobalt/example", child)
+//
+// With the mount above, a request to /cobalt/example/programs reaches the
+// child's handler as /programs.
+func (a *App) MountApp(prefix string, child *App) {
+	prefix = strings.TrimSpace(prefix)
+	if prefix == "" || child == nil {
+		return
+	}
+	prefix = "/" + strings.Trim(prefix, "/")
+	a.Mount(prefix+"/", http.StripPrefix(prefix, child.Build()))
+}
+
 // EnableGzip adds gzip compression middleware. It compresses all responses
 // when the client advertises gzip support, skipping WebSocket upgrades and
 // pre-compressed responses. Call this before Use() calls that write responses.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2522,6 +2522,60 @@ func TestMountAppStripsPrefixBeforeDelegating(t *testing.T) {
 	}
 }
 
+func TestMountAppRootPrefixDelegatesWithoutStrippingSlash(t *testing.T) {
+	child := New()
+	var childSawPath string
+	child.Mount("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		childSawPath = r.URL.Path
+		_, _ = w.Write([]byte("root-child-ok"))
+	}))
+
+	parent := New()
+	parent.MountApp("/", child)
+
+	handler := parent.Build()
+	req := httptest.NewRequest(http.MethodGet, "/foo", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "root-child-ok") {
+		t.Fatalf("expected root-child-ok body, got %q", body)
+	}
+	if childSawPath != "/foo" {
+		t.Fatalf("expected child to see /foo for root mount, got %q", childSawPath)
+	}
+}
+
+func TestMountAppIncludesRoutesRegisteredAfterMount(t *testing.T) {
+	child := New()
+	parent := New()
+	parent.MountApp("/child", child)
+
+	var childSawPath string
+	child.Mount("/late", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		childSawPath = r.URL.Path
+		_, _ = w.Write([]byte("late-child-ok"))
+	}))
+
+	handler := parent.Build()
+	req := httptest.NewRequest(http.MethodGet, "/child/late", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "late-child-ok") {
+		t.Fatalf("expected late-child-ok body, got %q", body)
+	}
+	if childSawPath != "/late" {
+		t.Fatalf("expected child to see /late after prefix strip, got %q", childSawPath)
+	}
+}
+
 func TestAppServesBootstrapStubWhenNoBuildExists(t *testing.T) {
 	// Use a temp dir with no build artifacts at all — simulates `go run`
 	// without ever running `gosx build`.

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2495,6 +2495,33 @@ func TestMountedHandlerPreservesFlushUnderObservers(t *testing.T) {
 	}
 }
 
+func TestMountAppStripsPrefixBeforeDelegating(t *testing.T) {
+	child := New()
+	var childSawPath string
+	child.Mount("/foo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		childSawPath = r.URL.Path
+		_, _ = w.Write([]byte("child-ok"))
+	}))
+
+	parent := New()
+	parent.MountApp("/cobalt/example", child)
+
+	handler := parent.Build()
+	req := httptest.NewRequest(http.MethodGet, "/cobalt/example/foo", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "child-ok") {
+		t.Fatalf("expected child-ok body, got %q", body)
+	}
+	if childSawPath != "/foo" {
+		t.Fatalf("expected child to see /foo after prefix strip, got %q", childSawPath)
+	}
+}
+
 func TestAppServesBootstrapStubWhenNoBuildExists(t *testing.T) {
 	// Use a temp dir with no build artifacts at all — simulates `go run`
 	// without ever running `gosx build`.


### PR DESCRIPTION
## Summary

Adds `(*App).MountApp(prefix string, child *App)` so a parent GoSX app can host another GoSX app as a sub-application under a path prefix.

```go
parent := server.New()
child  := server.New()
// ... configure child routes ...
parent.MountApp("/cobalt/example", child)
```

With the mount above, a request to `/cobalt/example/programs` reaches the child's handler as `/programs` — the child's routes, which are rooted at `/`, work unchanged.

## How it works

- Wraps the child's built `http.Handler` with `http.StripPrefix` so the prefix is removed before the child dispatches
- Registers the wrapped handler under `prefix+"/"` via the existing `Mount` infrastructure, so all current dispatcher wiring (observers, flush preservation, public-file precedence, rewrites) applies unchanged
- ServeMux's subtree semantics auto-redirect bare-prefix requests (`/cobalt/example` → `/cobalt/example/`) without extra code
- Implementation is ~10 lines; the rest is doc comments and a test

## Motivation

Lets a single GoSX process host multiple apps composed under a shared domain — for example, a marketing site that mounts a product's evidence/proof-pack app at `/product/example/` without either side knowing about the other, and without needing a reverse proxy or duplicating route infrastructure.

## Test plan

- [x] `go test -count=1 ./server/` — 0 failures, includes new `TestMountAppStripsPrefixBeforeDelegating` which verifies a child handler registered at `/foo` receives a request to `/cobalt/example/foo` as `/foo`
- [x] `go build ./...` — exit 0
- [x] Existing mount tests (`TestAppRewriteCanTargetMountedHandler`, `TestAppPublicFilesBeatMountedCatchall`, `TestMountedHandlerPreservesFlushUnderObservers`) — unchanged and passing