### PR TITLE
fix(runtime): serve /gosx/relay.js through the asset pipeline

### DIFF
--- a/buildmanifest/manifest.go
+++ b/buildmanifest/manifest.go
@@ -33,6 +33,7 @@ type RuntimeAssets struct {
 	Patch                            HashedAsset `json:"patch"`
 	VideoHLS                         HashedAsset `json:"videoHLS,omitempty"`
 	StripeBridge                     HashedAsset `json:"stripeBridge,omitempty"`
+	Relay                            HashedAsset `json:"relay,omitempty"`
 }
 
 type IslandAsset struct {
@@ -79,6 +80,7 @@ type RuntimePaths struct {
 	Patch                            string
 	VideoHLS                         string
 	StripeBridge                     string
+	Relay                            string
 }
 
 // Load reads a build manifest from disk.
@@ -114,6 +116,7 @@ func (m *Manifest) RuntimeURLs(assetBaseURL string) RuntimePaths {
 		Patch:                            AssetURL(assetBaseURL, "runtime", m.Runtime.Patch.File),
 		VideoHLS:                         AssetURL(assetBaseURL, "runtime", m.Runtime.VideoHLS.File),
 		StripeBridge:                     AssetURL(assetBaseURL, "runtime", m.Runtime.StripeBridge.File),
+		Relay:                            AssetURL(assetBaseURL, "runtime", m.Runtime.Relay.File),
 	}
 }
 

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -499,6 +499,7 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 		{"patch", filepath.Join(gosxRoot, "client", "js", "patch.js"), &manifest.Runtime.Patch},
 		{"hls.min", filepath.Join(gosxRoot, "client", "js", "vendor", "hls.min.js"), &manifest.Runtime.VideoHLS},
 		{"stripe-bridge", filepath.Join(gosxRoot, "client", "js", "stripe-bridge.js"), &manifest.Runtime.StripeBridge},
