### PR TITLE
release: v0.29.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## v0.29.3 (2026-07-06)
+
+Fix: `/gosx/relay.js` was emitted by `island.EnablePreviewBootstrap` but never
+staged, hashed, or served by the asset pipeline, so any app that turned on
+preview bootstrap shipped a 404 for the relay script. `relay.js` is now wired
+through the same path as every other runtime asset: the build manifest embeds
+it, `gosx build`/`gosx dev`/`gosx export` stage and hash it alongside the rest
+of the runtime bundle, and the server's runtime-asset resolvers serve it (with
+regression tests covering manifest, build, and server resolution). (#31)
+
 ## v0.29.2 (2026-07-05)
 
 Maintenance release: repo health, version truth, and changelog backfill.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.29.2**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.29.3**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -722,7 +722,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.29.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.29.3**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.29.2"
+const Current = "v0.29.3"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.29.2"
+const Number = "0.29.3"


### PR DESCRIPTION
## Summary
- Bumps `internal/version` to v0.29.3 and syncs README.md's two "current release" statements.
- Adds a v0.29.3 CHANGELOG.md section documenting the /gosx/relay.js asset-pipeline fix merged in #31 (0ffaf30): relay.js is emitted by `island.EnablePreviewBootstrap` but was never staged, hashed, or served by the asset pipeline. It is now wired through the build manifest, `gosx build`/`dev`/`export`, and the server's runtime-asset resolvers, with regression tests.

## Test plan
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...` (one pre-existing, unrelated `unreachable code` warning in `crdt/crdt/convergence_scenarios.dmj`, confirmed present on main too)
- [x] `GOWORK=off go test ./...`
- [x] `make release-gate` (all 4 gates pass)