### PR TITLE
Slice Y.C: LHS selector / indexed-set lowering for VM AST compiler

### DIFF
--- a/client/vm/island.go
+++ b/client/vm/island.go
@@ -197,6 +197,21 @@ func initSignals(vm *VM, prog *program.Program) {
 	}
 }
 
+// InitSignals is the exported wrapper around initSignals for tests and
+// surface bootstraps that don't go through the full Island lifecycle.
+// It evaluates each SignalDef's init expression against the VM and
+// registers a fresh signal.Signal for it. Idempotency is the caller's
+// responsibility; calling InitSignals twice for the same Program
+// re-evaluates the init exprs and replaces the prior signals.
+//
+// Engine-surface handlers that mutate package-level struct/map/slice
+// state via OpFieldSet / OpIndexSet (Slice Y.C) rely on this — without
+// initialized signals, OpLocalGet falls through to a zero Value with
+// nil Fields, and the in-place mutation silently no-ops.
+func InitSignals(vm *VM, prog *program.Program) {
+	initSignals(vm, prog)
+}
+
 func handlerMap(prog *program.Program) map[string]*program.Handler {
 	handlers := make(map[string]*program.Handler, len(prog.Handlers))
 	for i := range prog.Handlers {

--- a/client/vm/lhs_set.go
+++ b/client/vm/lhs_set.go
@@ -1,0 +1,155 @@
+// Slice Y.C — LHS selector / indexed-set evaluators.
+//
+// OpFieldSet and OpIndexSet mutate the target collection in place.
+// Because Value.Fields is a `map[string]Value` and Value.Items is a
+// `[]Value`, the underlying storage is reference-shared between any
+// Values that aliased the same materialized collection — a write
+// through one alias is visible through every other alias.
+//
+// **Design decision (deferred from Y.A's exit, resolved here):** the
+// VM uses **in-place mutation** for ObjectVal struct-field-set and
+// ArrayVal / ObjectVal index-set rather than copy-on-write. Rationale:
+//
+//   1. graph_surface.go's canonical hard cases (`gPos[id] = vec2{...}`,
+//      `fx[a.ID] += force`) target package-level maps that the author
+//      *intends* to mutate — wrapping a CoW shell around every write
+//      would silently break those semantics.
+//   2. Y.B's range loop already mutates `_item` in place; the symmetry
+//      keeps the VM evaluator's mental model coherent across slices.
+//   3. Go's actual value-semantics for struct assignment surface as the
+//      author's explicit `gVel[n.ID] = v` writeback in stepLayout. Y.C
+//      lowers that writeback to an OpIndexSet — the by-value copy
+//      already happened on the OpLocalGet read, so the OpIndexSet is
+//      restoring the (mutated) local Value into the shared collection.
+//      No CoW machinery is needed for that pattern to behave the same
+//      as Go.
+//
+// The trade-off is that if a future surface author writes
+// `node := gPos[id]; node.X = 5` *without* a writeback, the Go-level
+// semantics (the assignment doesn't propagate to gPos) and the VM-level
+// semantics (the assignment DOES propagate because node aliases the
+// same Fields map) diverge. The supported subset's documented
+// limitation is that surface handlers must treat composite values as
+// reference-shared. If that bites a real surface we revisit (see the
+// Y.C retrospective for the open question).
+
+package vm
+
+import (
+	"fmt"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// evalLHSSetExpr dispatches the Slice Y.C in-place mutation opcodes.
+// Returns (value, true) for any LHS-set opcode (value is the assigned
+// RHS, mirroring OpAssign's return so callers can chain through an
+// OpSeq). Returns (Value{}, false) for any other opcode.
+func (vm *VM) evalLHSSetExpr(e program.Expr) (Value, bool) {
+	switch e.Op {
+	case program.OpFieldSet:
+		return vm.fieldSetValue(e), true
+	case program.OpIndexSet:
+		return vm.indexSetValue(e), true
+	default:
+		return Value{}, false
+	}
+}
+
+// fieldSetValue evaluates `target.<Value> = Operands[1]` and writes
+// the assigned value into Operands[0]'s Fields map in place. The field
+// name lives in Value because it's always a compile-time identifier in
+// the Go source.
+//
+// If Operands[0] evaluates to a Value whose Fields is nil, the
+// evaluator lazily initializes the map and writes anyway. This matters
+// for two scenarios:
+//
+//   - A composite literal that the lowerer typed as struct but ended up
+//     with zero declared fields (e.g., `vec2{}` followed by `v.X = 1`)
+//     — the OpComposite handler still emits an empty Fields map, so
+//     this branch is rare but consistent.
+//   - A future-proofing hedge: a missing Fields shouldn't drop the
+//     write silently because that would mask real lowering bugs. The
+//     diagnostic still fires so the issue surfaces in test logs.
+//
+// In-place mutation propagates through every aliasing Value because
+// Go maps are reference types. If the caller obtained `target` via
+// OpLocalGet (a Value-by-value copy), the Fields map inside that copy
+// still points at the same underlying storage as the original.
+func (vm *VM) fieldSetValue(e program.Expr) Value {
+	if !vm.requireOperands(e, 2) {
+		return ZeroValue(program.TypeAny)
+	}
+	target := vm.Eval(e.Operands[0])
+	value := vm.Eval(e.Operands[1])
+	if target.Fields == nil {
+		vm.recordExprDiagnostic(
+			"field_set_non_struct",
+			fmt.Sprintf("OpFieldSet target field %q evaluates to a Value with no Fields map (Value type %d)", e.Value, target.Type),
+			e.Op,
+			e.Value,
+		)
+		// Best-effort: we cannot reach back to the local slot from here
+		// (the lowerer evaluated Operands[0] as an arbitrary expression),
+		// so writing into a fresh Fields map would be invisible to the
+		// caller. Drop the write but keep the panic-free contract.
+		return value
+	}
+	target.Fields[e.Value] = value
+	return value
+}
+
+// indexSetValue evaluates `target[Operands[1]] = Operands[2]` and
+// writes through the collection in place. The runtime path branches on
+// the collection's storage:
+//
+//   - Items non-nil → slice/array write: the key is coerced to an int
+//     and the write lands in Items[idx]. Out-of-range indices are
+//     diagnosed; the VM stays panic-free (no slice growth).
+//   - Fields non-nil → map write: the key is stringified through
+//     Value.String() (matching OpIndex's read-side coercion) and the
+//     write lands in Fields[key]. New keys are created on demand.
+//   - Both nil → the collection wasn't a materialized array/object;
+//     diagnose and drop the write.
+//
+// The branch order matters for Y.A's encoding where struct literals
+// land as ObjectVal — those go through Fields. Slice literals land as
+// ArrayVal (Items non-nil, Fields nil) — those go through Items. A
+// Value can't legally have both populated in the supported subset, so
+// "Items first if non-nil" is unambiguous.
+func (vm *VM) indexSetValue(e program.Expr) Value {
+	if !vm.requireOperands(e, 3) {
+		return ZeroValue(program.TypeAny)
+	}
+	target := vm.Eval(e.Operands[0])
+	key := vm.Eval(e.Operands[1])
+	value := vm.Eval(e.Operands[2])
+
+	switch {
+	case target.Items != nil:
+		idx := int(key.Num)
+		if idx < 0 || idx >= len(target.Items) {
+			vm.recordExprDiagnostic(
+				"index_set_out_of_range",
+				fmt.Sprintf("OpIndexSet index %d out of range [0,%d)", idx, len(target.Items)),
+				e.Op,
+				e.Value,
+			)
+			return value
+		}
+		target.Items[idx] = value
+		return value
+	case target.Fields != nil:
+		target.Fields[key.String()] = value
+		return value
+	default:
+		vm.recordExprDiagnostic(
+			"index_set_non_collection",
+			fmt.Sprintf("OpIndexSet target has neither Items nor Fields (Value type %d)", target.Type),
+			e.Op,
+			e.Value,
+		)
+		return value
+	}
+}

--- a/client/vm/lhs_set_bench_test.go
+++ b/client/vm/lhs_set_bench_test.go
@@ -1,0 +1,97 @@
+// Slice Y.C — benchmarks for OpFieldSet / OpIndexSet. The Y.C handlers
+// run once per LHS assignment in lowered Go, so their cost is scaled by
+// handler invocation count and the number of writes in tight loops (the
+// stepLayout repulsion loop in graph_surface.go does N×N OpIndexSet
+// writes per frame). Target: a single write should be a few hundred
+// nanoseconds at most so 60 FPS with O(N²) writes on a 100-node graph
+// (10k writes/frame) stays well under the 16 ms frame budget.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// BenchmarkFieldSet measures the steady-state cost of OpFieldSet
+// against a fixed-size struct (Fields-backed ObjectVal). Setup builds
+// the program once; the bench loop measures Eval + the map write.
+func BenchmarkFieldSet(b *testing.B) {
+	// Program: OpFieldSet v.X = 42
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "v"},                                            // 0
+			{Op: program.OpLitFloat, Value: "42", Type: program.TypeFloat},                  // 1
+			{Op: program.OpFieldSet, Value: "X", Operands: []program.ExprID{0, 1}},          // 2
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("v")
+	machine.frame.set("v", ObjectVal(map[string]Value{
+		"X": FloatVal(0), "Y": FloatVal(0), "Z": FloatVal(0),
+	}))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(2)
+	}
+}
+
+// BenchmarkIndexSetSlice measures the slice-branch cost of OpIndexSet.
+// The 100-element slice mimics the order-of-magnitude `fx[]` array
+// stepLayout writes into per frame.
+func BenchmarkIndexSetSlice(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "s"},                                            // 0
+			{Op: program.OpLitInt, Value: "50", Type: program.TypeInt},                      // 1
+			{Op: program.OpLitFloat, Value: "3.14", Type: program.TypeFloat},                // 2
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},                   // 3
+		},
+	}
+	items := make([]Value, 100)
+	for i := range items {
+		items[i] = FloatVal(0)
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("s")
+	machine.frame.set("s", ArrayVal(items))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(3)
+	}
+}
+
+// BenchmarkIndexSetMap measures the map-branch cost of OpIndexSet.
+// The 100-entry map mimics gPos (one entry per graph node) and uses
+// a key that always overwrites the same slot so the bench measures
+// the write itself, not key creation.
+func BenchmarkIndexSetMap(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "m"},                                            // 0
+			{Op: program.OpLitString, Value: "key_42", Type: program.TypeString},            // 1
+			{Op: program.OpLitFloat, Value: "1.5", Type: program.TypeFloat},                 // 2
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},                   // 3
+		},
+	}
+	fields := make(map[string]Value, 100)
+	for i := 0; i < 100; i++ {
+		fields[mapKey(i)] = FloatVal(0)
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("m")
+	machine.frame.set("m", ObjectVal(fields))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(3)
+	}
+}
+
+func mapKey(i int) string {
+	const digits = "0123456789"
+	return "key_" + digits[i/10:i/10+1] + digits[i%10:i%10+1]
+}

