### PR TITLE
release: v0.29.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## v0.29.4 (2026-07-06)
+
+Fix: Scene3D client bootstrap dropped instanced-mesh cull fields —
+`cullKernelWGSL`, `cullKernelEntry`, `cullRadius`, `cullBackend` — in
+`normalizeSceneInstancedMeshEntry()` (`client/js/bootstrap-src/10-runtime-scene-core.js`).
+The function rebuilt each `instancedMeshes` scene entry into a whitelisted
+object and never carried these four fields forward, even though the Go scene
+types (`scene.InstancedMeshIR`) and the manifest JSON carry them end-to-end.
+Consequence: `updateInstancedCullSystems` in `16a-scene-webgpu.js` always saw
+`mesh.cullKernelWGSL === undefined` and never created a GPU cull system, so
+WebGPU GPU-cull systems were never created and `cullSurvivors` telemetry
+stayed `{}` forever — even after the v0.29.x shaderLib-dedup inflation
+(`cullKernelWGSLRef` → `cullKernelWGSL`) ran. The normalizer now carries all
+four fields through, mirroring the existing `shaderSource`/`shaderSourceFiles`
+whitelist pattern. (#33)
+
 ## v0.29.3 (2026-07-06)
 
 Fix: `/gosx/relay.js` was emitted by `island.EnablePreviewBootstrap` but never

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.29.3**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.29.4**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -722,7 +722,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.29.3**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.29.4**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.29.3"
+const Current = "v0.29.4"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.29.3"
+const Number = "0.29.4"


### PR DESCRIPTION
## Summary
- Releases v0.29.4: `internal/version` bumped, README current-release mentions synced, CHANGELOG.md dated 2026-07-06 entry added for the Scene3D instanced-mesh cull-field fix merged in #33.

## Gates
- [x] `GOWORK=off go build ./...`
- [x] `GOWORK=off go vet ./...` (pre-existing unrelated `unreachable code` note in a generated `.dmj` file, reproduces identically on `main`)
- [x] `GOWORK=off go test ./...` — all packages pass
- [x] `make release-gate`