### PR TITLE
add(engine/surface): Add exported HostCanvasImpl seam for out-of-package hosts

### DIFF
--- a/engine/surface/canvas_host_impl.go
+++ b/engine/surface/canvas_host_impl.go
@@ -1,0 +1,119 @@
+// Slice Y.F — exported CanvasImpl seam for out-of-package hosts.
+//
+// The package-internal CanvasImpl interface uses lowercase method names
+// (width/height/clearRect/...) so the only legal implementations are
+// inside the surface package — canvas_js.go (JS-side) and
+// canvas_stub_host.go (no-op). That's intentional for the production
+// pipeline: every real canvas binds through the JS bootstrap or the
+// in-process stub.
+//
+// However, the Slice Y.F SSIM parity test
+// (~/work/hyphae/cmd/hypha-viz/dogfood_parity_test.go) needs to drive
+// the native-Go execution of an engine surface's handler bodies against
+// a pure-Go rasterizer it owns. Hard-coding the rasterizer inside the
+// surface package would couple gosx to the hyphae test infrastructure;
+// re-exporting CanvasImpl with capitalized methods would force every
+// internal call site to rename. Neither is the right shape.
+//
+// Instead this file adds a one-page exported seam:
+//
+//   - HostCanvasImpl is an exported mirror of CanvasImpl with
+//     capitalized method names. Any out-of-package type that wants to
+//     impersonate a real canvas (for parity tests, CPU-side previews,
+//     server-side static rendering, …) satisfies this interface.
+//
+//   - NewCanvasFromHostImpl wraps a HostCanvasImpl into a *Canvas. The
+//     wrapper adapter translates the capitalized methods into the
+//     package-private interface so the rest of the surface package
+//     stays unchanged.
+//
+// This seam is additive only — production code paths (canvas_js.go,
+// stubImpl) are untouched.
+
+package surface
+
+// HostCanvasImpl is the exported mirror of the package-internal
+// CanvasImpl interface. Out-of-package hosts (parity tests,
+// preview renderers, server-side static rasterizers) implement this
+// interface and pass it through NewCanvasFromHostImpl to obtain a
+// *Canvas that engine-surface handlers can draw to.
+//
+// The method set mirrors CanvasImpl exactly, just capitalized.
+// StartLoop is omitted: hosts that want to drive a loop should do so
+// from the host side directly (calling stepLayout + draw in test code
+// per the Slice Y.E retrospective's Option F.b recommendation, since
+// FuncLit closures remain a Phase 4 expression-language gap).
+type HostCanvasImpl interface {
+	Width() int
+	Height() int
+	Clear()
+	ClearRect(x, y, w, h float64)
+	FillRect(x, y, w, h float64)
+	BeginPath()
+	MoveTo(x, y float64)
+	LineTo(x, y float64)
+	Arc(x, y, r, start, end float64)
+	Stroke()
+	Fill()
+	FillText(text string, x, y float64)
+	SetFillStyle(css string)
+	SetStrokeStyle(css string)
+	SetLineWidth(w float64)
+	SetFont(css string)
+	SetTextAlign(align string)
+	Save()
+	Restore()
+	Translate(x, y float64)
+	Scale(x, y float64)
+	Rotate(rad float64)
+	SetTransform(a, b, c2, d, e, f float64)
+	RequestFrame()
+}
+
+// hostImplAdapter wraps a HostCanvasImpl so it satisfies the
+// package-private CanvasImpl interface. Every method forwards to the
+// corresponding capitalized method on the host. startLoop is a no-op
+// in this adapter — see HostCanvasImpl's doc for the rationale.
+type hostImplAdapter struct {
+	h HostCanvasImpl
+}
+
+func (a *hostImplAdapter) width() int                                 { return a.h.Width() }
+func (a *hostImplAdapter) height() int                                { return a.h.Height() }
+func (a *hostImplAdapter) clear()                                     { a.h.Clear() }
+func (a *hostImplAdapter) clearRect(x, y, w, h float64)               { a.h.ClearRect(x, y, w, h) }
+func (a *hostImplAdapter) fillRect(x, y, w, h float64)                { a.h.FillRect(x, y, w, h) }
+func (a *hostImplAdapter) beginPath()                                 { a.h.BeginPath() }
+func (a *hostImplAdapter) moveTo(x, y float64)                        { a.h.MoveTo(x, y) }
+func (a *hostImplAdapter) lineTo(x, y float64)                        { a.h.LineTo(x, y) }
+func (a *hostImplAdapter) arc(x, y, r, start, end float64)            { a.h.Arc(x, y, r, start, end) }
+func (a *hostImplAdapter) stroke()                                    { a.h.Stroke() }
+func (a *hostImplAdapter) fill()                                      { a.h.Fill() }
+func (a *hostImplAdapter) fillText(text string, x, y float64)         { a.h.FillText(text, x, y) }
+func (a *hostImplAdapter) setFillStyle(css string)                    { a.h.SetFillStyle(css) }
+func (a *hostImplAdapter) setStrokeStyle(css string)                  { a.h.SetStrokeStyle(css) }
+func (a *hostImplAdapter) setLineWidth(w float64)                     { a.h.SetLineWidth(w) }
+func (a *hostImplAdapter) setFont(css string)                         { a.h.SetFont(css) }
+func (a *hostImplAdapter) setTextAlign(align string)                  { a.h.SetTextAlign(align) }
+func (a *hostImplAdapter) save()                                      { a.h.Save() }
+func (a *hostImplAdapter) restore()                                   { a.h.Restore() }
+func (a *hostImplAdapter) translate(x, y float64)                     { a.h.Translate(x, y) }
+func (a *hostImplAdapter) scale(x, y float64)                         { a.h.Scale(x, y) }
+func (a *hostImplAdapter) rotate(rad float64)                         { a.h.Rotate(rad) }
+func (a *hostImplAdapter) setTransform(p, q, c2, d, e, f float64)     { a.h.SetTransform(p, q, c2, d, e, f) }
+func (a *hostImplAdapter) requestFrame()                              { a.h.RequestFrame() }
+func (a *hostImplAdapter) startLoop(step func(dt float64))            { /* host drives the loop */ }
+
+// NewCanvasFromHostImpl returns a *Canvas whose drawing methods
+// forward to impl. The returned Canvas is fully usable by any
+// engine-surface handler — same observable behavior as the production
+// JS-backed canvas, just with the host's CPU-side implementation
+// instead of CanvasRenderingContext2D.
+//
+// Passing nil is treated like the host stub (returns a no-op canvas).
+func NewCanvasFromHostImpl(impl HostCanvasImpl) *Canvas {
+	if impl == nil {
+		return newNoopCanvas()
+	}
+	return &Canvas{impl: &hostImplAdapter{h: impl}}
+}

