### PR TITLE
y g raf scheduler

### DIFF
--- a/client/vm/closure.go
+++ b/client/vm/closure.go
@@ -128,6 +128,22 @@ func (vm *VM) invokeClosureFromIndirectCall(cv Value, args []Value, e program.Ex
 	return result
 }
 
+// NewHostClosure constructs a ClosureVal for use cases where the
+// closure has no enclosing frame to capture against — primarily host-
+// side bridge tests that want to feed `c.StartLoop(closure)` a real
+// ClosureVal without going through OpClosure. funcName must name a
+// FuncDef registered in vm.funcs at invocation time; captured is the
+// list of captured-by-reference names (typically nil for host-test
+// closures with no enclosing scope). The returned Value satisfies
+// IsClosure and is dispatchable via vm.InvokeClosure.
+//
+// Production closures continue to be created exclusively by OpClosure
+// (see evalClosureExpr) so the captured-frame pointer reflects the
+// caller's live locals.
+func NewHostClosure(funcName string, captured []string) Value {
+	return ClosureVal(funcName, captured, nil)
+}
+
 // InvokeClosure is the public host-side hook to invoke a ClosureVal
 // the host captured (e.g. via c.StartLoop(cb)) at a later time. This
 // is the symmetric companion to BindHost — it lets a HostReceiver

--- a/engine/surface/vm_host.go
+++ b/engine/surface/vm_host.go
@@ -101,6 +101,37 @@ func NewCanvasHostReceiver(machine *vm.VM, canvas *Canvas) *CanvasHostReceiver {
 	return &CanvasHostReceiver{vm: machine, canvas: canvas}
 }
 
+// BindCanvas is the convenience helper future bytecode-VM hydration
+// paths will use: it constructs a CanvasHostReceiver, binds it under
+// name (conventionally "c") on the VM, and spawns a single watcher
+// goroutine that calls Dispose when ctx is torn down.
+//
+// Returns the receiver so callers can drive RunFrames in tests or
+// hold a reference for explicit teardown. ctx may be nil — callers
+// that own their teardown can omit the watcher and call Dispose
+// directly.
+//
+// This is the natural "wire it once" entry point; both sides
+// (StartLoop closure capture + Dispose-on-dismount) are handled
+// together so future hydration code doesn't have to remember the
+// dispose hook.
+func BindCanvas(machine *vm.VM, name string, canvas *Canvas, ctx *Context) *CanvasHostReceiver {
+	recv := NewCanvasHostReceiver(machine, canvas)
+	if machine != nil {
+		machine.BindHost(name, recv)
+	}
+	if ctx != nil {
+		go func() {
+			<-ctx.Done()
+			recv.Dispose()
+			if machine != nil {
+				machine.BindHost(name, nil)
+			}
+		}()
+	}
+	return recv
+}
+
 // Call satisfies vm.HostReceiver. The method name comes from the
 // source-level `c.<Method>` call as it was lowered by Y.E's host-call
 // path. Argument values are pre-evaluated by the VM.

