### PR TITLE
Slice Y.A: composite literal lowering for VM AST compiler

### DIFF
--- a/client/vm/composite_test.go
+++ b/client/vm/composite_test.go
@@ -1,0 +1,163 @@
+// Slice Y.A — composite-literal evaluator tests. These exercise the
+// new OpComposite handler in vm.go directly against handcrafted
+// programs (no lowerer round-trip). Lowerer-end tests live in
+// ir/golower/composite_lit_test.go and assert end-to-end behavior; the
+// tests here pin the operand encoding so a future encoding tweak
+// breaks loudly at the VM seam first.
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestOpCompositeStructPositional builds a struct Value from a
+// positional-style expression: the lowerer pre-emits the field name
+// keys, the VM stores them in Fields, and a follow-up OpIndex with
+// the field-name key reads them back.
+func TestOpCompositeStructPositional(t *testing.T) {
+	// Program shape:
+	//   exprs:
+	//     0: "X" (string lit)
+	//     1: 3.5 (float lit)
+	//     2: "Y" (string lit)
+	//     3: 1.25 (float lit)
+	//     4: OpComposite("struct:vec2", [0,1,2,3])
+	exprs := []program.Expr{
+		{Op: program.OpLitString, Value: "X", Type: program.TypeString},
+		{Op: program.OpLitFloat, Value: "3.5", Type: program.TypeFloat},
+		{Op: program.OpLitString, Value: "Y", Type: program.TypeString},
+		{Op: program.OpLitFloat, Value: "1.25", Type: program.TypeFloat},
+		{
+			Op:       program.OpComposite,
+			Value:    "struct:vec2",
+			Operands: []program.ExprID{0, 1, 2, 3},
+		},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(4)
+	if got.Fields == nil {
+		t.Fatalf("OpComposite struct: Fields nil; got %+v", got)
+	}
+	if got.Fields["X"].Num != 3.5 {
+		t.Errorf("Fields[X] = %f, want 3.5", got.Fields["X"].Num)
+	}
+	if got.Fields["Y"].Num != 1.25 {
+		t.Errorf("Fields[Y] = %f, want 1.25", got.Fields["Y"].Num)
+	}
+}
+
+// TestOpCompositeSliceMaterialization confirms a slice literal becomes
+// an array Value whose Items reflect the pair order.
+func TestOpCompositeSliceMaterialization(t *testing.T) {
+	// Program: ["alpha", "beta", "gamma"] via OpComposite("slice", ...).
+	exprs := []program.Expr{
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},
+		{Op: program.OpLitString, Value: "alpha", Type: program.TypeString},
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},
+		{Op: program.OpLitString, Value: "beta", Type: program.TypeString},
+		{Op: program.OpLitInt, Value: "2", Type: program.TypeInt},
+		{Op: program.OpLitString, Value: "gamma", Type: program.TypeString},
+		{
+			Op:       program.OpComposite,
+			Value:    "slice",
+			Operands: []program.ExprID{0, 1, 2, 3, 4, 5},
+		},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(6)
+	if len(got.Items) != 3 {
+		t.Fatalf("Items length = %d, want 3", len(got.Items))
+	}
+	if got.Items[0].Str != "alpha" || got.Items[2].Str != "gamma" {
+		t.Errorf("Items = %+v, want [alpha beta gamma]", got.Items)
+	}
+}
+
+// TestOpCompositeMapMaterialization confirms a map literal becomes an
+// object Value whose Fields keys reflect the evaluated key expressions.
+func TestOpCompositeMapMaterialization(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpLitString, Value: "x", Type: program.TypeString},
+		{Op: program.OpLitFloat, Value: "1.5", Type: program.TypeFloat},
+		{Op: program.OpLitString, Value: "y", Type: program.TypeString},
+		{Op: program.OpLitFloat, Value: "2.5", Type: program.TypeFloat},
+		{
+			Op:       program.OpComposite,
+			Value:    "map",
+			Operands: []program.ExprID{0, 1, 2, 3},
+		},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(4)
+	if got.Fields == nil || len(got.Fields) != 2 {
+		t.Fatalf("Fields = %+v, want 2 entries", got.Fields)
+	}
+	if got.Fields["x"].Num != 1.5 || got.Fields["y"].Num != 2.5 {
+		t.Errorf("Fields = %+v, want {x:1.5, y:2.5}", got.Fields)
+	}
+}
+
+// TestOpCompositeEmptyStruct verifies an empty composite still
+// materializes a Fields map (so downstream IndexVal reads zero rather
+// than nil-deref).
+func TestOpCompositeEmptyStruct(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpComposite, Value: "struct:vec2"},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(0)
+	if got.Fields == nil {
+		t.Fatalf("empty struct should still allocate Fields, got %+v", got)
+	}
+	if len(got.Fields) != 0 {
+		t.Errorf("empty struct Fields = %d entries, want 0", len(got.Fields))
+	}
+}
+
+// TestOpCompositeOddOperandsDiagnostic ensures a malformed program
+// (odd operand count) returns the zero Value and records a structured
+// diagnostic instead of panicking.
+func TestOpCompositeOddOperandsDiagnostic(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpLitString, Value: "X", Type: program.TypeString},
+		{
+			Op:       program.OpComposite,
+			Value:    "struct:vec2",
+			Operands: []program.ExprID{0}, // odd — invalid
+		},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(1)
+	if got.Fields != nil {
+		t.Errorf("malformed OpComposite should fall back to zero Any, got %+v", got)
+	}
+	diags := machine.Diagnostics()
+	if len(diags) != 1 || diags[0].Code != "invalid_composite" {
+		t.Errorf("expected invalid_composite diagnostic, got %+v", diags)
+	}
+}
+
+// TestOpCompositeUnknownKindDiagnostic ensures an unrecognized kind tag
+// records a structured diagnostic.
+func TestOpCompositeUnknownKindDiagnostic(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpComposite, Value: "tuple"},
+	}
+	prog := &program.Program{Exprs: exprs}
+	machine := NewVM(prog, nil)
+	got := machine.Eval(0)
+	if got.Fields != nil || got.Items != nil {
+		t.Errorf("unknown OpComposite kind should fall back to zero Any, got %+v", got)
+	}
+	diags := machine.Diagnostics()
+	if len(diags) != 1 || diags[0].Code != "invalid_composite" {
+		t.Errorf("expected invalid_composite diagnostic, got %+v", diags)
+	}
+}

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -124,6 +124,9 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 	if value, ok := vm.evalSequencingExpr(e); ok {
 		return value
 	}
