### PR TITLE
ast y d user fn calls

### DIFF
--- a/client/vm/user_fn_calls.go
+++ b/client/vm/user_fn_calls.go
@@ -1,0 +1,140 @@
+// Slice Y.D — OpIndirectCall evaluator: user-defined function dispatch.
+//
+// OpIndirectCall is emitted by ir/golower for `helper(args...)` calls
+// that resolve to a sibling function in the same surface (a registered
+// program.FuncDef). The VM evaluator here:
+//
+//  1. Looks up the callee FuncDef in vm.funcs by name.
+//  2. Evaluates each argument expression left-to-right in the CALLER's
+//     frame (so unevaluated argument expressions see the caller's
+//     locals, not the callee's parameter slots).
+//  3. Enforces the program-level call-depth cap so a runaway recursion
+//     surfaces as a structured `call_depth_exceeded` diagnostic instead
+//     of panicking the host.
+//  4. Pushes a fresh frame, binds each evaluated argument to the
+//     callee's parameter name in that frame, evaluates the callee's
+//     body, then pops the frame.
+//  5. For single-return callees, returns the body's value (with the
+//     ControlReturn signal consumed at the call boundary — matching
+//     EvalWithFrame's handler-boundary contract).
+//  6. For multi-return callees (FuncDef.Results > 1), wraps the
+//     return-tuple in an ObjectVal carrier with the "__ret_<i>" key
+//     scheme so lowerMultiAssign's bindFromTmp helper can extract each
+//     return slot through OpIndex reads — same shape as Slice Y.B's
+//     OpMapLookup return carrier.
+//
+// Call-stack mechanism. The implementation deliberately extends the
+// existing flat single-frame mechanism (vm.frame pointer + defer
+// restore) rather than introducing a new explicit stack data structure.
+// Each OpIndirectCall save-and-restores vm.frame via the Go host's
+// goroutine stack — recursive calls nest the saves naturally and the
+// cap enforced via vm.callDepth keeps the host stack growth bounded.
+// This decision is documented at length in the Y.D retrospective
+// (lessons/2026-05-26-y-d-user-fn-calls-retrospective.md).
+//
+// Parameter semantics. Argument Values are bound by value-copy in the
+// callee's frame — but because Value.Fields (map) and Value.Items
+// (slice) are reference types in Go, composite arguments share their
+// underlying storage with the caller. This preserves Slice Y.C's
+// retrospective guarantee: "OpFieldSet on a parameter-typed receiver
+// already propagates because Value.Fields is reference-typed." Scalar
+// args (int/float/bool/string) pass by value — Go's normal semantics.
+
+package vm
+
+import (
+	"fmt"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// evalIndirectCallExpr dispatches an OpIndirectCall through the VM's
+// user-function registry. Returns (zero, false) for non-IndirectCall
+// opcodes so the dispatcher in evalExpr keeps cascading; returns
+// (result, true) once the call resolves (success OR diagnostic).
+func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
+	if e.Op != program.OpIndirectCall {
+		return Value{}, false
+	}
+	def, ok := vm.funcs[e.Value]
+	if !ok {
+		vm.recordExprDiagnostic(
+			"unknown_user_function",
+			fmt.Sprintf("OpIndirectCall callee %q is not in the program's Funcs registry", e.Value),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+
+	// Cap recursion depth so a runaway call sequence is panic-free.
+	// Default 256 if MaxCallDepth wasn't set on the Program. The cap
+	// includes the current call — exceeding triggers the diagnostic.
+	cap := vm.program.MaxCallDepth
+	if cap <= 0 {
+		cap = program.DefaultMaxCallDepth
+	}
+	if vm.callDepth >= cap {
+		vm.recordExprDiagnostic(
+			"call_depth_exceeded",
+			fmt.Sprintf("OpIndirectCall %q exceeded MaxCallDepth=%d", e.Value, cap),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+
+	// Step 1: evaluate arguments in the CALLER's frame.
+	// Arity mismatch is recorded but doesn't abort — extra args are
+	// dropped, missing args bind to the zero Value so a stale call
+	// site still produces a deterministic (if wrong) result instead of
+	// panicking the host.
+	args := make([]Value, len(e.Operands))
+	for i, opID := range e.Operands {
+		args[i] = vm.Eval(opID)
+	}
+	if len(args) != len(def.Params) {
+		vm.recordExprDiagnostic(
+			"call_arity_mismatch",
+			fmt.Sprintf("OpIndirectCall %q expects %d arg(s), got %d", e.Value, len(def.Params), len(args)),
+			e.Op,
+			e.Value,
+		)
+	}
+
+	// Step 2: push a fresh frame and bind parameters.
+	prevFrame := vm.frame
+	vm.frame = newFrame()
+	vm.callDepth++
+	defer func() {
+		vm.frame = prevFrame
+		vm.callDepth--
+	}()
+
+	for i, paramName := range def.Params {
+		vm.frame.declare(paramName)
+		if i < len(args) {
+			vm.frame.set(paramName, args[i])
+		}
+	}
+
+	// Step 3: evaluate the body. The callee's OpReturn unwinds back to
+	// here via the ControlReturn sentinel; consuming it at the call
+	// boundary keeps the return semantics symmetric with
+	// EvalWithFrame's handler-boundary contract.
+	var result Value
+	for _, bodyID := range def.Body {
+		result = vm.Eval(bodyID)
+		if result.Control == ControlReturn {
+			result.Control = ControlNone
+			break
+		}
+	}
+
+	// Step 4: multi-return shaping. When the callee declares 2+
+	// results, the body's OpReturn payload is already an ObjectVal
+	// carrier (lowered by lowerMultiReturn — see ir/golower for the
+	// `__ret_<i>` keying contract). Pass it through unchanged so the
+	// caller's lowerMultiAssign reads it via OpIndex.
+	return result, true
+}

--- a/client/vm/user_fn_calls_bench_test.go
+++ b/client/vm/user_fn_calls_bench_test.go
@@ -1,0 +1,96 @@
+// Slice Y.D — benchmarks for OpIndirectCall. User function calls are
+// the heaviest opcode in the Y series: each call pushes a fresh frame
+// (one map alloc per dispatch) and binds parameters, so even a
+// 100ns/call cost compounds in tight graph-surface helper loops. Y.D
+// targets the same "fits in 60fps budget" envelope as Y.C: thousands
+// of calls per frame should still leave headroom for the lowerer's
+// other opcodes.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// BenchmarkIndirectCallNoArg measures the bare dispatch cost: no
+// arguments to evaluate, no return-value carrier shaping, just the
+// frame push/pop + body eval.
+func BenchmarkIndirectCallNoArg(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "42", Type: program.TypeInt},     // 0
+			{Op: program.OpReturn, Operands: []program.ExprID{0}},          // 1
+			{Op: program.OpSeq, Operands: []program.ExprID{1}},             // 2 body
+			{Op: program.OpIndirectCall, Value: "f"},                       // 3
+		},
+		Funcs: []program.FuncDef{
+			{Name: "f", Params: nil, Body: []program.ExprID{2}, Results: 1},
+		},
+	}
+	machine := NewVM(prog, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(3)
+	}
+}
+
+// BenchmarkIndirectCallTwoArgs measures the typical
+// graph_surface.go helper shape: two-arg call with a scalar return.
+// Tracks the marginal cost of argument evaluation + parameter
+// binding on top of BenchmarkIndirectCallNoArg.
+func BenchmarkIndirectCallTwoArgs(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "a"},                            // 0
+			{Op: program.OpLocalGet, Value: "b"},                            // 1
+			{Op: program.OpAdd, Operands: []program.ExprID{0, 1}},           // 2
+			{Op: program.OpReturn, Operands: []program.ExprID{2}},           // 3
+			{Op: program.OpSeq, Operands: []program.ExprID{3}},              // 4 body
+			{Op: program.OpLitInt, Value: "3", Type: program.TypeInt},       // 5
+			{Op: program.OpLitInt, Value: "4", Type: program.TypeInt},       // 6
+			{Op: program.OpIndirectCall, Value: "add", Operands: []program.ExprID{5, 6}}, // 7
+		},
+		Funcs: []program.FuncDef{
+			{Name: "add", Params: []string{"a", "b"}, Body: []program.ExprID{4}, Results: 1},
+		},
+	}
+	machine := NewVM(prog, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(7)
+	}
+}
+
+// BenchmarkIndirectCallRecursive measures the dispatch cost in a
+// recursive call chain. n=8 keeps allocations modest while still
+// exercising the call-depth tracker. The arithmetic is intentionally
+// trivial so the bench measures dispatch overhead, not work.
+func BenchmarkIndirectCallRecursive(b *testing.B) {
+	// fact-like recursion with depth 8.
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "n"},                            // 0
+			{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},       // 1
+			{Op: program.OpLte, Operands: []program.ExprID{0, 1}},           // 2 n<=1
+			{Op: program.OpReturn, Operands: []program.ExprID{1}},           // 3 return 1
+			{Op: program.OpSub, Operands: []program.ExprID{0, 1}},           // 4 n-1
+			{Op: program.OpIndirectCall, Value: "fact", Operands: []program.ExprID{4}}, // 5 fact(n-1)
+			{Op: program.OpMul, Operands: []program.ExprID{0, 5}},           // 6 n*fact(n-1)
+			{Op: program.OpReturn, Operands: []program.ExprID{6}},           // 7
+			{Op: program.OpCond, Operands: []program.ExprID{2, 3, 7}},       // 8 if
+			{Op: program.OpSeq, Operands: []program.ExprID{8}},              // 9 body
+			{Op: program.OpLitInt, Value: "8", Type: program.TypeInt},       // 10
+			{Op: program.OpIndirectCall, Value: "fact", Operands: []program.ExprID{10}}, // 11 fact(8)
+		},
+		Funcs: []program.FuncDef{
+			{Name: "fact", Params: []string{"n"}, Body: []program.ExprID{9}, Results: 1},
+		},
+	}
+	machine := NewVM(prog, nil)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = machine.Eval(11)
+	}
+}