--- a/engine/surface/vm_host.go
+++ b/engine/surface/vm_host.go
@@ -1,0 +1,285 @@
+// Package surface — VM-side canvas host receiver bridge (v0.22.1).
+//
+// CanvasHostReceiver is the production glue that finally makes
+// `c.StartLoop(func(dt float64) { ... })` run per-frame when a surface
+// handler executes as shared-VM bytecode (the path Y.G unlocked).
+//
+// # The handoff chain
+//
+// 1. The bytecode handler lowers to OpHostCall("c.StartLoop", [closure])
+//    where `closure` evaluates to a vm.ClosureVal carrying the
+//    synthetic FuncDef name and a captured-frame pointer (Y.G).
+// 2. The VM dispatches OpHostCall into the receiver bound under "c" —
+//    this CanvasHostReceiver.
+// 3. CanvasHostReceiver.Call("StartLoop", [closure]) wraps the
+//    ClosureVal in a Go `func(dt float64)` that calls
+//    vm.InvokeClosure(closure, [vm.FloatVal(dt)]) and hands the wrapped
+//    Go closure to the underlying *Canvas.StartLoop. From there:
+//
+//      - On WASM (canvas_js.go): startLoop stores the step fn and
+//        kicks the JS rAF loop via __gosx_surface_request_frame, which
+//        cycles back as __gosx_surface_frame → Canvas.TickFrame →
+//        stepFn(dt). vm.InvokeClosure runs on the WASM main thread
+//        (same goroutine as the JS callback under the Go wasm runtime),
+//        so the captured-by-reference frame remains valid.
+//
+//      - On host/stub (canvas_stub_host.go): the underlying startLoop
+//        is a no-op (no browser to schedule against). Tests drive the
+//        loop manually by calling RunFrames(n) on the receiver, which
+//        directly invokes the bound closure n times against a
+//        synthetic monotonic clock.
+//
+// # Cleanup contract
+//
+// Dispose() (called by the surface runtime on dismount — see
+// runtime/canvas_js.go's __gosx_surface_dispose handler) drops the
+// stored closure reference and clears the canvas step fn so the
+// captured VM frame can be GC'd. Idempotent: calling Dispose twice is
+// safe; a subsequent StartLoop is also legal (and the host receiver
+// is re-usable).
+//
+// # Idempotent restart
+//
+// Calling StartLoop twice replaces the prior closure. The canvas-side
+// stepFn pointer is overwritten in lockstep, so the rAF callback only
+// ever invokes the most recently-registered closure. This matches the
+// Canvas.StartLoop contract documented in surface.go.
+//
+// # Why not extend HostCanvasImpl
+//
+// HostCanvasImpl (canvas_host_impl.go) is the test-time CPU rasterizer
+// seam Y.F added — it deliberately omits startLoop because hosts
+// drive their own loop. The CanvasHostReceiver lives one level up: it
+// adapts a *Canvas (which DOES carry a startLoop method that already
+// wires the rAF path on WASM) to the vm.HostReceiver contract, so the
+// VM-driven path benefits from the existing rAF plumbing without
+// duplicating it.
+
+package surface
+
+import (
+	"fmt"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// CanvasHostReceiver bridges a *Canvas to the vm.HostReceiver
+// interface so bytecode handlers can call canvas methods (including
+// the closure-bearing StartLoop) via OpHostCall.
+//
+// Construct one per surface mount via NewCanvasHostReceiver and bind
+// it under the surface author's chosen identifier ("c" by convention):
+//
+//	recv := surface.NewCanvasHostReceiver(machine, canvas)
+//	machine.BindHost("c", recv)
+//
+// On surface dismount, call recv.Dispose() to drop the loop closure
+// reference and clear the canvas step function — this prevents the
+// captured VM frame from being kept alive by the rAF schedule.
+type CanvasHostReceiver struct {
+	vm     *vm.VM
+	canvas *Canvas
+
+	// loop holds the most recently-registered animation-loop closure,
+	// or the zero Value when no loop is active. We keep it explicitly
+	// (rather than only inside the canvas.stepFn) so HasLoop() and
+	// RunFrames() have a single source of truth for the active state.
+	loop vm.Value
+}
+
+// NewCanvasHostReceiver wraps machine + canvas as a vm.HostReceiver
+// suitable for the surface author's canvas parameter binding.
+//
+// Either argument may be nil; nil canvas falls back to a no-op canvas
+// (StartLoop accepts the closure but no rAF schedule is ever kicked).
+// Nil machine causes StartLoop to record a "no VM bound" error per
+// the panic-free engine-surface contract.
+func NewCanvasHostReceiver(machine *vm.VM, canvas *Canvas) *CanvasHostReceiver {
+	if canvas == nil {
+		canvas = newNoopCanvas()
+	}
+	return &CanvasHostReceiver{vm: machine, canvas: canvas}
+}
+
+// Call satisfies vm.HostReceiver. The method name comes from the
+// source-level `c.<Method>` call as it was lowered by Y.E's host-call
+// path. Argument values are pre-evaluated by the VM.
+//
+// StartLoop is the only method that consumes a ClosureVal arg; every
+// other canvas method is forwarded to the underlying *Canvas via
+// dispatchCanvasMethod. Unknown methods surface as
+// "unknown method <name>" errors which the VM records as a
+// host_call_error diagnostic.
+func (r *CanvasHostReceiver) Call(method string, args []vm.Value) (vm.Value, error) {
+	if method == "StartLoop" {
+		return r.startLoop(args)
+	}
+	return r.dispatchCanvasMethod(method, args)
+}
+
+// startLoop is the closure-bearing dispatch: validate args, wrap the
+// ClosureVal in a Go func(dt) that invokes it via vm.InvokeClosure,
+// and hand the wrapped closure to canvas.StartLoop so the existing
+// rAF schedule picks it up.
+//
+// Idempotency: replacing the previous closure here also overwrites
+// the canvas.stepFn (canvas_js.go: startLoop sets c.stepFn = step),
+// so subsequent __gosx_surface_frame ticks invoke only the latest
+// closure. The previous closure's captured frame becomes eligible for
+// GC as soon as the host drops its reference (i.e., this assignment).
+func (r *CanvasHostReceiver) startLoop(args []vm.Value) (vm.Value, error) {
+	if len(args) != 1 {
+		return vm.ZeroValue(0), fmt.Errorf("StartLoop expects 1 arg, got %d", len(args))
+	}
+	cv := args[0]
+	if !vm.IsClosure(cv) {
+		return vm.ZeroValue(0), fmt.Errorf("StartLoop arg must be a closure, got %v", cv.Type)
+	}
+	if r.vm == nil {
+		return vm.ZeroValue(0), fmt.Errorf("StartLoop: no VM bound to host receiver")
+	}
+
+	r.loop = cv
+	machine := r.vm
+	step := func(dt float64) {
+		machine.InvokeClosure(cv, []vm.Value{vm.FloatVal(dt)})
+	}
+	r.canvas.impl.startLoop(step)
+	return vm.ZeroValue(0), nil
+}
+
+// HasLoop reports whether StartLoop has been called with a valid
+// closure that hasn't yet been cleared by Dispose. Primarily a test
+// observability hook; production callers should not need this.
+func (r *CanvasHostReceiver) HasLoop() bool {
+	return vm.IsClosure(r.loop)
+}
+
+// Dispose cancels the active animation loop (if any) by clearing the
+// canvas step function and dropping the receiver's closure reference.
+// Called by the surface runtime when the canvas element is detached
+// from the DOM (__gosx_surface_dispose path) to prevent the closure
+// from keeping the captured VM frame alive past surface teardown.
+//
+// Idempotent: safe to call multiple times. After Dispose, a fresh
+// StartLoop call re-arms the loop (the receiver is re-usable).
+func (r *CanvasHostReceiver) Dispose() {
+	r.loop = vm.Value{}
+	if r.canvas != nil {
+		// SetStepFn is the existing exported seam on Canvas that
+		// canvas_js.go uses to install the step fn. Setting it to nil
+		// makes TickFrame a no-op for any pending rAF callbacks.
+		r.canvas.SetStepFn(nil)
+	}
+}
+
+// RunFrames synchronously invokes the bound animation loop closure n
+// times with a synthetic monotonically-increasing dt. Intended for
+// host-side unit tests of bytecode handlers (where there is no
+// browser to schedule rAF callbacks). Returns immediately if no loop
+// is active.
+//
+// Each frame's dt is the elapsed time since the previous RunFrames
+// invocation in the same call (frame 0 dt = 0, frame i dt =
+// frameDuration for i > 0). This matches the canvas_js.go contract
+// where TickFrame computes dt = ts - lastTS and the first frame
+// records 0.
+//
+// On WASM, the production rAF path drives invocations directly via
+// canvas.TickFrame; this method is not used in the browser.
+func (r *CanvasHostReceiver) RunFrames(n int) {
+	if n <= 0 || !r.HasLoop() || r.vm == nil {
+		return
+	}
+	const frameDuration = 1.0 / 60.0 // seconds (~16.67ms at 60fps)
+	for i := 0; i < n; i++ {
+		dt := frameDuration
+		if i == 0 {
+			dt = 0
+		}
+		r.vm.InvokeClosure(r.loop, []vm.Value{vm.FloatVal(dt)})
+	}
+}
+
+// dispatchCanvasMethod handles non-StartLoop calls against the
+// underlying canvas. The dispatch table mirrors the public methods on
+// *Canvas; methods that return a Value (Width, Height) wrap the
+// result in vm.IntVal, void methods return the zero Value.
+//
+// The set is deliberately conservative: only methods authors actually
+// call from a bytecode-lowered handler need an entry here. Adding a
+// new method is a one-line case in the switch. Unknown methods
+// surface as an error which the VM records as host_call_error.
+func (r *CanvasHostReceiver) dispatchCanvasMethod(method string, args []vm.Value) (vm.Value, error) {
+	c := r.canvas
+	switch method {
+	case "Width":
+		return vm.IntVal(c.Width()), nil
+	case "Height":
+		return vm.IntVal(c.Height()), nil
+	case "Clear":
+		c.Clear()
+	case "ClearRect":
+		c.ClearRect(arg(args, 0), arg(args, 1), arg(args, 2), arg(args, 3))
+	case "FillRect":
+		c.FillRect(arg(args, 0), arg(args, 1), arg(args, 2), arg(args, 3))
+	case "BeginPath":
+		c.BeginPath()
+	case "MoveTo":
+		c.MoveTo(arg(args, 0), arg(args, 1))
+	case "LineTo":
+		c.LineTo(arg(args, 0), arg(args, 1))
+	case "Arc":
+		c.Arc(arg(args, 0), arg(args, 1), arg(args, 2), arg(args, 3), arg(args, 4))
+	case "Stroke":
+		c.Stroke()
+	case "Fill":
+		c.Fill()
+	case "FillText":
+		c.FillText(argStr(args, 0), arg(args, 1), arg(args, 2))
+	case "SetFillStyle":
+		c.SetFillStyle(argStr(args, 0))
+	case "SetStrokeStyle":
+		c.SetStrokeStyle(argStr(args, 0))
+	case "SetLineWidth":
+		c.SetLineWidth(arg(args, 0))
+	case "SetFont":
+		c.SetFont(argStr(args, 0))
+	case "SetTextAlign":
+		c.SetTextAlign(argStr(args, 0))
+	case "Save":
+		c.Save()
+	case "Restore":
+		c.Restore()
+	case "Translate":
+		c.Translate(arg(args, 0), arg(args, 1))
+	case "Scale":
+		c.Scale(arg(args, 0), arg(args, 1))
+	case "Rotate":
+		c.Rotate(arg(args, 0))
+	case "SetTransform":
+		c.SetTransform(arg(args, 0), arg(args, 1), arg(args, 2), arg(args, 3), arg(args, 4), arg(args, 5))
+	case "RequestFrame":
+		c.RequestFrame()
+	default:
+		return vm.ZeroValue(0), fmt.Errorf("unknown canvas method %q", method)
+	}
+	return vm.ZeroValue(0), nil
+}
+
+// arg returns args[i].Num or 0 if i is out of range. Centralizes the
+// bounds-tolerance contract so each dispatch case stays one line.
+func arg(args []vm.Value, i int) float64 {
+	if i < 0 || i >= len(args) {
+		return 0
+	}
+	return args[i].Num
+}
+
+// argStr returns args[i].Str or "" if i is out of range.
+func argStr(args []vm.Value, i int) string {
+	if i < 0 || i >= len(args) {
+		return ""
+	}
+	return args[i].Str
+}

--- a/engine/surface/vm_host_e2e_test.go
+++ b/engine/surface/vm_host_e2e_test.go
@@ -1,0 +1,92 @@
+// End-to-end proof: a VM dispatches OpHostCall("c.StartLoop", [closure])
+// through CanvasHostReceiver, and the receiver-installed step fn
+// drives the closure via the same path canvas_js.go's TickFrame uses
+// on WASM.
+//
+// This stops short of importing ir/golower (which would create an
+// import cycle since engine/surface already depends on it). Instead
+// we construct a Program by hand whose shape matches what the lowerer
+// emits for `c.StartLoop(func(dt float64) { rec.Tick(dt) })`. That
+// keeps the test focused on the OpHostCall → CanvasHostReceiver →
+// canvas.startLoop hand-off rather than re-testing the lowerer.
+
+package surface
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestCanvasHostReceiver_E2E_OpHostCallDispatchAndStep proves the
+// full round-trip:
+//
+//   1. Lowerer emits OpHostCall("c.StartLoop", [OpClosure ...]) (we
+//      construct this by hand).
+//   2. VM evaluates the OpHostCall → CanvasHostReceiver.Call.
+//   3. Receiver wraps the ClosureVal in a Go func(dt) and installs it
+//      on the canvas.
+//   4. Driving the canvas-installed step fn (what TickFrame does on
+//      WASM) invokes the closure via vm.InvokeClosure, which records
+//      ticks against the bound recorder.
+func TestCanvasHostReceiver_E2E_OpHostCallDispatchAndStep(t *testing.T) {
+	// Synthetic FuncDef body: `OpHostCall("rec.Tick", [OpLocalGet("dt")])`
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "dt"},                                            // 0
+			{Op: program.OpHostCall, Value: "rec.Tick", Operands: []program.ExprID{0}},       // 1
+			{Op: program.OpClosure, Value: "__e2e_synth_closure"},                            // 2
+			{Op: program.OpHostCall, Value: "c.StartLoop", Operands: []program.ExprID{2}},    // 3
+		},
+		Funcs: []program.FuncDef{
+			{Name: "__e2e_synth_closure", Params: []string{"dt"}, Body: []program.ExprID{1}},
+		},
+		Handlers: []program.Handler{
+			{Name: "Mount", Body: []program.ExprID{3}},
+		},
+	}
+
+	machine := vm.NewVM(prog, nil)
+
+	// Bind the recording host first so the closure body's
+	// OpHostCall("rec.Tick", ...) has a target.
+	var ticks []float64
+	machine.BindHost("rec", &tickRecorder{ticks: &ticks})
+
+	// Bind the canvas host receiver under "c" via the convenience
+	// helper; nil ctx — explicit Dispose at end of test.
+	canvasRec := &recordingCanvasImpl{}
+	canvas := &Canvas{impl: canvasRec}
+	recv := BindCanvas(machine, "c", canvas, nil)
+	defer recv.Dispose()
+
+	// Drive the Mount handler: this evaluates the OpHostCall that
+	// hands the closure to c.StartLoop.
+	machine.EvalWithFrame(prog.Handlers[0].Body[0])
+
+	if !recv.HasLoop() {
+		t.Fatal("HasLoop = false after Mount; OpHostCall(c.StartLoop) did not install closure")
+	}
+	if canvasRec.stepFn == nil {
+		t.Fatal("canvas step fn nil after Mount; CanvasHostReceiver did not call canvas.startLoop")
+	}
+
+	// Now drive the canvas step the way __gosx_surface_frame /
+	// TickFrame would on WASM. Each step must dispatch through
+	// vm.InvokeClosure into the synthetic FuncDef body, which fires
+	// rec.Tick(dt).
+	canvasRec.stepFn(0.016)
+	canvasRec.stepFn(0.020)
+	canvasRec.stepFn(0.018)
+
+	if got := len(ticks); got != 3 {
+		t.Fatalf("rec.Tick called %d times after 3 step-fn invocations; want 3", got)
+	}
+	wantDTs := []float64{0.016, 0.020, 0.018}
+	for i, want := range wantDTs {
+		if ticks[i] != want {
+			t.Errorf("tick[%d] dt = %v, want %v", i, ticks[i], want)
+		}
+	}
+}

