### PR TITLE
Slice Y.E: make() + canvas binding via OpHostCall for VM AST compiler

### DIFF
--- a/client/vm/host_call.go
+++ b/client/vm/host_call.go
@@ -1,0 +1,188 @@
+// Slice Y.E.2 — Host-receiver dispatch for OpHostCall.
+//
+// Engine-surface handlers call methods on *surface.Canvas and
+// *surface.Context. These objects live host-side (they wrap CSS
+// pixels and the browser's CanvasRenderingContext2D — neither can be
+// expressed as a pure Value transformation). The VM exposes a binding
+// mechanism so the surface bootstrap can hand each VM a concrete
+// receiver per source-level identifier ("c", "ctx", ...) and the
+// lowered OpHostCall opcodes dispatch into it at evaluation time.
+//
+// Design choice (Y.E exit report):
+//
+//   - **Single OpHostCall opcode**, not one-opcode-per-canvas-method.
+//     33+ canvas methods would explode the opcode ladder and force a
+//     program-wire-format bump every time a method is added. The
+//     dispatch table lives in user code (the HostReceiver
+//     implementation), where it belongs.
+//
+//   - **Per-VM binding**, not a global registry. Each engine-surface
+//     instance has its own canvas/context. A global registry would
+//     force the bootstrap to thread a "which surface am I" parameter
+//     into every host method, which is exactly what BindHost avoids.
+//
+//   - **Receiver-name addressing**, not type-name addressing. The
+//     lowered call carries `<receiver>.<MethodName>` so the dispatch
+//     respects the author's source identifier. Two parameters of the
+//     same type bind independently if needed (rare but legal).
+//
+// Discrimination from OpCall (stdlib intrinsics): OpCall hits the
+// global intrinsics registry (math.Sin, strings.Join — pure functions
+// from the standard library). OpHostCall hits the per-VM host
+// receivers (canvas/context/etc. — capability-bearing objects from
+// the surface bootstrap). The lowerer disambiguates by checking the
+// receiver identifier against the file's import list: imports →
+// OpCall; non-imports → OpHostCall.
+
+package vm
+
+import (
+	"fmt"
+	"strings"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// HostReceiver is the contract a host-bound object must satisfy to
+// receive OpHostCall dispatches. The single `Call` method takes the
+// source-level method name and the evaluated argument list; the
+// receiver is free to look up the method in any way it likes
+// (reflect-based dispatch, hand-rolled switch, JS-bridge passthrough).
+//
+// Methods that don't return a value should return the zero Value;
+// errors surface as `host_call_error` diagnostics on the VM (the
+// receiver itself stays panic-free per the engine-surface contract).
+type HostReceiver interface {
+	Call(method string, args []Value) (Value, error)
+}
+
+// BindHost registers a host receiver under the given identifier. The
+// identifier is the source-level parameter name the author used
+// (typically "c" for the canvas and "ctx" for the context). The
+// lowerer emits OpHostCall opcodes whose Value is "<identifier>.<Method>";
+// the VM looks up the identifier in the binding table at dispatch
+// time.
+//
+// Re-binding the same name replaces the previous receiver — useful
+// for tests that swap a recorder in mid-evaluation. A nil receiver
+// clears the binding.
+func (vm *VM) BindHost(name string, recv HostReceiver) {
+	if vm.hosts == nil {
+		vm.hosts = make(map[string]HostReceiver)
+	}
+	if recv == nil {
+		delete(vm.hosts, name)
+		return
+	}
+	vm.hosts[name] = recv
+}
+
+// LookupHost returns the host receiver bound to name (mainly for
+// tests). The second return is false when no binding exists.
+func (vm *VM) LookupHost(name string) (HostReceiver, bool) {
+	recv, ok := vm.hosts[name]
+	return recv, ok
+}
+
+// evalHostCallExpr dispatches OpHostCall into the bound host receiver.
+// The Value carries "<receiver>.<MethodName>"; we split on the first
+// dot to recover the binding key and the method name. Args are
+// evaluated left-to-right before the host call fires.
+//
+// Errors from the host receiver are recorded as diagnostics and
+// surface as the zero Any value — the VM stays panic-free even when
+// the host receiver misbehaves. Unbound receivers (no BindHost call
+// for the given identifier) record a `host_unbound` diagnostic and
+// likewise yield the zero value so handler bodies continue to
+// evaluate the rest of their statements.
+func (vm *VM) evalHostCallExpr(e program.Expr) (Value, bool) {
+	if e.Op != program.OpHostCall {
+		return Value{}, false
+	}
+	dot := strings.IndexByte(e.Value, '.')
+	if dot <= 0 || dot == len(e.Value)-1 {
+		vm.recordExprDiagnostic(
+			"host_call_invalid",
+			fmt.Sprintf("OpHostCall Value %q must be \"<receiver>.<Method>\"", e.Value),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+	recvName := e.Value[:dot]
+	methodName := e.Value[dot+1:]
+	recv, ok := vm.hosts[recvName]
+	if !ok {
+		vm.recordExprDiagnostic(
+			"host_unbound",
+			fmt.Sprintf("OpHostCall: no host bound under name %q (method %q)", recvName, methodName),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+	args := make([]Value, len(e.Operands))
+	for i, op := range e.Operands {
+		args[i] = vm.Eval(op)
+	}
+	result, err := recv.Call(methodName, args)
+	if err != nil {
+		vm.recordExprDiagnostic(
+			"host_call_error",
+			fmt.Sprintf("host call %s: %v", e.Value, err),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+	return result, true
+}
+
+// --- Test helper: HostRecorder ---
+
+// HostRecorder is a HostReceiver that records every call it receives
+// (method name + evaluated args). Tests use it to assert that the
+// lowerer emitted the right OpHostCall sequence and that the VM
+// evaluated arguments in source order. Not part of the production
+// dispatch path — production surfaces bind a real *surface.Canvas
+// adapter that forwards to the host CanvasImpl.
+type HostRecorder struct {
+	Calls []HostCall
+	// ReturnFor, if set, returns the configured Value for the given
+	// method name. Unset methods return the zero Value. Lets tests
+	// stub query-style methods (Width, Height, PropsInto) without
+	// inventing a per-test receiver implementation.
+	ReturnFor map[string]Value
+}
+
+// HostCall is one entry in HostRecorder.Calls.
+type HostCall struct {
+	Method string
+	Args   []Value
+}
+
+// NewHostRecorder constructs an empty recorder.
+func NewHostRecorder() *HostRecorder {
+	return &HostRecorder{}
+}
+
+// Call satisfies HostReceiver. Records the call then either returns
+// the configured ReturnFor value or the zero Value.
+func (r *HostRecorder) Call(method string, args []Value) (Value, error) {
+	// Defensive copy so callers can't mutate the recorder's history.
+	argsCopy := make([]Value, len(args))
+	copy(argsCopy, args)
+	r.Calls = append(r.Calls, HostCall{Method: method, Args: argsCopy})
+	if r.ReturnFor != nil {
+		if v, ok := r.ReturnFor[method]; ok {
+			return v, nil
+		}
+	}
+	return ZeroValue(program.TypeAny), nil
+}
+
+// Reset clears the call history. Useful for tests that exercise
+// multiple phases against the same recorder.
+func (r *HostRecorder) Reset() {
+	r.Calls = nil
+}

--- a/client/vm/host_call_bench_test.go
+++ b/client/vm/host_call_bench_test.go
@@ -1,0 +1,111 @@
+// Slice Y.E benchmarks for OpMake + OpHostCall.
+//
+// These document the per-operation cost so the WASM-size + frame-budget
+// gates (Phase 1d) have concrete data to assess against. The
+// expectation is the cost stays well within 60 fps frame budget
+// (16ms / frame) even at canvas dispatch rates of hundreds of calls
+// per frame (graph_surface.go's draw issues ~5 calls per node * up
+// to 200 nodes = ~1000 calls per frame).
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+func BenchmarkOpMakeMap(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpMake, Value: "map"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = vm.Eval(0)
+	}
+}
+
+func BenchmarkOpMakeSliceSized(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "16", Type: program.TypeInt}, // id 0
+			{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{0}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = vm.Eval(1)
+	}
+}
+
+func BenchmarkOpHostCallZeroArg(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.BeginPath"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.BindHost("c", &noopHost{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = vm.Eval(0)
+	}
+}
+
+func BenchmarkOpHostCallTwoArgs(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitFloat, Value: "1.5", Type: program.TypeFloat}, // id 0
+			{Op: program.OpLitFloat, Value: "2.5", Type: program.TypeFloat}, // id 1
+			{Op: program.OpHostCall, Value: "c.MoveTo", Operands: []program.ExprID{0, 1}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.BindHost("c", &noopHost{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = vm.Eval(2)
+	}
+}
+
+// BenchmarkOpHostCallDrawShape mirrors the inner loop of
+// graph_surface.go's draw handler: 4 canvas calls per edge.
+func BenchmarkOpHostCallDrawShape(b *testing.B) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitFloat, Value: "1.0", Type: program.TypeFloat},                 // id 0
+			{Op: program.OpLitFloat, Value: "2.0", Type: program.TypeFloat},                 // id 1
+			{Op: program.OpLitFloat, Value: "3.0", Type: program.TypeFloat},                 // id 2
+			{Op: program.OpLitFloat, Value: "4.0", Type: program.TypeFloat},                 // id 3
+			{Op: program.OpHostCall, Value: "c.BeginPath"},                                  // id 4
+			{Op: program.OpHostCall, Value: "c.MoveTo", Operands: []program.ExprID{0, 1}},   // id 5
+			{Op: program.OpHostCall, Value: "c.LineTo", Operands: []program.ExprID{2, 3}},   // id 6
+			{Op: program.OpHostCall, Value: "c.Stroke"},                                     // id 7
+			{Op: program.OpSeq, Operands: []program.ExprID{4, 5, 6, 7}},                     // id 8
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.BindHost("c", &noopHost{})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = vm.Eval(8)
+	}
+}
+
+// noopHost is a HostReceiver that does nothing. Used by the
+// benchmarks so the dispatch cost is measured in isolation from the
+// host work.
+type noopHost struct{}
+
+func (*noopHost) Call(method string, args []Value) (Value, error) {
+	return Value{}, nil
+}

--- a/client/vm/host_call_test.go
+++ b/client/vm/host_call_test.go
@@ -1,0 +1,189 @@
+// Slice Y.E.2.3 — VM-level tests for OpHostCall + BindHost.
+//
+// These cover the evaluator contract independently of the lowerer (the
+// lowering side gets its own coverage in ir/golower/host_call_test.go).
+// The shape: programs assembled by hand, BindHost called explicitly,
+// HostRecorder used to capture the dispatch sequence.
+
+package vm
+
+import (
+	"errors"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestEvalHostCallZeroArg verifies the simplest dispatch path: the
+// receiver receives the method name and an empty args slice.
+func TestEvalHostCallZeroArg(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.BeginPath"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	rec := NewHostRecorder()
+	vm.BindHost("c", rec)
+	vm.Eval(0)
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "BeginPath" {
+		t.Errorf("expected one BeginPath call; got %+v", rec.Calls)
+	}
+	if len(rec.Calls[0].Args) != 0 {
+		t.Errorf("expected zero args; got %d", len(rec.Calls[0].Args))
+	}
+}
+
+// TestEvalHostCallEvaluatesArgsInSourceOrder verifies that operand
+// evaluation runs left-to-right and the result Values reach the host
+// in the same order.
+func TestEvalHostCallEvaluatesArgsInSourceOrder(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitFloat, Value: "1.5", Type: program.TypeFloat}, // id 0
+			{Op: program.OpLitFloat, Value: "2.5", Type: program.TypeFloat}, // id 1
+			{Op: program.OpHostCall, Value: "c.MoveTo", Operands: []program.ExprID{0, 1}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	rec := NewHostRecorder()
+	vm.BindHost("c", rec)
+	vm.Eval(2)
+	if len(rec.Calls) != 1 {
+		t.Fatalf("expected one call; got %+v", rec.Calls)
+	}
+	args := rec.Calls[0].Args
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args; got %d", len(args))
+	}
+	if args[0].Num != 1.5 {
+		t.Errorf("args[0] = %f, want 1.5", args[0].Num)
+	}
+	if args[1].Num != 2.5 {
+		t.Errorf("args[1] = %f, want 2.5", args[1].Num)
+	}
+}
+
+// TestEvalHostCallReturnValue verifies that ReturnFor wiring lets the
+// host return a Value to the VM (mirrors Width()/Height() shape).
+func TestEvalHostCallReturnValue(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.Width"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	rec := NewHostRecorder()
+	rec.ReturnFor = map[string]Value{
+		"Width": IntVal(800),
+	}
+	vm.BindHost("c", rec)
+	got := vm.Eval(0)
+	if int(got.Num) != 800 {
+		t.Errorf("c.Width() returned %d, want 800", int(got.Num))
+	}
+}
+
+// TestEvalHostCallUnboundReceiverIsPanicFree verifies the contract:
+// an OpHostCall with no bound receiver records a diagnostic and
+// returns the zero Value — the VM never panics.
+func TestEvalHostCallUnboundReceiverIsPanicFree(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.MoveTo"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(0)
+	if got.Type != program.TypeAny {
+		t.Errorf("unbound host call should yield TypeAny zero; got Type=%d", got.Type)
+	}
+}
+
+// TestEvalHostCallTwoReceiversIndependent verifies that binding two
+// different identifiers gives two independent dispatch paths.
+func TestEvalHostCallTwoReceiversIndependent(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.BeginPath"},  // id 0
+			{Op: program.OpHostCall, Value: "ctx.Register"}, // id 1
+		},
+	}
+	vm := NewVM(prog, nil)
+	canvasRec := NewHostRecorder()
+	ctxRec := NewHostRecorder()
+	vm.BindHost("c", canvasRec)
+	vm.BindHost("ctx", ctxRec)
+	vm.Eval(0)
+	vm.Eval(1)
+	if len(canvasRec.Calls) != 1 || canvasRec.Calls[0].Method != "BeginPath" {
+		t.Errorf("canvas recorder got %+v", canvasRec.Calls)
+	}
+	if len(ctxRec.Calls) != 1 || ctxRec.Calls[0].Method != "Register" {
+		t.Errorf("ctx recorder got %+v", ctxRec.Calls)
+	}
+}
+
+// TestEvalHostCallErrorBecomesDiagnostic verifies that an error
+// returned by the host receiver becomes a host_call_error diagnostic
+// without panicking the VM.
+func TestEvalHostCallErrorBecomesDiagnostic(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.Boom"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.BindHost("c", &errorReceiver{})
+	got := vm.Eval(0)
+	if got.Type != program.TypeAny {
+		t.Errorf("erroring host call should yield TypeAny zero; got Type=%d", got.Type)
+	}
+}
+
+// TestEvalHostCallInvalidValueShape covers the diagnostic for a Value
+// missing the receiver-dot-method format. Shouldn't happen with the
+// lowerer but the VM stays panic-free even on hand-built bad programs.
+func TestEvalHostCallInvalidValueShape(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "noDot"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	vm.BindHost("c", NewHostRecorder())
+	got := vm.Eval(0)
+	if got.Type != program.TypeAny {
+		t.Errorf("invalid OpHostCall shape should yield TypeAny zero")
+	}
+}
+
+// TestBindHostNilClears verifies that BindHost(name, nil) removes
+// the binding so a subsequent host call records the unbound diagnostic.
+func TestBindHostNilClears(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpHostCall, Value: "c.Ping"},
+		},
+	}
+	vm := NewVM(prog, nil)
+	rec := NewHostRecorder()
+	vm.BindHost("c", rec)
+	vm.Eval(0)
+	if len(rec.Calls) != 1 {
+		t.Fatalf("expected one call after BindHost; got %d", len(rec.Calls))
+	}
+	vm.BindHost("c", nil)
+	rec.Reset()
+	vm.Eval(0)
+	if len(rec.Calls) != 0 {
+		t.Errorf("expected zero calls after BindHost(nil); got %+v", rec.Calls)
+	}
+}
+
+// errorReceiver always errors. Used by TestEvalHostCallErrorBecomesDiagnostic.
+type errorReceiver struct{}
+
+func (*errorReceiver) Call(method string, args []Value) (Value, error) {
+	return Value{}, errors.New("intentional test error")
+}

