### PR TITLE
fix: test-health sweep — build tags, boardgpu golden, server cache-control, docs truth

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ data/
 docs/blog-outlines/
 docs/specs/
 docs/superpowers/
+
+# Local dev workspace overlay (links sibling prism/selena checkouts) — never commit
+go.work
+go.work.sum

--- a/MODULES.md
+++ b/MODULES.md
@@ -2,8 +2,8 @@
 
 This repository contains independently versioned Go modules:
 
-- `github.com/odvcencio/gosx`: the core framework.
-- `github.com/odvcencio/gosx/editor`: the optional browser editor shell and assets.
+- `m31labs.dev/gosx`: the core framework.
+- `m31labs.dev/gosx/editor`: the optional browser editor shell and assets.
 
 Markdown++ rendering is the canonical content-source layer for the core
 `content` package through `github.com/odvcencio/mdpp`. The framework owns the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.25.3**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.29.1**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -722,7 +722,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.25.3**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.29.1**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/client/wasm/main_stub.go
+++ b/client/wasm/main_stub.go
@@ -1,0 +1,11 @@
+//go:build !js || !wasm
+
+package main
+
+// main is a no-op stub so `go build ./...` succeeds on native (non
+// js/wasm) toolchains. cross_frame_parse.go is deliberately left without a
+// js/wasm build tag so its pure-Go query parser can be unit-tested with
+// `go test ./client/wasm` on a native toolchain; that leaves this directory,
+// on native builds, containing only cross_frame_parse.go — a package main
+// with no func main. The real js/wasm entry point lives in main.go.
+func main() {}

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.25.3"
+const Current = "v0.29.1"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.25.3"
+const Number = "0.29.1"


### PR DESCRIPTION
## Summary

Repo-evaluation sweep fixing pre-existing build/test/doc issues found on a clean `main` checkout (v0.29.1).

1. **`client/wasm` broke native `go build ./...`.** `main.go` (`package main`, `//go:build js && wasm`) is the only implementation file in the package; `cross_frame_parse.go` is deliberately left untagged so its pure-Go query parser (`parsePreviewModeQuery`) can be unit-tested with a native `go test ./client/wasm` (no wasm runtime needed). That means on a native build the package = `cross_frame_parse.go` only — `package main` with no `func main`, which `go build` rejects (`go test` doesn't need `func main` since it builds its own test binary, which is why the test passed while the build failed). Tagging `cross_frame_parse.go` the same as `main.go` (the naive fix) would have removed it — and its native-only test — from native builds entirely. Fixed by adding `client/wasm/main_stub.go` (`//go:build !js || !wasm`, no-op `func main(){}`), mirroring the existing `main_stub.go` pattern already used by `examples/*-spike/`. Verified: `go build ./...` and `go build ./client/wasm/...` are clean natively, `GOOS=js GOARCH=wasm go build ./client/wasm/...` still compiles, and `go test ./client/wasm` still runs `cross_frame_parse_test.go` natively.

2. **`render/boardgpu` golden drift (`TestBoardTextStaticMaterialMatchesSelenaCompile`).** Root-caused and did **not** reproduce: the pinned `boardTextShaderLayout` literal in `board_text.go` already carries `"dimension": "2d"` on the texture descriptor (present since the file's original commit), and the test passes cleanly under both the workspace-local selena checkout (via `go.work`) and the published `m31labs.dev/selena v0.3.2` pin (`GOWORK=off`), with a cleared test cache. No code change made — verified green, comparison left unweakened.

3. **`server` cache-control failures.** Also did not reproduce: all 5 named subtests plus the full `server` package (150 tests) pass cleanly on this checkout; `server/cache.go`'s immutable-vs-no-cache policy already matches the test expectations (immutable for hashed/build-manifest assets, no-cache for source-build assets).

   Items 2 and 3 do not currently reproduce on a clean `main` checkout — verified with `-count=1` (bypassing test cache) and, for item 2, both dependency resolution modes. No code changes were needed for either.

4. **Stale generated artifact.** `examples/gosx-docs/dist/` was an untracked, `.git/info/exclude`d, regenerable build output containing a duplicate `cloneWaterSourceFiles` declaration that broke `go build ./...`/`go vet`. Confirmed untracked (`git ls-files` empty) and deleted.

5. **Docs truth pass.** `README.md`'s two "Current release" statements were stale at `v0.25.3` (latest tag/CHANGELOG heading is `v0.29.1`) — updated. That surfaced the real root cause: `internal/version/version.go`'s `Current`/`Number` constants (the source of truth `gosx.Version` derives from, and what `cmd/gosx`'s `release check` command validates against) were *also* stale at `v0.25.3`, self-consistent with the old README text — which is why `TestRunReleaseCheckCommandPassesCurrentRepo` passed before this change and would have started failing once README alone was bumped. Bumped `internal/version.Current`/`Number` to `v0.29.1` to match the actual latest tag and CHANGELOG heading, restoring self-consistency at the true current value. `MODULES.md` also referenced the wrong module path (`github.com/odvcencio/gosx*`) — corrected to `m31labs.dev/gosx*` (verified against `go.mod`/`editor/go.mod`); `github.com/odvcencio/mdpp` reference left untouched (that's a real, correctly-pathed dependency).

6. **`.gitignore`.** Added `go.work` / `go.work.sum` (a local, deliberately untracked dev workspace overlay linking sibling `prism`/`selena` checkouts).

## Verification

- `go build ./...` — clean
- `go vet ./...` — clean except the pre-existing `crdt/crdt/convergence_scenarios.dmj:125: unreachable code` cosmetic note (confirmed pre-existing on unmodified `main`)
- `go test ./render/boardgpu ./server ./client/wasm -count=1` — all green
- `go test ./... -count=1` — 88 packages `ok`, 55 `no test files`, 0 `FAIL` (includes `cmd/gosx`'s `TestRunReleaseCheckCommandPassesCurrentRepo`, which required the `internal/version` fix above)

## Test plan

- [x] `go build ./...`
- [x] `GOOS=js GOARCH=wasm go build ./client/wasm/...`
- [x] `go vet ./...` (pre-existing `.dmj` note only)
- [x] `go test ./render/boardgpu ./server ./client/wasm -count=1`
- [x] `go test ./... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)