--- a/engine/surface/vm_host_test.go
+++ b/engine/surface/vm_host_test.go
@@ -20,6 +20,7 @@
 package surface
 
 import (
+	"runtime"
 	"testing"
 
 	"m31labs.dev/gosx/client/vm"
@@ -235,6 +236,49 @@ func TestCanvasHostReceiver_StartLoopRejectsBadArity(t *testing.T) {
 	}
 	if recv.HasLoop() {
 		t.Errorf("HasLoop = true after rejected calls; want false")
+	}
+}
+
+// TestBindCanvas_DisposeOnContextClose verifies that the BindCanvas
+// convenience helper correctly cancels the loop and unbinds the host
+// receiver from the VM when the surface context is closed.
+func TestBindCanvas_DisposeOnContextClose(t *testing.T) {
+	machine, ticks := newTestVMWithFunc(t, "__test_bind_dispose")
+	ctx := NewContext(nil)
+
+	recv := BindCanvas(machine, "c", newNoopCanvas(), ctx)
+
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("__test_bind_dispose")}); err != nil {
+		t.Fatalf("StartLoop: %v", err)
+	}
+	recv.RunFrames(2)
+	if len(*ticks) != 2 {
+		t.Fatalf("pre-close ticks = %d, want 2", len(*ticks))
+	}
+
+	// Verify the host is bound under "c".
+	if got, ok := machine.LookupHost("c"); !ok || got == nil {
+		t.Fatal("host receiver not bound under 'c' after BindCanvas")
+	}
+
+	// Closing the context fires the watcher goroutine; give it a
+	// moment to run.
+	ctx.Close()
+	// Synchronization without sleeps: poll the receiver state via
+	// the (already-tested) HasLoop / LookupHost contract.
+	for i := 0; i < 100; i++ {
+		_, bound := machine.LookupHost("c")
+		if !recv.HasLoop() && !bound {
+			break
+		}
+		runtime.Gosched()
+	}
+
+	if recv.HasLoop() {
+		t.Errorf("HasLoop = true after ctx.Close; want false (Dispose must drop closure)")
+	}
+	if _, bound := machine.LookupHost("c"); bound {
+		t.Errorf("host receiver still bound after ctx.Close; want unbound")
 	}
 }
 

