### PR TITLE
ctx receiver wire up

### DIFF
--- a/client/bridge/bridge_engine_surface.go
+++ b/client/bridge/bridge_engine_surface.go
@@ -158,15 +158,14 @@ func (b *Bridge) HydrateEngineSurface(id, componentName, propsJSON string, progr
 	recv := surface.NewCanvasHostReceiver(machine, canvas)
 	machine.BindHost("c", recv)
 
-	// "ctx" is the other half of the surface author contract (per
-	// surface.go package doc). Today the only operation lowerer-side is
-	// ctx.PropsInto(&p) which the Y.E + Y.G machinery resolves through
-	// OpHostCall on a host that no-ops in this minimal hydrator. A
-	// follow-up will wire a real ctx receiver that materializes
-	// propsJSON into the struct local — for now leaving it unbound is
-	// safe; the VM records a `host_unbound` diagnostic but evaluation
-	// continues panic-free per the engine-surface contract.
-	_ = propsJSON
+	// "ctx" is the other half of the surface author contract. The
+	// ContextHostReceiver decodes propsJSON into the surface's typed
+	// props struct via OpHostCall("ctx.PropsInto", [&props]) — Y.G's
+	// eager struct zero-init guarantees props.Fields is non-nil at the
+	// call site, and Y.C's in-place mutation propagates the writes
+	// back to the handler's local.
+	ctxRecv := surface.NewContextHostReceiver([]byte(propsJSON))
+	machine.BindHost("ctx", ctxRecv)
 
 	inst := &engineSurfaceInstance{
 		machine:       machine,

--- a/engine/surface/context_host.go
+++ b/engine/surface/context_host.go
@@ -1,0 +1,155 @@
+// Package surface — VM-side context host receiver bridge (v0.23.1).
+//
+// ContextHostReceiver is the companion to CanvasHostReceiver: it
+// services the `ctx.*` calls a bytecode-lowered surface handler makes,
+// most notably `ctx.PropsInto(&props)` which decodes the per-mount
+// props JSON into the surface's typed props struct.
+//
+// # The handoff chain
+//
+//  1. The hydrate path receives a propsJSON string from the JS layer
+//     (sycamore's __gosx_hydrate_engine_surface entry — PR #19).
+//  2. Bridge wraps it via NewContextHostReceiver(propsJSON) and binds
+//     under "ctx" alongside the canvas receiver bound under "c".
+//  3. The handler's `ctx.PropsInto(&props)` lowers to
+//     OpHostCall("ctx.PropsInto", [&props]). The VM dispatches into
+//     ContextHostReceiver.Call("PropsInto", [target]).
+//  4. PropsInto unmarshals the propsJSON and writes each top-level
+//     key into target.Fields by reference (Y.C in-place mutation +
+//     Y.G eager struct zero-init guarantees target.Fields is non-nil).
+
+package surface
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/island/program"
+)
+
+// ContextHostReceiver bridges per-mount surface context state (props,
+// in particular) to the vm.HostReceiver interface so bytecode handlers
+// can resolve `ctx.PropsInto(&p)` and future ctx.* calls via
+// OpHostCall.
+//
+// Construct one per surface mount via NewContextHostReceiver and bind
+// it under the surface author's chosen identifier ("ctx" by
+// convention):
+//
+//	recv := surface.NewContextHostReceiver([]byte(propsJSON))
+//	machine.BindHost("ctx", recv)
+type ContextHostReceiver struct {
+	propsJSON []byte
+}
+
+// NewContextHostReceiver wraps the per-mount propsJSON as a
+// vm.HostReceiver. propsJSON may be nil or empty — in that case
+// PropsInto leaves the target untouched and returns nil (matching the
+// Go default-zero-value contract authors expect from
+// `var p T; ctx.PropsInto(&p)`).
+func NewContextHostReceiver(propsJSON []byte) *ContextHostReceiver {
+	return &ContextHostReceiver{propsJSON: propsJSON}
+}
+
+// BindContext is the convenience wire-once entry point mirroring
+// BindCanvas. Binds a fresh ContextHostReceiver under name
+// (conventionally "ctx") on the VM and unbinds it when ctx is torn
+// down. ctx may be nil — callers owning their own teardown can omit
+// the watcher.
+func BindContext(machine *vm.VM, name string, propsJSON []byte, ctx *Context) *ContextHostReceiver {
+	recv := NewContextHostReceiver(propsJSON)
+	if machine != nil {
+		machine.BindHost(name, recv)
+	}
+	if ctx != nil {
+		go func() {
+			<-ctx.Done()
+			if machine != nil {
+				machine.BindHost(name, nil)
+			}
+		}()
+	}
+	return recv
+}
+
+// Call satisfies vm.HostReceiver. Method name comes from the
+// source-level `ctx.<Method>` call as lowered by Y.E's host-call path.
+//
+// Today only PropsInto is dispatched. Future ctx.* methods (logging,
+// time, RNG seeding) add one case each in the switch.
+func (r *ContextHostReceiver) Call(method string, args []vm.Value) (vm.Value, error) {
+	if method == "PropsInto" {
+		return r.propsInto(args)
+	}
+	return vm.ZeroValue(0), fmt.Errorf("unknown context method %q", method)
+}
+
+// propsInto unmarshals propsJSON and writes top-level keys into the
+// target ObjectVal's Fields map by reference. Y.E's `&x` pass-through +
+// Y.G's eager struct zero-init contract means target.Fields is a
+// non-nil map shared by reference with the caller's local — writes
+// here propagate to the handler's `props` variable directly.
+//
+// Behavior:
+//   - 0 args / wrong arg count → error (host_call_error diagnostic)
+//   - nil target.Fields → error (props must declare a struct type so
+//     scanStructTypes registers it; primitive props aren't supported)
+//   - empty/nil propsJSON → no-op success (handler sees zero struct,
+//     matching `var p T` without any PropsInto call)
+//   - malformed propsJSON → error
+//   - well-formed → mutates target.Fields in-place, returns zero value
+func (r *ContextHostReceiver) propsInto(args []vm.Value) (vm.Value, error) {
+	if len(args) != 1 {
+		return vm.ZeroValue(0), fmt.Errorf("PropsInto expects 1 arg, got %d", len(args))
+	}
+	target := args[0]
+	if target.Fields == nil {
+		return vm.ZeroValue(0), fmt.Errorf("PropsInto target has nil Fields (declare props as a struct type so the lowerer's eager zero-init runs)")
+	}
+	if len(r.propsJSON) == 0 {
+		return vm.ZeroValue(0), nil
+	}
+
+	var raw map[string]any
+	if err := json.Unmarshal(r.propsJSON, &raw); err != nil {
+		return vm.ZeroValue(0), fmt.Errorf("PropsInto: malformed propsJSON: %w", err)
+	}
+
+	for key, val := range raw {
+		target.Fields[key] = jsonToVMValue(val)
+	}
+	return vm.ZeroValue(0), nil
+}
+
+// jsonToVMValue converts a decoded JSON value (from encoding/json's
+// any-target unmarshal) into the closest vm.Value shape. Recurses for
+// arrays and objects so nested struct/slice props materialize as
+// ObjectVal/Items chains the surface handler can read with the usual
+// OpFieldGet / OpIndex opcodes.
+func jsonToVMValue(v any) vm.Value {
+	switch x := v.(type) {
+	case nil:
+		return vm.ZeroValue(0)
+	case bool:
+		return vm.BoolVal(x)
+	case float64:
+		return vm.FloatVal(x)
+	case string:
+		return vm.StringVal(x)
+	case []any:
+		items := make([]vm.Value, len(x))
+		for i, e := range x {
+			items[i] = jsonToVMValue(e)
+		}
+		return vm.Value{Type: program.TypeAny, Items: items}
+	case map[string]any:
+		fields := make(map[string]vm.Value, len(x))
+		for k, val := range x {
+			fields[k] = jsonToVMValue(val)
+		}
+		return vm.ObjectVal(fields)
+	default:
+		return vm.ZeroValue(0)
+	}
+}

--- a/engine/surface/context_host_test.go
+++ b/engine/surface/context_host_test.go
@@ -1,0 +1,149 @@
+package surface
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+func TestContextHostReceiver_PropsIntoPopulatesFields(t *testing.T) {
+	propsJSON := `{"Name":"hello","Count":42,"Active":true}`
+	recv := NewContextHostReceiver([]byte(propsJSON))
+
+	// Mirror Y.G's eager zero-init: a struct local arrives with non-nil
+	// Fields but no entries. PropsInto must populate it by reference.
+	target := vm.ObjectVal(map[string]vm.Value{})
+
+	out, err := recv.Call("PropsInto", []vm.Value{target})
+	if err != nil {
+		t.Fatalf("PropsInto: %v", err)
+	}
+	if out.Str != "" || out.Num != 0 {
+		t.Fatalf("PropsInto should return zero Value, got %+v", out)
+	}
+	if got := target.Fields["Name"].Str; got != "hello" {
+		t.Fatalf("Name = %q, want %q", got, "hello")
+	}
+	if got := target.Fields["Count"].Num; got != 42 {
+		t.Fatalf("Count = %v, want 42", got)
+	}
+	if got := target.Fields["Active"].Bool; got != true {
+		t.Fatalf("Active = %v, want true", got)
+	}
+}
+
+func TestContextHostReceiver_PropsIntoHandlesNestedArrays(t *testing.T) {
+	propsJSON := `{"Nodes":[{"ID":"a"},{"ID":"b"}],"Tags":["x","y","z"]}`
+	recv := NewContextHostReceiver([]byte(propsJSON))
+	target := vm.ObjectVal(map[string]vm.Value{})
+
+	if _, err := recv.Call("PropsInto", []vm.Value{target}); err != nil {
+		t.Fatalf("PropsInto: %v", err)
+	}
+
+	nodes := target.Fields["Nodes"]
+	if len(nodes.Items) != 2 {
+		t.Fatalf("Nodes length = %d, want 2", len(nodes.Items))
+	}
+	if got := nodes.Items[0].Fields["ID"].Str; got != "a" {
+		t.Fatalf("Nodes[0].ID = %q, want %q", got, "a")
+	}
+	if got := nodes.Items[1].Fields["ID"].Str; got != "b" {
+		t.Fatalf("Nodes[1].ID = %q, want %q", got, "b")
+	}
+
+	tags := target.Fields["Tags"]
+	if len(tags.Items) != 3 {
+		t.Fatalf("Tags length = %d, want 3", len(tags.Items))
+	}
+	if tags.Items[2].Str != "z" {
+		t.Fatalf("Tags[2] = %q, want %q", tags.Items[2].Str, "z")
+	}
+}
+
+func TestContextHostReceiver_PropsIntoEmptyJSONIsNoOp(t *testing.T) {
+	recv := NewContextHostReceiver(nil)
+	target := vm.ObjectVal(map[string]vm.Value{})
+
+	if _, err := recv.Call("PropsInto", []vm.Value{target}); err != nil {
+		t.Fatalf("empty propsJSON should be no-op success, got: %v", err)
+	}
+	if len(target.Fields) != 0 {
+		t.Fatalf("target Fields should stay empty, got %d entries", len(target.Fields))
+	}
+}
+
+func TestContextHostReceiver_PropsIntoRejectsMalformedJSON(t *testing.T) {
+	recv := NewContextHostReceiver([]byte("{not json"))
+	target := vm.ObjectVal(map[string]vm.Value{})
+
+	_, err := recv.Call("PropsInto", []vm.Value{target})
+	if err == nil {
+		t.Fatalf("malformed propsJSON should error, got nil")
+	}
+	if !strings.Contains(err.Error(), "malformed") {
+		t.Fatalf("error should mention malformed, got %q", err.Error())
+	}
+}
+
+func TestContextHostReceiver_PropsIntoRejectsNilFieldsTarget(t *testing.T) {
+	recv := NewContextHostReceiver([]byte(`{"X":1}`))
+	target := vm.Value{} // no Fields map — simulates a primitive arg by mistake
+
+	_, err := recv.Call("PropsInto", []vm.Value{target})
+	if err == nil {
+		t.Fatalf("nil-Fields target should error, got nil")
+	}
+	if !strings.Contains(err.Error(), "nil Fields") {
+		t.Fatalf("error should mention nil Fields, got %q", err.Error())
+	}
+}
+
+func TestContextHostReceiver_PropsIntoRejectsWrongArgCount(t *testing.T) {
+	recv := NewContextHostReceiver([]byte(`{"X":1}`))
+
+	_, err := recv.Call("PropsInto", nil)
+	if err == nil {
+		t.Fatalf("0 args should error")
+	}
+
+	_, err = recv.Call("PropsInto", []vm.Value{vm.ObjectVal(nil), vm.ObjectVal(nil)})
+	if err == nil {
+		t.Fatalf("2 args should error")
+	}
+}
+
+func TestContextHostReceiver_UnknownMethodRejects(t *testing.T) {
+	recv := NewContextHostReceiver(nil)
+
+	_, err := recv.Call("BogusMethod", nil)
+	if err == nil {
+		t.Fatalf("unknown method should error")
+	}
+	if !strings.Contains(err.Error(), "unknown") {
+		t.Fatalf("error should mention unknown, got %q", err.Error())
+	}
+}
+
+func TestContextHostReceiver_MutationPropagatesByReference(t *testing.T) {
+	// Critical: PropsInto mutates target.Fields in place. The caller's
+	// Value (passed by Go value semantics) must see the writes because
+	// Fields is a reference type. This pins Y.C's in-place-mutation
+	// contract — if it ever regresses, hyphae's graph_surface.go Mount
+	// will see empty props and the whole bytecode hydration arc breaks.
+	recv := NewContextHostReceiver([]byte(`{"NodeCount":7}`))
+
+	original := vm.ObjectVal(map[string]vm.Value{})
+	copyOfOriginal := original // Go value copy of the Value struct
+
+	if _, err := recv.Call("PropsInto", []vm.Value{copyOfOriginal}); err != nil {
+		t.Fatalf("PropsInto: %v", err)
+	}
+
+	// The mutation went through the shared Fields map, so the original
+	// sees it too.
+	if got := original.Fields["NodeCount"].Num; got != 7 {
+		t.Fatalf("by-reference propagation failed: original NodeCount = %v, want 7", got)
+	}
+}


### PR DESCRIPTION
- **add(engine/surface): add ContextHostReceiver for surface props decoding**
- **test(engine/surface): Add tests for ContextHostReceiver.PropsInto**
- **update(bridge): Wire up ctx host receiver to decode props**