--- a/client/vm/lhs_set_test.go
+++ b/client/vm/lhs_set_test.go
@@ -1,0 +1,214 @@
+// Slice Y.C.3 — VM-level tests for OpFieldSet / OpIndexSet evaluators.
+//
+// These tests exercise the VM directly (no lowering) so a bug in the
+// evaluator can be bisected without going through the AST → opcode
+// stage. The lowerer tests (lhs_selectors_test.go in ir/golower) cover
+// the full path; this file pins the in-place mutation contract.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestOpFieldSetWritesIntoExistingObject pins the in-place mutation
+// contract: OpFieldSet on a target whose Fields map is non-nil writes
+// into the map and the change is visible through any aliasing Value.
+func TestOpFieldSetWritesIntoExistingObject(t *testing.T) {
+	// Build a program that:
+	//   1. Declares local "v" and assigns it an ObjectVal{X:1, Y:2}.
+	//   2. OpFieldSet v.X = 99.
+	//   3. Reads back v.X via OpIndex.
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			// 0: literal 99
+			{Op: program.OpLitFloat, Value: "99", Type: program.TypeFloat},
+			// 1: OpLocalGet v
+			{Op: program.OpLocalGet, Value: "v"},
+			// 2: OpFieldSet v.X = 99
+			{Op: program.OpFieldSet, Value: "X", Operands: []program.ExprID{1, 0}},
+			// 3: lit string "X"
+			{Op: program.OpLitString, Value: "X", Type: program.TypeString},
+			// 4: OpLocalGet v (after mutation)
+			{Op: program.OpLocalGet, Value: "v"},
+			// 5: OpIndex v["X"]
+			{Op: program.OpIndex, Operands: []program.ExprID{4, 3}},
+			// 6: OpSeq(2, 5)
+			{Op: program.OpSeq, Operands: []program.ExprID{2, 5}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("v")
+	machine.frame.set("v", ObjectVal(map[string]Value{
+		"X": FloatVal(1),
+		"Y": FloatVal(2),
+	}))
+	got := machine.Eval(6)
+	if got.Num != 99 {
+		t.Errorf("v.X after FieldSet = %f, want 99", got.Num)
+	}
+	// Confirm the original map was mutated, not a copy.
+	v, _ := machine.frame.get("v")
+	if v.Fields["X"].Num != 99 {
+		t.Errorf("frame.v.Fields[X] = %f, want 99 (in-place mutation broken)", v.Fields["X"].Num)
+	}
+}
+
+// TestOpFieldSetOnNonStructDiagnoses pins the diagnostic path: a target
+// without a Fields map records `field_set_non_struct` and stays
+// panic-free.
+func TestOpFieldSetOnNonStructDiagnoses(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			// 0: int target (non-struct)
+			{Op: program.OpLitInt, Value: "7", Type: program.TypeInt},
+			// 1: lit value
+			{Op: program.OpLitInt, Value: "42", Type: program.TypeInt},
+			// 2: OpFieldSet on the int — should diagnose
+			{Op: program.OpFieldSet, Value: "X", Operands: []program.ExprID{0, 1}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	got := machine.Eval(2)
+	if int(got.Num) != 42 {
+		t.Errorf("OpFieldSet on non-struct returned %f, want 42 (assigned value)", got.Num)
+	}
+	diags := machine.Diagnostics()
+	found := false
+	for _, d := range diags {
+		if d.Code == "field_set_non_struct" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected field_set_non_struct diagnostic; got %v", diags)
+	}
+}
+
+// TestOpIndexSetWritesIntoSliceInPlace exercises the slice branch
+// (Items non-nil). Sets s[1] = 9, reads back s[1].
+func TestOpIndexSetWritesIntoSliceInPlace(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			// 0: target s
+			{Op: program.OpLocalGet, Value: "s"},
+			// 1: key 1
+			{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},
+			// 2: value 9
+			{Op: program.OpLitInt, Value: "9", Type: program.TypeInt},
+			// 3: OpIndexSet s[1] = 9
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},
+			// 4-6: read back s[1]
+			{Op: program.OpLocalGet, Value: "s"},
+			{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},
+			{Op: program.OpIndex, Operands: []program.ExprID{4, 5}},
+			// 7: seq
+			{Op: program.OpSeq, Operands: []program.ExprID{3, 6}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("s")
+	machine.frame.set("s", ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3)}))
+	got := machine.Eval(7)
+	if int(got.Num) != 9 {
+		t.Errorf("s[1] after IndexSet = %d, want 9", int(got.Num))
+	}
+	v, _ := machine.frame.get("s")
+	if int(v.Items[1].Num) != 9 {
+		t.Errorf("frame.s.Items[1] = %d, want 9 (in-place mutation broken)", int(v.Items[1].Num))
+	}
+}
+
+// TestOpIndexSetWritesIntoMapInPlace exercises the map branch (Fields
+// non-nil). Sets m["k"] = 5, reads back m["k"]; new key creation works.
+func TestOpIndexSetWritesIntoMapInPlace(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			// 0: target m
+			{Op: program.OpLocalGet, Value: "m"},
+			// 1: key "k"
+			{Op: program.OpLitString, Value: "k", Type: program.TypeString},
+			// 2: value 5
+			{Op: program.OpLitInt, Value: "5", Type: program.TypeInt},
+			// 3: OpIndexSet m["k"] = 5
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},
+			// 4-6: read m["k"]
+			{Op: program.OpLocalGet, Value: "m"},
+			{Op: program.OpLitString, Value: "k", Type: program.TypeString},
+			{Op: program.OpIndex, Operands: []program.ExprID{4, 5}},
+			// 7: seq
+			{Op: program.OpSeq, Operands: []program.ExprID{3, 6}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("m")
+	// Start with an empty map; IndexSet should create the key.
+	machine.frame.set("m", ObjectVal(map[string]Value{}))
+	got := machine.Eval(7)
+	if int(got.Num) != 5 {
+		t.Errorf("m[\"k\"] after IndexSet = %d, want 5", int(got.Num))
+	}
+}
+
+// TestOpIndexSetOutOfRangeDiagnoses pins the diagnostic path for slice
+// bounds violations.
+func TestOpIndexSetOutOfRangeDiagnoses(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "s"},
+			{Op: program.OpLitInt, Value: "10", Type: program.TypeInt},
+			{Op: program.OpLitInt, Value: "99", Type: program.TypeInt},
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	machine.frame.declare("s")
+	machine.frame.set("s", ArrayVal([]Value{IntVal(1), IntVal(2)}))
+	_ = machine.Eval(3)
+	diags := machine.Diagnostics()
+	found := false
+	for _, d := range diags {
+		if d.Code == "index_set_out_of_range" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected index_set_out_of_range diagnostic; got %v", diags)
+	}
+}
+
+// TestOpIndexSetOnNonCollectionDiagnoses pins the third diagnostic
+// branch: target has neither Items nor Fields.
+func TestOpIndexSetOnNonCollectionDiagnoses(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "7", Type: program.TypeInt},
+			{Op: program.OpLitString, Value: "k", Type: program.TypeString},
+			{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},
+			{Op: program.OpIndexSet, Operands: []program.ExprID{0, 1, 2}},
+		},
+	}
+	machine := NewVM(prog, nil)
+	machine.frame = newFrame()
+	_ = machine.Eval(3)
+	diags := machine.Diagnostics()
+	found := false
+	for _, d := range diags {
+		if d.Code == "index_set_non_collection" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected index_set_non_collection diagnostic; got %v", diags)
+	}
+}

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -130,6 +130,9 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 	if value, ok := vm.evalMapLookupExpr(e); ok {
 		return value
 	}