--- a/engine/surface/vm_host_test.go
+++ b/engine/surface/vm_host_test.go
@@ -282,6 +282,60 @@ func TestBindCanvas_DisposeOnContextClose(t *testing.T) {
 	}
 }
 
+// TestCanvasHostReceiver_StepFnInstalledOnCanvas pins the key
+// production contract: StartLoop must install the wrapped Go closure
+// as the canvas's step function via the package-internal startLoop
+// path. On WASM, this is the hook __gosx_surface_frame → TickFrame
+// reads — so installing it correctly is what makes the rAF loop
+// actually drive the closure each frame in the browser. Here we
+// observe the install via a recording canvas impl.
+func TestCanvasHostReceiver_StepFnInstalledOnCanvas(t *testing.T) {
+	machine, ticks := newTestVMWithFunc(t, "__test_install")
+	rec := &recordingCanvasImpl{}
+	canvas := &Canvas{impl: rec}
+	recv := NewCanvasHostReceiver(machine, canvas)
+
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("__test_install")}); err != nil {
+		t.Fatalf("StartLoop: %v", err)
+	}
+	if rec.stepFn == nil {
+		t.Fatal("CanvasHostReceiver did not install a step fn on the canvas")
+	}
+
+	// Drive the installed step fn directly, mimicking what
+	// __gosx_surface_frame would do via canvas.TickFrame on WASM:
+	// the step fn must dispatch through vm.InvokeClosure into the
+	// captured ClosureVal.
+	rec.stepFn(0.016)
+	rec.stepFn(0.033)
+	if len(*ticks) != 2 {
+		t.Fatalf("ticks after 2 rAF-style invocations = %d, want 2", len(*ticks))
+	}
+	if (*ticks)[0] != 0.016 || (*ticks)[1] != 0.033 {
+		t.Errorf("step fn delivered dts %v, want [0.016 0.033]", *ticks)
+	}
+
+	// Dispose drops the receiver-held closure so future RunFrames
+	// is a no-op (HasLoop returns false). Clearing the canvas-side
+	// stepFn is a WASM-only contract via SetStepFn (canvas_js.go's
+	// TickFrame guards on stepFn != nil); on host builds the canvas
+	// step is irrelevant because no rAF loop runs.
+	recv.Dispose()
+	if recv.HasLoop() {
+		t.Error("Dispose did not drop receiver closure")
+	}
+}
+
+// recordingCanvasImpl is a stubImpl-shaped canvas impl that records
+// the step function passed to startLoop so the test above can drive
+// it the way __gosx_surface_frame does on WASM.
+type recordingCanvasImpl struct {
+	stubImpl
+	stepFn func(dt float64)
+}
+
+func (r *recordingCanvasImpl) startLoop(step func(dt float64)) { r.stepFn = step }
+
 // TestCanvasHostReceiver_DispatchesCanvasMethods verifies that the
 // receiver forwards regular canvas method calls (Width/Height/...) to
 // the wrapped *Canvas rather than treating them as unknown methods.