--- a/client/vm/user_fn_calls_test.go
+++ b/client/vm/user_fn_calls_test.go
@@ -1,0 +1,153 @@
+// Slice Y.D VM-level tests — exercise OpIndirectCall directly against
+// hand-built Program / FuncDef shapes so the call-frame mechanism,
+// parameter binding, multi-return carrier, and recursion cap each get
+// covered without relying on the golower's lowering decisions.
+
+package vm
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestEvalIndirectCallZeroArg verifies the simplest dispatch shape:
+// a callee with no params and a single string return value.
+func TestEvalIndirectCallZeroArg(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitString, Value: "hi", Type: program.TypeString}, // expr 0
+			{Op: program.OpReturn, Operands: []program.ExprID{0}},            // expr 1
+			{Op: program.OpSeq, Operands: []program.ExprID{1}},               // expr 2 (body)
+			{Op: program.OpIndirectCall, Value: "greet", Operands: nil},      // expr 3 (call site)
+		},
+		Funcs: []program.FuncDef{
+			{Name: "greet", Params: nil, Body: []program.ExprID{2}, Results: 1},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(3)
+	if got.Str != "hi" {
+		t.Errorf("OpIndirectCall greet() = %q, want %q", got.Str, "hi")
+	}
+}
+
+// TestEvalIndirectCallSingleParam pins the parameter-binding contract:
+// the call site's argument value must arrive in the callee's frame
+// under the registered Param name.
+func TestEvalIndirectCallSingleParam(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "n"},                            // 0: read param
+			{Op: program.OpLitInt, Value: "2", Type: program.TypeInt},       // 1
+			{Op: program.OpMul, Operands: []program.ExprID{0, 1}},           // 2: n*2
+			{Op: program.OpReturn, Operands: []program.ExprID{2}},           // 3
+			{Op: program.OpSeq, Operands: []program.ExprID{3}},              // 4 (body)
+			{Op: program.OpLitInt, Value: "21", Type: program.TypeInt},      // 5 (arg)
+			{Op: program.OpIndirectCall, Value: "double", Operands: []program.ExprID{5}}, // 6 (call)
+		},
+		Funcs: []program.FuncDef{
+			{Name: "double", Params: []string{"n"}, Body: []program.ExprID{4}, Results: 1},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(6)
+	if int(got.Num) != 42 {
+		t.Errorf("double(21) = %d, want 42", int(got.Num))
+	}
+}
+
+// TestEvalIndirectCallUnknownCallee verifies that calling an
+// unregistered function records a structured diagnostic and returns
+// the zero Value, preserving the VM's panic-free contract.
+func TestEvalIndirectCallUnknownCallee(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpIndirectCall, Value: "noSuchFn"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(0)
+	if got.Type != program.TypeAny {
+		t.Errorf("unknown callee should yield TypeAny zero, got Type=%d", got.Type)
+	}
+	requireDiag(t, vm, "unknown_user_function")
+}
+
+// TestEvalIndirectCallDepthCapDefault verifies a runaway recursion
+// hits the DefaultMaxCallDepth cap without panicking the host.
+func TestEvalIndirectCallDepthCapDefault(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpIndirectCall, Value: "rec"},               // 0: rec() inside body
+			{Op: program.OpReturn, Operands: []program.ExprID{0}},    // 1
+			{Op: program.OpSeq, Operands: []program.ExprID{1}},       // 2: body
+			{Op: program.OpIndirectCall, Value: "rec"},               // 3: outer call
+		},
+		Funcs: []program.FuncDef{
+			{Name: "rec", Params: nil, Body: []program.ExprID{2}, Results: 1},
+		},
+	}
+	vm := NewVM(prog, nil)
+	// Must not panic and must surface a diagnostic.
+	got := vm.Eval(3)
+	if got.Type != program.TypeAny {
+		t.Errorf("runaway recursion should yield TypeAny zero, got Type=%d", got.Type)
+	}
+	requireDiag(t, vm, "call_depth_exceeded")
+}
+
+// TestEvalIndirectCallDepthCapCustom verifies that a Program can lower
+// the cap to a finite value and the diagnostic fires at exactly that
+// boundary. Using MaxCallDepth=3 keeps the test fast and unambiguous.
+func TestEvalIndirectCallDepthCapCustom(t *testing.T) {
+	prog := &program.Program{
+		MaxCallDepth: 3,
+		Exprs: []program.Expr{
+			{Op: program.OpIndirectCall, Value: "rec"},               // 0
+			{Op: program.OpReturn, Operands: []program.ExprID{0}},    // 1
+			{Op: program.OpSeq, Operands: []program.ExprID{1}},       // 2
+			{Op: program.OpIndirectCall, Value: "rec"},               // 3
+		},
+		Funcs: []program.FuncDef{
+			{Name: "rec", Params: nil, Body: []program.ExprID{2}, Results: 1},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.Eval(3)
+	requireDiag(t, vm, "call_depth_exceeded")
+}
+
+// TestEvalIndirectCallArityMismatch verifies that providing the wrong
+// argument count records the `call_arity_mismatch` diagnostic but
+// keeps evaluating (missing params bind to zero) so a stale call site
+// produces a deterministic result rather than panicking.
+func TestEvalIndirectCallArityMismatch(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "a"},                            // 0
+			{Op: program.OpReturn, Operands: []program.ExprID{0}},           // 1
+			{Op: program.OpSeq, Operands: []program.ExprID{1}},              // 2: body
+			{Op: program.OpIndirectCall, Value: "ident", Operands: nil},     // 3: 0 args (expects 1)
+		},
+		Funcs: []program.FuncDef{
+			{Name: "ident", Params: []string{"a"}, Body: []program.ExprID{2}, Results: 1},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.Eval(3)
+	requireDiag(t, vm, "call_arity_mismatch")
+}
+
+// requireDiag asserts the VM has recorded at least one diagnostic
+// whose Code matches the expected substring.
+func requireDiag(t *testing.T, vm *VM, codeSubstr string) {
+	t.Helper()
+	for _, d := range vm.diagnostics {
+		if strings.Contains(d.Code, codeSubstr) {
+			return
+		}
+	}
+	t.Fatalf("expected diagnostic code containing %q, got %d diagnostics: %+v", codeSubstr, len(vm.diagnostics), vm.diagnostics)
+}

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -15,9 +15,11 @@ type VM struct {
 	props          map[string]Value
 	signals        map[string]*signal.Signal[Value]
 	exprs          []program.Expr
-	eventData      map[string]string // current event data (set during handler dispatch)
-	frame          *frame            // locals table for the current handler evaluation (X.A)
-	forCap         int               // per-loop iteration cap (X.C); 0 → default
+	eventData      map[string]string    // current event data (set during handler dispatch)
+	frame          *frame               // locals table for the current handler evaluation (X.A)
+	forCap         int                  // per-loop iteration cap (X.C); 0 → default
+	funcs          map[string]*program.FuncDef // user-function registry (Y.D)
+	callDepth      int                  // current OpIndirectCall recursion depth (Y.D)
 	diagnostics    []Diagnostic
 	diagnosticSink DiagnosticSink
 }
@@ -63,6 +65,16 @@ func NewVM(prog *program.Program, props map[string]Value) *VM {
 		return vm
 	}
 	vm.exprs = prog.Exprs
+	// Slice Y.D: build a fast funcDef lookup so OpIndirectCall is one
+	// map probe. Programs without user functions (Funcs nil/empty)
+	// pay nothing — the map stays nil and the dispatcher records the
+	// missing-callee diagnostic.
+	if len(prog.Funcs) > 0 {
+		vm.funcs = make(map[string]*program.FuncDef, len(prog.Funcs))
+		for i := range prog.Funcs {
+			vm.funcs[prog.Funcs[i].Name] = &prog.Funcs[i]
+		}
+	}
 	return vm
 }
 