--- a/client/vm/make.go
+++ b/client/vm/make.go
@@ -1,0 +1,86 @@
+// Slice Y.E.1 — VM evaluator for the make() builtin opcode (OpMake).
+//
+// OpMake allocates an empty collection. The kind tag in Expr.Value
+// selects which:
+//
+//   - "map"   — fresh ObjectVal with an empty Fields map. The lowerer
+//     drops Go's optional capacity hint at lower time; the VM has no
+//     concept of map capacity (Go's runtime ignores it for iteration
+//     semantics anyway).
+//
+//   - "slice" — fresh ArrayVal whose Items slice has length n
+//     (Operands[0] evaluates to the length). Pre-filled with the
+//     ZeroValue(TypeAny) entries so subsequent OpIndex reads on
+//     out-of-range slots return safely; OpIndexSet writes through the
+//     same slice in place per Slice Y.C's mutation contract.
+//
+// Per Y.D's retrospective handoff, the lowerer detects `make` BEFORE
+// reaching the user-function registry probe, so this evaluator is the
+// authoritative landing site for every `make(...)` call expression in
+// a lowered Go source file. The Y.A composite-literal path remains the
+// way to allocate a *populated* collection in one expression; OpMake
+// only covers the explicit allocation form.
+
+package vm
+
+import (
+	"fmt"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// evalMakeExpr dispatches OpMake by inspecting the Value kind tag and
+// either allocating an empty map (ObjectVal) or a length-n slice
+// (ArrayVal). Unknown tags record an "invalid_make" diagnostic and
+// fall back to the zero Any value so the VM's panic-free contract
+// holds.
+func (vm *VM) evalMakeExpr(e program.Expr) (Value, bool) {
+	if e.Op != program.OpMake {
+		return Value{}, false
+	}
+	switch e.Value {
+	case "map":
+		return ObjectVal(map[string]Value{}), true
+	case "slice":
+		return vm.makeSlice(e), true
+	default:
+		vm.recordExprDiagnostic(
+			"invalid_make",
+			fmt.Sprintf("OpMake has unknown kind tag %q (want \"map\" or \"slice\")", e.Value),
+			e.Op,
+			e.Value,
+		)
+		return ZeroValue(program.TypeAny), true
+	}
+}
+
+// makeSlice evaluates the length operand and returns an ArrayVal with n
+// zero-Value entries. Negative or non-numeric lengths record a
+// diagnostic and fall back to a zero-length slice — the engine-surface
+// authoring contract is permissive about runtime type errors so the VM
+// stays panic-free (matches the Y.A / Y.C convention).
+func (vm *VM) makeSlice(e program.Expr) Value {
+	if len(e.Operands) == 0 {
+		// `make([]T)` is not valid Go syntactically, but `make([]T, 0)`
+		// produces an empty slice — preserve that even if the lowerer
+		// ever emits the no-length form.
+		return ArrayVal([]Value{})
+	}
+	lenVal := vm.Eval(e.Operands[0])
+	n := int(lenVal.Num)
+	if n < 0 {
+		vm.recordExprDiagnostic(
+			"invalid_make",
+			fmt.Sprintf("OpMake(slice) length must be non-negative, got %d", n),
+			e.Op,
+			e.Value,
+		)
+		n = 0
+	}
+	items := make([]Value, n)
+	zero := ZeroValue(program.TypeAny)
+	for i := range items {
+		items[i] = zero
+	}
+	return ArrayVal(items)
+}

--- a/client/vm/make_test.go
+++ b/client/vm/make_test.go
@@ -1,0 +1,130 @@
+// Slice Y.E.1.3 — VM-level tests for OpMake. The lowering side gets
+// its own coverage in ir/golower/make_test.go; this file pins the
+// evaluator contract independently so a future opcode-shape refactor
+// can land without coupling to the lowerer's encoder.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestEvalOpMakeEmptyMap verifies the simplest path: kind tag "map"
+// returns a fresh ObjectVal with an empty (non-nil) Fields map. The
+// non-nil distinction matters — OpFieldSet / OpIndexSet branch on
+// Fields presence per Y.C's evaluator.
+func TestEvalOpMakeEmptyMap(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpMake, Value: "map"}, // id 0
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(0)
+	if got.Fields == nil {
+		t.Fatalf("OpMake(map) should return a Value with a non-nil Fields map")
+	}
+	if len(got.Fields) != 0 {
+		t.Errorf("OpMake(map) should be empty; got %d entries", len(got.Fields))
+	}
+}
+
+// TestEvalOpMakeSizedSlice verifies that the length operand pre-sizes
+// the Items slice and that each slot holds the zero Value (so OpIndex
+// reads on uninitialized slots don't panic).
+func TestEvalOpMakeSizedSlice(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "5", Type: program.TypeInt}, // id 0 — length
+			{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{0}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(1)
+	if got.Items == nil {
+		t.Fatalf("OpMake(slice, 5) should return a Value with a non-nil Items slice")
+	}
+	if len(got.Items) != 5 {
+		t.Errorf("OpMake(slice, 5) len = %d, want 5", len(got.Items))
+	}
+}
+
+// TestEvalOpMakeEmptySlice verifies the zero-length form `make([]T, 0)`
+// is distinct from a nil slice — len() returns 0 but the slice itself
+// is allocated so subsequent appends work.
+func TestEvalOpMakeEmptySlice(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "0", Type: program.TypeInt}, // id 0
+			{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{0}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(1)
+	if got.Items == nil {
+		t.Errorf("OpMake(slice, 0) should still allocate a non-nil empty slice")
+	}
+	if len(got.Items) != 0 {
+		t.Errorf("OpMake(slice, 0) len = %d, want 0", len(got.Items))
+	}
+}
+
+// TestEvalOpMakeNegativeLength documents the panic-free contract: a
+// negative length records a diagnostic and yields a zero-length slice
+// (matching Y.C's "stay safe under malformed input" pattern).
+func TestEvalOpMakeNegativeLength(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLitInt, Value: "-3", Type: program.TypeInt}, // id 0
+			{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{0}},
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(1)
+	if len(got.Items) != 0 {
+		t.Errorf("OpMake(slice, -3) should clamp to len=0; got len=%d", len(got.Items))
+	}
+	// A diagnostic should have been recorded — the VM's recordExprDiagnostic
+	// surface is internal to the test scope; we verify the safe-output
+	// contract instead.
+}
+
+// TestEvalOpMakeUnknownKindTag verifies unknown kind tags yield the
+// zero Any value plus a diagnostic. The VM never panics on bad input.
+func TestEvalOpMakeUnknownKindTag(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpMake, Value: "chan"}, // id 0 — channels are not supported
+		},
+	}
+	vm := NewVM(prog, nil)
+	got := vm.Eval(0)
+	if got.Fields != nil {
+		t.Errorf("OpMake(\"chan\") should NOT return a populated Fields map; got %v", got.Fields)
+	}
+	if got.Items != nil {
+		t.Errorf("OpMake(\"chan\") should NOT return a populated Items slice; got %v", got.Items)
+	}
+}
+
+// TestEvalOpMakeMapIsFreshAllocation verifies each evaluation of an
+// OpMake(map) returns a distinct Fields map — important because Y.C's
+// in-place mutation contract relies on aliasing being explicit
+// (multiple holders of "the same" map share storage; multiple OpMake
+// evals do not).
+func TestEvalOpMakeMapIsFreshAllocation(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpMake, Value: "map"}, // id 0
+		},
+	}
+	vm := NewVM(prog, nil)
+	a := vm.Eval(0)
+	b := vm.Eval(0)
+	a.Fields["k"] = StringVal("from-a")
+	if _, ok := b.Fields["k"]; ok {
+		t.Errorf("each OpMake(map) eval must allocate a fresh Fields map; got aliased storage")
+	}
+}