--- a/engine/surface/vm_host_test.go
+++ b/engine/surface/vm_host_test.go
@@ -1,0 +1,264 @@
+// Slice v0.22.1 — VM-side canvas host receiver tests.
+//
+// These tests pin the contract for NewCanvasHostReceiver: the bridge
+// that takes a *vm.VM + *Canvas, exposes itself as a vm.HostReceiver,
+// and translates the bytecode-side `c.StartLoop(closure)` into the
+// existing Canvas.startLoop machinery (which on WASM rides the
+// __gosx_surface_request_frame / __gosx_surface_frame rAF path, and
+// on host stubs is driven by RunFrames).
+//
+// The TDD failing-first commit pins:
+//   1. StartLoop accepts a ClosureVal and stores it as the canvas step.
+//   2. RunFrames(n) invokes the bound closure n times with monotonic dt.
+//   3. Calling StartLoop a second time replaces the prior closure
+//      (idempotent restart).
+//   4. Dispose drops the closure reference so leaked closures don't
+//      keep VM frames live.
+//   5. Unknown methods surface as host_call_error diagnostics on the
+//      caller's VM, not panics.
+
+package surface
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/island/program"
+)
+
+// newTestVMWithFunc builds a minimal VM whose only synthetic FuncDef
+// pushes a marker into a captured slice each time it runs. Returns the
+// VM plus a pointer to the marker slice so tests can assert call count.
+func newTestVMWithFunc(t *testing.T, funcName string) (*vm.VM, *[]float64) {
+	t.Helper()
+	// The FuncDef body increments a captured counter via OpHostCall
+	// against a recorder bound under "rec". Body: rec.Tick(dt).
+	// Expr ids: 0 = OpLocalGet("dt"), 1 = OpHostCall("rec.Tick", [0]).
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "dt"},
+			{Op: program.OpHostCall, Value: "rec.Tick", Operands: []program.ExprID{0}},
+		},
+		Funcs: []program.FuncDef{
+			{Name: funcName, Params: []string{"dt"}, Body: []program.ExprID{1}},
+		},
+	}
+	machine := vm.NewVM(prog, nil)
+	ticks := &[]float64{}
+	machine.BindHost("rec", &tickRecorder{ticks: ticks})
+	return machine, ticks
+}
+
+// tickRecorder is a HostReceiver that appends the first arg as a
+// float64 to its ticks slice each time Tick is called.
+type tickRecorder struct {
+	ticks *[]float64
+}
+
+func (r *tickRecorder) Call(method string, args []vm.Value) (vm.Value, error) {
+	if method == "Tick" && len(args) == 1 {
+		*r.ticks = append(*r.ticks, args[0].Num)
+	}
+	return vm.ZeroValue(program.TypeAny), nil
+}
+
+// closureForFunc constructs a ClosureVal pointing at the named
+// synthetic FuncDef. Used by tests to feed StartLoop a real closure
+// without going through the lowerer.
+func closureForFunc(name string) vm.Value {
+	return vm.NewHostClosure(name, nil)
+}
+
+// TestCanvasHostReceiver_StartLoopStoresClosure verifies that calling
+// StartLoop with a ClosureVal arg stores it as the canvas's step
+// function (observable via RunFrames).
+func TestCanvasHostReceiver_StartLoopStoresClosure(t *testing.T) {
+	machine, ticks := newTestVMWithFunc(t, "__test_step_1")
+	canvas := newNoopCanvas()
+	recv := NewCanvasHostReceiver(machine, canvas)
+
+	cv := closureForFunc("__test_step_1")
+	if _, err := recv.Call("StartLoop", []vm.Value{cv}); err != nil {
+		t.Fatalf("StartLoop returned error: %v", err)
+	}
+
+	if recv.HasLoop() != true {
+		t.Fatalf("HasLoop = false after StartLoop; want true")
+	}
+
+	recv.RunFrames(3)
+	if got := len(*ticks); got != 3 {
+		t.Fatalf("ticks count = %d, want 3 (closure should run on each RunFrames)", got)
+	}
+}
+
+// TestCanvasHostReceiver_RunFramesDeltaMonotonic verifies the dt
+// argument passed to the closure grows monotonically (each frame
+// reports a positive elapsed-time delta).
+func TestCanvasHostReceiver_RunFramesDeltaMonotonic(t *testing.T) {
+	machine, ticks := newTestVMWithFunc(t, "__test_step_2")
+	canvas := newNoopCanvas()
+	recv := NewCanvasHostReceiver(machine, canvas)
+
+	cv := closureForFunc("__test_step_2")
+	if _, err := recv.Call("StartLoop", []vm.Value{cv}); err != nil {
+		t.Fatalf("StartLoop returned error: %v", err)
+	}
+	recv.RunFrames(4)
+
+	if len(*ticks) != 4 {
+		t.Fatalf("ticks count = %d, want 4", len(*ticks))
+	}
+	// First tick is the zero-delta frame (no prior timestamp). Subsequent
+	// ticks must be strictly positive (RunFrames advances the synthetic
+	// clock by one frame each call).
+	if (*ticks)[0] != 0 {
+		t.Errorf("first tick dt = %v, want 0", (*ticks)[0])
+	}
+	for i := 1; i < len(*ticks); i++ {
+		if (*ticks)[i] <= 0 {
+			t.Errorf("tick[%d] dt = %v, want > 0", i, (*ticks)[i])
+		}
+	}
+}
+
+// TestCanvasHostReceiver_StartLoopIdempotent verifies that calling
+// StartLoop a second time replaces the prior closure rather than
+// running both: the second closure must be the one RunFrames invokes.
+func TestCanvasHostReceiver_StartLoopIdempotent(t *testing.T) {
+	prog := &program.Program{
+		Exprs: []program.Expr{
+			{Op: program.OpLocalGet, Value: "dt"},
+			{Op: program.OpHostCall, Value: "rec.TickA", Operands: []program.ExprID{0}},
+			{Op: program.OpHostCall, Value: "rec.TickB", Operands: []program.ExprID{0}},
+		},
+		Funcs: []program.FuncDef{
+			{Name: "__test_first", Params: []string{"dt"}, Body: []program.ExprID{1}},
+			{Name: "__test_second", Params: []string{"dt"}, Body: []program.ExprID{2}},
+		},
+	}
+	machine := vm.NewVM(prog, nil)
+	var aTicks, bTicks []float64
+	machine.BindHost("rec", &abRecorder{a: &aTicks, b: &bTicks})
+
+	recv := NewCanvasHostReceiver(machine, newNoopCanvas())
+
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("__test_first")}); err != nil {
+		t.Fatalf("first StartLoop: %v", err)
+	}
+	recv.RunFrames(1)
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("__test_second")}); err != nil {
+		t.Fatalf("second StartLoop: %v", err)
+	}
+	recv.RunFrames(2)
+
+	if len(aTicks) != 1 {
+		t.Errorf("first closure tick count = %d, want 1 (run once before swap)", len(aTicks))
+	}
+	if len(bTicks) != 2 {
+		t.Errorf("second closure tick count = %d, want 2 (post-swap)", len(bTicks))
+	}
+}
+
+type abRecorder struct {
+	a, b *[]float64
+}
+
+func (r *abRecorder) Call(method string, args []vm.Value) (vm.Value, error) {
+	if len(args) != 1 {
+		return vm.ZeroValue(program.TypeAny), nil
+	}
+	switch method {
+	case "TickA":
+		*r.a = append(*r.a, args[0].Num)
+	case "TickB":
+		*r.b = append(*r.b, args[0].Num)
+	}
+	return vm.ZeroValue(program.TypeAny), nil
+}
+
+// TestCanvasHostReceiver_DisposeDropsClosure verifies that Dispose
+// cancels the loop and drops the closure reference so it doesn't keep
+// the captured VM frames alive past surface teardown.
+func TestCanvasHostReceiver_DisposeDropsClosure(t *testing.T) {
+	machine, ticks := newTestVMWithFunc(t, "__test_dispose")
+	recv := NewCanvasHostReceiver(machine, newNoopCanvas())
+
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("__test_dispose")}); err != nil {
+		t.Fatalf("StartLoop: %v", err)
+	}
+	recv.RunFrames(2)
+	if len(*ticks) != 2 {
+		t.Fatalf("pre-dispose ticks = %d, want 2", len(*ticks))
+	}
+
+	recv.Dispose()
+
+	if recv.HasLoop() {
+		t.Errorf("HasLoop = true after Dispose; want false (closure must be dropped)")
+	}
+
+	// Post-dispose RunFrames is a no-op — the closure should be gone.
+	recv.RunFrames(5)
+	if len(*ticks) != 2 {
+		t.Errorf("post-dispose ticks = %d, want 2 (no new invocations after Dispose)", len(*ticks))
+	}
+}
+
+// TestCanvasHostReceiver_StartLoopRejectsNonClosure verifies that
+// calling StartLoop with a non-closure value records a diagnostic-style
+// error rather than panicking; the loop must remain inactive.
+func TestCanvasHostReceiver_StartLoopRejectsNonClosure(t *testing.T) {
+	machine := vm.NewVM(&program.Program{}, nil)
+	recv := NewCanvasHostReceiver(machine, newNoopCanvas())
+
+	_, err := recv.Call("StartLoop", []vm.Value{vm.StringVal("not-a-closure")})
+	if err == nil {
+		t.Fatal("StartLoop with non-closure arg returned nil error; want non-nil")
+	}
+	if recv.HasLoop() {
+		t.Errorf("HasLoop = true after rejected StartLoop; want false")
+	}
+}
+
+// TestCanvasHostReceiver_StartLoopRejectsBadArity verifies that
+// calling StartLoop with the wrong number of args surfaces an error.
+func TestCanvasHostReceiver_StartLoopRejectsBadArity(t *testing.T) {
+	machine := vm.NewVM(&program.Program{}, nil)
+	recv := NewCanvasHostReceiver(machine, newNoopCanvas())
+
+	if _, err := recv.Call("StartLoop", nil); err == nil {
+		t.Errorf("StartLoop() returned nil error; want non-nil")
+	}
+	if _, err := recv.Call("StartLoop", []vm.Value{closureForFunc("x"), closureForFunc("y")}); err == nil {
+		t.Errorf("StartLoop(x,y) returned nil error; want non-nil")
+	}
+	if recv.HasLoop() {
+		t.Errorf("HasLoop = true after rejected calls; want false")
+	}
+}
+
+// TestCanvasHostReceiver_DispatchesCanvasMethods verifies that the
+// receiver forwards regular canvas method calls (Width/Height/...) to
+// the wrapped *Canvas rather than treating them as unknown methods.
+func TestCanvasHostReceiver_DispatchesCanvasMethods(t *testing.T) {
+	machine := vm.NewVM(&program.Program{}, nil)
+	canvas := &Canvas{impl: &stubImpl{w: 1024, h: 768}}
+	recv := NewCanvasHostReceiver(machine, canvas)
+
+	got, err := recv.Call("Width", nil)
+	if err != nil {
+		t.Fatalf("Width: %v", err)
+	}
+	if int(got.Num) != 1024 {
+		t.Errorf("Width = %v, want 1024", got.Num)
+	}
+
+	got, err = recv.Call("Height", nil)
+	if err != nil {
+		t.Fatalf("Height: %v", err)
+	}
+	if int(got.Num) != 768 {
+		t.Errorf("Height = %v, want 768", got.Num)
+	}
+}


### PR DESCRIPTION
- **test(surface): add tests for CanvasHostReceiver contract and lifecycle**
- **add(vm): add NewHostClosure helper for test closure construction**
- **add(surface): Add canvas VM host receiver bridge**
- **add(surface): Add BindCanvas convenience helper for VM hydration**
- **test(surface): Add test for StartLoop step function installation**
- **add(engine/surface): Add e2e test for OpHostCall dispatch and stepping**