@@ -131,6 +143,9 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 		return value
 	}
 	if value, ok := vm.evalLHSSetExpr(e); ok {
+		return value
+	}
+	if value, ok := vm.evalIndirectCallExpr(e); ok {
 		return value
 	}
 	vm.recordExprDiagnostic(

--- a/ir/golower/bench_test.go
+++ b/ir/golower/bench_test.go
@@ -48,16 +48,42 @@ func buildLargeSource(lines int) []byte {
 // bench picks up the lowering cost of OpFieldSet / OpIndexSet handlers
 // — the actual shape graph_surface.go uses for state mutations.
 func makeBenchFunc(i int) string {
-	switch i % 4 {
+	switch i % 5 {
 	case 0:
 		return funcPure(i)
 	case 1:
 		return funcLoop(i)
 	case 2:
 		return funcIntrinsic(i)
-	default:
+	case 3:
 		return funcLHS(i)
+	default:
+		return funcUserFn(i)
 	}
+}
+
+// funcUserFn produces a Y.D-shaped handler that exercises the user-
+// function call registry: a helper declared in the same package is
+// called from the handler with multiple arguments and a composite
+// return. Mirrors the `makeNode(id, x, y)` / `screenToWorld(sx, sy)`
+// dispatch shape from graph_surface.go.
+func funcUserFn(i int) string {
+	idx := itoa(i)
+	return `type pt` + idx + ` struct { X, Y float64 }
+
+func makePt` + idx + `(x float64, y float64) pt` + idx + ` {
+	return pt` + idx + `{X: x, Y: y}
+}
+
+func split` + idx + `(n float64) (float64, float64) {
+	return n * 0.5, n * 0.25
+}
+
+func UserFn` + idx + `(n float64) float64 {
+	p := makePt` + idx + `(n, n*2.0)
+	hx, hy := split` + idx + `(n)
+	return p.X + p.Y + hx + hy
+}`
 }
 
 // funcLHS produces a Y.C-shaped handler that exercises both

--- a/ir/golower/decl.go
+++ b/ir/golower/decl.go
@@ -38,7 +38,15 @@ func (c *lowerCtx) lowerFuncDecl(fn *ast.FuncDecl) {
 		return
 	}
 	c.handler = fn.Name.Name
-	defer func() { c.handler = "" }()
+	// Slice Y.D: thread the declared return-value count through so
+	// lowerReturnStmt knows whether to emit the multi-value ObjectVal
+	// carrier or stay on the single-return path.
+	prevResults := c.currentResults
+	c.currentResults = countResults(fn.Type.Results)
+	defer func() {
+		c.handler = ""
+		c.currentResults = prevResults
+	}()
 
 	if fn.Body == nil {
 		// Forward declaration / external linkage — skip silently.

--- a/ir/golower/decl.go
+++ b/ir/golower/decl.go
@@ -65,6 +65,21 @@ func (c *lowerCtx) lowerFuncDecl(fn *ast.FuncDecl) {
 		Name: fn.Name.Name,
 		Body: []program.ExprID{seqID},
 	})
+
+	// Slice Y.D: every user function is ALSO registered as a FuncDef
+	// so OpIndirectCall can dispatch into it from another handler.
+	// Reusing the same Body ExprID keeps the lowering single-pass —
+	// edits flow into both call sites and the event-dispatch path
+	// uniformly. The registry pre-pass (scanUserFuncs) populates the
+	// param/result metadata so we don't re-walk the FieldList here.
+	if info, ok := c.lookupUserFunc(fn.Name.Name); ok {
+		c.prog.Funcs = append(c.prog.Funcs, program.FuncDef{
+			Name:    fn.Name.Name,
+			Params:  info.params,
+			Body:    []program.ExprID{seqID},
+			Results: info.results,
+		})
+	}
 }
 
 // lowerGenDecl handles `var` and `const` declarations. `var x = expr`

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -211,6 +211,14 @@ func (c *lowerCtx) lowerCallExpr(call *ast.CallExpr) program.ExprID {
 			argID := c.lowerExpr(call.Args[0])
 			return c.addExpr(program.Expr{Op: program.OpToString, Operands: []program.ExprID{argID}})
 		default:
+			// Slice Y.D: route in-package calls into OpIndirectCall when
+			// the name resolves through the user-function registry built
+			// by scanUserFuncs. Unregistered bare identifiers still emit
+			// the legacy diagnostic so authors get a clear pointer when
+			// they typo a sibling function or call into a deleted helper.
+			if _, ok := c.lookupUserFunc(id.Name); ok {
+				return c.emitIndirectCall(id.Name, call.Args)
+			}
 			c.addIssue(call, fmt.Sprintf("calls to user-defined function %q are not supported", id.Name), escapeHatchSuggestion)
 			return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
 		}

--- a/ir/golower/failure_modes_test.go
+++ b/ir/golower/failure_modes_test.go
@@ -52,13 +52,17 @@ func F() { fmt.Println("hi") }`)
 	requireLowerError(t, err, "ADR 0006", 0)
 }
 
-// TestFailureMode_MultiReturnUserFunctionCall verifies Y.B's multi-
-// value assignment dispatch emits a clear, actionable diagnostic for
-// the user-function multi-return form (`a, b := f()`) — pointing at
-// Slice Y.D as the natural follow-up rather than the generic escape
-// hatch. Y.B explicitly defers this to Y.D so the diagnostic must
-// say so.
-func TestFailureMode_MultiReturnUserFunctionCall(t *testing.T) {
+// TestFailureMode_MultiReturnUserFunctionCall_NowSupported is the
+// Y.D-era successor to Y.B's failure-mode test for `a, b := f()`.
+// Y.B explicitly deferred the user-function multi-return form to
+// Slice Y.D; Y.D now lowers it through OpIndirectCall + the
+// `__ret_<i>` ObjectVal carrier so the call resolves cleanly. We
+// keep the test in failure_modes_test.go (rather than relocating to
+// user_fn_calls_test.go) as a permanent regression guard: if the
+// LowerFile call ever starts emitting a Y.D-deferral diagnostic
+// again, this test catches the regression before any handler-level
+// test does.
+func TestFailureMode_MultiReturnUserFunctionCall_NowSupported(t *testing.T) {
 	src := []byte(`package handlers
 
 func screenToWorld(x int, y int) (int, int) { return x, y }
@@ -68,8 +72,9 @@ func F() int {
 	return wx + wy
 }`)
 	_, err := LowerFile(src)
-	requireLowerError(t, err, "Slice Y.D", 0)
-	requireLowerError(t, err, "ADR 0006", 0)
+	if err != nil {
+		t.Fatalf("Y.D should lower multi-return user function calls cleanly, got: %v", err)
+	}
 }
 
 func TestFailureMode_LabeledBreak(t *testing.T) {

--- a/ir/golower/golower.go
+++ b/ir/golower/golower.go
@@ -150,6 +150,13 @@ type lowerCtx struct {
 	exprs   []program.Expr
 	handler string // name of the handler currently being lowered (for diagnostics)
 
+	// currentResults is the declared return-value count of the function
+	// whose body is currently being lowered. Used by lowerReturnStmt
+	// (Slice Y.D) to decide whether `return a, b` lowers to a multi-
+	// value ObjectVal carrier or stays a diagnostic. Zero outside a
+	// FuncDecl body.
+	currentResults int
+
 	// structs holds the ordered field-name list for every struct type
 	// declared at the top level of the file. Populated by
 	// scanStructTypes (Slice Y.A) so positional struct literals like

--- a/ir/golower/golower.go
+++ b/ir/golower/golower.go
@@ -115,6 +115,14 @@ func LowerASTFile(fset *token.FileSet, file *ast.File) (*program.Program, error)
 	// cheap and keeps the lowering paths uniform.
 	ctx.scanStructTypes(file)
 
+	// Pre-pass (Slice Y.D): build the user-function registry so
+	// in-package calls (`updatePosition(node)` calling a sibling
+	// helper) can resolve through OpIndirectCall instead of the
+	// legacy "calls to user-defined function" diagnostic. The pass
+	// runs BEFORE lowerTopLevelDecl so forward references resolve
+	// (Go allows `func A() { B() }; func B() {}`).
+	ctx.scanUserFuncs(file)
+
 	// Two passes:
 	//   1. Hoist package-level var declarations into signal defs so
 	//      function bodies can reference them by name. Init expressions
@@ -148,6 +156,13 @@ type lowerCtx struct {
 	// `vec2{x, y}` can recover field names without a separate
 	// go/types pass.
 	structs map[string]structTypeInfo
+
+	// funcs is the per-file user-function registry. Populated by
+	// scanUserFuncs (Slice Y.D) so call sites can detect a
+	// bare-identifier call into a sibling helper and emit
+	// OpIndirectCall instead of the legacy "calls to user-defined
+	// function" diagnostic.
+	funcs funcRegistry
 }
 
 // addExpr appends e to the program's expression table and returns the

--- a/ir/golower/multi_assign.go
+++ b/ir/golower/multi_assign.go
@@ -43,13 +43,26 @@ func (c *lowerCtx) lowerMultiAssign(s *ast.AssignStmt) program.ExprID {
 
 	// Pattern A: comma-ok map index. `v, ok := m[k]` — exactly two LHS,
 	// single Rhs that is an *ast.IndexExpr.
-	if len(s.Lhs) == 2 && len(s.Rhs) == 1 {
-		if idx, ok := s.Rhs[0].(*ast.IndexExpr); ok {
+	if len(s.Lhs) >= 2 && len(s.Rhs) == 1 {
+		if idx, ok := s.Rhs[0].(*ast.IndexExpr); ok && len(s.Lhs) == 2 {
 			return c.lowerCommaOkMapIndex(s, idx)
 		}
-		// Single-Rhs multi-Lhs that isn't a map index would be a
-		// multi-return function call — Y.D territory.
-		c.addIssue(s, "multi-value assignment from a function call is not supported (use comma-ok map index, parallel assign, or wait for Slice Y.D)", escapeHatchSuggestion)
+		// Slice Y.D: user-function multi-return — `a, b := f()`.
+		// Resolve the call's callee through the user-function
+		// registry. If it's a registered multi-return user function,
+		// emit OpIndirectCall into a tmp ObjectVal carrier and bind
+		// each LHS via OpIndex against the `__ret_<i>` keys (reusing
+		// Y.B's bindFromTmp helper verbatim per Y.C's handoff note).
+		if call, ok := s.Rhs[0].(*ast.CallExpr); ok {
+			if id, idOK := call.Fun.(*ast.Ident); idOK {
+				if info, regOK := c.lookupUserFunc(id.Name); regOK && info.results == len(s.Lhs) {
+					return c.lowerUserFnMultiReturn(s, call, id.Name)
+				}
+			}
+		}
+		// Anything else (intrinsic multi-return is out of scope for Y.D)
+		// surfaces the legacy diagnostic so the author has a clear pointer.
+		c.addIssue(s, "multi-value assignment from a function call is not supported (use comma-ok map index, parallel assign, or a registered user function)", escapeHatchSuggestion)
 		return c.addExpr(program.Expr{Op: program.OpSeq})
 	}
 
@@ -203,4 +216,51 @@ func lhsTarget(e ast.Expr) (string, bool) {
 // statements in the same handler from colliding on their tmp slot.
 func (c *lowerCtx) freshLocal(kind string, pos token.Pos) string {
 	return fmt.Sprintf("__y_b_%s_%d", kind, int(pos))
+}
+
+// freshCallLocal mirrors freshLocal with Y.D's own prefix so the
+// retrospective-friendly bisect-on-tmp-name property survives: a tmp
+// named `__y_d_call_<pos>` is unambiguously a Y.D multi-return
+// carrier, while `__y_b_*` belongs to Y.B. Suggested by Y.C's handoff
+// notes for Y.D.
+func (c *lowerCtx) freshCallLocal(pos token.Pos) string {
+	return fmt.Sprintf("__y_d_call_%d", int(pos))
+}
+
+// lowerUserFnMultiReturn emits the bytecode for `a, b := f()` where f
+// is a registered user function with 2+ returns. The shape:
+//
+//     __tmp := OpIndirectCall(f, args...)   // returns ObjectVal{__ret_0, __ret_1, ...}
+//     a     := __tmp["__ret_0"]              // OpIndex read
+//     b     := __tmp["__ret_1"]              // OpIndex read
+//
+// Reuses Y.B's bindFromTmp helper directly — the key scheme is the
+// only thing that differs from comma-ok lookups. Blank-identifier
+// bindings (`_`) skip the per-LHS bind, matching Y.B's semantics.
+func (c *lowerCtx) lowerUserFnMultiReturn(s *ast.AssignStmt, call *ast.CallExpr, calleeName string) program.ExprID {
+	// Lower the call as a normal OpIndirectCall — same code path as a
+	// single-return user fn, but the VM materializes the multi-value
+	// return as an ObjectVal carrier (FuncDef.Results > 1 triggers
+	// that in lowerReturnStmt → buildReturnCarrier).
+	callID := c.emitIndirectCall(calleeName, call.Args)
+
+	tmpName := c.freshCallLocal(s.Pos())
+
+	var ops []program.ExprID
+	ops = append(ops, c.addExpr(program.Expr{Op: program.OpLocalDecl, Value: tmpName}))
+	ops = append(ops, c.addExpr(program.Expr{
+		Op:       program.OpAssign,
+		Value:    tmpName,
+		Operands: []program.ExprID{callID},
+	}))
+
+	for i, lhs := range s.Lhs {
+		name, isBlank := lhsTarget(lhs)
+		if isBlank {
+			continue
+		}
+		ops = append(ops, c.bindFromTmp(name, tmpName, returnKey(i), s.Tok))
+	}
+
+	return c.addExpr(program.Expr{Op: program.OpSeq, Operands: ops})
 }

--- a/ir/golower/stmt.go
+++ b/ir/golower/stmt.go
@@ -248,6 +248,12 @@ func (c *lowerCtx) lowerOptionalCond(e ast.Expr) program.ExprID {
 // lowerReturnStmt emits OpReturn so the enclosing OpSeq / OpFor /
 // OpForRange unwinds back to the handler's EvalWithFrame boundary.
 // `return` with no value lowers to a bare OpReturn with no operand.
+//
+// Slice Y.D extends this for multi-value returns: `return a, b` in a
+// function declared with 2+ return values lowers to an OpReturn whose
+// payload is an OpComposite ObjectVal carrier keyed `__ret_<i>`. The
+// caller's lowerMultiAssign reads each `__ret_<i>` field via OpIndex
+// — same pattern as Slice Y.B's OpMapLookup carrier.
 func (c *lowerCtx) lowerReturnStmt(s *ast.ReturnStmt) program.ExprID {
 	switch len(s.Results) {
 	case 0:
@@ -256,9 +262,44 @@ func (c *lowerCtx) lowerReturnStmt(s *ast.ReturnStmt) program.ExprID {
 		valueID := c.lowerExpr(s.Results[0])
 		return c.addExpr(program.Expr{Op: program.OpReturn, Operands: []program.ExprID{valueID}})
 	default:
-		c.addIssue(s, "multi-value returns are not supported", escapeHatchSuggestion)
-		return c.addExpr(program.Expr{Op: program.OpReturn})
+		// Multi-value return: build an OpComposite carrier of kind
+		// "map" with __ret_<i> keys. This reuses Y.A's compositeMap
+		// path without expanding the Value model. The caller binds
+		// each LHS via OpIndex against the carrier (Y.B's bindFromTmp
+		// helper, called via lowerMultiAssign).
+		carrierID := c.buildReturnCarrier(s.Results)
+		return c.addExpr(program.Expr{Op: program.OpReturn, Operands: []program.ExprID{carrierID}})
 	}
+}
+
+// buildReturnCarrier emits an OpComposite ObjectVal of kind "map"
+// whose Fields are keyed `__ret_0`, `__ret_1`, ... — one per return
+// value, in declaration order. The Slice Y.D multi-return contract
+// expects the OpIndirectCall caller to read each slot via OpIndex on
+// the same key scheme.
+func (c *lowerCtx) buildReturnCarrier(results []ast.Expr) program.ExprID {
+	operands := make([]program.ExprID, 0, len(results)*2)
+	for i, res := range results {
+		keyID := c.addExpr(program.Expr{
+			Op:    program.OpLitString,
+			Value: returnKey(i),
+			Type:  program.TypeString,
+		})
+		valueID := c.lowerExpr(res)
+		operands = append(operands, keyID, valueID)
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpComposite,
+		Value:    "map",
+		Operands: operands,
+	})
+}
+
+// returnKey is the Y.D multi-return carrier's key scheme. Reserved
+// prefix (`__ret_`) prevents collision with user identifiers and
+// matches Y.B's `__y_b_*` / Y.D's `__y_d_*` namespacing convention.
+func returnKey(i int) string {
+	return fmt.Sprintf("__ret_%d", i)
 }
 
 // lowerBlockStmt wraps a block's statements in OpSeq. Empty blocks

--- a/ir/golower/user_fn_calls.go
+++ b/ir/golower/user_fn_calls.go
@@ -1,0 +1,165 @@
+// Slice Y.D — user-defined function call lowering.
+//
+// Engine-surface handlers frequently dispatch into sibling helpers
+// declared in the same file. Pre-Y.D the lowerer rejected every
+// bare-identifier call with "calls to user-defined function ..."
+// because the supported subset offered no cross-handler dispatch.
+//
+// Y.D's approach:
+//
+//  1. A pre-pass (scanUserFuncs, run at LowerASTFile time alongside
+//     scanStructTypes from Slice Y.A) walks the file's top-level
+//     *ast.FuncDecl nodes and records every non-method function in a
+//     per-file registry — name → (ordered param names, return count).
+//
+//  2. lowerFuncDecl (decl.go) is unchanged for receivers/parameters,
+//     but after lowering the function body it ALSO emits a
+//     program.FuncDef carrying the body's OpSeq + the registry's
+//     metadata. The same lowered Body lives in both the Handler list
+//     (so the existing event-dispatch path still finds it) AND in the
+//     Funcs list (so OpIndirectCall can dispatch into it).
+//
+//  3. lowerCallExpr (expr.go) consults the registry first. Bare
+//     identifiers that match a registered function emit OpIndirectCall
+//     with the callee name in Value and the argument expressions in
+//     Operands. Calls whose callee isn't registered fall through to
+//     the existing builtin / "unsupported user function" diagnostics.
+//
+//  4. The VM (client/vm/user_fn_calls.go) pushes a fresh frame on
+//     dispatch, binds the evaluated arguments to the FuncDef's Params,
+//     evaluates Body, pops the frame, and propagates the return value
+//     (or an ObjectVal carrier for multi-return — see lowerMultiAssign
+//     in multi_assign.go, which adopts the same `__y_d_call_<pos>`
+//     prefix Y.C's retrospective handed off to Y.D).
+//
+// Composite parameter semantics. Y.C's retrospective documented that
+// OpFieldSet on a parameter-typed receiver already propagates because
+// Value.Fields is a reference-typed map. Y.D preserves this: argument
+// Values are passed via the same struct-field-set semantics, so
+// `func upd(v vec2)` that calls `v.X = 1` does mutate the caller's vec2.
+// This matches Slice Y.C's in-place mutation contract and explicitly
+// keeps the Y.C → Y.D handoff intact.
+//
+// Recursion safety. The VM caps recursion depth at Program.MaxCallDepth
+// (default 256 per program.DefaultMaxCallDepth) and records a
+// structured `call_depth_exceeded` diagnostic so a runaway recursion
+// is panic-free.
+
+package golower
+
+import (
+	"go/ast"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// funcRegistry maps a user-function name to its parameter list and
+// return count so the lowerer can emit OpIndirectCall + bind args
+// without revisiting the AST.
+type funcRegistry struct {
+	defs map[string]userFuncInfo
+}
+
+// userFuncInfo holds the bits the lowerer needs at call sites: the
+// ordered parameter names (for the VM's frame binding) and the return
+// count (for the multi-return ObjectVal carrier decision).
+type userFuncInfo struct {
+	params  []string
+	results int
+}
+
+// scanUserFuncs walks file.Decls and registers every top-level
+// (non-method) *ast.FuncDecl with a body. Method receivers are skipped
+// — the existing lowerFuncDecl already rejects them with a diagnostic;
+// emitting a registry entry for a method would be misleading because
+// OpIndirectCall has no receiver binding contract.
+//
+// Forward declarations (FuncDecl with nil Body) are skipped: nothing
+// for the VM to execute. External linkage is out of scope for the
+// engine-surface subset.
+func (c *lowerCtx) scanUserFuncs(file *ast.File) {
+	c.funcs = funcRegistry{defs: map[string]userFuncInfo{}}
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok {
+			continue
+		}
+		if fn.Recv != nil || fn.Body == nil || fn.Name == nil {
+			continue
+		}
+		info := userFuncInfo{
+			params:  paramNames(fn.Type.Params),
+			results: countResults(fn.Type.Results),
+		}
+		c.funcs.defs[fn.Name.Name] = info
+	}
+}
+
+// paramNames flattens a *ast.FieldList into the ordered list of
+// parameter names. A field with multiple names (`func f(a, b int)`)
+// emits one entry per name; a field with no name (unusual in Go but
+// valid for the `func(int)` interface-method form) emits a synthetic
+// "_param_<i>" so the call site can still bind by position.
+func paramNames(list *ast.FieldList) []string {
+	if list == nil {
+		return nil
+	}
+	var out []string
+	for _, field := range list.List {
+		if len(field.Names) == 0 {
+			out = append(out, "_param_unnamed")
+			continue
+		}
+		for _, name := range field.Names {
+			if name == nil {
+				continue
+			}
+			out = append(out, name.Name)
+		}
+	}
+	return out
+}
+
+// countResults counts the total number of return values a function
+// declaration produces. `func f() int` → 1; `func f() (int, error)` →
+// 2; `func f()` → 0. The VM uses this to decide whether to wrap the
+// return as a multi-value ObjectVal carrier.
+func countResults(list *ast.FieldList) int {
+	if list == nil {
+		return 0
+	}
+	total := 0
+	for _, field := range list.List {
+		if len(field.Names) == 0 {
+			total++
+			continue
+		}
+		total += len(field.Names)
+	}
+	return total
+}
+
+// lookupUserFunc reports whether name names a registered user function
+// and returns the registry entry if so. Called by lowerCallExpr to
+// decide whether to emit OpIndirectCall or fall through to the
+// existing diagnostic path.
+func (c *lowerCtx) lookupUserFunc(name string) (userFuncInfo, bool) {
+	info, ok := c.funcs.defs[name]
+	return info, ok
+}
+
+// emitIndirectCall builds the OpIndirectCall expr for `name(args...)`.
+// Arguments lower left-to-right; the VM binds them to the registry's
+// param names in dispatch order. The callee name lives in Value so the
+// VM's FuncDef lookup is one map probe.
+func (c *lowerCtx) emitIndirectCall(name string, args []ast.Expr) program.ExprID {
+	argIDs := make([]program.ExprID, 0, len(args))
+	for _, a := range args {
+		argIDs = append(argIDs, c.lowerExpr(a))
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpIndirectCall,
+		Value:    name,
+		Operands: argIDs,
+	})
+}

--- a/ir/golower/user_fn_calls_test.go
+++ b/ir/golower/user_fn_calls_test.go
@@ -1,0 +1,271 @@
+// Slice Y.D.1 — failing-first tests for user-defined function call
+// lowering.
+//
+// Pre-Y.D the lowerer rejects every bare-identifier call with
+// "calls to user-defined function %q are not supported" (from
+// expr.go's lowerCallExpr). Y.D's plan covers:
+//
+//   1. Same-package zero-arg call:       greet()                 -> string
+//   2. Single-arg call w/ composite arg: makeNode(id) -> Node{...}
+//   3. Multi-arg call with return:       add(a, b) -> int
+//   4. Multi-return user fn:             a, b := splitVec(v)     (Y.B handoff)
+//   5. Recursive call:                   fact(n) -> int
+//   6. Call returning composite:         node := makeNode(id) -> Node
+//   7. Call with composite literal arg:  f(vec2{x, y}) -> int
+//
+// At Y.D.1 each lowering call still fails: expr.go's lowerCallExpr's
+// `default` branch produces the "user-defined function ... not
+// supported" diagnostic. Y.D.2 adds OpIndirectCall, Y.D.3 the
+// function-registry pass, Y.D.4 the VM eval. Y.D.5 marks PASS.
+
+package golower
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerUserFnCallZeroArg verifies the simplest case: one function
+// calls another in the same package with no arguments.
+func TestLowerUserFnCallZeroArg(t *testing.T) {
+	src := []byte(`package handlers
+
+func greet() string {
+	return "hi"
+}
+
+func F() string {
+	return greet()
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Str != "hi" {
+		t.Errorf("F() = %q, want %q", got.Str, "hi")
+	}
+}
+
+// TestLowerUserFnCallSingleArg verifies a one-arg call with a primitive
+// return. Mirrors graph_surface.go's `typeColor(kind)` shape.
+func TestLowerUserFnCallSingleArg(t *testing.T) {
+	src := []byte(`package handlers
+
+func double(n int) int {
+	return n * 2
+}
+
+func F() int {
+	return double(21)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 42 {
+		t.Errorf("F() = %d, want 42", int(got.Num))
+	}
+}
+
+// TestLowerUserFnCallMultiArg verifies a multi-arg call. Parameter
+// order matters — wrong binding would still compute the right value
+// for `add` (commutative) but fail for `sub`.
+func TestLowerUserFnCallMultiArg(t *testing.T) {
+	src := []byte(`package handlers
+
+func sub(a int, b int) int {
+	return a - b
+}
+
+func F() int {
+	return sub(10, 3)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 7 {
+		t.Errorf("F() = %d, want 7", int(got.Num))
+	}
+}
+
+// TestLowerUserFnCallReturnsComposite verifies that the caller can
+// receive a struct-shaped Value back from a user function. Mirrors
+// graph_surface.go's `node := makeNode(id)` shape.
+func TestLowerUserFnCallReturnsComposite(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func makeVec(x float64, y float64) vec2 {
+	return vec2{X: x, Y: y}
+}
+
+func F() float64 {
+	v := makeVec(3.0, 4.0)
+	return v.X + v.Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 7.0 {
+		t.Errorf("F() = %f, want 7.0", got.Num)
+	}
+}
+
+// TestLowerUserFnCallCompositeArg verifies that a composite literal
+// flows into a parameter correctly. Mirrors graph_surface.go's
+// `screenToWorld(vec2{x, y})` shape.
+func TestLowerUserFnCallCompositeArg(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+func magSq(v vec2) float64 {
+	return v.X*v.X + v.Y*v.Y
+}
+
+func F() float64 {
+	return magSq(vec2{X: 3.0, Y: 4.0})
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 25.0 {
+		t.Errorf("F() = %f, want 25.0", got.Num)
+	}
+}
+
+// TestLowerUserFnCallRecursion verifies that a user function may call
+// itself. Pinned at modest depth (factorial of 6 = 720) so the test
+// runs deterministically without depending on the depth-cap value.
+func TestLowerUserFnCallRecursion(t *testing.T) {
+	src := []byte(`package handlers
+
+func fact(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	return n * fact(n-1)
+}
+
+func F() int {
+	return fact(6)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 720 {
+		t.Errorf("F() = %d, want 720", int(got.Num))
+	}
+}
+
+// TestLowerUserFnCallMultiReturn verifies the multi-return form Y.B
+// deferred. Mirrors `wx, wy := screenToWorld(sx, sy)` from
+// graph_surface.go's OnMove handler.
+func TestLowerUserFnCallMultiReturn(t *testing.T) {
+	src := []byte(`package handlers
+
+func split(n int) (int, int) {
+	return n / 2, n - n/2
+}
+
+func F() int {
+	a, b := split(10)
+	return a + b
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 10 {
+		t.Errorf("F() = %d, want 10", int(got.Num))
+	}
+}
+
+// TestLowerUserFnCallVoidReturn verifies a side-effecting helper that
+// mutates a package-level signal. Mirrors graph_surface.go's helpers
+// like `initPositions()` that don't return a value but reshape the
+// shared state.
+func TestLowerUserFnCallVoidReturn(t *testing.T) {
+	src := []byte(`package handlers
+
+var counter = 0
+
+func bump() {
+	counter = counter + 1
+}
+
+func F() int {
+	bump()
+	bump()
+	bump()
+	return counter
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Num))
+	}
+}
+
+// TestLowerUserFnCallFailureDiagnosticGoneAtY_D is a meta-check that
+// once Y.D ships the supported subset stops emitting the
+// "calls to user-defined function" diagnostic for in-package callees.
+// This is the test that flips green when the diagnostic is removed.
+func TestLowerUserFnCallNoFailureDiagnosticForInPackageCallee(t *testing.T) {
+	src := []byte(`package handlers
+
+func helper() int {
+	return 1
+}
+
+func F() int {
+	return helper()
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		return
+	}
+	if strings.Contains(err.Error(), "calls to user-defined function \"helper\"") {
+		t.Fatalf("Y.D should not emit the in-package callee diagnostic for helper(): %v", err)
+	}
+}

--- a/ir/golower/user_fn_composite_param_test.go
+++ b/ir/golower/user_fn_composite_param_test.go
@@ -1,0 +1,136 @@
+// Slice Y.D composite-parameter regression tests — pin Y.C's
+// retrospective handoff guarantee.
+//
+// Y.C's retrospective documented: "OpFieldSet on a parameter-typed
+// receiver already propagates because Value.Fields is reference-
+// typed." Y.D inherits this verbatim — composite arguments are passed
+// by Value-by-value copy but their Fields/Items storage is shared, so
+// the callee's mutations land in the caller's storage.
+//
+// The tests below pin this behavior so a future Y.E refactor (or any
+// VM change to Value semantics) doesn't silently regress it.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_StructParamMutationPropagates verifies that a callee
+// mutating a struct param's field via OpFieldSet reflects back into
+// the caller's local — Y.C's retrospective Decision 2.
+func TestY_D_StructParamMutationPropagates(t *testing.T) {
+	src := []byte(`package handlers
+
+type point struct {
+	X float64
+	Y float64
+}
+
+func bump(p point) {
+	p.X = p.X + 100.0
+}
+
+func F() float64 {
+	pt := point{X: 1.0, Y: 2.0}
+	bump(pt)
+	return pt.X
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 101.0 {
+		t.Errorf("F() = %f, want 101.0 (struct param mutation must propagate per Y.C retrospective)", got.Num)
+	}
+}
+
+// TestY_D_MapParamMutationPropagates verifies the same guarantee for
+// map-typed parameters. graph_surface.go's `updateNode(node, gPos)`
+// shape relies on this for the package-level position map.
+func TestY_D_MapParamMutationPropagates(t *testing.T) {
+	src := []byte(`package handlers
+
+func setKey(m map[string]float64, k string, v float64) {
+	m[k] = v
+}
+
+func F() float64 {
+	m := map[string]float64{"a": 1.0}
+	setKey(m, "b", 42.0)
+	return m["a"] + m["b"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 43.0 {
+		t.Errorf("F() = %f, want 43.0 (map param mutation must propagate per Y.C retrospective)", got.Num)
+	}
+}
+
+// TestY_D_SliceParamElementMutationPropagates verifies slice element
+// writes (OpIndexSet) made by a callee land in the caller's slice.
+// graph_surface.go's `zeroForces(fx)` pattern depends on this.
+func TestY_D_SliceParamElementMutationPropagates(t *testing.T) {
+	src := []byte(`package handlers
+
+func zeroOut(s []float64) {
+	for i := 0; i < len(s); i = i + 1 {
+		s[i] = 0.0
+	}
+}
+
+func F() float64 {
+	s := []float64{1.0, 2.0, 3.0}
+	zeroOut(s)
+	return s[0] + s[1] + s[2]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 0.0 {
+		t.Errorf("F() = %f, want 0.0 (slice element mutation through param must propagate)", got.Num)
+	}
+}
+
+// TestY_D_ScalarParamIsByValue verifies that scalar (non-composite)
+// parameter mutations do NOT propagate — matching Go's normal scalar
+// pass-by-value semantics. This is the symmetric guarantee that
+// catches a regression if someone "fixes" the composite case by
+// passing every Value by reference indiscriminately.
+func TestY_D_ScalarParamIsByValue(t *testing.T) {
+	src := []byte(`package handlers
+
+func tryBump(n int) {
+	n = n + 100
+}
+
+func F() int {
+	x := 7
+	tryBump(x)
+	return x
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 7 {
+		t.Errorf("F() = %d, want 7 (scalar param must NOT mutate caller's value)", int(got.Num))
+	}
+}

--- a/ir/golower/user_fn_failure_modes_test.go
+++ b/ir/golower/user_fn_failure_modes_test.go
@@ -1,0 +1,57 @@
+// Slice Y.D failure-mode tests — diagnostics for unsupported user-
+// function call shapes. The supported subset is bounded:
+//
+//   - In-package calls to a registered FuncDecl: supported.
+//   - Calls to undeclared identifiers: legacy diagnostic with the
+//     escape-hatch suggestion (so a typo'd callee gets a clear pointer
+//     instead of a silent OpIndirectCall to a nonexistent FuncDef).
+//   - Cross-package calls into unregistered intrinsics: unchanged
+//     "not in the supported intrinsic set" diagnostic from Slice X.B.
+//   - Method calls on user types: still unsupported (the VM lacks a
+//     receiver-binding contract).
+//
+// Each test asserts the diagnostic still surfaces with the right
+// context after Y.D's registry pre-pass takes effect.
+
+package golower
+
+import "testing"
+
+// TestY_D_UnregisteredCalleeStillDiagnoses verifies that a typo'd or
+// missing callee identifier still produces the legacy
+// "calls to user-defined function" diagnostic, NOT a silent
+// OpIndirectCall to a nonexistent FuncDef. The check is important
+// because Y.D's registry probe is the only thing that distinguishes
+// these two paths.
+func TestY_D_UnregisteredCalleeStillDiagnoses(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() int {
+	return mistypedCallee(42)
+}`)
+	_, err := LowerFile(src)
+	requireLowerError(t, err, "mistypedCallee", 0)
+	requireLowerError(t, err, "ADR 0006", 0)
+}
+
+// TestY_D_MethodCallOnUserTypeStillDiagnoses verifies that method
+// receivers remain unsupported even with the user-function registry
+// in place. graph_surface.go itself uses `c.DrawLine(...)` (Y.E
+// territory), but receiver method dispatch in general is not Y.D's
+// scope.
+func TestY_D_MethodCallOnUserTypeStillDiagnoses(t *testing.T) {
+	src := []byte(`package handlers
+
+type box struct {
+	V int
+}
+
+func (b box) Get() int { return b.V }
+
+func F() int {
+	b := box{V: 7}
+	return b.Get()
+}`)
+	_, err := LowerFile(src)
+	requireLowerError(t, err, "ADR 0006", 0)
+}

--- a/ir/golower/user_fn_graph_surface_test.go
+++ b/ir/golower/user_fn_graph_surface_test.go
@@ -1,0 +1,161 @@
+// Slice Y.D graph_surface end-to-end test — exercises the full
+// Y.A+Y.B+Y.C+Y.D stack against a fixture modeled after
+// graph_surface.go's `nodeAt` / `screenToWorld` / `updateNode`
+// helpers calling each other across handlers.
+//
+// The fixture intentionally mirrors the kinds of cross-handler
+// dispatch the real graph_surface.go uses: a multi-return helper
+// for coordinate transforms, a composite-returning helper for new
+// node allocation, and a recursive helper (depth-bounded) that
+// approximates the iterative drag-update fan-out without needing
+// the full canvas surface.
+
+package golower
+
+import (
+	"math"
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_GraphSurfaceHelpersEndToEnd lowers the full graph-surface-
+// style fixture and verifies the returned value matches a Go
+// reference computation. Failure here means one of the Y.D building
+// blocks (registry, dispatch, multi-return, composite return) silently
+// regressed in a way the smaller tests didn't catch.
+func TestY_D_GraphSurfaceHelpersEndToEnd(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+type node struct {
+	ID  string
+	Pos vec2
+}
+
+func screenToWorld(sx float64, sy float64) (float64, float64) {
+	return sx*2.0 + 10.0, sy*2.0 - 5.0
+}
+
+func makeNode(id string, x float64, y float64) node {
+	return node{ID: id, Pos: vec2{X: x, Y: y}}
+}
+
+func magSq(v vec2) float64 {
+	return v.X*v.X + v.Y*v.Y
+}
+
+func fact(n int) int {
+	if n <= 1 {
+		return 1
+	}
+	return n * fact(n-1)
+}
+
+func F() float64 {
+	// Multi-return user function call.
+	wx, wy := screenToWorld(3.0, 4.0)            // 16.0, 3.0
+
+	// Call returning composite, with composite arg threading.
+	n := makeNode("origin", wx, wy)              // node{ID:"origin", Pos:vec2{16,3}}
+
+	// Composite arg flow + scalar return.
+	m := magSq(n.Pos)                            // 256 + 9 = 265
+
+	// Recursion.
+	f := fact(5)                                 // 120
+
+	return m + float64(f)                        // 385
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	want := refGraphSurfaceHelpers()
+	if math.Abs(got.Num-want) > 1e-9 {
+		t.Errorf("F() = %f, want %f", got.Num, want)
+	}
+}
+
+// refGraphSurfaceHelpers is the Go reference for the fixture above.
+// Keeping it explicit (rather than computing inline) makes future
+// fixture tweaks easy to validate against a single source of truth.
+func refGraphSurfaceHelpers() float64 {
+	wx := 3.0*2.0 + 10.0 // 16.0
+	wy := 4.0*2.0 - 5.0  // 3.0
+	m := wx*wx + wy*wy   // 265
+	f := 1
+	for i := 1; i <= 5; i++ {
+		f *= i
+	}
+	return m + float64(f) // 385
+}
+
+// TestY_D_GraphSurfaceMutationThroughCallee combines the composite-
+// parameter mutation guarantee with cross-call dispatch: a helper
+// that mutates a map argument is invoked from another helper which
+// is itself called from the handler. The mutation must propagate
+// through both call frames.
+func TestY_D_GraphSurfaceMutationThroughCallee(t *testing.T) {
+	src := []byte(`package handlers
+
+func setPos(positions map[string]float64, id string, val float64) {
+	positions[id] = val
+}
+
+func ensureSeeded(positions map[string]float64) {
+	setPos(positions, "a", 1.0)
+	setPos(positions, "b", 2.0)
+}
+
+func F() float64 {
+	gPos := map[string]float64{}
+	ensureSeeded(gPos)
+	return gPos["a"] + gPos["b"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 3.0 {
+		t.Errorf("F() = %f, want 3.0 (map mutation through nested call frames)", got.Num)
+	}
+}
+
+// TestY_D_GraphSurfaceForwardReference verifies that a handler may
+// call a user function declared LATER in the same file. Go allows
+// this without forward declarations because the type-check pass sees
+// all top-level decls before checking bodies; Y.D's registry pre-pass
+// preserves the same property because scanUserFuncs runs before any
+// body lowers.
+func TestY_D_GraphSurfaceForwardReference(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() int {
+	return helperDefinedLater(10)
+}
+
+func helperDefinedLater(n int) int {
+	return n + 32
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 42 {
+		t.Errorf("F() = %d, want 42 (forward reference must resolve via registry pre-pass)", int(got.Num))
+	}
+}

--- a/ir/golower/user_fn_init_positions_test.go
+++ b/ir/golower/user_fn_init_positions_test.go
@@ -1,0 +1,97 @@
+// Slice Y.D — `initPositions` shape regression test. Closest analogue
+// in graph_surface.go: a handler invocation seeds the package-level
+// position/velocity maps by calling a sibling helper, which in turn
+// loops over the node list and writes into the maps via OpIndexSet.
+//
+// This is the test that proves the Y.A + Y.C + Y.D stack supports
+// the exact shape graph_surface.go's Mount → initPositions flow uses.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_InitPositionsShape lowers a fixture that mirrors
+// graph_surface.go's Mount → initPositions → seedNode cascade. The
+// handler dispatches to a helper that walks an input node-id list and
+// stores a fresh vec2 in a package-level map for each id. The final
+// reduction over the map confirms every write landed in the shared
+// storage.
+func TestY_D_InitPositionsShape(t *testing.T) {
+	src := []byte(`package handlers
+
+type vec2 struct {
+	X float64
+	Y float64
+}
+
+var gPos = map[string]vec2{}
+
+func placeNode(id string, x float64, y float64) {
+	gPos[id] = vec2{X: x, Y: y}
+}
+
+func initPositions() {
+	placeNode("n0", 1.0, 0.0)
+	placeNode("n1", 0.0, 2.0)
+	placeNode("n2", 3.0, 4.0)
+}
+
+func F() float64 {
+	initPositions()
+	a := gPos["n0"]
+	b := gPos["n1"]
+	c := gPos["n2"]
+	return a.X + b.Y + c.X + c.Y
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 1.0 + 2.0 + 3.0 + 4.0 = 10.0
+	if got.Num != 10.0 {
+		t.Errorf("F() = %f, want 10.0 (initPositions cascade must populate gPos through nested user-fn calls)", got.Num)
+	}
+}
+
+// TestY_D_RecursiveHelperOverPackageState combines Y.D's recursion
+// with Y.C's package-state mutation: a helper writes one entry then
+// recurses to seed the next. Bounded by an explicit base case to
+// stay well inside the MaxCallDepth cap.
+func TestY_D_RecursiveHelperOverPackageState(t *testing.T) {
+	src := []byte(`package handlers
+
+var acc = map[string]int{}
+
+func seed(i int, n int) {
+	if i >= n {
+		return
+	}
+	acc["k"] = acc["k"] + i
+	seed(i+1, n)
+}
+
+func F() int {
+	seed(0, 5)
+	return acc["k"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 0+1+2+3+4 = 10
+	if int(got.Num) != 10 {
+		t.Errorf("F() = %d, want 10 (recursive seeding over package state must accumulate)", int(got.Num))
+	}
+}

--- a/ir/golower/user_fn_multi_return_edge_test.go
+++ b/ir/golower/user_fn_multi_return_edge_test.go
@@ -1,0 +1,152 @@
+// Slice Y.D multi-return edge-case tests — pin the behavior of
+// blank-identifier discards, mixed-type multi-returns, and 3+ return
+// values so future refactors can't silently regress them.
+//
+// graph_surface.go uses `_, ok := gPos[id]` style discards heavily;
+// these tests ensure Y.D's user-function multi-return follows the
+// same blank-identifier convention Y.B established for the comma-ok
+// map index pattern.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_MultiReturnBlankFirst verifies discarding the first return
+// (`_, b := f()`) skips the bind for that slot but still evaluates
+// the call once.
+func TestY_D_MultiReturnBlankFirst(t *testing.T) {
+	src := []byte(`package handlers
+
+func split(n int) (int, int) {
+	return n / 3, n - n/3
+}
+
+func F() int {
+	_, b := split(10)
+	return b
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 10/3 = 3 (int division); 10 - 3 = 7
+	if int(got.Num) != 7 {
+		t.Errorf("F() = %d, want 7", int(got.Num))
+	}
+}
+
+// TestY_D_MultiReturnBlankSecond verifies the symmetric case where
+// the second return is discarded.
+func TestY_D_MultiReturnBlankSecond(t *testing.T) {
+	src := []byte(`package handlers
+
+func split(n int) (int, int) {
+	return n / 3, n - n/3
+}
+
+func F() int {
+	a, _ := split(10)
+	return a
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Num))
+	}
+}
+
+// TestY_D_MultiReturnThreeValues stretches the carrier scheme past
+// the 2-value case Y.B's failure mode covered. Three return values
+// exercise the `__ret_<i>` key scheme at scale.
+func TestY_D_MultiReturnThreeValues(t *testing.T) {
+	src := []byte(`package handlers
+
+func triple(n int) (int, int, int) {
+	return n, n * 2, n * 3
+}
+
+func F() int {
+	a, b, c := triple(5)
+	return a + b + c
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// 5 + 10 + 15 = 30
+	if int(got.Num) != 30 {
+		t.Errorf("F() = %d, want 30", int(got.Num))
+	}
+}
+
+// TestY_D_MultiReturnMixedTypes verifies that returns of different
+// Value kinds (string + bool + float) round-trip through the
+// ObjectVal carrier correctly. The lowerer doesn't know the per-slot
+// types — Value's runtime kind preserves the distinction.
+func TestY_D_MultiReturnMixedTypes(t *testing.T) {
+	src := []byte(`package handlers
+
+func describe(n int) (string, bool, float64) {
+	return "n", n > 0, float64(n) + 0.5
+}
+
+func F() float64 {
+	_, ok, f := describe(7)
+	if ok {
+		return f
+	}
+	return -1.0
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 7.5 {
+		t.Errorf("F() = %f, want 7.5", got.Num)
+	}
+}
+
+// TestY_D_MultiReturnAssignWithoutDefine verifies the `=` (re-assign)
+// form, not just `:=`. Authors sometimes pre-declare the LHS locals.
+func TestY_D_MultiReturnAssignWithoutDefine(t *testing.T) {
+	src := []byte(`package handlers
+
+func split(n int) (int, int) {
+	return n / 2, n - n/2
+}
+
+func F() int {
+	var a int
+	var b int
+	a, b = split(10)
+	return a + b
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 10 {
+		t.Errorf("F() = %d, want 10", int(got.Num))
+	}
+}

--- a/ir/golower/user_fn_mutual_recursion_test.go
+++ b/ir/golower/user_fn_mutual_recursion_test.go
@@ -1,0 +1,86 @@
+// Slice Y.D mutual-recursion regression test — verifies that two
+// user functions calling each other resolve through the registry's
+// forward-reference contract.
+//
+// Mutual recursion is the cleanest stress test for the pre-pass
+// design: even-handed `isEven`/`isOdd` only works if scanUserFuncs
+// has registered BOTH functions before lowering either body. The
+// equivalent code with `go vet` style sequential resolution would
+// silently fall through to the legacy "calls to user-defined
+// function" diagnostic for the forward call.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_MutualRecursion verifies isEven/isOdd cross-dispatch works
+// at modest depth.
+func TestY_D_MutualRecursion(t *testing.T) {
+	src := []byte(`package handlers
+
+func isEven(n int) bool {
+	if n == 0 {
+		return true
+	}
+	return isOdd(n - 1)
+}
+
+func isOdd(n int) bool {
+	if n == 0 {
+		return false
+	}
+	return isEven(n - 1)
+}
+
+func F() bool {
+	return isEven(10)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if !got.Bool {
+		t.Errorf("isEven(10) = %v, want true (mutual recursion must resolve via registry pre-pass)", got.Bool)
+	}
+}
+
+// TestY_D_MutualRecursionOddCase rounds out the table — verifies the
+// false branch of the cross-dispatch chain produces the right answer.
+func TestY_D_MutualRecursionOddCase(t *testing.T) {
+	src := []byte(`package handlers
+
+func isEven(n int) bool {
+	if n == 0 {
+		return true
+	}
+	return isOdd(n - 1)
+}
+
+func isOdd(n int) bool {
+	if n == 0 {
+		return false
+	}
+	return isEven(n - 1)
+}
+
+func F() bool {
+	return isEven(7)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Bool {
+		t.Errorf("isEven(7) = %v, want false", got.Bool)
+	}
+}

--- a/ir/golower/user_fn_scope_test.go
+++ b/ir/golower/user_fn_scope_test.go
@@ -1,0 +1,145 @@
+// Slice Y.D scope-isolation tests — verify that the per-call frame
+// correctly shadows package signals when a parameter shares a name
+// with one, and that the caller's frame is restored cleanly when the
+// callee returns.
+//
+// These behaviors emerge from the EvalWithFrame save/restore +
+// OpLocalGet's frame→signals→props fallback chain; the tests pin
+// them so a future refactor can't quietly break the scoping rules
+// engine-surface authors rely on.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_D_ParamShadowsSignal verifies a parameter named the same as
+// a package-level signal binds to the call argument inside the
+// callee's frame, NOT to the signal. The caller's signal is
+// untouched after the call returns.
+func TestY_D_ParamShadowsSignal(t *testing.T) {
+	src := []byte(`package handlers
+
+var counter = 100
+
+func inspect(counter int) int {
+	return counter
+}
+
+func F() int {
+	return inspect(7)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	vm.InitSignals(machine, prog)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 7 {
+		t.Errorf("F() = %d, want 7 (param must shadow signal in callee frame)", int(got.Num))
+	}
+}
+
+// TestY_D_CallerFrameRestoredAfterCall verifies that locals declared
+// in the caller's frame remain bound after the callee returns. A
+// frame-restore bug would surface as the caller's local being zero
+// after the call.
+func TestY_D_CallerFrameRestoredAfterCall(t *testing.T) {
+	src := []byte(`package handlers
+
+func noop(n int) int {
+	return n
+}
+
+func F() int {
+	x := 42
+	noop(99)
+	return x
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 42 {
+		t.Errorf("F() = %d, want 42 (caller's local must survive the call)", int(got.Num))
+	}
+}
+
+// TestY_D_NestedCallsRestoreFramesInOrder verifies that two levels of
+// nested calls properly stack and unstack frames — A calls B calls
+// C, then we're back in A's frame.
+func TestY_D_NestedCallsRestoreFramesInOrder(t *testing.T) {
+	src := []byte(`package handlers
+
+func c(n int) int {
+	x := n + 100
+	return x
+}
+
+func b(n int) int {
+	x := c(n) + 10
+	return x
+}
+
+func a(n int) int {
+	x := b(n) + 1
+	return x
+}
+
+func F() int {
+	return a(5)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	// a(5) = b(5)+1 = (c(5)+10)+1 = (5+100+10)+1 = 116
+	if int(got.Num) != 116 {
+		t.Errorf("F() = %d, want 116 (3-deep nested call stack must compose)", int(got.Num))
+	}
+}
+
+// TestY_D_CalleeLocalDoesNotLeak verifies that a local declared in a
+// callee's frame is invisible to the caller after the callee returns.
+// (A regression here would mean OpLocalDecl is leaking into the
+// caller's frame.)
+func TestY_D_CalleeLocalDoesNotLeak(t *testing.T) {
+	src := []byte(`package handlers
+
+func helper() int {
+	hiddenVar := 42
+	return hiddenVar
+}
+
+func F() int {
+	helper()
+	// hiddenVar is invisible here; OpLocalGet falls through to props
+	// then to a missing_local diagnostic. The runtime returns zero.
+	return hiddenVar
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		// In this fixture the lowerer happily emits OpLocalGet for any
+		// bare identifier (X.A's design); the VM is the one that
+		// diagnoses the missing local. So LowerFile should still
+		// succeed and the value should be zero.
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 0 {
+		t.Errorf("F() = %d, want 0 (callee's hiddenVar must not leak into caller frame)", int(got.Num))
+	}
+}

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -225,7 +225,72 @@ const (
 	// OpFieldSet / OpIndexSet keep evaluating exactly as before.
 	OpFieldSet
 	OpIndexSet
+
+	// User-defined function call (Slice Y.D — AST-compiler initiative).
+	// OpIndirectCall dispatches into a user-function registered on the
+	// containing Program (FuncDef table). The callee name lives in
+	// Value; the call arguments are evaluated left-to-right and bound
+	// to the callee's parameter names in a fresh call frame.
+	//
+	//   Value    — callee function name (the FuncDef.Name).
+	//   Operands — argument expressions, in source order.
+	//
+	// The result is the value returned by the callee. Multi-return
+	// callees materialize their results into an ObjectVal carrier
+	// keyed by the callee's output param names ("__ret_0", "__ret_1",
+	// ...) so the lowerer can bind each LHS via OpIndex reads — same
+	// shape as Slice Y.B's OpMapLookup result. Void callees return
+	// the zero Value of TypeAny.
+	//
+	// **Recursion safety.** The VM enforces a per-evaluation call-stack
+	// depth cap (Program.MaxCallDepth; default 256) so a runaway
+	// recursion records a structured `call_depth_exceeded` diagnostic
+	// instead of stack-overflowing the host. Tunable per Program for
+	// surfaces that genuinely need deeper recursion.
+	//
+	// **Parameter semantics.** Composite params (struct/slice/map) pass
+	// by reference because Value.Fields and Value.Items are map / slice
+	// reference types — the callee's mutations via OpFieldSet /
+	// OpIndexSet land in the caller's storage. This matches Slice Y.C's
+	// in-place mutation contract and explicitly preserves the Y.C
+	// retrospective's "OpFieldSet on parameter-typed receivers already
+	// propagates" guarantee. Scalar params (int/float/bool/string) are
+	// passed by Value-by-value copy — Go's normal scalar semantics.
+	//
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpIndirectCall keep evaluating exactly as before.
+	OpIndirectCall
 )
+
+// FuncDef defines a user-defined function callable from a handler or
+// from another user function via OpIndirectCall (Slice Y.D). The lowerer
+// (ir/golower/decl.go's pre-pass) walks the surface's top-level FuncDecls
+// and emits one FuncDef per declaration; the VM looks them up by Name
+// when an OpIndirectCall fires.
+//
+// Params is the ordered list of parameter names; the call site evaluates
+// each argument expression and binds it to the corresponding name in the
+// callee's fresh frame. Body is the OpSeq root for the function's
+// statement body, identical in shape to Handler.Body.
+//
+// Results is the count of return values (0 for void, 1 for the common
+// case, 2+ for multi-return like `func split(n int) (int, int)`). The
+// VM uses Results to decide whether to materialize the return as an
+// ObjectVal carrier (Y.B-style) for the lowerer's multi-LHS bindings.
+type FuncDef struct {
+	Name    string   `json:"name"`
+	Params  []string `json:"params"`
+	Body    []ExprID `json:"body"`
+	Results int      `json:"results"`
+}
+
+// DefaultMaxCallDepth is the cap applied when Program.MaxCallDepth is
+// zero. 256 is comfortably below typical Go goroutine stack limits
+// (typically 8MB starting size on 64-bit) yet deep enough that any
+// recursive engine-surface helper a human would write fits within it.
+// Surfaces that genuinely need deeper recursion can raise the cap via
+// Program.MaxCallDepth.
+const DefaultMaxCallDepth = 256
 
 // SurfaceKind identifies the rendering surface a program targets.
 // Carried as a runtime-only field on Program — not serialized.
@@ -285,9 +350,15 @@ type Program struct {
 	Signals     []SignalDef   `json:"signals"`
 	Computeds   []ComputedDef `json:"computeds"`
 	Handlers    []Handler     `json:"handlers"`
+	Funcs       []FuncDef     `json:"funcs,omitempty"` // user-defined helpers (Slice Y.D)
 	StaticMask  []bool        `json:"static_mask"`
 	EngineNodes []EngineNode  `json:"engineNodes,omitempty"` // populated for SurfaceScene3D/Canvas2D
 	Surface     SurfaceKind   `json:"-"`
+
+	// MaxCallDepth caps the OpIndirectCall recursion depth (Slice Y.D).
+	// Zero means "use DefaultMaxCallDepth (256)". Surfaces with
+	// genuinely-deep recursion can raise the value at lowering time.
+	MaxCallDepth int `json:"maxCallDepth,omitempty"`
 }
 
 // Node represents a single node in the island's DOM tree.

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1227,3 +1227,128 @@ func TestIndexSetOpcodeShape(t *testing.T) {
 		t.Errorf("OpIndexSet Value must stay empty (key lives in Operands[1]); got %q", iset.Value)
 	}
 }
+
+// --- Slice Y.D: user-defined function call opcode ---
+
+// TestIndirectCallOpcodeIsDistinct guards Y.D's iota slot from
+// colliding with Y.A/Y.B/Y.C additions. A collision would route every
+// user-function call into the wrong evaluator silently.
+func TestIndirectCallOpcodeIsDistinct(t *testing.T) {
+	all := []OpCode{
+		// pre-existing (TestOpCodeRange + Y.A/Y.B/Y.C)
+		OpLitString, OpLitInt, OpLitFloat, OpLitBool,
+		OpPropGet, OpSignalGet, OpSignalSet, OpSignalUpdate,
+		OpAdd, OpSub, OpMul, OpDiv, OpMod, OpNeg,
+		OpEq, OpNeq, OpLt, OpGt, OpLte, OpGte,
+		OpAnd, OpOr, OpNot,
+		OpConcat, OpFormat,
+		OpCond, OpCall, OpIndex, OpLen, OpRange,
+		OpEventGet,
+		OpMap, OpFilter, OpFind, OpSlice, OpAppend, OpContains,
+		OpToUpper, OpToLower, OpTrim, OpSplit, OpJoin, OpReplace,
+		OpSubstring, OpStartsWith, OpEndsWith,
+		OpToString, OpToInt, OpToFloat,
+		OpSeq, OpAssign, OpLocalDecl, OpLocalGet, OpLocalSet,
+		OpFor, OpForRange, OpReturn, OpBreak, OpContinue,
+		OpComposite, OpMapLookup, OpFieldSet, OpIndexSet,
+		// Y.D (new)
+		OpIndirectCall,
+	}
+	seen := map[OpCode]bool{}
+	for _, op := range all {
+		if seen[op] {
+			t.Errorf("OpCode %d appears twice in the opcode ladder", op)
+		}
+		seen[op] = true
+	}
+}
+
+// TestIndirectCallOpcodeShape documents the operand encoding for a
+// user-function call. The callee name lives in Value (the FuncDef
+// lookup key); Operands are the argument expressions in source order.
+func TestIndirectCallOpcodeShape(t *testing.T) {
+	call := Expr{
+		Op:       OpIndirectCall,
+		Value:    "helper",
+		Operands: []ExprID{0, 1, 2}, // three args
+	}
+	if call.Op != OpIndirectCall {
+		t.Errorf("opcode = %d, want OpIndirectCall", call.Op)
+	}
+	if call.Value != "helper" {
+		t.Errorf("OpIndirectCall callee name lives in Value, want %q got %q", "helper", call.Value)
+	}
+	if len(call.Operands) != 3 {
+		t.Errorf("OpIndirectCall Operands carry the call args; got len=%d", len(call.Operands))
+	}
+}
+
+// TestFuncDefShape verifies the FuncDef carrier fields are wired so the
+// lowerer can stash the per-surface registry. Params is the ordered
+// parameter-name list; Body is the OpSeq root for the function's
+// statement body; Results is the count of return values (0 for void,
+// 1 for the common case, 2+ for multi-return).
+func TestFuncDefShape(t *testing.T) {
+	def := FuncDef{
+		Name:    "split",
+		Params:  []string{"n"},
+		Body:    []ExprID{0},
+		Results: 2,
+	}
+	if def.Name != "split" {
+		t.Errorf("FuncDef.Name = %q, want %q", def.Name, "split")
+	}
+	if len(def.Params) != 1 || def.Params[0] != "n" {
+		t.Errorf("FuncDef.Params = %v, want [n]", def.Params)
+	}
+	if len(def.Body) != 1 {
+		t.Errorf("FuncDef.Body should carry the OpSeq root; got len=%d", len(def.Body))
+	}
+	if def.Results != 2 {
+		t.Errorf("FuncDef.Results = %d, want 2", def.Results)
+	}
+}
+
+// TestProgramFuncsField verifies the Program.Funcs slice serializes
+// round-trip through JSON without dropping FuncDef metadata. This is
+// the carrier that ferries a surface's user-helpers to the VM.
+func TestProgramFuncsField(t *testing.T) {
+	p := Program{
+		Name: "TestSurface",
+		Funcs: []FuncDef{
+			{Name: "greet", Params: nil, Body: []ExprID{0}, Results: 1},
+			{Name: "split", Params: []string{"n"}, Body: []ExprID{1}, Results: 2},
+		},
+	}
+	data, err := json.Marshal(p)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var p2 Program
+	if err := json.Unmarshal(data, &p2); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if len(p2.Funcs) != 2 {
+		t.Fatalf("round-trip len(Funcs) = %d, want 2", len(p2.Funcs))
+	}
+	if p2.Funcs[1].Results != 2 {
+		t.Errorf("round-trip Funcs[1].Results = %d, want 2", p2.Funcs[1].Results)
+	}
+	if len(p2.Funcs[1].Params) != 1 || p2.Funcs[1].Params[0] != "n" {
+		t.Errorf("round-trip Funcs[1].Params = %v, want [n]", p2.Funcs[1].Params)
+	}
+}
+
+// TestProgramMaxCallDepthDefault documents that an unset (zero)
+// MaxCallDepth means "use DefaultMaxCallDepth". The VM reads the field
+// at OpIndirectCall dispatch time; surfaces opt into a deeper stack by
+// raising the value at lowering time.
+func TestProgramMaxCallDepthDefault(t *testing.T) {
+	p := Program{Name: "TestSurface"}
+	if p.MaxCallDepth != 0 {
+		t.Errorf("zero MaxCallDepth = %d, want 0 (sentinel for DefaultMaxCallDepth)", p.MaxCallDepth)
+	}
+	if DefaultMaxCallDepth != 256 {
+		t.Errorf("DefaultMaxCallDepth = %d, want 256", DefaultMaxCallDepth)
+	}
+}


### PR DESCRIPTION
- **add(ir/golower): Add failing-first tests for user function call lowering**
- **add(program): add user-defined function call opcode and FuncDef support**
- **add(golower): Add indirect dispatch for user-defined functions**
- **add(vm): add user-defined function call dispatch to VM**
- **add(ir/golower): Add Slice Y.D: multi-value returns and user calls**
- **add(ir/golower): add tests for Y.D user function failure modes**
- **add(vm): Add tests for OpIndirectCall handling**
- **test(golower): Add composite parameter mutation propagation tests**
- **add(ir/golower): Add end-to-end tests for graph-surface lowering pipeline**
- **test(vm): Add benchmarks for indirect function calls**
- **add(bench): add user-function handler benchmark**
- **add(ir/golower): add mutual recursion regression test**
- **test(golower): add multi-return edge-case tests for Y.D**
- **test(vm): add tests for function frame isolation and scoping**
- **test(golower): Add tests for nested user-fn calls and recursive helpers**