--- a/client/vm/value.go
+++ b/client/vm/value.go
@@ -462,8 +462,38 @@ func (v Value) EndsWithVal(suffix Value) Value {
 // --- Type conversions ---
 
 // ToStringVal converts any Value to a StringVal.
+//
+// Slice Y.E.3: when v is an ArrayVal whose Items are all StringVals
+// (the shape produced by `[]rune(s)` via OpToRunes), the conversion
+// concatenates the items — mirroring Go's `string([]rune{...})` which
+// joins the runes back into a string. This is what makes the
+// graph_surface.go pattern `string([]rune(label)[:22])` produce a
+// truncated label rather than the debug-formatted `"[h, e, l, l, o]"`
+// shape that the array's String() form returns.
 func (v Value) ToStringVal() Value {
+	if v.Items != nil && allStringItems(v.Items) {
+		var b strings.Builder
+		for _, item := range v.Items {
+			b.WriteString(item.Str)
+		}
+		return StringVal(b.String())
+	}
 	return StringVal(v.String())
+}
+
+// allStringItems reports whether every element in items is a TypeString
+// Value. Used by ToStringVal to decide between joining (the rune-array
+// case) and debug-formatting (heterogeneous arrays).
+func allStringItems(items []Value) bool {
+	if len(items) == 0 {
+		return false
+	}
+	for _, item := range items {
+		if item.Type != program.TypeString {
+			return false
+		}
+	}
+	return true
 }
 
 // ToIntVal converts a Value to an IntVal. Parses strings, truncates floats.

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -148,6 +148,9 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 	if value, ok := vm.evalIndirectCallExpr(e); ok {
 		return value
 	}
+	if value, ok := vm.evalMakeExpr(e); ok {
+		return value
+	}
 	vm.recordExprDiagnostic(
 		"unknown_opcode",
 		fmt.Sprintf("unknown island VM opcode %d", e.Op),

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -810,6 +810,16 @@ func (vm *VM) sliceValue(e program.Expr) Value {
 		coll := vm.Eval(e.Operands[0])
 		start := int(vm.Eval(e.Operands[1]).Num)
 		end := int(vm.Eval(e.Operands[2]).Num)
+		// Slice Y.E.3: OpSlice now dispatches on the runtime collection
+		// kind so the lowerer's *ast.SliceExpr handler can emit a single
+		// opcode without knowing whether the source operand is a slice
+		// or a string. String operands route through SubstringVal;
+		// rune-array operands (produced by Y.E's `[]rune(s)` cast)
+		// route through the existing SliceVal path because they carry
+		// Items, not Str.
+		if coll.Items == nil && coll.Str != "" {
+			return coll.SubstringVal(start, end)
+		}
 		return coll.SliceVal(start, end)
 	}
 	return ArrayVal(nil)

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -678,6 +678,21 @@ func (vm *VM) evalConversionExpr(e program.Expr) (Value, bool) {
 		return vm.intUnary(e, Value.ToIntVal), true
 	case program.OpToFloat:
 		return vm.floatUnary(e, Value.ToFloatVal), true
+	case program.OpToRunes:
+		// Slice Y.E.3: `[]rune(s)` / `[]byte(s)` — convert a string
+		// into an ArrayVal whose Items are one-rune StringVals. Reading
+		// len() returns the rune count; slicing returns a rune
+		// subsequence; OpToString concatenates back to a string via
+		// the ToStringVal join path.
+		if !vm.requireOperands(e, 1) {
+			return ArrayVal(nil), true
+		}
+		src := vm.Eval(e.Operands[0]).Str
+		items := make([]Value, 0, len(src))
+		for _, r := range src {
+			items = append(items, StringVal(string(r)))
+		}
+		return ArrayVal(items), true
 	default:
 		return Value{}, false
 	}

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -20,6 +20,7 @@ type VM struct {
 	forCap         int                  // per-loop iteration cap (X.C); 0 → default
 	funcs          map[string]*program.FuncDef // user-function registry (Y.D)
 	callDepth      int                  // current OpIndirectCall recursion depth (Y.D)
+	hosts          map[string]HostReceiver // per-VM host-receiver bindings for OpHostCall (Y.E)
 	diagnostics    []Diagnostic
 	diagnosticSink DiagnosticSink
 }
@@ -149,6 +150,9 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 		return value
 	}
 	if value, ok := vm.evalMakeExpr(e); ok {
+		return value
+	}
+	if value, ok := vm.evalHostCallExpr(e); ok {
 		return value
 	}
 	vm.recordExprDiagnostic(

--- a/ir/golower/array_type_cast.go
+++ b/ir/golower/array_type_cast.go
@@ -1,0 +1,55 @@
+// Slice Y.E.3 — `[]T(x)` ArrayType-cast lowering.
+//
+// Go's AST represents `[]rune(s)` as a CallExpr whose Fun is an
+// *ast.ArrayType with Elt = "rune". This was Y.D's "residual #3" —
+// not in Y.D's plan-defined scope but recognized as needing handling
+// before graph_surface.go could lower cleanly.
+//
+// Supported element types — exactly what graph_surface.go uses:
+//
+//   []rune(s)   → OpToRunes(s)         — string → rune-array
+//   []byte(s)   → OpToRunes(s)         — same VM shape; bytes/runes
+//                                        are indistinguishable at the
+//                                        Value level (no byte type).
+//
+// Other element types (`[]int(...)`, `[]Node(...)`) are rejected with
+// a clear diagnostic — they'd need genuine type-aware conversion that
+// the supported subset doesn't promise.
+
+package golower
+
+import (
+	"go/ast"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// lowerArrayTypeCast emits OpToRunes for `[]rune(s)` / `[]byte(s)`.
+// Other element types fall through to an issue + zero-value Expr so
+// the rest of the surrounding expression keeps lowering.
+func (c *lowerCtx) lowerArrayTypeCast(at *ast.ArrayType, call *ast.CallExpr) program.ExprID {
+	if at.Len != nil {
+		c.addIssue(call, "fixed-length array conversions are not supported (use []T or []rune)", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+	if len(call.Args) != 1 {
+		c.addIssue(call, "[]T(x) cast requires exactly 1 argument", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+	elt, ok := at.Elt.(*ast.Ident)
+	if !ok {
+		c.addIssue(call, "only `[]rune(s)` and `[]byte(s)` casts are supported (element type must be a builtin identifier)", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+	switch elt.Name {
+	case "rune", "byte", "int32", "uint8":
+		argID := c.lowerExpr(call.Args[0])
+		return c.addExpr(program.Expr{
+			Op:       program.OpToRunes,
+			Operands: []program.ExprID{argID},
+		})
+	default:
+		c.addIssue(call, "only `[]rune(s)` and `[]byte(s)` casts are supported", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+}

--- a/ir/golower/bench_test.go
+++ b/ir/golower/bench_test.go
@@ -48,7 +48,7 @@ func buildLargeSource(lines int) []byte {
 // bench picks up the lowering cost of OpFieldSet / OpIndexSet handlers
 // — the actual shape graph_surface.go uses for state mutations.
 func makeBenchFunc(i int) string {
-	switch i % 5 {
+	switch i % 6 {
 	case 0:
 		return funcPure(i)
 	case 1:
@@ -57,9 +57,27 @@ func makeBenchFunc(i int) string {
 		return funcIntrinsic(i)
 	case 3:
 		return funcLHS(i)
-	default:
+	case 4:
 		return funcUserFn(i)
+	default:
+		return funcHostMake(i)
 	}
+}
+
+// funcHostMake produces a Y.E-shaped handler that exercises both
+// OpHostCall (`c.MoveTo(...)`, `c.LineTo(...)`) and OpMake (a
+// per-call force-table map) in a loop. Mirrors graph_surface.go's
+// draw + stepLayout shapes more faithfully than the Y.A-Y.D
+// fixtures, which kept canvas dispatch out of scope.
+func funcHostMake(i int) string {
+	idx := itoa(i)
+	return `func HostMake` + idx + `(n int) int {
+	m := make(map[string]float64, n)
+	for j := 0; j < n; j = j + 1 {
+		m["k"] = float64(j)
+	}
+	return len(m)
+}`
 }
 
 // funcUserFn produces a Y.D-shaped handler that exercises the user-

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -234,6 +234,17 @@ func (c *lowerCtx) lowerCallExpr(call *ast.CallExpr) program.ExprID {
 		}
 	}
 
+	// Slice Y.E.3: ArrayType "call" — Go's `[]T(x)` conversion syntax.
+	// The canonical case from graph_surface.go is `[]rune(label)`, used
+	// to rune-count + truncate a label string. The lowerer treats it as
+	// a runtime string-to-rune-array conversion via OpToRunes; the VM
+	// produces an ArrayVal whose Items are one-rune StringVals so
+	// subsequent OpLen returns the rune count and OpSlice returns a
+	// rune subsequence (which `string(...)` re-collapses).
+	if at, ok := call.Fun.(*ast.ArrayType); ok {
+		return c.lowerArrayTypeCast(at, call)
+	}
+
 	// Selector: pkg.Func or obj.Method.
 	sel, ok := call.Fun.(*ast.SelectorExpr)
 	if !ok {

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -131,6 +131,18 @@ func (c *lowerCtx) lowerUnaryExpr(u *ast.UnaryExpr) program.ExprID {
 	case token.NOT:
 		argID := c.lowerExpr(u.X)
 		return c.addExpr(program.Expr{Op: program.OpNot, Operands: []program.ExprID{argID}})
+	case token.AND:
+		// Slice Y.E.3: `&x` (address-of). The VM has no pointer
+		// concept — composite Values (struct/slice/map) are already
+		// reference-shared because Value.Fields/Items are Go reference
+		// types (Y.C / Y.D contract). For scalar `x`, taking the
+		// address has no meaningful semantics in the supported subset.
+		// We honor the Go author's intent (pass by reference) by
+		// simply lowering to the underlying Value — host receivers and
+		// user functions both already propagate composite mutations
+		// through this path. Documented as ADR-style decision in
+		// Y.E's retrospective.
+		return c.lowerExpr(u.X)
 	default:
 		c.addIssue(u, fmt.Sprintf("unsupported unary operator %s", u.Op), escapeHatchSuggestion)
 		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -210,6 +210,14 @@ func (c *lowerCtx) lowerCallExpr(call *ast.CallExpr) program.ExprID {
 			}
 			argID := c.lowerExpr(call.Args[0])
 			return c.addExpr(program.Expr{Op: program.OpToString, Operands: []program.ExprID{argID}})
+		case "make":
+			// Slice Y.E: `make(...)` allocates an empty collection. Routed
+			// BEFORE the user-fn registry probe per Y.D's retrospective
+			// handoff so a user-declared `make` can't accidentally shadow
+			// the builtin. The first arg is the collection type literal
+			// (a *ast.MapType or *ast.ArrayType); the rest are the
+			// optional length / capacity hints.
+			return c.lowerMakeCall(call)
 		default:
 			// Slice Y.D: route in-package calls into OpIndirectCall when
 			// the name resolves through the user-function registry built

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -50,6 +50,8 @@ func (c *lowerCtx) lowerExpr(e ast.Expr) program.ExprID {
 		return c.lowerCallExpr(ex)
 	case *ast.IndexExpr:
 		return c.lowerIndexExpr(ex)
+	case *ast.SliceExpr:
+		return c.lowerSliceExpr(ex)
 	case *ast.CompositeLit:
 		return c.lowerCompositeLit(ex)
 	default:

--- a/ir/golower/expr.go
+++ b/ir/golower/expr.go
@@ -243,16 +243,30 @@ func (c *lowerCtx) lowerCallExpr(call *ast.CallExpr) program.ExprID {
 		c.addIssue(call, "method calls on non-package receivers are not supported", escapeHatchSuggestion)
 		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
 	}
-	qualified := pkg + "." + sel.Sel.Name
-	if !isIntrinsic(qualified) {
-		c.addIssue(call, fmt.Sprintf("call to %s is not in the supported intrinsic set", qualified), escapeHatchSuggestion)
-		return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	// Slice Y.E: discriminate intrinsic vs host call by checking the
+	// receiver against the file's import set. Receivers that aren't
+	// imported packages (`c`, `ctx`, ...) route into OpHostCall;
+	// imported packages stay on the OpCall intrinsic path. This is
+	// also the catch-all for stdlib package names — `math.Sin` is
+	// imported, so it goes through intrinsics; a typo `maht.Sin`
+	// falls through to host dispatch and records a `host_unbound`
+	// diagnostic at evaluation time.
+	if c.isImportedPackage(pkg) {
+		qualified := pkg + "." + sel.Sel.Name
+		if !isIntrinsic(qualified) {
+			c.addIssue(call, fmt.Sprintf("call to %s is not in the supported intrinsic set", qualified), escapeHatchSuggestion)
+			return c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+		}
+		argIDs := make([]program.ExprID, 0, len(call.Args))
+		for _, a := range call.Args {
+			argIDs = append(argIDs, c.lowerExpr(a))
+		}
+		return c.addExpr(program.Expr{Op: program.OpCall, Value: qualified, Operands: argIDs})
 	}
-	argIDs := make([]program.ExprID, 0, len(call.Args))
-	for _, a := range call.Args {
-		argIDs = append(argIDs, c.lowerExpr(a))
-	}
-	return c.addExpr(program.Expr{Op: program.OpCall, Value: qualified, Operands: argIDs})
+	// Receiver is not an imported package — treat as a host method
+	// call. The VM looks up the bound HostReceiver by the receiver
+	// identifier ("c", "ctx", ...) at evaluation time.
+	return c.lowerHostCall(pkg, sel, call.Args)
 }
 
 // lowerIndexExpr emits OpIndex for both slice and map indexing — the

--- a/ir/golower/failure_modes_test.go
+++ b/ir/golower/failure_modes_test.go
@@ -29,7 +29,22 @@ func F() {
 	requireLowerError(t, err, "ADR 0006", 0)
 }
 
-func TestFailureMode_Interface(t *testing.T) {
+// TestFailureMode_Interface_NowHostDispatched documents the Y.E-era
+// behavior shift: pre-Y.E the lowerer rejected every method call on
+// a non-package receiver with "method calls on non-package receivers
+// are not supported." Y.E generalizes that path into OpHostCall (so
+// `c.MoveTo()` and `ctx.PropsInto()` can lower against runtime-bound
+// HostReceivers). The trade is that an interface call now lowers
+// cleanly and only fails at *evaluation* time, recording a
+// `host_unbound` diagnostic when no receiver is bound.
+//
+// The test pins the new contract: lowering succeeds, and the surface
+// bootstrap (or test setup) is responsible for binding the host
+// receiver. Interfaces remain semantically unsupported — there's no
+// way to ship a generic interface-method dispatch through the VM
+// without a separate vtable mechanism — but the lowerer is no longer
+// the gatekeeper.
+func TestFailureMode_Interface_NowHostDispatched(t *testing.T) {
 	src := []byte(`package handlers
 
 type Greeter interface {
@@ -37,8 +52,13 @@ type Greeter interface {
 }
 
 func F(g Greeter) string { return g.Hello() }`)
-	_, err := LowerFile(src)
-	requireLowerError(t, err, "ADR 0006", 0)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("Y.E lowers interface method calls as OpHostCall; got error: %v", err)
+	}
+	if prog == nil {
+		t.Fatal("expected a non-nil Program from successful lowering")
+	}
 }
 
 func TestFailureMode_UnknownIntrinsic(t *testing.T) {

--- a/ir/golower/golower.go
+++ b/ir/golower/golower.go
@@ -123,6 +123,12 @@ func LowerASTFile(fset *token.FileSet, file *ast.File) (*program.Program, error)
 	// (Go allows `func A() { B() }; func B() {}`).
 	ctx.scanUserFuncs(file)
 
+	// Pre-pass (Slice Y.E): record the source-level identifier of
+	// each imported package so lowerCallExpr's selector branch can
+	// tell pkg.Func (intrinsic) apart from receiver.Method (host
+	// dispatch through OpHostCall).
+	ctx.scanImports(file)
+
 	// Two passes:
 	//   1. Hoist package-level var declarations into signal defs so
 	//      function bodies can reference them by name. Init expressions
@@ -170,6 +176,13 @@ type lowerCtx struct {
 	// OpIndirectCall instead of the legacy "calls to user-defined
 	// function" diagnostic.
 	funcs funcRegistry
+
+	// imports holds the source-level identifier of each imported
+	// package in the current file (Slice Y.E). Populated by
+	// scanImports so lowerCallExpr can tell `math.Sin(x)` (intrinsic
+	// dispatch through OpCall) apart from `c.MoveTo(x, y)` (host
+	// receiver dispatch through OpHostCall).
+	imports map[string]bool
 }
 
 // addExpr appends e to the program's expression table and returns the

--- a/ir/golower/graph_surface_y_e_test.go
+++ b/ir/golower/graph_surface_y_e_test.go
@@ -1,0 +1,132 @@
+// Slice Y.E.4 — graph_surface.go end-to-end lowering check.
+//
+// Lowers the actual graph_surface.go from `~/work/hyphae/cmd/hypha-viz`
+// and verifies the issue count drops to the Y.E exit target.
+//
+// Pre-Y.E:   40 issues
+// Post-Y.E:  1 issue (the *ast.FuncLit closure in Mount's StartLoop —
+//            deferred to Y.G or a future "expression-language breadth"
+//            slice; not in Y.E's plan-defined scope).
+//
+// The test runs only when GOSX_TEST_GRAPH_SURFACE_PATH is set or the
+// default hyphae checkout is present. CI runners without the hyphae
+// repo skip silently — the synthetic fixture above (TestGraphSurface*)
+// is the always-on coverage.
+
+package golower
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestY_E_GraphSurfaceEndToEnd lowers the real graph_surface.go and
+// pins the post-Y.E issue count. The test is the canonical proof that
+// Y.E's surface coverage matches the plan's exit criteria.
+func TestY_E_GraphSurfaceEndToEnd(t *testing.T) {
+	path := graphSurfacePath()
+	if path == "" {
+		t.Skip("graph_surface.go not present; set GOSX_TEST_GRAPH_SURFACE_PATH to enable")
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	prog, lerr := LowerFile(src)
+	if prog == nil {
+		t.Fatal("LowerFile returned a nil Program — the lowerer should never drop the whole file")
+	}
+	// Issue count target: 1 (the FuncLit closure in StartLoop).
+	const wantIssues = 1
+	if lerr == nil {
+		if wantIssues == 0 {
+			return
+		}
+		t.Fatalf("LowerFile: expected %d residual issue(s), got 0", wantIssues)
+	}
+	got := lowerErrorIssueCount(lerr)
+	if got != wantIssues {
+		t.Errorf("LowerFile: post-Y.E issue count = %d, want %d. Errors:\n%s", got, wantIssues, lerr.Error())
+	}
+	// The one residual must be the FuncLit case — fail loudly if any
+	// other diagnostic creeps back so a regression in Y.E's coverage
+	// is visible immediately.
+	if !strings.Contains(lerr.Error(), "FuncLit") {
+		t.Errorf("post-Y.E residual should be the FuncLit (closure) gap; got:\n%s", lerr.Error())
+	}
+}
+
+// TestY_E_GraphSurfaceHandlersAreEmitted verifies the Program from
+// lowering graph_surface.go carries every handler the file declares,
+// even though one handler (Mount) has a deferred FuncLit residual.
+// This pins the lowerer's "keep going on diagnostics" contract.
+func TestY_E_GraphSurfaceHandlersAreEmitted(t *testing.T) {
+	path := graphSurfacePath()
+	if path == "" {
+		t.Skip("graph_surface.go not present")
+	}
+	src, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	prog, _ := LowerFile(src) // ignore residual errors
+	if prog == nil {
+		t.Fatal("nil Program")
+	}
+	expected := []string{
+		"Mount", "OnDown", "OnMove", "OnUp", "OnZoom", "OnDouble",
+		"OnResize", "stepLayout", "typeColor", "isGraftKind",
+		"initPositions", "draw", "screenToWorld", "nodeAt",
+	}
+	have := make(map[string]bool, len(prog.Handlers))
+	for _, h := range prog.Handlers {
+		have[h.Name] = true
+	}
+	for _, name := range expected {
+		if !have[name] {
+			t.Errorf("Handler %s missing from lowered Program; got: %v", name, handlerNames(prog.Handlers))
+		}
+	}
+}
+
+// graphSurfacePath returns the source path of the hyphae graph
+// surface, or "" when not present.
+func graphSurfacePath() string {
+	if p := os.Getenv("GOSX_TEST_GRAPH_SURFACE_PATH"); p != "" {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	candidates := []string{
+		filepath.Join(os.Getenv("HOME"), "work", "hyphae", "cmd", "hypha-viz", "graphsurface", "graph_surface.go"),
+	}
+	for _, p := range candidates {
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return ""
+}
+
+func lowerErrorIssueCount(err error) int {
+	if err == nil {
+		return 0
+	}
+	le, ok := err.(*LowerError)
+	if !ok {
+		return 1 // unstructured error; count as one residual for the assertion
+	}
+	return len(le.Issues)
+}
+
+func handlerNames(handlers []program.Handler) []string {
+	out := make([]string, len(handlers))
+	for i, h := range handlers {
+		out[i] = h.Name
+	}
+	return out
+}

--- a/ir/golower/host_call.go
+++ b/ir/golower/host_call.go
@@ -1,0 +1,132 @@
+// Slice Y.E.2 — host-receiver method-call lowering.
+//
+// Engine-surface handlers receive `c *surface.Canvas` and
+// `ctx *surface.Context` parameters and dispatch through them like:
+//
+//   c.MoveTo(x, y)
+//   ctx.PropsInto(&props)
+//
+// Pre-Y.E the lowerer treated every selector-call as a stdlib
+// intrinsic candidate and rejected unknown ones with "call to <X> is
+// not in the supported intrinsic set." Y.E introduces OpHostCall and
+// routes selector-calls whose receiver is NOT an imported package
+// into the host-dispatch path.
+//
+// Discrimination algorithm — the lowerer needs to tell apart:
+//
+//   math.Sin(x)           — receiver "math" is an imported package
+//                           → OpCall("math.Sin", x) into intrinsic registry
+//
+//   c.MoveTo(x, y)        — receiver "c" is NOT an imported package
+//                           → OpHostCall("c.MoveTo", x, y) into host receiver
+//
+// To make this decision, a pre-pass walks file.Imports and records the
+// set of import names (the alias if present, otherwise the package name
+// derived from the import path). lowerCallExpr's selector branch then
+// checks the receiver identifier against this set.
+//
+// The fallback case (receiver is an Ident but not an imported package,
+// not in the intrinsic table) routes to OpHostCall. Unbound receivers
+// at runtime record a `host_unbound` diagnostic — the same shape as a
+// user-fn dispatch into an unregistered name. This means a typo on a
+// stdlib package name (`maht.Sin`) now produces a `host_unbound`
+// diagnostic at runtime instead of a build-time intrinsic-set error.
+// Worth it: the alternative (rejecting every non-imported selector at
+// build time) would block every legitimate canvas call.
+
+package golower
+
+import (
+	"go/ast"
+	"path"
+	"strconv"
+	"strings"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// scanImports populates ctx.imports with the source-level identifier
+// each import declaration introduces. The alias takes precedence over
+// the path-derived name when present.
+func (c *lowerCtx) scanImports(file *ast.File) {
+	c.imports = make(map[string]bool, len(file.Imports))
+	for _, spec := range file.Imports {
+		if spec == nil || spec.Path == nil {
+			continue
+		}
+		name := importLocalName(spec)
+		if name == "" {
+			continue
+		}
+		c.imports[name] = true
+	}
+}
+
+// importLocalName returns the source-level identifier under which an
+// import is referenced. Honors the alias if present (`m "math"` →
+// "m") and falls back to the last path segment otherwise
+// (`"strings"` → "strings", `"m31labs.dev/gosx/engine/surface"` →
+// "surface").
+func importLocalName(spec *ast.ImportSpec) string {
+	if spec.Name != nil && spec.Name.Name != "" && spec.Name.Name != "_" {
+		if spec.Name.Name == "." {
+			// Dot-imports merge into the local namespace; the supported
+			// subset doesn't use them, but treat as not contributing a
+			// name so receivers don't accidentally classify.
+			return ""
+		}
+		return spec.Name.Name
+	}
+	raw, err := strconv.Unquote(spec.Path.Value)
+	if err != nil {
+		return ""
+	}
+	base := path.Base(raw)
+	if base == "" || base == "." || base == "/" {
+		return ""
+	}
+	// Strip a major-version suffix (e.g., ".../v2").
+	if strings.HasPrefix(base, "v") && len(base) > 1 {
+		allDigits := true
+		for _, r := range base[1:] {
+			if r < '0' || r > '9' {
+				allDigits = false
+				break
+			}
+		}
+		if allDigits {
+			// Use the second-to-last segment instead.
+			parts := strings.Split(raw, "/")
+			if len(parts) >= 2 {
+				base = parts[len(parts)-2]
+			}
+		}
+	}
+	return base
+}
+
+// isImportedPackage reports whether name is the source-level
+// identifier of an imported package in the current file.
+func (c *lowerCtx) isImportedPackage(name string) bool {
+	if c.imports == nil {
+		return false
+	}
+	return c.imports[name]
+}
+
+// lowerHostCall emits OpHostCall for a selector-style call where the
+// receiver is NOT an imported package. The Value carries
+// "<receiverName>.<MethodName>" so the VM can split on the first dot
+// and look up the bound HostReceiver.
+func (c *lowerCtx) lowerHostCall(recvName string, sel *ast.SelectorExpr, args []ast.Expr) program.ExprID {
+	qualified := recvName + "." + sel.Sel.Name
+	argIDs := make([]program.ExprID, 0, len(args))
+	for _, a := range args {
+		argIDs = append(argIDs, c.lowerExpr(a))
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpHostCall,
+		Value:    qualified,
+		Operands: argIDs,
+	})
+}

--- a/ir/golower/host_call_graph_surface_test.go
+++ b/ir/golower/host_call_graph_surface_test.go
@@ -1,0 +1,143 @@
+// Slice Y.E.4 — graph_surface-shape integration tests for the VM
+// side of OpHostCall. Pairs with TestY_E_GraphSurfaceEndToEnd
+// (lowering smoke test) by exercising the *runtime* dispatch shape
+// for the canvas patterns graph_surface.go's draw and stepLayout
+// handlers produce.
+//
+// Tier 5 in the X/Y test pyramid: synthetic fixtures + real
+// HostRecorder + VM evaluation, end-to-end. The actual hyphae file
+// stays the lowering smoke target; this file pins the call sequence
+// the lowered Program emits when evaluated.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_E_GraphSurfaceDrawShape lowers a stepwise distillation of
+// graph_surface.go's draw handler and asserts the HostRecorder
+// observes exactly the expected canvas call sequence.
+func TestY_E_GraphSurfaceDrawShape(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func Draw(c *surface.Canvas, x1 float64, y1 float64, x2 float64, y2 float64, color string) {
+	c.BeginPath()
+	c.MoveTo(x1, y1)
+	c.LineTo(x2, y2)
+	c.SetStrokeStyle(color)
+	c.SetLineWidth(1.5)
+	c.Stroke()
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Draw")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"x1":    vm.FloatVal(10),
+		"y1":    vm.FloatVal(20),
+		"x2":    vm.FloatVal(30),
+		"y2":    vm.FloatVal(40),
+		"color": vm.StringVal("rgba(120,100,75,0.25)"),
+	})
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+
+	wantMethods := []string{"BeginPath", "MoveTo", "LineTo", "SetStrokeStyle", "SetLineWidth", "Stroke"}
+	if len(rec.Calls) != len(wantMethods) {
+		t.Fatalf("call count = %d, want %d; got=%+v", len(rec.Calls), len(wantMethods), rec.Calls)
+	}
+	for i, want := range wantMethods {
+		if rec.Calls[i].Method != want {
+			t.Errorf("call %d = %q, want %q", i, rec.Calls[i].Method, want)
+		}
+	}
+	// Spot-check arg propagation.
+	if rec.Calls[1].Args[0].Num != 10 || rec.Calls[1].Args[1].Num != 20 {
+		t.Errorf("MoveTo args = %+v, want [10, 20]", rec.Calls[1].Args)
+	}
+	if rec.Calls[2].Args[0].Num != 30 || rec.Calls[2].Args[1].Num != 40 {
+		t.Errorf("LineTo args = %+v, want [30, 40]", rec.Calls[2].Args)
+	}
+	if rec.Calls[3].Args[0].Str != "rgba(120,100,75,0.25)" {
+		t.Errorf("SetStrokeStyle arg = %q, want \"rgba(120,100,75,0.25)\"", rec.Calls[3].Args[0].Str)
+	}
+}
+
+// TestY_E_GraphSurfaceStepLayoutShape exercises the per-tick force
+// table allocation pattern from stepLayout (`make(map[string]float64,
+// len(gNodes))`) plus a host call into the canvas at the end.
+// Demonstrates that Y.E's OpMake and OpHostCall co-evaluate cleanly
+// in a single handler — the exact pattern stepLayout uses.
+func TestY_E_GraphSurfaceStepLayoutShape(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func Step(c *surface.Canvas, n int) int {
+	fx := make(map[string]float64, n)
+	fx["a"] = 1.0
+	fx["b"] = 2.0
+	c.SetFillStyle("debug")
+	return len(fx)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Step")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"n": vm.IntVal(8),
+	})
+	machine.BindHost("c", rec)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 2 {
+		t.Errorf("Step returned %d, want 2 (len of fx after two writes)", int(got.Num))
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
+		t.Errorf("expected one SetFillStyle host call; got %+v", rec.Calls)
+	}
+}
+
+// TestY_E_GraphSurfaceUserFnCallsCanvas verifies that a user-defined
+// helper which calls the canvas dispatches through the bound
+// HostReceiver correctly — Y.D's user-fn dispatch composes cleanly
+// with Y.E's host-call dispatch (no special integration needed per
+// Y.D's retrospective handoff).
+func TestY_E_GraphSurfaceUserFnCallsCanvas(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func drawEdge(c *surface.Canvas, x1 float64, y1 float64, x2 float64, y2 float64) {
+	c.BeginPath()
+	c.MoveTo(x1, y1)
+	c.LineTo(x2, y2)
+	c.Stroke()
+}
+
+func Draw(c *surface.Canvas) {
+	drawEdge(c, 0, 0, 10, 10)
+	drawEdge(c, 10, 10, 20, 20)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Draw")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, nil)
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	// Two drawEdge calls × 4 canvas calls each = 8 total.
+	if len(rec.Calls) != 8 {
+		t.Errorf("call count = %d, want 8; got=%+v", len(rec.Calls), rec.Calls)
+	}
+}

--- a/ir/golower/host_call_test.go
+++ b/ir/golower/host_call_test.go
@@ -1,0 +1,237 @@
+// Slice Y.E.2.1 — failing-first tests for method calls on non-package
+// receivers (the engine-surface Canvas + Context host bindings).
+//
+// graph_surface.go's handlers receive `c *surface.Canvas` and
+// `ctx *surface.Context` parameters and dispatch through them like:
+//
+//   c.MoveTo(x, y)        // host call: canvas dispatch with "MoveTo"
+//   c.SetFillStyle("...") // host call: canvas dispatch with "SetFillStyle"
+//   ctx.PropsInto(&props) // host call: context dispatch with "PropsInto"
+//
+// Pre-Y.E the lowerer treats every selector-call as a stdlib intrinsic
+// candidate and rejects unknown ones with "call to <X> is not in the
+// supported intrinsic set." Y.E.2 introduces OpHostCall, which lets the
+// VM dispatch into a runtime-bound receiver (the actual *surface.Canvas
+// instance threaded in by the surface bootstrap).
+//
+// The patterns pinned here cover the three shapes graph_surface.go uses:
+//
+//   1. Zero-arg host method:        c.BeginPath()
+//   2. Numeric-args host method:    c.MoveTo(x, y)
+//   3. String-arg host method:      c.SetFillStyle(color)
+//   4. Context-receiver host call:  ctx.PropsInto(&props)
+//   5. Mixed-arg host method:       c.FillText(label, p.X, p.Y+r+12)
+//
+// At Y.E.2.1 each lowering call still fails. Y.E.2.2 adds OpHostCall,
+// Y.E.2.3 the VM evaluator + BindHost, Y.E.2.4 the lowerer dispatch
+// (import-pre-pass + receiver name classification), Y.E.2.5 marks PASS.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerHostCallZeroArg verifies the simplest case: a method call on
+// a non-package receiver with no arguments. The VM dispatches the call
+// into a bound host-receiver and records the method name for the test
+// to inspect.
+func TestLowerHostCallZeroArg(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(c *surface.Canvas) {
+	c.BeginPath()
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, nil)
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "BeginPath" {
+		t.Errorf("expected one canvas.BeginPath call; got %+v", rec.Calls)
+	}
+}
+
+// TestLowerHostCallTwoFloatArgs verifies that float args are evaluated
+// and passed through in source order. Mirrors `c.MoveTo(x, y)` from
+// graph_surface.go's draw handler.
+func TestLowerHostCallTwoFloatArgs(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(c *surface.Canvas, x float64, y float64) {
+	c.MoveTo(x, y)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"x": vm.FloatVal(3.5),
+		"y": vm.FloatVal(7.25),
+	})
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 {
+		t.Fatalf("expected one canvas.MoveTo call; got %+v", rec.Calls)
+	}
+	if rec.Calls[0].Method != "MoveTo" {
+		t.Errorf("call.Method = %q, want MoveTo", rec.Calls[0].Method)
+	}
+	if len(rec.Calls[0].Args) != 2 {
+		t.Fatalf("call.Args len = %d, want 2", len(rec.Calls[0].Args))
+	}
+	if rec.Calls[0].Args[0].Num != 3.5 {
+		t.Errorf("args[0] = %f, want 3.5", rec.Calls[0].Args[0].Num)
+	}
+	if rec.Calls[0].Args[1].Num != 7.25 {
+		t.Errorf("args[1] = %f, want 7.25", rec.Calls[0].Args[1].Num)
+	}
+}
+
+// TestLowerHostCallStringArg verifies that a string-typed argument
+// flows through unchanged. Mirrors `c.SetFillStyle("#7b5c3a")` from
+// graph_surface.go's draw handler.
+func TestLowerHostCallStringArg(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(c *surface.Canvas, color string) {
+	c.SetFillStyle(color)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"color": vm.StringVal("#7b5c3a"),
+	})
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
+		t.Fatalf("expected one canvas.SetFillStyle call; got %+v", rec.Calls)
+	}
+	if rec.Calls[0].Args[0].Str != "#7b5c3a" {
+		t.Errorf("args[0] = %q, want %q", rec.Calls[0].Args[0].Str, "#7b5c3a")
+	}
+}
+
+// TestLowerHostCallContextReceiver verifies that a second host receiver
+// (`ctx`) is dispatched independently of the canvas receiver. Mirrors
+// `ctx.PropsInto(&props)` from graph_surface.go's Mount handler.
+//
+// Note: the `&props` argument is `*ast.UnaryExpr{Op: AND, X: Ident}`.
+// The host-dispatch path doesn't need a real address — it just needs
+// the operand to lower. We pass a primitive props value here so the
+// argument count is what matters; PropsInto's actual JSON unmarshaling
+// stays a host-side concern of the bound receiver.
+func TestLowerHostCallContextReceiver(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(ctx *surface.Context, slot int) {
+	ctx.RegisterSlot(slot)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"slot": vm.IntVal(42),
+	})
+	machine.BindHost("ctx", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "RegisterSlot" {
+		t.Fatalf("expected one ctx.RegisterSlot call; got %+v", rec.Calls)
+	}
+	if int(rec.Calls[0].Args[0].Num) != 42 {
+		t.Errorf("args[0] = %d, want 42", int(rec.Calls[0].Args[0].Num))
+	}
+}
+
+// TestLowerHostCallMixedArgs verifies a multi-arg call with mixed
+// string and float types. Mirrors `c.FillText(label, p.X, p.Y+12)`.
+func TestLowerHostCallMixedArgs(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(c *surface.Canvas, label string, x float64, y float64) {
+	c.FillText(label, x, y + 12)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"label": vm.StringVal("hello"),
+		"x":     vm.FloatVal(10),
+		"y":     vm.FloatVal(20),
+	})
+	machine.BindHost("c", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 {
+		t.Fatalf("expected one canvas.FillText call; got %+v", rec.Calls)
+	}
+	if rec.Calls[0].Method != "FillText" {
+		t.Errorf("call.Method = %q, want FillText", rec.Calls[0].Method)
+	}
+	if len(rec.Calls[0].Args) != 3 {
+		t.Fatalf("call.Args len = %d, want 3", len(rec.Calls[0].Args))
+	}
+	if rec.Calls[0].Args[0].Str != "hello" {
+		t.Errorf("args[0] = %q, want \"hello\"", rec.Calls[0].Args[0].Str)
+	}
+	if rec.Calls[0].Args[1].Num != 10 {
+		t.Errorf("args[1] = %f, want 10", rec.Calls[0].Args[1].Num)
+	}
+	if rec.Calls[0].Args[2].Num != 32 {
+		t.Errorf("args[2] = %f, want 32 (y + 12)", rec.Calls[0].Args[2].Num)
+	}
+}
+
+// TestLowerHostCallStdlibIntrinsicStillRoutes verifies that stdlib
+// package calls (math.Sin, strings.Join, etc.) STILL route through the
+// intrinsic path even though the host-call dispatch is now wired. This
+// is the discrimination test: pkg.X where pkg is imported → intrinsic;
+// receiver.X where receiver is not imported → host call.
+func TestLowerHostCallStdlibIntrinsicStillRoutes(t *testing.T) {
+	src := []byte(`package handlers
+
+import "math"
+
+func F(x float64) float64 {
+	return math.Sin(x)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"x": vm.FloatVal(0),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 0 {
+		t.Errorf("sin(0) = %f, want 0", got.Num)
+	}
+}

--- a/ir/golower/lhs_edge_cases_test.go
+++ b/ir/golower/lhs_edge_cases_test.go
@@ -80,7 +80,15 @@ func F() float64 {
 	}
 }
 
-// TestLowerLHSStarUnsupported pins the failure mode for `*p = v`
+// TestLowerLHSStarUnsupported pins the failure mode for `*p = v`.
+//
+// Slice Y.E.3 update: pre-Y.E this test relied on `p := &x` being
+// rejected at the `&` operator. Y.E now lowers `&x` cleanly (treats
+// it as a pass-through for the underlying Value because composite
+// values are reference-shared via Value.Fields/Items per Y.C/Y.D).
+// The test now reaches the `*p` LHS rejection, which surfaces as
+// "left-hand side must be a simple identifier" — the dispatcher in
+// lowerAssignStmt's bare-ident branch is the gatekeeper.
 // (pointer dereference LHS). Pointers aren't in the supported subset,
 // so the lowerer should diagnose without panicking.
 func TestLowerLHSStarUnsupported(t *testing.T) {
@@ -96,8 +104,12 @@ func F() {
 	if err == nil {
 		t.Fatalf("LowerFile: expected an issue for *p = 5, got nil")
 	}
-	if !strings.Contains(err.Error(), "unsupported") {
-		t.Errorf("LowerFile error %v should mention unsupported", err)
+	// Y.E: accept either the legacy "unsupported" diagnostic or the
+	// post-Y.E "left-hand side must be a simple identifier" rejection
+	// that surfaces after `&` lowers as a pass-through.
+	msg := err.Error()
+	if !strings.Contains(msg, "unsupported") && !strings.Contains(msg, "left-hand side") {
+		t.Errorf("LowerFile error %v should mention unsupported or left-hand side", err)
 	}
 }
 

--- a/ir/golower/make.go
+++ b/ir/golower/make.go
@@ -1,0 +1,69 @@
+// Slice Y.E.1 — lowering for the `make(...)` builtin.
+//
+// `make` is a Go builtin (not a user function), and the lowerer must
+// route it BEFORE the user-function registry probe in lowerCallExpr.
+// Per Y.D's retrospective handoff, the dispatch lives alongside
+// len/append/int/float64/string in the `switch id.Name` block so a
+// user-declared `make` (even though such a declaration would shadow the
+// builtin and confuse Go itself) cannot misroute the call.
+//
+// Supported forms — matches the Y.E plan's coverage exactly:
+//
+//   make(map[K]V)               → OpMake("map")
+//   make(map[K]V, hint)         → OpMake("map")          // hint is ignored
+//   make([]T, len)              → OpMake("slice", len)
+//   make([]T, len, cap)         → OpMake("slice", len)   // cap is ignored
+//   make([]T, 0)                → OpMake("slice", 0)
+//
+// The VM has no concept of map capacity or slice capacity; both Go
+// values are advisory at runtime in the standard library too (the
+// runtime grows storage on demand). Dropping them at lower time keeps
+// the wire format clean. Channels (`make(chan T)`) are not supported —
+// goroutines / channels are explicitly out of the engine-surface
+// authoring subset per the package doc in golower.go.
+
+package golower
+
+import (
+	"go/ast"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// lowerMakeCall lowers a call expression whose callee is the bare
+// identifier `make`. The first argument carries the type literal that
+// selects map vs slice; the remaining arguments are sizing hints which
+// the VM doesn't use (see file-level doc).
+func (c *lowerCtx) lowerMakeCall(call *ast.CallExpr) program.ExprID {
+	if len(call.Args) == 0 {
+		c.addIssue(call, "make requires at least 1 argument (the type literal)", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpMake, Value: "map"})
+	}
+	switch typ := call.Args[0].(type) {
+	case *ast.MapType:
+		// make(map[K]V) or make(map[K]V, hint). The optional hint is
+		// dropped — the VM has no notion of map capacity, and Go's
+		// runtime treats the hint as advisory only.
+		return c.addExpr(program.Expr{Op: program.OpMake, Value: "map"})
+	case *ast.ArrayType:
+		// make([]T, n) or make([]T, n, cap). The cap is dropped for the
+		// same reason as the map hint. ArrayType with a non-nil Len
+		// would be a fixed-size array literal, which Go's `make` doesn't
+		// accept syntactically, so we treat it as the slice form.
+		if len(call.Args) < 2 {
+			// `make([]T)` is invalid Go but the VM tolerates it as an
+			// empty slice — record a diagnostic and emit a zero-length
+			// OpMake so the rest of the function continues to lower.
+			c.addIssue(call, "make([]T) requires a length argument", escapeHatchSuggestion)
+			lenZero := c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+			return c.addExpr(program.Expr{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{lenZero}})
+		}
+		lenID := c.lowerExpr(call.Args[1])
+		// Args[2] (cap) is intentionally dropped — see file-level doc.
+		_ = typ
+		return c.addExpr(program.Expr{Op: program.OpMake, Value: "slice", Operands: []program.ExprID{lenID}})
+	default:
+		c.addIssue(call, "make: only []T and map[K]V types are supported (chan T and named types are not)", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpMake, Value: "map"})
+	}
+}

--- a/ir/golower/make_test.go
+++ b/ir/golower/make_test.go
@@ -1,0 +1,153 @@
+// Slice Y.E.1.1 — failing-first tests for the `make(...)` builtin.
+//
+// Pre-Y.E the lowerer treats `make` as a bare-identifier function call
+// and falls through to the user-fn registry probe — which fails with
+// "calls to user-defined function \"make\" are not supported" because
+// no FuncDef ever registers under that name. graph_surface.go's
+// stepLayout uses two `make(map[string]float64, len(gNodes))` calls
+// (lines 231-232), which is the dominant Y.E.1 motivating shape.
+//
+// The patterns pinned here cover the three forms graph_surface.go and
+// the broader engine-surface authoring contract actually use:
+//
+//   1. make(map[K]V)            — zero-arg empty-map allocation
+//   2. make(map[K]V, hint)      — capacity-hinted map (hint ignored at runtime)
+//   3. make([]T, 0)             — empty slice allocation
+//   4. make([]T, n)             — pre-sized slice (n zero-values)
+//   5. make([]T, 0, cap)        — explicit cap argument (cap ignored)
+//
+// At Y.E.1.1 each lowering call still fails. Y.E.1.2 adds the OpMake
+// opcode, Y.E.1.3 the VM evaluator, Y.E.1.4 the lowerCallExpr dispatch
+// (`case "make":` BEFORE the user-fn registry probe per Y.D's handoff),
+// Y.E.1.5 marks these tests PASS.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerMakeEmptyMap verifies `make(map[string]float64)` allocates
+// an empty map that can be read + written through the normal Y.B / Y.C
+// dispatchers.
+func TestLowerMakeEmptyMap(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() float64 {
+	m := make(map[string]float64)
+	m["k"] = 3.5
+	return m["k"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 3.5 {
+		t.Errorf("F() = %f, want 3.5", got.Num)
+	}
+}
+
+// TestLowerMakeMapWithHint verifies that the capacity hint is accepted
+// (and ignored — Go's runtime ignores it for map iteration semantics)
+// rather than tripping an arity error. Matches the graph_surface.go
+// stepLayout shape: `make(map[string]float64, len(gNodes))`.
+func TestLowerMakeMapWithHint(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(n int) int {
+	m := make(map[string]float64, n)
+	m["a"] = 1
+	m["b"] = 2
+	return len(m)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"n": vm.IntVal(8),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 2 {
+		t.Errorf("F(8) = %d, want 2", int(got.Num))
+	}
+}
+
+// TestLowerMakeEmptySlice verifies `make([]T, 0)` allocates an empty
+// slice that participates in `append` and `len`.
+func TestLowerMakeEmptySlice(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() int {
+	s := make([]int, 0)
+	s = append(s, 7)
+	s = append(s, 8)
+	return len(s)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 2 {
+		t.Errorf("F() = %d, want 2", int(got.Num))
+	}
+}
+
+// TestLowerMakeSizedSlice verifies `make([]T, n)` allocates a slice of
+// length n pre-filled with the type's zero value. Reading any in-range
+// index returns the zero Value; writing through OpIndexSet mutates it.
+func TestLowerMakeSizedSlice(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(n int) int {
+	s := make([]int, n)
+	s[0] = 11
+	s[2] = 22
+	return s[0] + s[2] + len(s)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"n": vm.IntVal(3),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 36 {
+		t.Errorf("F(3) = %d, want 36 (11 + 22 + 3)", int(got.Num))
+	}
+}
+
+// TestLowerMakeSliceWithCap verifies the three-arg form `make([]T, n, cap)`
+// drops the cap argument cleanly (the VM has no capacity concept).
+func TestLowerMakeSliceWithCap(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() int {
+	s := make([]int, 0, 100)
+	s = append(s, 1)
+	s = append(s, 2)
+	s = append(s, 3)
+	return len(s)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, nil)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Num))
+	}
+}

--- a/ir/golower/residuals_test.go
+++ b/ir/golower/residuals_test.go
@@ -151,6 +151,52 @@ func F(s string) int {
 	}
 }
 
+// TestLowerAddressOfDropsThrough verifies that `&x` lowers to the
+// underlying expression (composite reference semantics already
+// propagate through Value.Fields/Items per Y.C/Y.D; the explicit `&`
+// has no additional opcode-level meaning in the supported subset).
+// Mirrors graph_surface.go's Mount handler: `ctx.PropsInto(&props)`.
+func TestLowerAddressOfDropsThrough(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(x float64) float64 {
+	p := &x
+	return *p
+}`)
+	// We use `*p` here only to check the read side eventually — but
+	// the supported subset doesn't have * (dereference) either, so
+	// the test focuses on the &x side: lowering must succeed AND
+	// emit a Program; the dereference is rejected as a separate
+	// diagnostic. To keep the test simple we use &x as an arg to a
+	// host call instead.
+	_ = src
+
+	src2 := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(ctx *surface.Context, x float64) {
+	ctx.Set(&x)
+}`)
+	prog, err := LowerFile(src2)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"x": vm.FloatVal(7.5),
+	})
+	machine.BindHost("ctx", rec)
+	machine.EvalWithFrame(handler.Body[0])
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "Set" {
+		t.Fatalf("expected one Set call; got %+v", rec.Calls)
+	}
+	if rec.Calls[0].Args[0].Num != 7.5 {
+		t.Errorf("&x lowered arg = %f, want 7.5 (underlying value)", rec.Calls[0].Args[0].Num)
+	}
+}
+
 // TestLowerArrayTypeCastThenSliceThenString verifies the full
 // graph_surface.go pattern: `string([]rune(label)[:22]) + "…"`.
 func TestLowerArrayTypeCastThenSliceThenString(t *testing.T) {

--- a/ir/golower/residuals_test.go
+++ b/ir/golower/residuals_test.go
@@ -1,0 +1,174 @@
+// Slice Y.E.3 — failing-first tests for the three syntax residuals
+// Y.D's retrospective handed off: SwitchStmt, SliceExpr, and the
+// `[]T(x)` ArrayType cast.
+//
+// Per Y.D's handoff note these are NOT in Y.E's plan-defined scope
+// (the plan parked them under "residuals" and left a Y.G micro-slice
+// open). Y.E folds them in because we're already touching expr.go
+// (for OpHostCall) and stmt.go (potentially) — adding the three
+// handlers in the same slice avoids a tiny follow-up slice.
+//
+// Patterns pinned here:
+//
+//   1. switch: typeColor's string switch (graph_surface.go:303-330)
+//   2. switch with default fall-through: graph_surface.go uses default
+//   3. slice expr: dotted-line `[]float64{4, 4}` substring `s[i:j]`
+//   4. ArrayType cast: `[]rune(s)[:n]` rune conversion + slice
+//   5. ArrayType cast + len: `len([]rune(label)) > 24` in graph_surface.go
+//
+// At Y.E.3.1 each lowering call still fails. Y.E.3.2-4 add handlers
+// for each; Y.E.3.5 marks PASS.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestLowerSwitchStmt verifies that a string switch with multiple
+// cases (typeColor's shape) lowers to a chain of OpCond branches.
+func TestLowerSwitchStmt(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(t string) string {
+	switch t {
+	case "concept":
+		return "#7b5c3a"
+	case "decision":
+		return "#5a7b3a"
+	case "spec":
+		return "#5c7b3a"
+	default:
+		return "#9a8870"
+	}
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"concept", "#7b5c3a"},
+		{"decision", "#5a7b3a"},
+		{"spec", "#5c7b3a"},
+		{"unknown", "#9a8870"},
+		{"", "#9a8870"},
+	}
+	for _, tc := range cases {
+		machine := vm.NewVM(prog, map[string]vm.Value{
+			"t": vm.StringVal(tc.in),
+		})
+		got := machine.EvalWithFrame(handler.Body[0])
+		if got.Str != tc.want {
+			t.Errorf("F(%q) = %q, want %q", tc.in, got.Str, tc.want)
+		}
+	}
+}
+
+// TestLowerSwitchStmtMultipleCaseValues verifies the `case "a", "b":`
+// form where one case lists multiple match values.
+func TestLowerSwitchStmtMultipleCaseValues(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(t string) int {
+	switch t {
+	case "a", "b", "c":
+		return 1
+	case "d":
+		return 2
+	default:
+		return 0
+	}
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	for in, want := range map[string]int{"a": 1, "b": 1, "c": 1, "d": 2, "x": 0} {
+		machine := vm.NewVM(prog, map[string]vm.Value{
+			"t": vm.StringVal(in),
+		})
+		got := machine.EvalWithFrame(handler.Body[0])
+		if int(got.Num) != want {
+			t.Errorf("F(%q) = %d, want %d", in, int(got.Num), want)
+		}
+	}
+}
+
+// TestLowerSliceExpr verifies `s[i:j]` lowers through OpSlice (already
+// exists for the X.B intrinsic family). graph_surface.go's draw handler
+// uses `string([]rune(label)[:22])` — the slice expression is the
+// `[:22]` part.
+func TestLowerSliceExpr(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(s string) string {
+	return s[1:4]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"s": vm.StringVal("hello"),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Str != "ell" {
+		t.Errorf("F(\"hello\")[1:4] = %q, want \"ell\"", got.Str)
+	}
+}
+
+// TestLowerArrayTypeCastForLen verifies `len([]rune(s))` lowers — the
+// `[]rune(s)` is an ArrayType "call" in Go's AST. graph_surface.go
+// uses this on line 404 (`if len([]rune(label)) > 24`).
+func TestLowerArrayTypeCastForLen(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(s string) int {
+	return len([]rune(s))
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"s": vm.StringVal("héllo"),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	// "héllo" is 5 runes; the VM treats len(string) as byte length
+	// historically, but len([]rune(...)) must use rune count.
+	if int(got.Num) != 5 {
+		t.Errorf("len([]rune(\"héllo\")) = %d, want 5", int(got.Num))
+	}
+}
+
+// TestLowerArrayTypeCastThenSliceThenString verifies the full
+// graph_surface.go pattern: `string([]rune(label)[:22]) + "…"`.
+func TestLowerArrayTypeCastThenSliceThenString(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(label string) string {
+	return string([]rune(label)[:3]) + "…"
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"label": vm.StringVal("héllo world"),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Str != "hél…" {
+		t.Errorf("F(\"héllo world\") = %q, want %q", got.Str, "hél…")
+	}
+}

--- a/ir/golower/slice_expr.go
+++ b/ir/golower/slice_expr.go
@@ -1,0 +1,51 @@
+// Slice Y.E.3 — *ast.SliceExpr lowering.
+//
+// Go's slice-expression syntax (`s[i:j]`, `s[i:j:k]`) translates to
+// the VM's OpSlice opcode for arrays/slices and OpSubstring for
+// strings. The lowerer can't tell the operand type at lower time
+// without a go/types pass, so we emit OpSlice and rely on the VM's
+// sliceValue handler to dispatch on the runtime Value shape (Items
+// vs Str). The full-slice form `s[i:j:k]` is rejected — the
+// three-index form's `cap` is meaningless in the VM (it has no
+// capacity concept, see make.go's note).
+//
+// Missing bounds default to:
+//   - low (i):  0
+//   - high (j): len(s)
+// matching Go's semantics.
+
+package golower
+
+import (
+	"go/ast"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// lowerSliceExpr emits OpSlice with the collection and resolved
+// low/high bounds. The VM's sliceValue handler dispatches on the
+// collection's runtime kind.
+func (c *lowerCtx) lowerSliceExpr(s *ast.SliceExpr) program.ExprID {
+	if s.Slice3 {
+		c.addIssue(s, "three-index slice s[i:j:k] is not supported (cap is meaningless in the VM)", escapeHatchSuggestion)
+		return c.addExpr(program.Expr{Op: program.OpSlice})
+	}
+	collID := c.lowerExpr(s.X)
+	var lowID program.ExprID
+	if s.Low != nil {
+		lowID = c.lowerExpr(s.Low)
+	} else {
+		lowID = c.addExpr(program.Expr{Op: program.OpLitInt, Value: "0", Type: program.TypeInt})
+	}
+	var highID program.ExprID
+	if s.High != nil {
+		highID = c.lowerExpr(s.High)
+	} else {
+		// Default high bound is len(collection).
+		highID = c.addExpr(program.Expr{Op: program.OpLen, Operands: []program.ExprID{collID}})
+	}
+	return c.addExpr(program.Expr{
+		Op:       program.OpSlice,
+		Operands: []program.ExprID{collID, lowID, highID},
+	})
+}

--- a/ir/golower/stmt.go
+++ b/ir/golower/stmt.go
@@ -53,6 +53,8 @@ func (c *lowerCtx) lowerStmt(s ast.Stmt) program.ExprID {
 		return c.lowerIncDecStmt(st)
 	case *ast.BranchStmt:
 		return c.lowerBranchStmt(st)
+	case *ast.SwitchStmt:
+		return c.lowerSwitchStmt(st)
 	case *ast.EmptyStmt:
 		return c.addExpr(program.Expr{Op: program.OpSeq})
 	default:

--- a/ir/golower/switch_stmt.go
+++ b/ir/golower/switch_stmt.go
@@ -1,0 +1,211 @@
+// Slice Y.E.3 — *ast.SwitchStmt lowering.
+//
+// Go's switch statement is essentially syntactic sugar for an
+// if/else-if/else chain when the cases are scalar (value-switch, no
+// fallthrough). The supported subset in the engine-surface authoring
+// contract covers exactly that — graph_surface.go's typeColor is the
+// canonical example: a string-tag switch with a default case and no
+// fallthrough.
+//
+// Supported shapes:
+//
+//   switch tag {                    — tag-switch over a scalar
+//   case a, b, c: ...               — multi-value case (any/or match)
+//   case x: ...                     — single-value case
+//   default: ...                    — default case (optional)
+//   }
+//
+//   switch {                        — bare-switch (no tag); each case
+//   case cond1: ...                   carries its own boolean condition
+//   case cond2: ...
+//   }
+//
+// NOT supported:
+//
+//   - `fallthrough` keyword (translates to a new control-flow concept
+//     the VM doesn't model; rejected with a clear diagnostic).
+//   - `switch x.(type)` type-switches (out of subset; requires
+//     run-time type info).
+//   - `switch init; tag { ... }` init statements are folded into a
+//     preceding OpSeq member, same shape as lowerIfStmt.
+
+package golower
+
+import (
+	"go/ast"
+	"go/token"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// lowerSwitchStmt translates a Go switch into a chain of OpCond
+// branches. The tag (if any) is evaluated once into a synthetic local
+// so each case comparison can re-read it without re-evaluating
+// side-effectful tag expressions.
+func (c *lowerCtx) lowerSwitchStmt(s *ast.SwitchStmt) program.ExprID {
+	var seqOps []program.ExprID
+
+	// Init clause (`switch x := f(); tag { ... }`) lowers as a
+	// preceding OpSeq member so the init's local is visible to the
+	// rest of the switch body.
+	if s.Init != nil {
+		seqOps = append(seqOps, c.lowerStmt(s.Init))
+	}
+
+	// Cache the tag once so each case's comparison reads a local
+	// rather than re-evaluating the tag expression. The synthetic
+	// local uses a reserved prefix per the Y.B / Y.D convention.
+	var tagRefID program.ExprID
+	hasTag := s.Tag != nil
+	if hasTag {
+		tagName := freshSwitchTagLocal(s.Pos())
+		tagInitID := c.lowerExpr(s.Tag)
+		seqOps = append(seqOps, c.addExpr(program.Expr{Op: program.OpLocalDecl, Value: tagName}))
+		seqOps = append(seqOps, c.addExpr(program.Expr{
+			Op:       program.OpAssign,
+			Value:    tagName,
+			Operands: []program.ExprID{tagInitID},
+		}))
+		tagRefID = c.addExpr(program.Expr{Op: program.OpLocalGet, Value: tagName})
+	}
+
+	// Build the case chain from the bottom up so the final else is
+	// the default case body (or an OpSeq noop when no default).
+	cases := s.Body.List
+	var defaultBody []program.ExprID
+	cond := []caseClause{}
+	for _, cs := range cases {
+		cc, ok := cs.(*ast.CaseClause)
+		if !ok {
+			c.addIssue(cs, "switch body must contain CaseClause entries", escapeHatchSuggestion)
+			continue
+		}
+		// Reject fallthrough — the VM has no concept of falling
+		// through to the next case without re-checking its condition.
+		for _, st := range cc.Body {
+			if br, ok := st.(*ast.BranchStmt); ok && br.Tok == token.FALLTHROUGH {
+				c.addIssue(st, "fallthrough is not supported in switch", escapeHatchSuggestion)
+			}
+		}
+		if len(cc.List) == 0 {
+			// Default case.
+			defaultBody = c.lowerStmtList(cc.Body)
+			continue
+		}
+		cond = append(cond, caseClause{
+			matchExprs: cc.List,
+			body:       cc.Body,
+		})
+	}
+
+	// Materialize the default branch's body expression.
+	var elseID program.ExprID
+	if len(defaultBody) == 0 {
+		elseID = c.addExpr(program.Expr{Op: program.OpSeq})
+	} else {
+		elseID = c.addExpr(program.Expr{Op: program.OpSeq, Operands: defaultBody})
+	}
+
+	// Build the case chain right-to-left so the deepest else is the
+	// default, then each enclosing OpCond's else is the next case in
+	// source order.
+	currentElse := elseID
+	for i := len(cond) - 1; i >= 0; i-- {
+		clause := cond[i]
+		condID := c.buildCaseCondition(hasTag, tagRefID, clause.matchExprs)
+		thenID := c.addExpr(program.Expr{Op: program.OpSeq, Operands: c.lowerStmtList(clause.body)})
+		currentElse = c.addExpr(program.Expr{
+			Op:       program.OpCond,
+			Operands: []program.ExprID{condID, thenID, currentElse},
+		})
+	}
+
+	seqOps = append(seqOps, currentElse)
+	if len(seqOps) == 1 {
+		return seqOps[0]
+	}
+	return c.addExpr(program.Expr{Op: program.OpSeq, Operands: seqOps})
+}
+
+// buildCaseCondition emits the boolean expression for one case clause.
+// For a tag-switch, each matchExpr is `tag == matchExpr`; multi-value
+// cases (`case a, b, c:`) OR them together. For a bare-switch
+// (tag-less), the matchExpr is already a boolean expression.
+func (c *lowerCtx) buildCaseCondition(hasTag bool, tagRefID program.ExprID, matchExprs []ast.Expr) program.ExprID {
+	var condID program.ExprID
+	for i, me := range matchExprs {
+		var thisCondID program.ExprID
+		if hasTag {
+			// `tag == me`. The tag local is re-read fresh per case to
+			// keep OpLocalGet pure (no shared state across cases).
+			tagID := c.addExpr(program.Expr{Op: program.OpLocalGet, Value: switchTagLocalName(tagRefID, c)})
+			meID := c.lowerExpr(me)
+			thisCondID = c.addExpr(program.Expr{
+				Op:       program.OpEq,
+				Operands: []program.ExprID{tagID, meID},
+			})
+		} else {
+			thisCondID = c.lowerExpr(me)
+		}
+		if i == 0 {
+			condID = thisCondID
+		} else {
+			condID = c.addExpr(program.Expr{
+				Op:       program.OpOr,
+				Operands: []program.ExprID{condID, thisCondID},
+			})
+		}
+	}
+	return condID
+}
+
+// switchTagLocalName recovers the synthetic local name from a
+// previously emitted OpLocalGet ExprID. The lowerer's expression
+// table is append-only so reading c.exprs[tagRefID] gives back the
+// Value (the local name) we baked in.
+func switchTagLocalName(tagRefID program.ExprID, c *lowerCtx) string {
+	if int(tagRefID) >= len(c.exprs) {
+		return ""
+	}
+	return c.exprs[tagRefID].Value
+}
+
+// freshSwitchTagLocal generates a collision-free local name for the
+// cached switch tag. Uses the AST token.Pos so multiple switches in
+// the same handler don't collide. Reserved prefix `__y_e_switch_`.
+func freshSwitchTagLocal(pos token.Pos) string {
+	return "__y_e_switch_" + posToString(pos)
+}
+
+// caseClause is a small carrier used during the right-to-left
+// chain build.
+type caseClause struct {
+	matchExprs []ast.Expr
+	body       []ast.Stmt
+}
+
+// posToString turns a token.Pos into a tmp-local-safe suffix.
+func posToString(pos token.Pos) string {
+	if pos == token.NoPos {
+		return "0"
+	}
+	n := int(pos)
+	if n < 0 {
+		n = -n
+	}
+	// Small dependency-free integer-to-string. Reuses the same shape
+	// the LHS helpers use elsewhere in this package.
+	var (
+		buf [20]byte
+		i   = len(buf)
+	)
+	if n == 0 {
+		return "0"
+	}
+	for n > 0 {
+		i--
+		buf[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(buf[i:])
+}

--- a/ir/golower/y_e_compose_test.go
+++ b/ir/golower/y_e_compose_test.go
@@ -1,0 +1,194 @@
+// Slice Y.E compositional tests — exercise Y.A through Y.E features
+// together to catch interaction bugs that single-feature tests miss.
+
+package golower
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestY_E_TypeColorPlusSetFillStyle reproduces the canonical
+// graph_surface.go composition: `c.SetFillStyle(typeColor(n.Type))`.
+// Exercises Y.E.3 (switch — typeColor uses one), Y.D (user-fn call),
+// and Y.E.2 (host call on the result).
+func TestY_E_TypeColorPlusSetFillStyle(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func typeColor(t string) string {
+	switch t {
+	case "concept":
+		return "#7b5c3a"
+	case "decision":
+		return "#5a7b3a"
+	default:
+		return "#9a8870"
+	}
+}
+
+func Paint(c *surface.Canvas, kind string) {
+	c.SetFillStyle(typeColor(kind))
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Paint")
+	rec := vm.NewHostRecorder()
+
+	cases := map[string]string{
+		"concept":  "#7b5c3a",
+		"decision": "#5a7b3a",
+		"unknown":  "#9a8870",
+	}
+	for kind, want := range cases {
+		rec.Reset()
+		machine := vm.NewVM(prog, map[string]vm.Value{
+			"kind": vm.StringVal(kind),
+		})
+		machine.BindHost("c", rec)
+		machine.EvalWithFrame(handler.Body[0])
+		if len(rec.Calls) != 1 {
+			t.Errorf("kind=%q: got %d calls; want 1", kind, len(rec.Calls))
+			continue
+		}
+		if rec.Calls[0].Method != "SetFillStyle" {
+			t.Errorf("kind=%q: method = %q, want SetFillStyle", kind, rec.Calls[0].Method)
+		}
+		if rec.Calls[0].Args[0].Str != want {
+			t.Errorf("kind=%q: arg = %q, want %q", kind, rec.Calls[0].Args[0].Str, want)
+		}
+	}
+}
+
+// TestY_E_LabelTruncation reproduces graph_surface.go's
+// label-truncation idiom: `string([]rune(label)[:N]) + "…"`. Uses
+// rune-array semantics so multibyte characters count correctly.
+func TestY_E_LabelTruncation(t *testing.T) {
+	src := []byte(`package handlers
+
+func Trunc(label string, n int) string {
+	if len([]rune(label)) > n {
+		return string([]rune(label)[:n-2]) + "…"
+	}
+	return label
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Trunc")
+
+	cases := []struct {
+		label string
+		n     int
+		want  string
+	}{
+		{"hi", 5, "hi"},
+		{"héllo world", 6, "héll…"},
+		{"short", 10, "short"},
+	}
+	for _, tc := range cases {
+		machine := vm.NewVM(prog, map[string]vm.Value{
+			"label": vm.StringVal(tc.label),
+			"n":     vm.IntVal(tc.n),
+		})
+		got := machine.EvalWithFrame(handler.Body[0])
+		if got.Str != tc.want {
+			t.Errorf("Trunc(%q, %d) = %q, want %q", tc.label, tc.n, got.Str, tc.want)
+		}
+	}
+}
+
+// TestY_E_MakeMapInUserFn verifies a user function can call make()
+// internally and the caller observes the materialized map.
+func TestY_E_MakeMapInUserFn(t *testing.T) {
+	src := []byte(`package handlers
+
+func buildForces(n int) map[string]float64 {
+	m := make(map[string]float64, n)
+	m["a"] = 1.0
+	m["b"] = 2.0
+	return m
+}
+
+func F(n int) float64 {
+	fx := buildForces(n)
+	return fx["a"] + fx["b"]
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "F")
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"n": vm.IntVal(4),
+	})
+	got := machine.EvalWithFrame(handler.Body[0])
+	if got.Num != 3.0 {
+		t.Errorf("F(4) = %f, want 3.0 (1.0 + 2.0)", got.Num)
+	}
+}
+
+// TestY_E_StepLayoutKernel is the Y.E analog of Y.C's Tier-4 kernel
+// test: a stepwise distillation of graph_surface.go's stepLayout
+// integration loop. Exercises Y.A composite literals, Y.B comma-ok
+// map lookups, Y.C LHS index/field set, Y.D user-fn dispatch, AND
+// Y.E make() + host call.
+func TestY_E_StepLayoutKernel(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+type vec2 struct{ X, Y float64 }
+
+func updateVel(v vec2, fx float64, fy float64) vec2 {
+	v.X = (v.X + fx) * 0.82
+	v.Y = (v.Y + fy) * 0.82
+	return v
+}
+
+func Step(c *surface.Canvas, n int) int {
+	gPos := make(map[string]vec2, n)
+	gVel := make(map[string]vec2, n)
+	gPos["root"] = vec2{X: 100, Y: 200}
+	gVel["root"] = vec2{}
+
+	fx := make(map[string]float64, n)
+	fy := make(map[string]float64, n)
+	fx["root"] = 1.5
+	fy["root"] = -0.5
+
+	v := gVel["root"]
+	v = updateVel(v, fx["root"], fy["root"])
+	gVel["root"] = v
+
+	p := gPos["root"]
+	p.X = p.X + v.X
+	p.Y = p.Y + v.Y
+	gPos["root"] = p
+
+	c.SetFillStyle("debug")
+	return len(gPos)
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile: %v", err)
+	}
+	handler := findHandler(t, prog.Handlers, "Step")
+	rec := vm.NewHostRecorder()
+	machine := vm.NewVM(prog, map[string]vm.Value{
+		"n": vm.IntVal(4),
+	})
+	machine.BindHost("c", rec)
+	got := machine.EvalWithFrame(handler.Body[0])
+	if int(got.Num) != 1 {
+		t.Errorf("Step returned %d, want 1 (one node)", int(got.Num))
+	}
+	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
+		t.Errorf("expected one SetFillStyle host call; got %+v", rec.Calls)
+	}
+}

--- a/ir/golower/y_e_failure_modes_test.go
+++ b/ir/golower/y_e_failure_modes_test.go
@@ -1,0 +1,145 @@
+// Slice Y.E failure-mode tests. Pin diagnostic strings for the
+// Y.E-introduced rejection paths so a future refactor that changes
+// the wording fires a visible regression instead of silently swapping
+// out the author-facing message.
+
+package golower
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestFailureMode_MakeChannelType verifies that `make(chan T)` is
+// rejected with a diagnostic that points at the supported subset.
+// Channels are explicitly outside the engine-surface authoring
+// contract per the package-level golower.go doc.
+func TestFailureMode_MakeChannelType(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() {
+	ch := make(chan int)
+	_ = ch
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatal("LowerFile: expected diagnostic for make(chan int), got nil")
+	}
+	if !strings.Contains(err.Error(), "make") {
+		t.Errorf("diagnostic should mention make; got: %v", err)
+	}
+}
+
+// TestFailureMode_MakeNamedType verifies that `make(MyType)` is
+// rejected — only []T and map[K]V types are supported.
+func TestFailureMode_MakeNamedType(t *testing.T) {
+	src := []byte(`package handlers
+
+type MyMap map[string]float64
+
+func F() {
+	m := make(MyMap)
+	_ = m
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatal("LowerFile: expected diagnostic for make(MyMap), got nil")
+	}
+}
+
+// TestFailureMode_MakeWithoutArgs verifies the empty-args form
+// records the right diagnostic.
+func TestFailureMode_MakeWithoutArgs(t *testing.T) {
+	src := []byte(`package handlers
+
+func F() {
+	x := make
+	_ = x
+}`)
+	// "x := make" parses as a function-value assignment, not a call;
+	// the lowerer will reject it via lowerIdent → OpLocalGet which
+	// returns the zero value. The test pins that the case doesn't
+	// panic; an actual call without args is syntactically invalid in
+	// Go itself so the parser catches it before us.
+	_, _ = LowerFile(src)
+}
+
+// TestFailureMode_ArrayTypeCastWithFunkyElement verifies that
+// `[]float64(s)` (a slice cast that isn't []rune/[]byte) is rejected.
+func TestFailureMode_ArrayTypeCastWithFunkyElement(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(s string) int {
+	return len([]float64(s))
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatal("LowerFile: expected diagnostic for []float64(s), got nil")
+	}
+	if !strings.Contains(err.Error(), "rune") {
+		t.Errorf("diagnostic should suggest rune/byte; got: %v", err)
+	}
+}
+
+// TestFailureMode_SwitchFallthrough verifies that a switch case with
+// `fallthrough` records a diagnostic. The body still lowers (the
+// VM stays panic-free) but the author gets a clear pointer.
+func TestFailureMode_SwitchFallthrough(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(t string) int {
+	switch t {
+	case "a":
+		fallthrough
+	case "b":
+		return 1
+	default:
+		return 0
+	}
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatal("LowerFile: expected fallthrough diagnostic, got nil")
+	}
+	if !strings.Contains(err.Error(), "fallthrough") {
+		t.Errorf("diagnostic should mention fallthrough; got: %v", err)
+	}
+}
+
+// TestFailureMode_SliceExprThreeIndex verifies the three-index
+// slice form `s[i:j:k]` is rejected (cap is meaningless in the VM).
+func TestFailureMode_SliceExprThreeIndex(t *testing.T) {
+	src := []byte(`package handlers
+
+func F(s []int) []int {
+	return s[1:3:5]
+}`)
+	_, err := LowerFile(src)
+	if err == nil {
+		t.Fatal("LowerFile: expected diagnostic for s[i:j:k], got nil")
+	}
+	if !strings.Contains(err.Error(), "three-index") {
+		t.Errorf("diagnostic should mention three-index; got: %v", err)
+	}
+}
+
+// TestFailureMode_HostCallOnUnboundReceiverIsLoweringClean verifies
+// that lowering an OpHostCall succeeds even when no host is bound.
+// The runtime diagnostic (`host_unbound`) fires at evaluation time;
+// the lowerer doesn't need to know the host bindings.
+func TestFailureMode_HostCallOnUnboundReceiverIsLoweringClean(t *testing.T) {
+	src := []byte(`package handlers
+
+import "m31labs.dev/gosx/engine/surface"
+
+func F(c *surface.Canvas) {
+	c.Pretend()
+}`)
+	prog, err := LowerFile(src)
+	if err != nil {
+		t.Fatalf("LowerFile should succeed; got %v", err)
+	}
+	if prog == nil {
+		t.Fatal("expected a non-nil Program")
+	}
+}

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -314,6 +314,25 @@ const (
 	// Backwards-compatible per ADR 0002 — programs that never emit
 	// OpHostCall keep evaluating exactly as before.
 	OpHostCall
+
+	// String-to-rune-array conversion (Slice Y.E.3 — AST-compiler
+	// initiative). OpToRunes corresponds to Go's `[]rune(s)`
+	// conversion. The operand is a string Value; the result is an
+	// ArrayVal whose Items are one-rune StringVals (each containing
+	// exactly one UTF-8-encoded rune).
+	//
+	// This lets graph_surface.go's label truncation pattern
+	// (`len([]rune(label))` + `string([]rune(label)[:22])`) lower
+	// cleanly: OpLen on the resulting array gives the rune count,
+	// OpSlice gives a rune subsequence, and OpToString concatenates
+	// it back into a string (via the Y.E.3 ToStringVal join path).
+	//
+	//   Operands — Operands[0] evaluates to the source string.
+	//   Value    — unused.
+	//
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpToRunes keep evaluating exactly as before.
+	OpToRunes
 )
 
 // FuncDef defines a user-defined function callable from a handler or

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -282,6 +282,38 @@ const (
 	// Backwards-compatible per ADR 0002 — programs that never emit
 	// OpMake keep evaluating exactly as before.
 	OpMake
+
+	// Host-receiver method call (Slice Y.E — AST-compiler initiative).
+	// OpHostCall dispatches a method call into a runtime-bound host
+	// receiver — the engine-surface canvas, the surface context, or any
+	// other host-side object whose methods cannot be expressed as a pure
+	// Value transformation. Bound by the surface bootstrap via
+	// vm.BindHost(name, receiver).
+	//
+	//   Value    — qualified call target "<receiver>.<MethodName>"
+	//              (e.g., "c.MoveTo", "ctx.PropsInto"). The receiver
+	//              prefix is the source-level identifier the author
+	//              wrote, NOT a type name — multiple surfaces may bind
+	//              the same identifier to different concrete objects.
+	//   Operands — argument expressions, in source order, evaluated by
+	//              the VM left-to-right before the host call fires.
+	//
+	// The result is whatever the host receiver returns, as a Value. Void
+	// methods return the zero Value of TypeAny. Errors from the host
+	// receiver surface as `host_call_error` diagnostics — the VM stays
+	// panic-free.
+	//
+	// Unlike OpCall (stdlib intrinsics — global registry, pure
+	// functions), OpHostCall reaches into per-VM state: the bound
+	// receivers live on the VM struct, so each engine-surface instance
+	// has its own canvas/context bindings. This is the cleanest place
+	// to land the "host-supplied capability dispatch" surface that the
+	// engine-surface authoring contract has implicitly assumed since
+	// X.A but never had a first-class opcode for.
+	//
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpHostCall keep evaluating exactly as before.
+	OpHostCall
 )
 
 // FuncDef defines a user-defined function callable from a handler or

--- a/island/program/program.go
+++ b/island/program/program.go
@@ -260,6 +260,28 @@ const (
 	// Backwards-compatible per ADR 0002 — programs that never emit
 	// OpIndirectCall keep evaluating exactly as before.
 	OpIndirectCall
+
+	// make(...) builtin (Slice Y.E — AST-compiler initiative).
+	// OpMake allocates an empty collection: a fresh ObjectVal carrying a
+	// Fields map (for `make(map[K]V)`) or an ArrayVal carrying an Items
+	// slice (for `make([]T, n)`). Y.A's OpComposite handles populated
+	// composite literals; OpMake covers the explicit allocation form
+	// graph_surface.go's stepLayout uses to build per-tick force tables.
+	//
+	//   Value    — kind tag: "map" (always empty), "slice" (length-only)
+	//   Operands — for "slice", Operands[0] is the length expression
+	//              (cap is ignored — the VM has no capacity concept);
+	//              for "map", Operands is empty (the optional hint is
+	//              ignored, matching Go's runtime behavior).
+	//
+	// The lowerer detects `make(...)` BEFORE the user-function registry
+	// probe so a user can't accidentally shadow the builtin. Per Y.D's
+	// retrospective handoff, this lives alongside len/append/int/
+	// float64/string in lowerCallExpr's `switch id.Name` block.
+	//
+	// Backwards-compatible per ADR 0002 — programs that never emit
+	// OpMake keep evaluating exactly as before.
+	OpMake
 )
 
 // FuncDef defines a user-defined function callable from a handler or

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1256,6 +1256,7 @@ func TestIndirectCallOpcodeIsDistinct(t *testing.T) {
 		// Y.E (new)
 		OpMake,
 		OpHostCall,
+		OpToRunes,
 	}
 	seen := map[OpCode]bool{}
 	for _, op := range all {

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1255,6 +1255,7 @@ func TestIndirectCallOpcodeIsDistinct(t *testing.T) {
 		OpIndirectCall,
 		// Y.E (new)
 		OpMake,
+		OpHostCall,
 	}
 	seen := map[OpCode]bool{}
 	for _, op := range all {
@@ -1378,5 +1379,27 @@ func TestMakeOpcodeShape(t *testing.T) {
 	}
 	if len(sl.Operands) != 1 || sl.Operands[0] != 42 {
 		t.Errorf("OpMake(slice) Operands[0] carries the length expr, got %v", sl.Operands)
+	}
+}
+
+// TestHostCallOpcodeShape documents the operand encoding for OpHostCall
+// (Slice Y.E). The Value carries the qualified call target
+// "<receiver>.<MethodName>" — the receiver prefix is the source-level
+// identifier, NOT the receiver's type. Operands are the call args in
+// source order.
+func TestHostCallOpcodeShape(t *testing.T) {
+	call := Expr{
+		Op:       OpHostCall,
+		Value:    "c.MoveTo",
+		Operands: []ExprID{0, 1},
+	}
+	if call.Op != OpHostCall {
+		t.Errorf("opcode = %d, want OpHostCall", call.Op)
+	}
+	if call.Value != "c.MoveTo" {
+		t.Errorf("OpHostCall qualified target lives in Value, got %q", call.Value)
+	}
+	if len(call.Operands) != 2 {
+		t.Errorf("OpHostCall Operands carry the args; got len=%d", len(call.Operands))
 	}
 }

--- a/island/program/program_test.go
+++ b/island/program/program_test.go
@@ -1251,8 +1251,10 @@ func TestIndirectCallOpcodeIsDistinct(t *testing.T) {
 		OpSeq, OpAssign, OpLocalDecl, OpLocalGet, OpLocalSet,
 		OpFor, OpForRange, OpReturn, OpBreak, OpContinue,
 		OpComposite, OpMapLookup, OpFieldSet, OpIndexSet,
-		// Y.D (new)
+		// Y.D
 		OpIndirectCall,
+		// Y.E (new)
+		OpMake,
 	}
 	seen := map[OpCode]bool{}
 	for _, op := range all {
@@ -1350,5 +1352,31 @@ func TestProgramMaxCallDepthDefault(t *testing.T) {
 	}
 	if DefaultMaxCallDepth != 256 {
 		t.Errorf("DefaultMaxCallDepth = %d, want 256", DefaultMaxCallDepth)
+	}
+}
+
+// TestMakeOpcodeShape documents the operand encoding for the make()
+// builtin (Slice Y.E). Maps carry no operands (the optional capacity
+// hint is dropped at lowering time); slices carry the length expression
+// in Operands[0] (the optional cap argument is dropped). The kind tag
+// lives in Value — "map" or "slice".
+func TestMakeOpcodeShape(t *testing.T) {
+	mk := Expr{Op: OpMake, Value: "map"}
+	if mk.Op != OpMake {
+		t.Errorf("opcode = %d, want OpMake", mk.Op)
+	}
+	if mk.Value != "map" {
+		t.Errorf("OpMake kind tag lives in Value, got %q", mk.Value)
+	}
+	if len(mk.Operands) != 0 {
+		t.Errorf("OpMake(map) has no operands; got len=%d", len(mk.Operands))
+	}
+
+	sl := Expr{Op: OpMake, Value: "slice", Operands: []ExprID{42}}
+	if sl.Value != "slice" {
+		t.Errorf("OpMake(slice) kind tag = %q, want \"slice\"", sl.Value)
+	}
+	if len(sl.Operands) != 1 || sl.Operands[0] != 42 {
+		t.Errorf("OpMake(slice) Operands[0] carries the length expr, got %v", sl.Operands)
 	}
 }


### PR DESCRIPTION
## Summary

Slice Y.E of the VM AST-compiler initiative — closes the bulk of the
`gap-hyphae-graph-handlers` capability gap by adding:

- **`make()` builtin** via `OpMake` opcode (closes ~2 issues)
- **Canvas/Context method dispatch** via `OpHostCall` opcode + per-VM
  `HostReceiver` binding (closes ~33 canvas issues + 1 ctx.PropsInto)
- **SwitchStmt, SliceExpr, ArrayType cast, `&x` unary** lowering
  (closes the 3 plan-defined residuals + 1 collateral residual)

Lowering `~/work/hyphae/cmd/hypha-viz/graphsurface/graph_surface.go`
went from **40 issues (post-Y.D) → 1 issue (post-Y.E)**. The remaining
issue is a `*ast.FuncLit` closure (`c.StartLoop(func(dt float64) {...})`)
— closures are a Phase 4 "expression-language breadth" concern, deferred
to Y.G or a follow-up slice.

### Key design decisions

- **Single `OpHostCall` opcode** (Option B) over 33 method-specific
  opcodes (Option A) or intrinsic-registry reuse (Option C). The host
  dispatch is per-VM (each engine surface gets its own canvas binding),
  which the global intrinsic registry can't express. Method-specific
  opcodes would explode the opcode ladder; the open-set nature of
  canvas APIs makes a name-dispatched approach far better.

- **Receiver-name discrimination** via an `imports` pre-pass: stdlib
  package calls (`math.Sin`) route to `OpCall` intrinsics; non-package
  receivers (`c.MoveTo`) route to `OpHostCall`. This change converts
  the legacy "method calls on non-package receivers" rejection into
  a runtime-bound dispatch — interfaces lower cleanly now but require
  a runtime `BindHost` to actually fire.

- **`&x` lowers as pass-through**: composite Values are already
  reference-shared (Value.Fields/Items per Y.C/Y.D), so `&` has no
  additional opcode-level meaning. Documented as a Y.E.3 decision.

- **`[]rune(s)` via new `OpToRunes` opcode** + `ToStringVal` join path
  for `string(runeArray)` so the canonical
  `string([]rune(label)[:N]) + "…"` truncation works correctly with
  multibyte characters.

### TDD cadence

18 commits across the slice — matches Y.C/Y.D's cadence target. Each
commit is bisectable on a single behavior change (opcode add, VM eval,
lowerer dispatch, or end-to-end pattern).

### Benchmarks

- `OpMake(map)`: 96 ns/op, 1 alloc
- `OpMake(slice, 16)`: 370 ns/op, 1 alloc
- `OpHostCall(zero-arg)`: 92 ns/op, 0 allocs
- `OpHostCall(2 floats)`: 222 ns/op, 1 alloc
- 4-call edge-draw shape: 760 ns/op — at ~1000 host calls/frame for
  graph_surface.go, total ~0.76 ms (well within 16 ms 60fps budget)

## Test plan

- [x] All `ir/golower` tests pass (35+ new tests)
- [x] All `client/vm` tests pass (8 new tests + 5 benchmarks)
- [x] `island/program` opcode-ladder tests cover OpMake, OpHostCall, OpToRunes
- [x] End-to-end test lowers real `graph_surface.go` to 1 residual issue
- [x] Compositional tests exercise Y.A+Y.B+Y.C+Y.D+Y.E together
- [ ] Y.F SSIM parity test (separate slice — closes ADR 0005 clock)