--- a/engine/surface/canvas_host_impl_test.go
+++ b/engine/surface/canvas_host_impl_test.go
@@ -1,0 +1,112 @@
+// Slice Y.F — coverage for the HostCanvasImpl exported seam.
+
+package surface
+
+import "testing"
+
+// recordingHost is a HostCanvasImpl that records every call. It is the
+// minimal proof that an out-of-package type can satisfy the exported
+// interface and be wired into a *Canvas — exactly what the hyphae
+// SSIM parity test needs.
+type recordingHost struct {
+	w, h  int
+	calls []string
+}
+
+func (r *recordingHost) Width() int                                  { return r.w }
+func (r *recordingHost) Height() int                                 { return r.h }
+func (r *recordingHost) Clear()                                      { r.calls = append(r.calls, "Clear") }
+func (r *recordingHost) ClearRect(x, y, w, h float64)                { r.calls = append(r.calls, "ClearRect") }
+func (r *recordingHost) FillRect(x, y, w, h float64)                 { r.calls = append(r.calls, "FillRect") }
+func (r *recordingHost) BeginPath()                                  { r.calls = append(r.calls, "BeginPath") }
+func (r *recordingHost) MoveTo(x, y float64)                         { r.calls = append(r.calls, "MoveTo") }
+func (r *recordingHost) LineTo(x, y float64)                         { r.calls = append(r.calls, "LineTo") }
+func (r *recordingHost) Arc(x, y, rad, s, e float64)                 { r.calls = append(r.calls, "Arc") }
+func (r *recordingHost) Stroke()                                     { r.calls = append(r.calls, "Stroke") }
+func (r *recordingHost) Fill()                                       { r.calls = append(r.calls, "Fill") }
+func (r *recordingHost) FillText(text string, x, y float64)          { r.calls = append(r.calls, "FillText") }
+func (r *recordingHost) SetFillStyle(css string)                     { r.calls = append(r.calls, "SetFillStyle") }
+func (r *recordingHost) SetStrokeStyle(css string)                   { r.calls = append(r.calls, "SetStrokeStyle") }
+func (r *recordingHost) SetLineWidth(w float64)                      { r.calls = append(r.calls, "SetLineWidth") }
+func (r *recordingHost) SetFont(css string)                          { r.calls = append(r.calls, "SetFont") }
+func (r *recordingHost) SetTextAlign(a string)                       { r.calls = append(r.calls, "SetTextAlign") }
+func (r *recordingHost) Save()                                       { r.calls = append(r.calls, "Save") }
+func (r *recordingHost) Restore()                                    { r.calls = append(r.calls, "Restore") }
+func (r *recordingHost) Translate(x, y float64)                      { r.calls = append(r.calls, "Translate") }
+func (r *recordingHost) Scale(x, y float64)                          { r.calls = append(r.calls, "Scale") }
+func (r *recordingHost) Rotate(rad float64)                          { r.calls = append(r.calls, "Rotate") }
+func (r *recordingHost) SetTransform(a, b, c, d, e, f float64)       { r.calls = append(r.calls, "SetTransform") }
+func (r *recordingHost) RequestFrame()                               { r.calls = append(r.calls, "RequestFrame") }
+
+func TestY_F_NewCanvasFromHostImplForwardsCalls(t *testing.T) {
+	host := &recordingHost{w: 400, h: 300}
+	c := NewCanvasFromHostImpl(host)
+	if c == nil {
+		t.Fatal("NewCanvasFromHostImpl returned nil")
+	}
+	if got := c.Width(); got != 400 {
+		t.Errorf("Width = %d, want 400", got)
+	}
+	if got := c.Height(); got != 300 {
+		t.Errorf("Height = %d, want 300", got)
+	}
+	c.Save()
+	c.Translate(10, 20)
+	c.Scale(2, 2)
+	c.SetFillStyle("#ff0000")
+	c.BeginPath()
+	c.MoveTo(0, 0)
+	c.LineTo(10, 10)
+	c.Arc(5, 5, 3, 0, 6.28)
+	c.Stroke()
+	c.Fill()
+	c.FillText("hello", 1, 2)
+	c.SetTextAlign("center")
+	c.SetStrokeStyle("#00ff00")
+	c.SetLineWidth(1.5)
+	c.SetFont("bold 11px sans-serif")
+	c.ClearRect(0, 0, 100, 100)
+	c.FillRect(0, 0, 50, 50)
+	c.Rotate(0.1)
+	c.SetTransform(1, 0, 0, 1, 0, 0)
+	c.RequestFrame()
+	c.Restore()
+	// StartLoop is intentionally not forwarded (the adapter no-ops it).
+	c.StartLoop(func(dt float64) { t.Fatal("step should not fire on host adapter") })
+
+	want := []string{
+		"Save", "Translate", "Scale", "SetFillStyle", "BeginPath",
+		"MoveTo", "LineTo", "Arc", "Stroke", "Fill", "FillText",
+		"SetTextAlign", "SetStrokeStyle", "SetLineWidth", "SetFont",
+		"ClearRect", "FillRect", "Rotate", "SetTransform",
+		"RequestFrame", "Restore",
+	}
+	if len(host.calls) != len(want) {
+		t.Fatalf("call count = %d, want %d (%v)", len(host.calls), len(want), host.calls)
+	}
+	for i, got := range host.calls {
+		if got != want[i] {
+			t.Errorf("call[%d] = %s, want %s", i, got, want[i])
+		}
+	}
+}
+
+// TestY_F_NewCanvasFromHostImplNilReturnsNoop ensures the nil-impl
+// fallback yields a usable Canvas instead of panicking, so test
+// harnesses that wire a Canvas before they have a rasterizer get the
+// stub behavior production code already relies on.
+func TestY_F_NewCanvasFromHostImplNilReturnsNoop(t *testing.T) {
+	c := NewCanvasFromHostImpl(nil)
+	if c == nil {
+		t.Fatal("nil host yielded nil Canvas; want noop fallback")
+	}
+	// All calls should no-op without panicking.
+	c.Save()
+	c.MoveTo(1, 2)
+	c.LineTo(3, 4)
+	c.Stroke()
+	c.Restore()
+	if c.Width() != 0 || c.Height() != 0 {
+		t.Errorf("noop canvas dims = (%d, %d), want (0, 0)", c.Width(), c.Height())
+	}
+}


### PR DESCRIPTION
- Introduce HostCanvasImpl exported interface mirroring internal CanvasImpl with capitalized methods
- Implement adapter to translate exported methods to internal package-private interface
- Provide NewCanvasFromHostImpl constructor to enable parity tests and CPU-side rendering without internal coupling
- Add tests verifying method call forwarding and nil-host fallback to noop canvas