+	if value, ok := vm.evalCompositeExpr(e); ok {
+		return value
+	}
 	vm.recordExprDiagnostic(
 		"unknown_opcode",
 		fmt.Sprintf("unknown island VM opcode %d", e.Op),
@@ -131,6 +134,92 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 		e.Value,
 	)
 	return ZeroValue(program.TypeAny)
+}
+
+// evalCompositeExpr dispatches the Slice Y.A composite-literal opcode.
+// OpComposite materializes a struct, slice, or map value from its
+// operand pairs. The kind tag in Value selects the materialization
+// strategy:
+//
+//   - "struct:<TypeName>" — ObjectVal whose Fields map is keyed by the
+//     string-literal first-operand of each pair.
+//   - "slice"             — ArrayVal whose Items list is the
+//     second-operand of each pair in pair order (the index operand is
+//     informational; the lowerer emits 0..len-1 to keep the encoding
+//     uniform with the struct/map cases).
+//   - "map"               — ObjectVal keyed by each pair's first operand
+//     evaluated and stringified.
+//
+// Unknown kind tags record an "invalid_composite" diagnostic and fall
+// back to the zero Any value so the VM's panic-free contract holds.
+func (vm *VM) evalCompositeExpr(e program.Expr) (Value, bool) {
+	if e.Op != program.OpComposite {
+		return Value{}, false
+	}
+	if len(e.Operands)%2 != 0 {
+		vm.recordExprDiagnostic(
+			"invalid_composite",
+			fmt.Sprintf("OpComposite %q requires an even operand count (key/value pairs), got %d", e.Value, len(e.Operands)),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+	switch {
+	case e.Value == "slice":
+		return vm.compositeSlice(e), true
+	case e.Value == "map":
+		return vm.compositeMap(e), true
+	case len(e.Value) >= 7 && e.Value[:7] == "struct:":
+		return vm.compositeStruct(e), true
+	default:
+		vm.recordExprDiagnostic(
+			"invalid_composite",
+			fmt.Sprintf("OpComposite has unknown kind tag %q (want struct:<Name>, slice, or map)", e.Value),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+}
+
+// compositeStruct materializes a struct Value from interleaved
+// (keyExpr, valueExpr) operand pairs. Keys must evaluate to strings —
+// the lowerer always emits OpLitString for them, so this is a near-
+// noop string read at runtime.
+func (vm *VM) compositeStruct(e program.Expr) Value {
+	fields := make(map[string]Value, len(e.Operands)/2)
+	for i := 0; i < len(e.Operands); i += 2 {
+		key := vm.Eval(e.Operands[i]).String()
+		fields[key] = vm.Eval(e.Operands[i+1])
+	}
+	return ObjectVal(fields)
+}
+
+// compositeSlice materializes an array Value from the value half of
+// each (indexExpr, valueExpr) operand pair. The index operand is
+// evaluated for side effects but its result is discarded — items
+// land in the slice in pair order.
+func (vm *VM) compositeSlice(e program.Expr) Value {
+	items := make([]Value, 0, len(e.Operands)/2)
+	for i := 0; i < len(e.Operands); i += 2 {
+		// Evaluate the index expr for any side effects (typically a literal).
+		vm.Eval(e.Operands[i])
+		items = append(items, vm.Eval(e.Operands[i+1]))
+	}
+	return ArrayVal(items)
+}
+
+// compositeMap materializes a map Value whose Fields keys are each
+// pair's evaluated key (stringified through Value.String). Duplicate
+// keys are last-wins, matching Go's map literal evaluation order.
+func (vm *VM) compositeMap(e program.Expr) Value {
+	fields := make(map[string]Value, len(e.Operands)/2)
+	for i := 0; i < len(e.Operands); i += 2 {
+		key := vm.Eval(e.Operands[i]).String()
+		fields[key] = vm.Eval(e.Operands[i+1])
+	}
+	return ObjectVal(fields)
 }
 
 // evalSequencingExpr dispatches the Slice X.A statement-sequencing opcodes:

--- a/ir/golower/composite.go
+++ b/ir/golower/composite.go
@@ -1,0 +1,204 @@
+// Slice Y.A — composite literal lowering. Adds `*ast.CompositeLit`
+// support to expression lowering: struct, slice, and map literals all
+// become OpComposite expressions whose operand pairs are
+// (keyExpr, valueExpr) per the encoding documented on
+// program.OpComposite.
+//
+// The lowerer builds a per-file struct type registry at the start of
+// LowerASTFile so it can map positional struct literals like
+// `vec2{x, y}` to their named-field equivalent (`{X:x, Y:y}`) without
+// requiring the author to spell the names. Named literals
+// (`vec2{X:x, Y:y}`) skip the registry lookup entirely.
+//
+// Slice and map literals don't need the registry; their keys are
+// either positional integer indices (slice) or per-pair key
+// expressions (map).
+//
+// Nested composites (`[]Node{Node{ID:"a"}, Node{ID:"b"}}`) recurse
+// through the same lowerExpr path. Elided element types
+// (`[]Node{{ID:"a"}}`) are deferred to Y.B; they're rare in the Y.A
+// fixture set (graph_surface.go uses the explicit form everywhere).
+
+package golower
+
+import (
+	"fmt"
+	"go/ast"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// structTypeInfo records the ordered field names of a struct declared
+// somewhere in the source file. Positional composite literals look up
+// the entry by type name to recover field names.
+type structTypeInfo struct {
+	// fields is the ordered list of (field name, count) entries — a
+	// single declaration like `struct{ X, Y float64 }` contributes
+	// two entries ("X", "Y") in declaration order so positional
+	// literals map left-to-right.
+	fields []string
+}
+
+// scanStructTypes walks the file's top-level type declarations and
+// populates ctx.structs with one entry per struct TypeSpec. Non-struct
+// type declarations are ignored. Called once at the head of
+// LowerASTFile so positional struct-literal lowering has the field
+// names ready when expression lowering needs them.
+func (c *lowerCtx) scanStructTypes(file *ast.File) {
+	if c.structs == nil {
+		c.structs = map[string]structTypeInfo{}
+	}
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			c.structs[ts.Name.Name] = structInfoFromAST(st)
+		}
+	}
+}
+
+// structInfoFromAST flattens a Go struct type's field list into the
+// positional name list OpComposite needs. Embedded fields are ignored
+// (they would require an EmbeddedFieldName lookup, which the Y.A
+// supported subset doesn't claim to handle).
+func structInfoFromAST(st *ast.StructType) structTypeInfo {
+	var fields []string
+	if st == nil || st.Fields == nil {
+		return structTypeInfo{}
+	}
+	for _, field := range st.Fields.List {
+		for _, name := range field.Names {
+			fields = append(fields, name.Name)
+		}
+	}
+	return structTypeInfo{fields: fields}
+}
+
+// lowerCompositeLit dispatches the three shapes of *ast.CompositeLit
+// (struct, slice, map) by inspecting the literal's Type expression.
+// Element-type elision is rejected with a clear issue pointing at the
+// escape hatch — the Y.A subset requires explicit element types.
+func (c *lowerCtx) lowerCompositeLit(lit *ast.CompositeLit) program.ExprID {
+	switch t := lit.Type.(type) {
+	case *ast.Ident:
+		// `Name{ ... }` — named struct literal.
+		return c.lowerStructLit(t.Name, lit)
+	case *ast.ArrayType:
+		// `[]T{ ... }` — slice or array literal.
+		return c.lowerSliceLit(lit)
+	case *ast.MapType:
+		// `map[K]V{ ... }` — map literal.
+		return c.lowerMapLit(lit)
+	case nil:
+		c.addIssue(lit, "elided composite-literal element type is not supported in the Y.A subset", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	default:
+		c.addIssue(lit, fmt.Sprintf("unsupported composite literal type %T", lit.Type), escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+}
+
+// lowerStructLit handles both named-form (`Node{ID: id, Pos: pos}`)
+// and positional-form (`vec2{x, y}`) struct literals. The named form
+// uses the explicit keys directly; the positional form looks the type
+// up in the registry built by scanStructTypes and zips the element
+// list against the field list.
+func (c *lowerCtx) lowerStructLit(typeName string, lit *ast.CompositeLit) program.ExprID {
+	operands := make([]program.ExprID, 0, len(lit.Elts)*2)
+
+	for i, el := range lit.Elts {
+		if kv, ok := el.(*ast.KeyValueExpr); ok {
+			keyName, ok := identName(kv.Key)
+			if !ok {
+				c.addIssue(kv, "struct literal key must be a simple identifier (field name)", escapeHatchSuggestion)
+				continue
+			}
+			keyID := c.addExpr(program.Expr{Op: program.OpLitString, Value: keyName, Type: program.TypeString})
+			valueID := c.lowerExpr(kv.Value)
+			operands = append(operands, keyID, valueID)
+			continue
+		}
+
+		// Positional element — look up the i-th field name in the type
+		// registry. Missing entries surface a clear issue rather than
+		// silently emitting an empty key (which would alias every
+		// positional struct under "").
+		info, ok := c.structs[typeName]
+		if !ok || i >= len(info.fields) {
+			c.addIssue(el, fmt.Sprintf("positional struct literal needs known field layout for %q (field %d)", typeName, i), escapeHatchSuggestion)
+			continue
+		}
+		keyID := c.addExpr(program.Expr{Op: program.OpLitString, Value: info.fields[i], Type: program.TypeString})
+		valueID := c.lowerExpr(el)
+		operands = append(operands, keyID, valueID)
+	}
+
+	return c.addExpr(program.Expr{
+		Op:       program.OpComposite,
+		Value:    "struct:" + typeName,
+		Operands: operands,
+	})
+}
+
+// lowerSliceLit emits an OpComposite slice — operands are pairs of
+// (index literal, lowered element). Index literals are emitted so the
+// runtime encoding is uniform across all three composite kinds; the
+// VM evaluator ignores them on the read side.
+func (c *lowerCtx) lowerSliceLit(lit *ast.CompositeLit) program.ExprID {
+	operands := make([]program.ExprID, 0, len(lit.Elts)*2)
+	for i, el := range lit.Elts {
+		if kv, ok := el.(*ast.KeyValueExpr); ok {
+			// `[]T{2: x, 5: y}` — explicit indices. Lower the key as a
+			// regular expression so any constant int literal works.
+			keyID := c.lowerExpr(kv.Key)
+			valueID := c.lowerExpr(kv.Value)
+			operands = append(operands, keyID, valueID)
+			continue
+		}
+		keyID := c.addExpr(program.Expr{
+			Op:    program.OpLitInt,
+			Value: fmt.Sprintf("%d", i),
+			Type:  program.TypeInt,
+		})
+		valueID := c.lowerExpr(el)
+		operands = append(operands, keyID, valueID)
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpComposite,
+		Value:    "slice",
+		Operands: operands,
+	})
+}
+
+// lowerMapLit emits an OpComposite map — operands are arbitrary
+// (key expr, value expr) pairs as written in source. Maps without
+// KeyValueExpr elements are a parse error in Go, so the missing-key
+// branch records an issue rather than silently dropping the element.
+func (c *lowerCtx) lowerMapLit(lit *ast.CompositeLit) program.ExprID {
+	operands := make([]program.ExprID, 0, len(lit.Elts)*2)
+	for _, el := range lit.Elts {
+		kv, ok := el.(*ast.KeyValueExpr)
+		if !ok {
+			c.addIssue(el, "map literal element must be a key:value pair", escapeHatchSuggestion)
+			continue
+		}
+		keyID := c.lowerExpr(kv.Key)
+		valueID := c.lowerExpr(kv.Value)
+		operands = append(operands, keyID, valueID)
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpComposite,
+		Value:    "map",
+		Operands: operands,
+	})
+}

--- a/ir/golower/composite_lit_test.go
+++ b/ir/golower/composite_lit_test.go
@@ -1,0 +1,147 @@
+// Slice Y.A.1 — failing-first tests for composite literal lowering.
+//
+// These tests pin the five representative composite-literal patterns the
+// Y.A plan calls out as the simplest gaps blocking graph_surface.go:
+//
+//   1. positional struct literal:  vec2{X, Y}
+//   2. named struct literal:       Node{ID: "n1", Pos: p}
+//   3. empty struct literal:       vec2{}
+//   4. slice literal:              []Node{a, b}
+//   5. map literal:                map[string]float64{"x": 1.5}
+//
+// At Y.A.1 each lowering call still fails: the lowerer reports
+// "unsupported expression *ast.CompositeLit" because expr.go has no
+// CompositeLit case yet. Y.A.2-Y.A.4 add the OpComposite opcode, its
+// VM evaluator, and the lowering rules; Y.A.5 marks these tests PASS.
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerPositionalStructLiteral verifies `vec2{x, y}` lowers to a
+// composite value whose Fields["X"] / Fields["Y"] hold the operand
+// values in declaration order.
+func TestLowerPositionalStructLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct{ X, Y float64 }
+
+func F(x float64, y float64) float64 {
+	v := vec2{x, y}
+	return v.X + v.Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"x": vm.FloatVal(3.5),
+		"y": vm.FloatVal(1.25),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 4.75 {
+		t.Errorf("F(3.5, 1.25) = %f, want 4.75", got.Num)
+	}
+}
+
+// TestLowerNamedStructLiteral verifies `Node{ID: id, Pos: pos}` lowers
+// such that the resulting Value.Fields map is keyed by the explicit
+// field names.
+func TestLowerNamedStructLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type Node struct {
+	ID  string
+	Pos float64
+}
+
+func F(id string, pos float64) string {
+	n := Node{ID: id, Pos: pos}
+	return n.ID
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"id":  vm.StringVal("n42"),
+		"pos": vm.FloatVal(2.5),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Str != "n42" {
+		t.Errorf("F() = %q, want %q", got.Str, "n42")
+	}
+}
+
+// TestLowerEmptyStructLiteral verifies `vec2{}` produces a Value with
+// the field slots set to their zero values (so `v.X` reads as 0).
+func TestLowerEmptyStructLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct{ X, Y float64 }
+
+func F() float64 {
+	v := vec2{}
+	return v.X + v.Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 0 {
+		t.Errorf("F() = %f, want 0", got.Num)
+	}
+}
+
+// TestLowerSliceLiteral verifies `[]Node{a, b}` materializes an array
+// Value whose items are the operand values, observable through len().
+func TestLowerSliceLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type Node struct{ ID string }
+
+func F() int {
+	xs := []Node{Node{ID: "a"}, Node{ID: "b"}, Node{ID: "c"}}
+	return len(xs)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 3 {
+		t.Errorf("len([]Node{a,b,c}) = %d, want 3", int(got.Num))
+	}
+}
+
+// TestLowerMapLiteral verifies `map[string]float64{"x": 1.5}` lowers
+// to a Value whose Fields map carries the keys, observable through
+// the indexing operator.
+func TestLowerMapLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	m := map[string]float64{"x": 1.5, "y": 2.5}
+	return m["x"] + m["y"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 4.0 {
+		t.Errorf("F() = %f, want 4.0", got.Num)
+	}
+}

--- a/ir/golower/composite_lit_test.go
+++ b/ir/golower/composite_lit_test.go
@@ -145,3 +145,112 @@ func F() float64 {
 		t.Errorf("F() = %f, want 4.0", got.Num)
 	}
 }
+
+// TestLowerNestedStructInSlice covers the graph_surface.go-style
+// pattern of building a `[]Node` whose elements are named struct
+// literals — exercises both slice and (nested) struct composites in
+// the same expression.
+func TestLowerNestedStructInSlice(t *testing.T) {
+	src := []byte(`package handlers
+
+type Node struct {
+	ID  string
+	Pos float64
+}
+
+func F() string {
+	xs := []Node{
+		Node{ID: "first", Pos: 1.0},
+		Node{ID: "second", Pos: 2.0},
+	}
+	return xs[1].ID
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Str != "second" {
+		t.Errorf("F() = %q, want %q", got.Str, "second")
+	}
+}
+
+// TestLowerMapOfStructValues covers `map[string]vec2{ "origin": vec2{0,0} }`
+// — the pattern hyphae graph_surface.go uses for gPos / gVel.
+func TestLowerMapOfStructValues(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct{ X, Y float64 }
+
+func F() float64 {
+	m := map[string]vec2{
+		"a": vec2{1.0, 2.0},
+		"b": vec2{3.0, 4.0},
+	}
+	return m["b"].Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 4.0 {
+		t.Errorf("F() = %f, want 4.0", got.Num)
+	}
+}
+
+// TestLowerEmptyMapLiteral covers `map[string]vec2{}` — the
+// initialization pattern hyphae graph_surface.go uses for package-level
+// `gPos = map[string]vec2{}`.
+func TestLowerEmptyMapLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct{ X, Y float64 }
+
+func F() int {
+	m := map[string]vec2{}
+	return len(m)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 0 {
+		t.Errorf("F() = %d, want 0", int(got.Num))
+	}
+}
+
+// TestLowerPackageVarMapLiteral verifies that a package-level
+// `var x = map[string]vec2{}` declaration produces a SignalDef whose
+// Init evaluates to an empty map Value at runtime. This is the
+// hyphae graph_surface.go pattern (`var gPos = map[string]vec2{}`).
+func TestLowerPackageVarMapLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct{ X, Y float64 }
+
+var positions = map[string]vec2{}
+
+func Count() int { return len(positions) }`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	if len(prog.Signals) != 1 || prog.Signals[0].Name != "positions" {
+		t.Fatalf("Signals = %+v, want one entry named positions", prog.Signals)
+	}
+	machine := vm.NewVM(prog, nil)
+	// Initialize the signal from its Init expr — mirrors how the
+	// runtime sets up signals before invoking handlers.
+	initVal := machine.Eval(prog.Signals[0].Init)
+	if initVal.Fields == nil {
+		t.Errorf("positions init = %+v, want empty Fields map", initVal)
+	}
+}

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -50,6 +50,8 @@ func (c *lowerCtx) lowerExpr(e ast.Expr) program.ExprID {
 		return c.lowerCallExpr(ex)
 	case *ast.IndexExpr:
 		return c.lowerIndexExpr(ex)
+	case *ast.CompositeLit:
+		return c.lowerCompositeLit(ex)
 	default:
 		c.addIssue(e, fmt.Sprintf("unsupported expression %T", e), escapeHatchSuggestion)
 		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})

--- a/ir/golower/golower.go
+++ b/ir/golower/golower.go
@@ -108,6 +108,13 @@ func LowerASTFile(fset *token.FileSet, file *ast.File) (*program.Program, error)
 		exprs:  []program.Expr{},
 	}
 
+	// Pre-pass (Slice Y.A): build the struct-type registry so positional
+	// composite literals (`vec2{x, y}`) can recover field names without
+	// a full go/types pass. Named-form literals (`Node{ID: id}`) don't
+	// need this — they carry field names inline — but the registry is
+	// cheap and keeps the lowering paths uniform.
+	ctx.scanStructTypes(file)
+
 	// Two passes:
 	//   1. Hoist package-level var declarations into signal defs so
 	//      function bodies can reference them by name. Init expressions
@@ -134,6 +141,13 @@ type lowerCtx struct {
 	issues  *LowerError
 	exprs   []program.Expr
 	handler string // name of the handler currently being lowered (for diagnostics)
+
+	// structs holds the ordered field-name list for every struct type
+	// declared at the top level of the file. Populated by
+	// scanStructTypes (Slice Y.A) so positional struct literals like
+	// `vec2{x, y}` can recover field names without a separate
+	// go/types pass.
+	structs map[string]structTypeInfo
 }
 
 // addExpr appends e to the program's expression table and returns the

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -145,6 +145,25 @@ const (
 	// the same sentinel mechanism as OpReturn.
 	OpBreak
 	OpContinue
+
+	// Composite literals (Slice Y.A — AST-compiler initiative). OpComposite
+	// materializes a struct, slice, or map value at runtime. Value carries
+	// the kind tag — one of:
+	//   - "struct:<TypeName>" — named or positional struct literal.
+	//   - "slice"             — slice/array literal.
+	//   - "map"               — map literal.
+	// Operands are an interleaved key/value list:
+	//   - struct: pairs of (string-literal key expr, value expr); for
+	//     positional literals the lowerer pre-emits the field name as
+	//     the key from a compile-time type registry built from the
+	//     surrounding file's TypeSpec declarations.
+	//   - slice:  pairs of (int-literal index expr, value expr); indices
+	//     run 0..len-1 and are emitted by the lowerer.
+	//   - map:    pairs of (key expr, value expr); keys may be any
+	//     expression whose String() form becomes the map key.
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpComposite keep evaluating exactly as before.
+	OpComposite
 )
 
 // SurfaceKind identifies the rendering surface a program targets.

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1082,3 +1082,80 @@ func TestSequencingOpcodeShapes(t *testing.T) {
 		t.Errorf("OpLocalSet shape unexpected: %+v", set)
 	}
 }
+
+// --- Slice Y.A: composite literal opcode ---
+
+// TestCompositeOpcodeIsDistinct guards the new Y.A iota slot against
+// accidental collision with the X.A/X.B/X.C additions or any prior
+// opcode. OpComposite is the single new opcode introduced by Slice Y.A
+// (composite-literal lowering); a collision would silently corrupt
+// every struct/slice/map literal in lowered handlers.
+func TestCompositeOpcodeIsDistinct(t *testing.T) {
+	all := []OpCode{
+		// pre-existing (TestOpCodeRange)
+		OpLitString, OpLitInt, OpLitFloat, OpLitBool,
+		OpPropGet, OpSignalGet, OpSignalSet, OpSignalUpdate,
+		OpAdd, OpSub, OpMul, OpDiv, OpMod, OpNeg,
+		OpEq, OpNeq, OpLt, OpGt, OpLte, OpGte,
+		OpAnd, OpOr, OpNot,
+		OpConcat, OpFormat,
+		OpCond, OpCall, OpIndex, OpLen, OpRange,
+		OpEventGet,
+		OpMap, OpFilter, OpFind, OpSlice, OpAppend, OpContains,
+		OpToUpper, OpToLower, OpTrim, OpSplit, OpJoin, OpReplace,
+		OpSubstring, OpStartsWith, OpEndsWith,
+		OpToString, OpToInt, OpToFloat,
+		// X.A
+		OpSeq, OpAssign, OpLocalDecl, OpLocalGet, OpLocalSet,
+		// X.C
+		OpFor, OpForRange, OpReturn, OpBreak, OpContinue,
+		// Y.A (new)
+		OpComposite,
+	}
+	seen := map[OpCode]bool{}
+	for _, op := range all {
+		if seen[op] {
+			t.Errorf("OpCode %d appears twice in the opcode ladder", op)
+		}
+		seen[op] = true
+	}
+}
+
+// TestCompositeOpcodeShape documents the operand encoding for the three
+// kinds of composite literal (struct/slice/map). Operand pairs are
+// (keyExpr, valueExpr); the lowerer is responsible for pre-emitting the
+// keys as OpLitString / OpLitInt as appropriate.
+func TestCompositeOpcodeShape(t *testing.T) {
+	// struct: Value = "struct:vec2"; operands are (keyExpr, valueExpr) pairs.
+	structLit := Expr{
+		Op:       OpComposite,
+		Value:    "struct:vec2",
+		Operands: []ExprID{0, 1, 2, 3}, // ("X", x), ("Y", y)
+	}
+	if structLit.Value != "struct:vec2" {
+		t.Errorf("struct Value = %q, want %q", structLit.Value, "struct:vec2")
+	}
+	if len(structLit.Operands)%2 != 0 {
+		t.Errorf("struct operand count %d must be even (key/value pairs)", len(structLit.Operands))
+	}
+
+	// slice: Value = "slice"; operands are (indexExpr, valueExpr) pairs.
+	sliceLit := Expr{
+		Op:       OpComposite,
+		Value:    "slice",
+		Operands: []ExprID{0, 1, 2, 3, 4, 5}, // (0, a), (1, b), (2, c)
+	}
+	if sliceLit.Value != "slice" {
+		t.Errorf("slice Value = %q, want %q", sliceLit.Value, "slice")
+	}
+
+	// map: Value = "map"; operands are arbitrary (keyExpr, valueExpr) pairs.
+	mapLit := Expr{
+		Op:       OpComposite,
+		Value:    "map",
+		Operands: []ExprID{0, 1, 2, 3}, // ("x", 1.5), ("y", 2.5)
+	}
+	if mapLit.Value != "map" {
+		t.Errorf("map Value = %q, want %q", mapLit.Value, "map")
+	}
+}


### PR DESCRIPTION
## Summary

Ships **Slice Y.A** of the [VM AST-compiler Y initiative](https://github.com/odvcencio/m31labs-hyphae) — composite literal support for `ir/golower/` and the shared client VM. Closes ~6 of the 105 `gap-hyphae-graph-handlers` capability-gap issues that block hyphae `graph_surface.go` from lowering cleanly off the `surface=wasm` escape hatch (per ADR 0003 / ADR 0005).

- New `OpComposite` opcode in `island/program/program.go` carries struct, slice, and map literals through a single unified encoding (Value kind tag + interleaved key/value operand pairs).
- VM evaluator (`client/vm/vm.go`) materializes each kind through `ObjectVal` (struct/map) or `ArrayVal` (slice) — no `Value` type expansion.
- Lowerer (`ir/golower/composite.go`) handles named (`Node{ID: id}`) and positional (`vec2{x, y}`) struct literals, slice literals, and map literals. A per-file struct-type registry (`scanStructTypes`) recovers field names for positional forms without a full `go/types` pass.

Cites ADR 0003, ADR 0005, and the gosx-vm-capability-gaps spec via the hyphae knowledge tree.

## Test plan

- [x] `go test ./ir/golower/` — 21 tests including 9 new Y.A cases (positional/named/empty struct, slice, map, nested struct-in-slice, map-of-struct, empty map, package-var map)
- [x] `go test ./client/vm/` — 6 new VM-level OpComposite tests including malformed-program diagnostics
- [x] `go test ./island/program/` — opcode distinctness + operand-shape tests for OpComposite
- [x] `go test ./engine/surface/...` — existing surface lowering pipeline unaffected
- [x] `GOOS=js GOARCH=wasm go build ./client/wasm/` — WASM target compiles cleanly
- [x] Bench: 450-line synthetic file lowers in ~426 µs (target < 100 ms)
- [x] graph_surface.go lowering issue count: 105 → 99 (composite-literal sites now lower; remaining gaps are Y.B-Y.E)

## Follow-ups

- Y.B (multi-value assignment) — closes ~18 issues
- Y.C (LHS selectors / indexed-set) — closes ~33 issues
- Y.D (user-defined function calls) — closes ~12 issues
- Y.E (`make()` + `surface.Canvas` binding) — closes ~32 issues
- Y.F (SSIM parity test + ADR 0005 clock start)