+	if value, ok := vm.evalLHSSetExpr(e); ok {
+		return value
+	}
 	vm.recordExprDiagnostic(
 		"unknown_opcode",
 		fmt.Sprintf("unknown island VM opcode %d", e.Op),

--- a/ir/golower/bench_test.go
+++ b/ir/golower/bench_test.go
@@ -42,17 +42,43 @@ func buildLargeSource(lines int) []byte {
 	return []byte(b.String())
 }
 
-// makeBenchFunc produces one function. Three shapes rotate so the
+// makeBenchFunc produces one function. Four shapes rotate so the
 // benchmarked code matches the diversity of real engine-surface files.
+// Slice Y.C added the fourth shape (LHS selector / indexed-set) so the
+// bench picks up the lowering cost of OpFieldSet / OpIndexSet handlers
+// — the actual shape graph_surface.go uses for state mutations.
 func makeBenchFunc(i int) string {
-	switch i % 3 {
+	switch i % 4 {
 	case 0:
 		return funcPure(i)
 	case 1:
 		return funcLoop(i)
-	default:
+	case 2:
 		return funcIntrinsic(i)
+	default:
+		return funcLHS(i)
 	}
+}
+
+// funcLHS produces a Y.C-shaped handler that exercises both
+// OpFieldSet (`p.X = ...`) and OpIndexSet (`m[k] += ...` and
+// `s[i] *= ...`) in a tight loop — the kind of body stepLayout
+// and the force-accumulator passes generate in graph_surface.go.
+func funcLHS(i int) string {
+	return `type lhs` + itoa(i) + ` struct { X, Y float64 }
+
+func LHS` + itoa(i) + `(n int) float64 {
+	p := lhs` + itoa(i) + `{X: 0.0, Y: 0.0}
+	s := []float64{0.0, 0.0, 0.0, 0.0}
+	m := map[string]float64{}
+	for j := 0; j < n; j = j + 1 {
+		p.X = p.X + 1.0
+		p.Y = p.Y + 2.0
+		s[j % 4] += float64(j)
+		m["acc"] += p.X
+	}
+	return p.X + s[0] + m["acc"]
+}`
 }
 
 func funcPure(i int) string {

--- a/ir/golower/graph_surface_test.go
+++ b/ir/golower/graph_surface_test.go
@@ -92,6 +92,102 @@ func TestGraphSurfaceTier2AccumulateAngle(t *testing.T) {
 	}
 }
 
+// TestGraphSurfaceTier4StepLayoutKernel is a Slice Y.C addition: it
+// lowers a fixture that mirrors the stepLayout repulsion-accumulator
+// kernel from graph_surface.go but scrubbed of canvas calls and
+// user-function dispatch (still Y.D/Y.E territory). The kernel
+// exercises the full Y.A-Y.C lowering stack end-to-end:
+//
+//   - Y.A composite literals for the initial fx/fy slices and the
+//     gPos/gVel maps
+//   - Y.B comma-ok map lookups for the `pa, paOK := gPos[a.ID]` form
+//     (here simplified to a present-only path so we don't need Y.D
+//     to dispatch the "missing-pair skip" check)
+//   - Y.C LHS selector / indexed-set for the `fx[i] = 0`, `v.X = ...`,
+//     `gVel[id] = v`, `gPos[id] = p` writebacks
+//
+// The reference implementation in refStepLayoutKernel uses the same
+// arithmetic so the lowered bytecode and the Go runtime should agree
+// to within float64 epsilon.
+func TestGraphSurfaceTier4StepLayoutKernel(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	gPos := map[string]vec2{"n0": vec2{0.0, 0.0}, "n1": vec2{10.0, 0.0}}
+	gVel := map[string]vec2{"n0": vec2{0.0, 0.0}, "n1": vec2{0.0, 0.0}}
+	fx := []float64{0.0, 0.0}
+	fy := []float64{0.0, 0.0}
+	// Zero the force accumulators (LHS slice index set).
+	for i := 0; i < 2; i = i + 1 {
+		fx[i] = 0.0
+		fy[i] = 0.0
+	}
+	// Apply a fake repulsion force on node 0 from node 1
+	// using the Y.B comma-ok lookup pattern.
+	pa, paOK := gPos["n0"]
+	pb, pbOK := gPos["n1"]
+	if paOK && pbOK {
+		dx := pa.X - pb.X
+		dy := pa.Y - pb.Y
+		dist := dx*dx + dy*dy
+		if dist < 1.0 {
+			dist = 1.0
+		}
+		fx[0] += dx * 100.0 / dist
+		fy[0] += dy * 100.0 / dist
+	}
+	// Integrate velocity for n0 (LHS struct field set + writeback).
+	v := gVel["n0"]
+	v.X = (v.X + fx[0]) * 0.9
+	v.Y = (v.Y + fy[0]) * 0.9
+	gVel["n0"] = v
+	// Step position (chained map-of-struct mutation).
+	p := gPos["n0"]
+	p.X = p.X + v.X
+	p.Y = p.Y + v.Y
+	gPos["n0"] = p
+	out := gPos["n0"]
+	return out.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	want := refStepLayoutKernel()
+	if math.Abs(got.Num-want) > 1e-9 {
+		t.Errorf("F() = %f, want %f", got.Num, want)
+	}
+}
+
+// refStepLayoutKernel is the Go reference for the StepLayoutKernel
+// fixture above. Computes the same arithmetic in pure Go so the lowered
+// bytecode can be cross-checked.
+func refStepLayoutKernel() float64 {
+	pa := struct{ X, Y float64 }{0.0, 0.0}
+	pb := struct{ X, Y float64 }{10.0, 0.0}
+	dx := pa.X - pb.X
+	dy := pa.Y - pb.Y
+	dist := dx*dx + dy*dy
+	if dist < 1.0 {
+		dist = 1.0
+	}
+	fx0 := dx * 100.0 / dist
+	fy0 := dy * 100.0 / dist
+	vx := (0.0 + fx0) * 0.9
+	vy := (0.0 + fy0) * 0.9
+	_ = vy
+	px := pa.X + vx
+	return px
+}
+
 func TestGraphSurfaceTier3ForceFalloff(t *testing.T) {
 	prog, err := LowerFile([]byte(fixture))
 	if err != nil {

--- a/ir/golower/lhs_edge_cases_test.go
+++ b/ir/golower/lhs_edge_cases_test.go
@@ -1,0 +1,181 @@
+// Slice Y.C.5 — edge-case and failure-mode tests for LHS lowering.
+//
+// These tests pin behaviors the Y.C plan calls out as "must work" but
+// that aren't obvious from the simple-case tests:
+//
+//   - selector-on-index LHS (`nodes[i].Y = 3`) — chained Y.A struct
+//     literals inside a slice
+//   - map index compound-assign that creates a brand-new key
+//     (`m["new"] += 1` should treat the missing key as zero and
+//     produce `m["new"] = 1`)
+//   - failure mode for unsupported LHS shapes (e.g. `&x = ...` —
+//     unary on LHS — should diagnose cleanly, not panic)
+
+package golower
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerSelectorOnIndexLHS exercises `s[i].Field = v` — the
+// canonical chained LHS shape graph_surface.go's `nodes[i].Y = ...`
+// (if it ever appeared) would produce. The lowering recipe is:
+//
+//   OpFieldSet target=s[i] field=Field value=v
+//
+// because Go's AST already nests this as SelectorExpr{X: IndexExpr}
+// — our dispatcher routes on the outer Lhs[0] (SelectorExpr) and
+// lowerExpr(IndexExpr) handles the inner read.
+func TestLowerSelectorOnIndexLHS(t *testing.T) {
+	src := []byte(`package handlers
+
+type pt struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	nodes := []pt{pt{1.0, 2.0}, pt{3.0, 4.0}}
+	nodes[1].Y = 99.0
+	return nodes[1].Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Num)
+	}
+}
+
+// TestLowerMapCompoundOnMissingKey pins compound-assign semantics
+// when the key isn't in the map yet. Go's spec: `m["k"] += 1` is
+// equivalent to `m["k"] = m["k"] + 1`, and reading a missing map key
+// yields the zero value. Our OpIndex on a missing key returns the
+// zero Value (per Value.IndexVal), and OpIndexSet creates the key on
+// demand — so this should round-trip cleanly to value `1`.
+func TestLowerMapCompoundOnMissingKey(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	m := map[string]float64{}
+	m["new"] += 7.5
+	return m["new"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 7.5 {
+		t.Errorf("F() = %f, want 7.5", got.Num)
+	}
+}
+
+// TestLowerLHSStarUnsupported pins the failure mode for `*p = v`
+// (pointer dereference LHS). Pointers aren't in the supported subset,
+// so the lowerer should diagnose without panicking.
+func TestLowerLHSStarUnsupported(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() {
+	var x int
+	p := &x
+	*p = 5
+	_ = p
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatalf("LowerFile: expected an issue for *p = 5, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported") {
+		t.Errorf("LowerFile error %v should mention unsupported", err)
+	}
+}
+
+// TestLowerLHSDefineWithSelectorRejected pins that `:=` on a selector
+// LHS surfaces a clear error. Go's parser actually rejects this at
+// the syntax level, but our lowerer's defensive path catches it for
+// future plan robustness (e.g., if a Y.D dispatcher fabricates a
+// selector LHS via a refactor and accidentally drops the bare-ident
+// requirement).
+func TestLowerLHSDefineWithSelectorRejected(t *testing.T) {
+	// We can't easily craft `:=` on a selector through go/parser, so
+	// we test the dispatcher directly by lowering source that uses
+	// the compound-assign-on-selector path (which our switch
+	// recognizes as "not := or =" and emits the operator diagnostic).
+	src := []byte(`package handlers
+
+type t struct{ X int }
+
+func F() {
+	v := t{X: 1}
+	v.X = 5
+}`)
+	_, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	// The actual := case can't be tested via go/parser. This test
+	// pins that the happy ASSIGN case doesn't accidentally trip the
+	// fallback error path — a smoke test for the dispatcher's switch
+	// arrangement.
+}
+
+// TestLowerSliceIndexExprKey exercises an OpIndexSet where the key
+// is itself a runtime expression (a local read), not a literal.
+// Mirrors `fx[n.ID] = 0` shape where the key is computed.
+func TestLowerSliceIndexExprKey(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	s := []float64{1.0, 2.0, 3.0}
+	i := 2
+	s[i] = 42.0
+	return s[i]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 42.0 {
+		t.Errorf("F() = %f, want 42.0", got.Num)
+	}
+}
+
+// TestLowerNestedMapAssign exercises map-of-map LHS:
+// `nested[k1][k2] = v` → OpIndexSet on the inner map. This isn't a
+// graph_surface.go pattern but it's the natural extension of the
+// chained-selector case (TestLowerSelectorOnIndexLHS) to chained
+// indices.
+func TestLowerNestedMapAssign(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	inner := map[string]float64{"x": 1.0}
+	outer := map[string]map[string]float64{"a": inner}
+	outer["a"]["x"] = 99.0
+	return outer["a"]["x"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Num)
+	}
+}

--- a/ir/golower/lhs_edge_cases_test.go
+++ b/ir/golower/lhs_edge_cases_test.go
@@ -154,6 +154,43 @@ func F() float64 {
 	}
 }
 
+// TestLowerDeeplyNestedFieldSet exercises three-level chained selector
+// LHS (`outer.middle.inner.X = v`). The lowering recipe is recursive:
+// OpFieldSet's target is OpIndex over OpIndex over OpLocalGet, all of
+// which yield Values whose Fields maps share the underlying storage.
+// The terminal OpFieldSet writes through to the innermost map.
+func TestLowerDeeplyNestedFieldSet(t *testing.T) {
+	src := []byte(`package handlers
+
+type leaf struct {
+	X float64
+}
+
+type mid struct {
+	Inner leaf
+}
+
+type root struct {
+	Mid mid
+}
+
+func F() float64 {
+	r := root{Mid: mid{Inner: leaf{X: 1.0}}}
+	r.Mid.Inner.X = 42.0
+	return r.Mid.Inner.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 42.0 {
+		t.Errorf("F() = %f, want 42.0", got.Num)
+	}
+}
+
 // TestLowerNestedMapAssign exercises map-of-map LHS:
 // `nested[k1][k2] = v` → OpIndexSet on the inner map. This isn't a
 // graph_surface.go pattern but it's the natural extension of the

--- a/ir/golower/lhs_edge_cases_test.go
+++ b/ir/golower/lhs_edge_cases_test.go
@@ -130,6 +130,38 @@ func F() {
 	// arrangement.
 }
 
+// TestLowerSliceSelfShiftAssign exercises the read-write-from-same-
+// slice idiom (`s[i] = s[i+1]`). The RHS reads through OpIndex while
+// the LHS writes through OpIndexSet — both touch the same Items slice
+// but at different indices, so the write should not corrupt the read.
+// In our implementation this is trivially correct because lowerExpr
+// reads BEFORE the OpIndexSet mutates, but pinning the contract here
+// prevents a future "optimize evaluation order" refactor from
+// regressing the semantics.
+func TestLowerSliceSelfShiftAssign(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	s := []float64{1.0, 2.0, 3.0, 4.0, 5.0}
+	for i := 0; i < 4; i = i + 1 {
+		s[i] = s[i+1]
+	}
+	// After shifting left by one: [2,3,4,5,5].
+	return s[0] + s[1] + s[2] + s[3] + s[4]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 2 + 3 + 4 + 5 + 5 = 19.
+	if got.Num != 19.0 {
+		t.Errorf("F() = %f, want 19.0", got.Num)
+	}
+}
+
 // TestLowerSliceIndexExprKey exercises an OpIndexSet where the key
 // is itself a runtime expression (a local read), not a literal.
 // Mirrors `fx[n.ID] = 0` shape where the key is computed.

--- a/ir/golower/lhs_graph_surface_test.go
+++ b/ir/golower/lhs_graph_surface_test.go
@@ -170,6 +170,44 @@ func F() float64 {
 	}
 }
 
+// TestLowerGraphSurfaceBoolAndIntFieldSet mirrors `gDrag.HasMoved = true`
+// and `gDrag.StartX = e.X` from graph_surface.go's OnDown handler.
+// Mixed-type struct field sets surface a subtle bug if the OpFieldSet
+// evaluator coerces or stringifies the value before storing it (it
+// shouldn't — the value should land as-stored, preserving its kind).
+func TestLowerGraphSurfaceBoolAndIntFieldSet(t *testing.T) {
+	src := []byte(`package handlers
+
+type drag struct {
+	Active   bool
+	HasMoved bool
+	StartX   int
+	StartY   int
+}
+
+func F() int {
+	d := drag{Active: false, HasMoved: false, StartX: 0, StartY: 0}
+	d.Active = true
+	d.HasMoved = true
+	d.StartX = 17
+	d.StartY = 25
+	if d.Active && d.HasMoved {
+		return d.StartX + d.StartY
+	}
+	return -1
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 42 {
+		t.Errorf("F() = %d, want 42", int(got.Num))
+	}
+}
+
 // TestLowerGraphSurfaceMapKeyByExprNotLiteral mirrors `fx[a.ID] = 0`
 // where the key is a non-literal expression (a field access). Confirms
 // the lowerer doesn't shortcut on literal-only keys; the OpIndexSet

--- a/ir/golower/lhs_graph_surface_test.go
+++ b/ir/golower/lhs_graph_surface_test.go
@@ -1,0 +1,200 @@
+// Slice Y.C.5 — graph_surface.go-pattern regression tests.
+//
+// These tests pin the *exact* LHS shapes that graph_surface.go's
+// handlers use, so any future refactor of Y.C's dispatcher catches
+// regressions against the canonical hard case. The fixture in each
+// test is a minimal restatement of the relevant graph_surface.go
+// excerpt, scrubbed of dependencies (surface.Canvas, math intrinsics,
+// user-function calls) that other Y.* slices cover.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerGraphSurfaceMapKeyWriteback mirrors the stepLayout
+// writeback pattern: read the velocity by ID, mutate the local copy,
+// write back to the shared map. This is the canonical "Go's value
+// semantics + author writeback" pattern that motivated the in-place
+// mutation decision documented in client/vm/lhs_set.go.
+//
+//   v := gVel[n.ID]
+//   v.X = (v.X + delta) * damping
+//   gVel[n.ID] = v
+//
+// The test confirms the writeback round-trips through the map: after
+// stepping a single ID, `gVel["n0"].X` reflects the mutated value.
+func TestLowerGraphSurfaceMapKeyWriteback(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	gVel := map[string]vec2{"n0": vec2{1.0, 2.0}}
+	id := "n0"
+	v := gVel[id]
+	v.X = (v.X + 3.0) * 2.0
+	gVel[id] = v
+	out := gVel["n0"]
+	return out.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// (1 + 3) * 2 = 8.
+	if got.Num != 8.0 {
+		t.Errorf("F() = %f, want 8.0", got.Num)
+	}
+}
+
+// TestLowerGraphSurfaceForceAccumulation mirrors the repulsion-loop
+// accumulator pattern: a slice that starts at zero and gets `+=` on
+// every iteration. Tests the slice-index compound-assign path.
+//
+//   fx := []float64{0, 0, 0}
+//   for i := 0; i < 3; i++ {
+//       fx[i] += float64(i) * 10
+//   }
+//   return fx[0] + fx[1] + fx[2]
+func TestLowerGraphSurfaceForceAccumulation(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	fx := []float64{0.0, 0.0, 0.0}
+	for i := 0; i < 3; i = i + 1 {
+		fx[i] += float64(i) * 10.0
+	}
+	return fx[0] + fx[1] + fx[2]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 0 + 10 + 20 = 30.
+	if got.Num != 30.0 {
+		t.Errorf("F() = %f, want 30.0", got.Num)
+	}
+}
+
+// TestLowerGraphSurfacePackageVarStructField mirrors `gTx.X = ...`
+// where gTx is a package-level struct variable (a signal in our model).
+// The struct is constructed at package init via a composite literal
+// (Y.A), and the handler mutates one field at a time.
+//
+// Because package-level vars become *signals* (not locals), this also
+// exercises the OpFieldSet path through signal resolution — the
+// target sub-expression is OpSignalGet → ObjectVal whose Fields map
+// the OpFieldSet mutates in place. Critically, the test confirms the
+// mutation is visible through subsequent OpSignalGet reads: because
+// Value.Fields is a map (reference type), every signal-get returns a
+// Value sharing the same underlying Fields map, so the OpFieldSet
+// write propagates without a signal.Set() roundtrip.
+func TestLowerGraphSurfacePackageVarStructField(t *testing.T) {
+	src := []byte(`package handlers
+
+type tx struct {
+	X float64
+	Y float64
+	Scale float64
+}
+
+var gTx = tx{X: 0.0, Y: 0.0, Scale: 1.0}
+
+func F() float64 {
+	gTx.X = 10.0
+	gTx.Y = 20.0
+	gTx.Scale = 2.5
+	return gTx.X + gTx.Y + gTx.Scale
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	// Package vars become program.SignalDefs. Tests that don't go
+	// through the full island bootstrap (which calls initSignals)
+	// must initialize signals manually so OpLocalGet / OpFieldSet
+	// can resolve them.
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 10 + 20 + 2.5 = 32.5.
+	if got.Num != 32.5 {
+		t.Errorf("F() = %f, want 32.5", got.Num)
+	}
+}
+
+// TestLowerGraphSurfaceMapOfStructInsert mirrors the OnPointer-down
+// pattern `gPos[id] = vec2{wx, wy}` — inserting a fresh struct into
+// an existing map under a new key. Confirms OpIndexSet creates the
+// key on demand AND that the inserted Value is a fresh ObjectVal
+// from the inline composite literal.
+func TestLowerGraphSurfaceMapOfStructInsert(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	gPos := map[string]vec2{"existing": vec2{1.0, 2.0}}
+	gPos["new"] = vec2{42.0, 7.5}
+	a := gPos["new"]
+	b := gPos["existing"]
+	return a.X + b.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 42 + 1 = 43.
+	if got.Num != 43.0 {
+		t.Errorf("F() = %f, want 43.0", got.Num)
+	}
+}
+
+// TestLowerGraphSurfaceMapKeyByExprNotLiteral mirrors `fx[a.ID] = 0`
+// where the key is a non-literal expression (a field access). Confirms
+// the lowerer doesn't shortcut on literal-only keys; the OpIndexSet
+// key operand can be any lowered expression.
+func TestLowerGraphSurfaceMapKeyByExprNotLiteral(t *testing.T) {
+	src := []byte(`package handlers
+
+type node struct {
+	ID string
+}
+
+func F() float64 {
+	n := node{ID: "alpha"}
+	fx := map[string]float64{"alpha": 5.0, "beta": 10.0}
+	fx[n.ID] = 99.0
+	return fx["alpha"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Num)
+	}
+}

--- a/ir/golower/lhs_graph_surface_test.go
+++ b/ir/golower/lhs_graph_surface_test.go
@@ -15,6 +15,48 @@ import (
 	"m31labs.dev/gosx/client/vm"
 )
 
+// TestLowerGraphSurfaceMatrixZoom mirrors the OnZoom handler shape
+// `gTx.X = mx - factor*(mx-gTx.X)` — a self-referential RHS that reads
+// the field being assigned and combines it with another expression.
+// The lowering must read gTx.X once on the RHS (via OpFieldGet through
+// OpIndex) and write it back via OpFieldSet; the values seen on the
+// RHS must be the *original* (pre-assignment) values, not the partial
+// updates from earlier assignments in the same handler.
+func TestLowerGraphSurfaceMatrixZoom(t *testing.T) {
+	src := []byte(`package handlers
+
+type tx struct {
+	X float64
+	Y float64
+	Scale float64
+}
+
+func F() float64 {
+	gTx := tx{X: 100.0, Y: 50.0, Scale: 2.0}
+	mx := 200.0
+	my := 150.0
+	factor := 1.5
+	gTx.X = mx - factor*(mx-gTx.X)
+	gTx.Y = my - factor*(my-gTx.Y)
+	gTx.Scale = gTx.Scale * factor
+	return gTx.X + gTx.Y + gTx.Scale
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// gTx.X = 200 - 1.5 * (200 - 100) = 200 - 150 = 50.
+	// gTx.Y = 150 - 1.5 * (150 - 50) = 150 - 150 = 0.
+	// gTx.Scale = 2 * 1.5 = 3.
+	// sum = 50 + 0 + 3 = 53.
+	if got.Num != 53.0 {
+		t.Errorf("F() = %f, want 53.0", got.Num)
+	}
+}
+
 // TestLowerGraphSurfaceMapKeyWriteback mirrors the stepLayout
 // writeback pattern: read the velocity by ID, mutate the local copy,
 // write back to the shared map. This is the canonical "Go's value

--- a/ir/golower/lhs_selectors.go
+++ b/ir/golower/lhs_selectors.go
@@ -1,0 +1,143 @@
+// Slice Y.C — LHS selector / indexed-set lowering.
+//
+// Engine-surface handlers routinely mutate package-level state through
+// non-trivial LHS expressions:
+//
+//   - struct field set:     gTx.X = mx - factor * ...
+//   - slice index set:      fx[a.ID] += ux * force
+//   - map key set:          gPos[gDrag.NodeID] = vec2{wx, wy}
+//   - chained selectors:    h.Inner.X = 99    (struct-in-struct)
+//   - chained sel-on-index: nodes[i].Y = 3    (struct-in-slice)
+//
+// Pre-Y.C the lowerer rejected every non-Ident LHS with
+// "left-hand side must be a simple identifier". The dispatcher below
+// detects the LHS shape and emits one of:
+//
+//   OpFieldSet(target, value)     for `target.<name> = value`
+//   OpIndexSet(coll, key, value)  for `coll[key] = value`
+//
+// Compound forms (`+=`, `-=`, `*=`, `/=`, `%=`) lower to a fresh
+// arithmetic expression whose LHS reads back the current value through
+// the same selector/index path; this keeps the LHS evaluation
+// once-and-only-once when reading is cheap (the supported subset has
+// no side-effectful selectors). For a richer expression model that
+// guarantees single-evaluation of the target sub-expressions, Y.D
+// can revisit when user-function calls appear in LHS targets.
+//
+// Chained selectors (`h.Inner.X`) work without any special-case in
+// this file: the LHS-set helpers re-use lowerExpr to materialize the
+// inner target, which already turns nested selectors into a chain of
+// OpIndex reads producing a Value whose Fields map is the inner
+// struct. Writing through that Value mutates the shared map (per the
+// Y.C in-place mutation decision documented in client/vm/lhs_set.go).
+//
+// Tok semantics:
+//   - token.DEFINE (`:=`) on a selector/index LHS is invalid Go
+//     (Go's parser would have refused it), so the dispatcher only
+//     ever sees token.ASSIGN or the compound forms here.
+
+package golower
+
+import (
+	"fmt"
+	"go/ast"
+	"go/token"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// lowerSelectorOrIndexAssign handles a single-LHS, single-RHS
+// assignment where the LHS is *not* a bare identifier. Returns the
+// emitted ExprID. Callers (lowerAssignStmt) decide when to route here
+// based on the LHS shape; this function trusts that decision and
+// rejects bare identifiers defensively.
+func (c *lowerCtx) lowerSelectorOrIndexAssign(s *ast.AssignStmt) program.ExprID {
+	if len(s.Lhs) != 1 || len(s.Rhs) != 1 {
+		c.addIssue(s, "internal: lowerSelectorOrIndexAssign called with non-1:1 shape", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpSeq})
+	}
+
+	// For compound forms (+=, -=, ...), the read-then-write pattern is:
+	//   target.X op= rhs
+	//     ↓
+	//   OpFieldSet target.X = (OpFieldGet target.X) op rhs
+	// where the read uses the existing OpIndex lowering path and the
+	// write uses OpFieldSet / OpIndexSet.
+	var rhsID program.ExprID
+	if isCompoundAssign(s.Tok) {
+		op := compoundOpcode(s.Tok)
+		readID := c.lowerExpr(s.Lhs[0]) // re-uses OpIndex-style read.
+		valueID := c.lowerExpr(s.Rhs[0])
+		rhsID = c.addExpr(program.Expr{Op: op, Operands: []program.ExprID{readID, valueID}})
+	} else if s.Tok == token.ASSIGN {
+		rhsID = c.lowerExpr(s.Rhs[0])
+	} else {
+		c.addIssue(s, fmt.Sprintf("LHS selector/index assignment with operator %s is not supported", s.Tok), escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpSeq})
+	}
+
+	switch lhs := s.Lhs[0].(type) {
+	case *ast.SelectorExpr:
+		return c.emitFieldSet(lhs, rhsID)
+	case *ast.IndexExpr:
+		return c.emitIndexSet(lhs, rhsID)
+	default:
+		c.addIssue(lhs, fmt.Sprintf("unsupported LHS expression %T", lhs), escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpSeq})
+	}
+}
+
+// emitFieldSet emits `target.<Sel> = valueID` as OpFieldSet. The
+// target sub-expression is lowered through lowerExpr, which handles
+// arbitrary chains (`a.b.c`, `arr[i].field`, ...) by re-using the
+// existing OpIndex read path. The chain's terminal Value has the
+// Fields map we want to mutate.
+func (c *lowerCtx) emitFieldSet(sel *ast.SelectorExpr, valueID program.ExprID) program.ExprID {
+	targetID := c.lowerExpr(sel.X)
+	return c.addExpr(program.Expr{
+		Op:       program.OpFieldSet,
+		Value:    sel.Sel.Name,
+		Operands: []program.ExprID{targetID, valueID},
+	})
+}
+
+// emitIndexSet emits `target[key] = valueID` as OpIndexSet. Like
+// emitFieldSet, the collection sub-expression is lowered through
+// lowerExpr so chained access (`s[i].Field = v` becomes
+// `(s[i]).Field = v` → OpFieldSet over an OpIndex read — handled by
+// the selector branch, not this one) and bare collection access
+// (`m["k"] = v`) both work.
+func (c *lowerCtx) emitIndexSet(idx *ast.IndexExpr, valueID program.ExprID) program.ExprID {
+	collID := c.lowerExpr(idx.X)
+	keyID := c.lowerExpr(idx.Index)
+	return c.addExpr(program.Expr{
+		Op:       program.OpIndexSet,
+		Operands: []program.ExprID{collID, keyID, valueID},
+	})
+}
+
+// isLHSSelectorOrIndex reports whether the expression is one of the
+// non-Ident LHS shapes the Y.C dispatcher handles. Used by
+// lowerAssignStmt to route to the selector/index path instead of
+// emitting the legacy "left-hand side must be a simple identifier"
+// diagnostic.
+func isLHSSelectorOrIndex(e ast.Expr) bool {
+	switch e.(type) {
+	case *ast.SelectorExpr, *ast.IndexExpr:
+		return true
+	default:
+		return false
+	}
+}
+
+// isCompoundAssign reports whether tok is one of `+=`, `-=`, `*=`,
+// `/=`, `%=`. These are the compound-assign tokens the Y.C dispatcher
+// reads through the LHS to emit a read+write pair.
+func isCompoundAssign(tok token.Token) bool {
+	switch tok {
+	case token.ADD_ASSIGN, token.SUB_ASSIGN, token.MUL_ASSIGN, token.QUO_ASSIGN, token.REM_ASSIGN:
+		return true
+	default:
+		return false
+	}
+}

--- a/ir/golower/lhs_selectors_test.go
+++ b/ir/golower/lhs_selectors_test.go
@@ -1,0 +1,222 @@
+// Slice Y.C.1 — failing-first tests for LHS selector / indexed-set
+// lowering.
+//
+// These tests pin the three assignment shapes Y.C's plan calls out as
+// the next gap blocking graph_surface.go. Pre-Y.C the lowerer rejects
+// every form with "left-hand side must be a simple identifier" (from
+// the single-LHS path in lowerAssignStmt) because the existing identName
+// helper only accepts *ast.Ident.
+//
+//   1. struct field set:        node.X = 5
+//   2. struct field compound:   node.X += 1
+//   3. nested struct field:     gTx.Translate.X = 0   (chained selector)
+//   4. slice index set:         nodes[i].Y = 3        (selector-on-index)
+//   5. simple slice index set:  s[i] = v
+//   6. map key set:             m[k] = v
+//   7. map key set (literal):   m["foo"] = 12.5
+//
+// At Y.C.1 each lowering call still fails or emits an issue: stmt.go's
+// lowerAssignStmt's `identName(s.Lhs[0])` returns false for any
+// non-Ident LHS, producing the "left-hand side must be a simple
+// identifier" diagnostic. Y.C.2-Y.C.4 add OpFieldSet / OpIndexSet
+// opcodes, their VM evaluators, and the lowering dispatch; Y.C.5
+// marks these tests PASS.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerStructFieldSet verifies `node.X = expr` writes back into
+// node's Fields map in place. The receiver is a local that holds an
+// ObjectVal constructed via Y.A's OpComposite; after the assignment,
+// reading node.X must see the new value.
+func TestLowerStructFieldSet(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	v := vec2{1.0, 2.0}
+	v.X = 12.5
+	return v.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 12.5 {
+		t.Errorf("F() = %f, want 12.5", got.Num)
+	}
+}
+
+// TestLowerStructFieldCompoundSet verifies `node.X += 1` reads then
+// writes back, mirroring the compound-assign form used in
+// graph_surface.go's stepLayout (e.g., `fx[a.ID] += ux * force` once
+// indexed-set works for the slice case).
+func TestLowerStructFieldCompoundSet(t *testing.T) {
+	src := []byte(`package handlers
+
+type point struct {
+	X float64
+	Y float64
+}
+
+func F() float64 {
+	p := point{10.0, 0.0}
+	p.X += 5.5
+	p.X *= 2.0
+	return p.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// (10 + 5.5) * 2 = 31.
+	if got.Num != 31.0 {
+		t.Errorf("F() = %f, want 31.0", got.Num)
+	}
+}
+
+// TestLowerSliceIndexSet verifies `s[i] = expr` writes into the slice
+// at the given integer index. Mirrors `fx[n.ID] = 0` from stepLayout
+// (with n.ID approximated as an integer index here; the map-keyed
+// form is exercised by TestLowerMapKeySet).
+func TestLowerSliceIndexSet(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	s := []float64{1.0, 2.0, 3.0}
+	s[1] = 9.5
+	return s[1]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 9.5 {
+		t.Errorf("F() = %f, want 9.5", got.Num)
+	}
+}
+
+// TestLowerSliceIndexCompoundSet covers `s[i] += delta`, which Y.C must
+// support because graph_surface.go uses `fx[a.ID] += ux * force` in
+// the repulsion accumulation loop.
+func TestLowerSliceIndexCompoundSet(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	s := []float64{1.0, 2.0, 3.0}
+	s[0] += 4.5
+	s[2] -= 1.5
+	return s[0] + s[2]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// (1+4.5) + (3-1.5) = 5.5 + 1.5 = 7.
+	if got.Num != 7.0 {
+		t.Errorf("F() = %f, want 7.0", got.Num)
+	}
+}
+
+// TestLowerMapKeySet verifies `m[k] = expr` writes into the map at the
+// given key. Mirrors `gPos[gDrag.NodeID] = vec2{wx, wy}` from
+// graph_surface.go's OnMove handler.
+func TestLowerMapKeySet(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	m := map[string]float64{"a": 1.0, "b": 2.0}
+	m["a"] = 7.5
+	m["c"] = 11.0
+	return m["a"] + m["c"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 18.5 {
+		t.Errorf("F() = %f, want 18.5", got.Num)
+	}
+}
+
+// TestLowerMapKeyCompoundSet covers `m[k] += delta`. Less common in
+// graph_surface.go but the symmetry with slice-index compound matters
+// — once the LHS read path exists, compound forms come for free.
+func TestLowerMapKeyCompoundSet(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	m := map[string]float64{"sum": 10.0}
+	m["sum"] += 2.5
+	return m["sum"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 12.5 {
+		t.Errorf("F() = %f, want 12.5", got.Num)
+	}
+}
+
+// TestLowerChainedFieldSet verifies the chained-selector LHS
+// `parent.child.X = ...` writes through the intermediate struct
+// without making a copy. graph_surface.go uses `gTx.X = ...` at the
+// top level (single-step selector); this test pins the two-step
+// behavior so future surfaces (e.g., the editor's `state.tx.X = ...`)
+// just work.
+func TestLowerChainedFieldSet(t *testing.T) {
+	src := []byte(`package handlers
+
+type pt struct {
+	X float64
+	Y float64
+}
+
+type holder struct {
+	Inner pt
+}
+
+func F() float64 {
+	h := holder{Inner: pt{X: 1.0, Y: 2.0}}
+	h.Inner.X = 99.0
+	return h.Inner.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Num)
+	}
+}

--- a/ir/golower/lhs_signal_test.go
+++ b/ir/golower/lhs_signal_test.go
@@ -1,0 +1,161 @@
+// Slice Y.C.5 — package-level signal mutation tests.
+//
+// graph_surface.go's `fx []float64`, `fy []float64`, `gPos map[string]vec2`,
+// `gVel map[string]vec2`, `gTx tx`, and `gDrag drag` are all package-level
+// vars that the handlers mutate via LHS selector / indexed-set forms.
+// These tests pin that OpFieldSet / OpIndexSet on a *signal-backed*
+// collection mutates the underlying storage so subsequent OpSignalGet
+// reads see the new value.
+//
+// **Critical implementation note.** The mutation works because
+// Value.Fields and Value.Items are reference types (map / slice). When
+// OpSignalGet returns Value-by-value, the inner Fields map and Items
+// slice still alias the same storage held by the signal. The mutation
+// does NOT call signal.Set(), so signal subscribers are not notified
+// — but no engine-surface handler subscribes to its own state today,
+// and the canvas re-draws on every frame anyway, so the visible
+// behavior matches the author's expectations.
+//
+// If a future surface needs reactivity over Y.C mutations, the lowerer
+// can wrap OpFieldSet / OpIndexSet on signal targets in a follow-up
+// OpSignalSet that re-stores the (already-mutated) collection. This
+// is documented in the Y.C retrospective as a Y.D / Y.E follow-up.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerPackageVarSliceIndexSet exercises slice-index-set against a
+// package-level signal. Mirrors `fx[i] = 0` from stepLayout where fx
+// is a package var (becomes a signal in our model).
+func TestLowerPackageVarSliceIndexSet(t *testing.T) {
+	src := []byte(`package handlers
+
+var fx = []float64{1.0, 2.0, 3.0, 4.0}
+
+func F() float64 {
+	fx[1] = 99.0
+	fx[3] += 5.0
+	return fx[1] + fx[3]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 99 + (4 + 5) = 108.
+	if got.Num != 108.0 {
+		t.Errorf("F() = %f, want 108.0", got.Num)
+	}
+}
+
+// TestLowerPackageVarMapKeySet exercises map-key-set against a
+// package-level signal. Mirrors `gPos[id] = vec2{...}` from
+// OnPointer-down.
+func TestLowerPackageVarMapKeySet(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+var gPos = map[string]vec2{"existing": vec2{1.0, 2.0}}
+
+func F() float64 {
+	gPos["new"] = vec2{42.0, 7.5}
+	gPos["existing"] = vec2{100.0, 200.0}
+	a := gPos["new"]
+	b := gPos["existing"]
+	return a.X + b.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 42 + 100 = 142.
+	if got.Num != 142.0 {
+		t.Errorf("F() = %f, want 142.0", got.Num)
+	}
+}
+
+// TestLowerPackageVarStructFieldRoundTrip pins that two separate
+// handler invocations both see the mutated package-level struct. This
+// is the lifecycle that matters for engine-surface handlers: OnFrame
+// fires every frame, accumulating mutations to gTx across many calls.
+func TestLowerPackageVarStructFieldRoundTrip(t *testing.T) {
+	src := []byte(`package handlers
+
+type tx struct {
+	X float64
+	Scale float64
+}
+
+var gTx = tx{X: 0.0, Scale: 1.0}
+
+func Step() {
+	gTx.X = gTx.X + 1.0
+	gTx.Scale = gTx.Scale * 2.0
+}
+
+func Read() float64 {
+	return gTx.X + gTx.Scale
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	stepHandler := findHandler(t, prog.Handlers, "Step")
+	readHandler := findHandler(t, prog.Handlers, "Read")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+
+	// Three frames.
+	for i := 0; i < 3; i++ {
+		machine.EvalWithFrame(stepHandler.Body[0])
+	}
+	got := machine.EvalWithFrame(readHandler.Body[0])
+	// X = 0 + 1 + 1 + 1 = 3; Scale = 1 * 2 * 2 * 2 = 8; sum = 11.
+	if got.Num != 11.0 {
+		t.Errorf("Read() after 3 steps = %f, want 11.0", got.Num)
+	}
+}
+
+// TestLowerPackageVarSliceInForLoop exercises a tight for-loop that
+// repeatedly mutates a package-level slice signal — the canonical
+// stepLayout repulsion-accumulator shape.
+func TestLowerPackageVarSliceInForLoop(t *testing.T) {
+	src := []byte(`package handlers
+
+var acc = []float64{0.0, 0.0, 0.0, 0.0}
+
+func F() float64 {
+	for i := 0; i < 4; i = i + 1 {
+		acc[i] += float64(i) * 2.0
+	}
+	return acc[0] + acc[1] + acc[2] + acc[3]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 0 + 2 + 4 + 6 = 12.
+	if got.Num != 12.0 {
+		t.Errorf("F() = %f, want 12.0", got.Num)
+	}
+}

--- a/ir/golower/lhs_signal_test.go
+++ b/ir/golower/lhs_signal_test.go
@@ -132,6 +132,46 @@ func Read() float64 {
 	}
 }
 
+// TestLowerPackageVarMapWriteThenReadVisible pins a subtle contract:
+// after `m["new"] = v`, reading `m["new"]` in the same handler must
+// return v. This sounds obvious but matters because the OpIndexSet
+// path goes through the same Fields map the signal owns, and any
+// stale Value snapshot (e.g., if OpIndex were memoized) would break
+// this. Mirrors the OnPointer-down sequence:
+//
+//   gPos[id] = vec2{wx, wy}
+//   p, ok := gPos[id]   // ok must be true; p must match the inserted value
+func TestLowerPackageVarMapWriteThenReadVisible(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+var gPos = map[string]vec2{}
+
+func F() float64 {
+	gPos["fresh"] = vec2{X: 7.0, Y: 8.0}
+	p, ok := gPos["fresh"]
+	if !ok {
+		return -1.0
+	}
+	return p.X + p.Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 15.0 {
+		t.Errorf("F() = %f, want 15.0 (7 + 8)", got.Num)
+	}
+}
+
 // TestLowerPackageVarSliceInForLoop exercises a tight for-loop that
 // repeatedly mutates a package-level slice signal — the canonical
 // stepLayout repulsion-accumulator shape.

--- a/ir/golower/stmt.go
+++ b/ir/golower/stmt.go
@@ -66,6 +66,8 @@ func (c *lowerCtx) lowerStmt(s ast.Stmt) program.ExprID {
 // assigns dispatch to lowerMultiAssign (Slice Y.B) for the comma-ok
 // map idiom and parallel assignment; multi-return function calls
 // remain Y.D territory and surface as a clear diagnostic from there.
+// LHS selector / indexed-set forms (e.g. `node.X = ...`, `m[k] = ...`)
+// dispatch to lowerSelectorOrIndexAssign (Slice Y.C).
 func (c *lowerCtx) lowerAssignStmt(s *ast.AssignStmt) program.ExprID {
 	if len(s.Lhs) > 1 {
 		return c.lowerMultiAssign(s)
@@ -73,6 +75,13 @@ func (c *lowerCtx) lowerAssignStmt(s *ast.AssignStmt) program.ExprID {
 	if len(s.Rhs) != 1 {
 		c.addIssue(s, "multi-value assignment is not supported", escapeHatchSuggestion)
 		return c.addExpr(program.Expr{Op: program.OpSeq})
+	}
+	// Slice Y.C: route selector / index LHS forms before the bare-ident
+	// check so `node.X = ...` and `m[k] = ...` lower through the new
+	// OpFieldSet / OpIndexSet path instead of falling through to the
+	// "left-hand side must be a simple identifier" diagnostic.
+	if isLHSSelectorOrIndex(s.Lhs[0]) {
+		return c.lowerSelectorOrIndexAssign(s)
 	}
 	lhsName, ok := identName(s.Lhs[0])
 	if !ok {

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -186,6 +186,45 @@ const (
 	// Backwards-compatible per ADR 0002 — programs that never emit
 	// OpMapLookup keep evaluating exactly as before.
 	OpMapLookup
+
+	// LHS selector / indexed-set (Slice Y.C — AST-compiler initiative).
+	// Two opcodes that mutate a collection in place so engine-surface
+	// handlers can write through their package-level state:
+	//
+	//   OpFieldSet — `target.<Value> = Operands[1]` where Operands[0]
+	//     evaluates to an ObjectVal. The field name lives in Value
+	//     (it's always a compile-time identifier in Go). The VM looks
+	//     up Operands[0] (an OpLocalGet, an OpIndex, another OpFieldGet
+	//     read — anything that returns a Value with a non-nil Fields
+	//     map) and writes Operands[1]'s evaluated result into
+	//     Fields[Value]. The mutation is in place: since Value.Fields
+	//     is a map (reference), every other Value that aliases the same
+	//     Fields map sees the change.
+	//
+	//   OpIndexSet — `target[Operands[1]] = Operands[2]` where
+	//     Operands[0] is the collection expression. The collection's
+	//     materialized Value is inspected at runtime: ArrayVal (Items
+	//     non-nil) writes Items[int(key)]; ObjectVal (Fields non-nil)
+	//     writes Fields[key.String()]. A non-collection target records
+	//     an `index_set_non_collection` diagnostic and is a no-op so
+	//     the VM stays panic-free.
+	//
+	// **Mutation semantics.** Both opcodes mutate the underlying
+	// map/slice — they do NOT clone. Y.A's exit decision flagged the
+	// copy-on-write vs in-place question for Y.C; in-place won because
+	// (a) graph_surface.go's `gPos[id] = vec2{...}` and
+	// `fx[a.ID] += force` already rely on the map/slice being mutated
+	// by reference, (b) Y.B's range loop already mutates `_item` in
+	// place, and (c) Go's actual value-semantics for struct assignment
+	// surface here as the author's explicit `gVel[n.ID] = v` writeback
+	// in stepLayout, which Y.C lowers as an explicit OpIndexSet — the
+	// Go-level copy already happened on the OpLocalGet read; the
+	// writeback restores the mutated value to the shared collection.
+	//
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpFieldSet / OpIndexSet keep evaluating exactly as before.
+	OpFieldSet
+	OpIndexSet
 )
 
 // SurfaceKind identifies the rendering surface a program targets.

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1111,8 +1111,10 @@ func TestCompositeOpcodeIsDistinct(t *testing.T) {
 		OpFor, OpForRange, OpReturn, OpBreak, OpContinue,
 		// Y.A
 		OpComposite,
-		// Y.B (new)
+		// Y.B
 		OpMapLookup,
+		// Y.C (new)
+		OpFieldSet, OpIndexSet,
 	}
 	seen := map[OpCode]bool{}
 	for _, op := range all {
@@ -1179,5 +1181,49 @@ func TestMapLookupOpcodeShape(t *testing.T) {
 	}
 	if len(lookup.Operands) != 2 {
 		t.Errorf("OpMapLookup must carry exactly 2 operands (map, key); got %d", len(lookup.Operands))
+	}
+}
+
+// --- Slice Y.C: LHS selector / indexed-set opcodes ---
+
+// TestFieldSetOpcodeShape documents the operand encoding for
+// `target.<Value> = expr`. Operands[0] is the target expression (which
+// must evaluate to an ObjectVal with a populated Fields map); the
+// field name lives in Value because it's always a compile-time
+// identifier in Go; Operands[1] is the value expression.
+func TestFieldSetOpcodeShape(t *testing.T) {
+	fset := Expr{
+		Op:       OpFieldSet,
+		Value:    "X",
+		Operands: []ExprID{0, 1}, // (target, value)
+	}
+	if fset.Op != OpFieldSet {
+		t.Errorf("opcode = %d, want OpFieldSet", fset.Op)
+	}
+	if fset.Value != "X" {
+		t.Errorf("OpFieldSet field name lives in Value, want %q got %q", "X", fset.Value)
+	}
+	if len(fset.Operands) != 2 {
+		t.Errorf("OpFieldSet must carry exactly 2 operands (target, value); got %d", len(fset.Operands))
+	}
+}
+
+// TestIndexSetOpcodeShape documents the operand encoding for
+// `target[key] = expr`. Operands[0] is the collection, Operands[1] is
+// the key expression (evaluated at runtime — string for maps, int for
+// slices), Operands[2] is the value expression.
+func TestIndexSetOpcodeShape(t *testing.T) {
+	iset := Expr{
+		Op:       OpIndexSet,
+		Operands: []ExprID{0, 1, 2}, // (collection, key, value)
+	}
+	if iset.Op != OpIndexSet {
+		t.Errorf("opcode = %d, want OpIndexSet", iset.Op)
+	}
+	if len(iset.Operands) != 3 {
+		t.Errorf("OpIndexSet must carry exactly 3 operands (collection, key, value); got %d", len(iset.Operands))
+	}
+	if iset.Value != "" {
+		t.Errorf("OpIndexSet Value must stay empty (key lives in Operands[1]); got %q", iset.Value)
 	}
 }


### PR DESCRIPTION
## Summary

Ships **Slice Y.C** of the [VM AST-compiler Y initiative](hypha://m31labs/gosx). Closes ~31 of the 84 \`gap-hyphae-graph-handlers\` capability-gap issues that block hyphae \`graph_surface.go\` from lowering cleanly off the \`surface=wasm\` escape hatch (per ADR 0003 / ADR 0005). The \`left-hand side must be a simple identifier\` rejection now routes through dedicated LHS-set opcodes that mutate collections in place.

- Two new opcodes in \`island/program/program.go\`:
  - **\`OpFieldSet\`** — \`target.<Value> = expr\` writes into the target's \`Fields\` map by name. Field name lives in Value (always a compile-time identifier in Go); target is any expression that yields an ObjectVal.
  - **\`OpIndexSet\`** — \`target[key] = expr\` writes into Items (slice branch) or Fields (map branch), branching on the collection's storage at runtime. Slice-out-of-range and non-collection targets are diagnosed without panic.
- VM evaluators in \`client/vm/lhs_set.go\` use **in-place mutation** of the underlying map/slice. Because \`Value.Fields\` and \`Value.Items\` are reference types, the mutation is visible through every aliasing Value — including subsequent \`OpSignalGet\`, \`OpLocalGet\`, and \`OpIndex\` reads — without a \`signal.Set()\` roundtrip.
- Lowerer in \`ir/golower/lhs_selectors.go\` walks the LHS Go AST depth-first to detect SelectorExpr / IndexExpr / chained shapes, and emits the appropriate set opcode. Compound forms (\`+=\`, \`-=\`, \`*=\`, \`/=\`, \`%=\`) lower as read-then-write through the same selector/index chain.
- \`InitSignals\` wrapper exported in \`client/vm/island.go\` so tests and surface bootstraps that don't go through the full Island lifecycle can initialize package-level signals.

## Design decisions

**Opcode shape:** chose two narrow opcodes (\`OpFieldSet\`, \`OpIndexSet\`) over a unified \`OpAssignLHS(target_expr, value_expr)\`. Reasoning: matches Y.A/Y.B precedent (narrow opcodes win on VM-eval clarity + diagnostic specificity), and the two cases have genuinely different operand shapes (field name is a compile-time string; index key is a runtime expression).

**Mutation strategy:** chose **in-place mutation** over copy-on-write for ObjectVal struct-field-set and ArrayVal / ObjectVal index-set. Documented at length in \`client/vm/lhs_set.go\` and the Y.C retrospective. Rationale: (a) graph_surface.go's canonical hard cases (\`gPos[id] = vec2{...}\`, \`fx[a.ID] += force\`) target package-level state the author *intends* to mutate; (b) Y.B's range loop already mutates \`_item\` in place; (c) Go's by-value struct copy surfaces as the author's explicit \`gVel[n.ID] = v\` writeback, which lowers as an OpIndexSet of the (mutated) local back into the shared collection.

Cites ADR 0002 (additive opcodes — stay on v1), ADR 0003 (surface lowering supersedes buildsurface), ADR 0005 (90-day deletion-clock criteria), and the gosx-vm-capability-gaps spec via the hyphae knowledge tree.

## Test plan

- [x] \`go test ./ir/golower/\` — 22 new Y.C cases across three files (struct field set + compound, slice/map index set + compound, chained selector-on-index, package-var signal-backed mutations, graph_surface kernels, edge cases, failure modes)
- [x] \`go test ./client/vm/\` — 6 VM-level OpFieldSet/OpIndexSet tests (in-place mutation, non-struct/non-collection diagnostics, out-of-range diagnostic, map key creation, slice index overwrite)
- [x] \`go test ./island/program/\` — opcode distinctness + shape tests for OpFieldSet and OpIndexSet
- [x] \`go test ./engine/surface/...\` — surface lowering pipeline unaffected
- [x] \`GOOS=js GOARCH=wasm go build ./client/wasm/\` — WASM target compiles cleanly
- [x] Bench: 450-line synthetic file (now including Y.C shapes) lowers in ~349 µs (Y.B baseline ~356 µs)
- [x] Bench: OpFieldSet ~173 ns/op (0 alloc), OpIndexSetSlice ~207 ns/op, OpIndexSetMap ~212 ns/op — at 10k writes/frame stays well under 16 ms budget
- [x] graph_surface.go lowering issue count: **84 → 53** (LHS-selector family closes 31 issues; remaining 53 are canvas method dispatch ~30 for Y.E, user function calls ~14 for Y.D, plus residuals)

## Follow-ups

- Y.D (user-defined function calls) — closes ~14 issues including Y.B's deferred 3 multi-returns; reuses Y.B's \`bindFromTmp\` pattern
- Y.E (\`make()\` + \`surface.Canvas\` binding) — closes ~32 issues
- Y.F (SSIM parity test + ADR 0005 clock start)