+		{"relay", filepath.Join(gosxRoot, "client", "js", "relay.js"), &manifest.Runtime.Relay},
 	} {
 		data, err := os.ReadFile(js.path)
 		if err != nil {
@@ -959,6 +960,8 @@ func manifestRuntimeRefSourcePath(distDir string, manifest *BuildManifest, ref s
 		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.VideoHLS.File)
 	case "/gosx/stripe-bridge.js":
 		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.StripeBridge.File)
+	case "/gosx/relay.js":
+		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.Relay.File)
 	}
 	if rel, ok := strings.CutPrefix(ref, "/gosx/islands/"); ok && rel != "" {
 		name := filepath.Base(rel)

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -273,6 +273,7 @@ func TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets(t *testing.
 		filepath.Join(distDir, "assets", "runtime", "bootstrap-feature-hubs.8888.js"):    "bootstrap-feature-hubs",
 		filepath.Join(distDir, "assets", "runtime", "patch.9999.js"):                     "patch",
 		filepath.Join(distDir, "assets", "runtime", "hls.min.aaaa.js"):                   "hls",
+		filepath.Join(distDir, "assets", "runtime", "relay.bbbb.js"):                     "relay",
 		filepath.Join(distDir, "assets", "islands", "Counter.abcd.gxi"):                  "counter",
 		filepath.Join(distDir, "assets", "css", "counter.dcba.css"):                      "counter-css",
 	}
@@ -293,6 +294,7 @@ func TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets(t *testing.
 			BootstrapFeatureHubs:    HashedAsset{File: "bootstrap-feature-hubs.8888.js"},
 			Patch:                   HashedAsset{File: "patch.9999.js"},
 			VideoHLS:                HashedAsset{File: "hls.min.aaaa.js"},
+			Relay:                   HashedAsset{File: "relay.bbbb.js"},
 		},
 		Islands: []IslandAsset{{Name: "Counter", Format: "bin", HashedAsset: HashedAsset{File: "Counter.abcd.gxi"}}},
 		CSS:     []CSSAsset{{Component: "Counter", Source: "counter.css", HashedAsset: HashedAsset{File: "counter.dcba.css"}}},
@@ -302,6 +304,7 @@ func TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets(t *testing.
 		"/gosx/assets/runtime/bootstrap-runtime.5555.js",
 		"/gosx/bootstrap-feature-engines.js",
 		"/gosx/hls.min.js",
+		"/gosx/relay.js",
 		"/gosx/islands/Counter.gxi",
 		"/gosx/css/counter.css",
 	}
@@ -315,6 +318,7 @@ func TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets(t *testing.
 		"gosx/assets/runtime/bootstrap-runtime.5555.js.br",
 		"gosx/bootstrap-feature-engines.js",
 		"gosx/hls.min.js",
+		"gosx/relay.js",
 		"gosx/islands/Counter.gxi",
 		"gosx/css/counter.css",
 	} {

--- a/cmd/gosx/dev.go
+++ b/cmd/gosx/dev.go
@@ -208,6 +208,9 @@ func prepareDevAssets(dir string) error {
 	if err := copyFile(filepath.Join(buildDir, "stripe-bridge.js"), filepath.Join(gosxRoot, "client", "js", "stripe-bridge.js")); err != nil {
 		return fmt.Errorf("stage stripe-bridge.js: %w", err)
 	}
+	if err := copyFile(filepath.Join(buildDir, "relay.js"), filepath.Join(gosxRoot, "client", "js", "relay.js")); err != nil {
+		return fmt.Errorf("stage relay.js: %w", err)
+	}
 
 	if err := compileDevIslands(dir, islandDir); err != nil {
 		return err

--- a/cmd/gosx/export.go
+++ b/cmd/gosx/export.go
@@ -127,6 +127,8 @@ func exportRuntimeBuildPath(buildDir, ref string) (string, bool) {
 		return filepath.Join(buildDir, "hls.min.js"), true
 	case "/gosx/stripe-bridge.js":
 		return filepath.Join(buildDir, "stripe-bridge.js"), true
+	case "/gosx/relay.js":
+		return filepath.Join(buildDir, "relay.js"), true
 	}
 	if rel, ok := strings.CutPrefix(ref, "/gosx/islands/"); ok && rel != "" {
 		return filepath.Join(buildDir, "islands", filepath.FromSlash(rel)), true

--- a/cmd/gosx/size.go
+++ b/cmd/gosx/size.go
@@ -170,6 +170,7 @@ func runtimeSizeAssets(manifest *buildmanifest.Manifest) []runtimeSizeAsset {
 		{name: "patch.js", file: rt.Patch.File, role: "navigation patch"},
 		{name: "hls.min.js", file: rt.VideoHLS.File, role: "video hls chunk"},
 		{name: "stripe-bridge.js", file: rt.StripeBridge.File, role: "stripe bridge chunk"},
+		{name: "relay.js", file: rt.Relay.File, role: "cross-frame preview relay"},
 	}
 }
 

--- a/server/runtime_assets.go
+++ b/server/runtime_assets.go
@@ -258,6 +258,7 @@ func runtimeCompatSourcePath(root, name string) (string, bool) {
 		"patch.js":                     filepath.Join(buildDir, "patch.js"),
 		"hls.min.js":                   filepath.Join(buildDir, "hls.min.js"),
 		"stripe-bridge.js":             filepath.Join(buildDir, "stripe-bridge.js"),
+		"relay.js":                     filepath.Join(buildDir, "relay.js"),
 	}
 	if direct, ok := candidates[name]; ok && isFile(direct) {
 		return direct, true
@@ -281,6 +282,12 @@ func runtimeCompatSourcePath(root, name string) (string, bool) {
 		}
 	}
 	if name == "stripe-bridge.js" {
+		clientPath := filepath.Join(root, "client", "js", name)
+		if isFile(clientPath) {
+			return clientPath, true
+		}
+	}
+	if name == "relay.js" {
 		clientPath := filepath.Join(root, "client", "js", name)
 		if isFile(clientPath) {
 			return clientPath, true
@@ -344,6 +351,8 @@ func (a *App) runtimeCompatBuiltPath(root, name string) (string, bool) {
 		return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.VideoHLS.File)
 	case "stripe-bridge.js":
 		return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.StripeBridge.File)
+	case "relay.js":
+		return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.Relay.File)
 	}
 
 	if strings.HasPrefix(name, "islands/") {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1258,6 +1258,77 @@ func TestAppServesCompatRuntimeHLSAssetFromSourceBuild(t *testing.T) {
 	}
 }
 
+func TestAppServesCompatRelayJSFromSourceBuild(t *testing.T) {
+	root := t.TempDir()
+	clientJSDir := filepath.Join(root, "client", "js")
+	if err := os.MkdirAll(clientJSDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clientJSDir, "relay.js"), []byte("window.__gosxRelay = true;"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.SetRuntimeRoot(root)
+	handler := app.Build()
+
+	req := httptest.NewRequest(http.MethodGet, "/gosx/relay.js", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "__gosxRelay") {
+		t.Fatalf("unexpected relay.js body %q", body)
+	}
+}
+
+func TestAppServesCompatRelayJSFromBuildManifest(t *testing.T) {
+	root := t.TempDir()
+	assetsDir := filepath.Join(root, "assets", "runtime")
+	if err := os.MkdirAll(assetsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(assetsDir, "relay.9999.js"), []byte("window.__gosxRelay = 'hashed';"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := buildmanifest.Manifest{
+		Runtime: buildmanifest.RuntimeAssets{
+			Relay: buildmanifest.HashedAsset{
+				File: "relay.9999.js",
+				Hash: "9999",
+				Size: 30,
+			},
+		},
+	}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "build.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	app := New()
+	app.SetRuntimeRoot(root)
+	handler := app.Build()
+
+	req := httptest.NewRequest(http.MethodGet, "/gosx/relay.js", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if got := w.Header().Get("Cache-Control"); !strings.Contains(got, "immutable") {
+		t.Fatalf("expected built compat asset to be immutable, got %q", got)
+	}
+	if body := w.Body.String(); !strings.Contains(body, "hashed") {
+		t.Fatalf("unexpected built relay.js body %q", body)
+	}
+}
+
 func TestAppServesCompatRuntimeAssetsFromBuildManifest(t *testing.T) {
 	root := t.TempDir()
 	assetsDir := filepath.Join(root, "assets", "runtime")


### PR DESCRIPTION
## Summary
- `island.EnablePreviewBootstrap()` (ADR 0009 cross-frame relay) emits a hardcoded `<script src="/gosx/relay.js">` tag, but `client/js/relay.js` was never wired into any stage of the asset pipeline: the `buildmanifest.RuntimeAssets` struct had no `Relay` field, `gosx build`/`gosx dev`/`gosx export` never hashed, staged, or copied the file, and `server/runtime_assets.go`'s `/gosx/*` route handler had no case for `relay.js` in either the dev source-fallback or the build-manifest resolver. Every consumer page that opts into preview bootstrap (e.g. muddy-noni-commerce's admin editor, CanvasBoard hosts generally) gets a 404 fetching `/gosx/relay.js`.
- Adds `Relay` end-to-end: `buildmanifest.RuntimeAssets`/`RuntimePaths`/`RuntimeURLs`, the `gosx build` hashing loop + static-export ref resolver, `gosx dev`'s staging step, `gosx export`'s static-copy switch, the bundle-size report, and both resolution paths in `server/runtime_assets.go` (dev source fallback from `client/js/relay.js`, and manifest-driven built-asset lookup), mirroring the existing `stripe-bridge.js` pattern.

## Root cause
`island/island.go` emits `/gosx/relay.js` unconditionally when preview bootstrap is enabled, but nothing on the serving side ever resolved that name — `server/runtime_assets.go`'s `runtimeCompatSourcePath`/`runtimeCompatBuiltPath` had no `relay.js` case, and the production build tooling (`cmd/gosx/build.go`, `dev.go`, `export.go`) never copied/hashed `client/js/relay.js` at all, so no build artifact for it ever existed.

## Test plan
- [x] Added `TestAppServesCompatRelayJSFromSourceBuild` / `TestAppServesCompatRelayJSFromBuildManifest` (`server/server_test.go`) — both reproduced a 404 before the fix, now pass.
- [x] Extended `TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets` (`cmd/gosx/build_test.go`) to cover `/gosx/relay.js` static-export resolution.
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...` (pre-existing unrelated `.dmj` vet note, reproduces identically on `main`)
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `make release-gate` — all gates pass