### PR TITLE
scene.Props.Audio: typed gosxAudio manifest seam

### DIFF
--- a/scene/audio_test.go
+++ b/scene/audio_test.go
@@ -385,3 +385,30 @@ func TestAudioCueGoldenSynthPatch(t *testing.T) {
 	}
 	goldenJSON(t, "audio_cue_patch_golden.json", cue.Props())
 }
+
+// TestPropsAudioManifestLowersUnderAudioKey pins the Props.Audio seam: a
+// scene-level manifest lands under the "audio" prop key mountEngine already
+// forwards to gosxAudio.registerManifest, and an absent manifest emits no key.
+func TestPropsAudioManifestLowersUnderAudioKey(t *testing.T) {
+	vol := 0.8
+	props := Props{
+		Audio: &Audio{
+			Buses: []AudioBus{{ID: "music", Volume: &vol}, {ID: "sfx"}},
+		},
+	}
+	lowered := props.LegacyProps()
+	audio, ok := lowered["audio"].(map[string]any)
+	if !ok {
+		t.Fatalf("audio key missing or wrong shape: %T", lowered["audio"])
+	}
+	buses, ok := audio["buses"].([]map[string]any)
+	if !ok || len(buses) != 2 {
+		t.Fatalf("buses = %#v, want 2 entries", audio["buses"])
+	}
+	if buses[0]["id"] != "music" {
+		t.Fatalf("first bus = %#v, want music", buses[0])
+	}
+	if _, present := (Props{}).LegacyProps()["audio"]; present {
+		t.Fatal("zero Props must not emit an audio key")
+	}
+}

--- a/scene/scene.go
+++ b/scene/scene.go
@@ -174,6 +174,12 @@ type Props struct {
 	Shadows               Shadows
 	Physics               PhysicsWorld
 	Graph                 Graph
+	// Audio optionally declares a gosxAudio manifest (buses + clips) for
+	// this scene's engine. It lowers under the "audio" prop key, which the
+	// client's mountEngine already forwards to
+	// window.__gosx.audio.registerManifest — see the Audio type
+	// (scene/audio.go) for the two-engine (gosxAudio/arcadeAudio) model.
+	Audio *Audio
 }
 
 // Compression configures TurboQuant compression for Scene3D vertex data.
@@ -1641,6 +1647,11 @@ func (p Props) spreadPropsFast() map[string]any {
 
 func (p Props) legacyBaseProps() map[string]any {
 	out := map[string]any{}
+	if p.Audio != nil {
+		if audio := p.Audio.Props(); len(audio) > 0 {
+			out["audio"] = audio
+		}
+	}
 	setInt(out, "width", p.Width)
 	setInt(out, "height", p.Height)
 	setString(out, "label", p.Label)


### PR DESCRIPTION
Adds the missing seam between the E6 typed audio surface and scene mounting: `Props.Audio *Audio` lowers under the `audio` prop key, which the client's mountEngine already forwards to `window.__gosx.audio.registerManifest` — no JS changes needed. First consumer: primalrage's fight scene registers music/sfx buses (slots declared, silent until tracks land, per spec v0.2 §6).

Test: `TestPropsAudioManifestLowersUnderAudioKey` (manifest lands under the key; zero Props emits none). `go test ./scene/`: green.

Note: the working tree carries unrelated in-flight edits (ci.yml, Makefile, webgpu bundle) from another session — deliberately NOT included here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)