### PR TITLE
fix(build): stage content collections in deployment bundles

### DIFF
--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -1079,6 +1079,7 @@ func writeBuildReadme(path string, builtServer bool) error {
 		"Contents:",
 		"- `assets/` contains immutable hashed runtime, island, and CSS assets.",
 		"- `app/` contains runtime file-routed page sources used by `route.AddDir(...)`.",
+		"- `content/` contains collection documents loaded by server-rendered and prerendered routes.",
 		"- `public/` contains root-served static assets when present.",
 		"- `build.json` maps hashed asset names for runtime/island loading.",
 		"- `edge/worker.js` can serve prerendered routes at the edge and proxy misses/actions to origin.",

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -844,7 +844,11 @@ func stageDeploymentBundle(projectDir, distDir string, builtServer bool, serverB
 	// prerendered documentation routes. Keep the conventional project-level
 	// content tree beside app/ in the deployment root so ResolveAppRoot and
 	// content.Load observe the same layout in development and production.
-	if err := copyDirIfPresent(filepath.Join(projectDir, "content"), filepath.Join(distDir, "content")); err != nil {
+	contentDistDir := filepath.Join(distDir, "content")
+	if err := os.RemoveAll(contentDistDir); err != nil {
+		return fmt.Errorf("clean staged content: %w", err)
+	}
+	if err := copyDirIfPresent(filepath.Join(projectDir, "content"), contentDistDir); err != nil {
 		return err
 	}
 	if err := copyDirIfPresent(filepath.Join(projectDir, "public"), filepath.Join(distDir, "public")); err != nil {

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -641,7 +641,7 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	fmt.Println("  • Runtime assets cached forever with content hashes (Tier 2)")
 	fmt.Println("  • Island programs cached forever, invalidated by hash (Tier 3)")
 	fmt.Println("  • Manifest tells the server which hashed URLs to reference")
-	fmt.Println("  • dist/ includes app/ and public/ for file-routed runtime deployment")
+	fmt.Println("  • dist/ includes app/, content/, and public/ for file-routed runtime deployment")
 	if !opts.Dev && builtServer {
 		fmt.Println("  • dist/edge/worker.js can serve prerendered HTML at the edge and proxy dynamic requests to origin")
 		fmt.Println("  • dist/platform/ contains deployment metadata and cache headers for hosted platforms")
@@ -838,6 +838,13 @@ func buildServerBinaryIfPresent(dir, outputPath string) (bool, error) {
 
 func stageDeploymentBundle(projectDir, distDir string, builtServer bool, serverBinaryPath string) error {
 	if err := copyDirIfPresent(filepath.Join(projectDir, "app"), filepath.Join(distDir, "app")); err != nil {
+		return err
+	}
+	// Content collections are runtime inputs for server-rendered and
+	// prerendered documentation routes. Keep the conventional project-level
+	// content tree beside app/ in the deployment root so ResolveAppRoot and
+	// content.Load observe the same layout in development and production.
+	if err := copyDirIfPresent(filepath.Join(projectDir, "content"), filepath.Join(distDir, "content")); err != nil {
 		return err
 	}
 	if err := copyDirIfPresent(filepath.Join(projectDir, "public"), filepath.Join(distDir, "public")); err != nil {

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -31,6 +31,7 @@ func TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts(t *testing.T) 
 	distDir := filepath.Join(t.TempDir(), "dist")
 
 	mustWriteFile(t, filepath.Join(projectDir, "app", "page.gsx"), "package app\n")
+	mustWriteFile(t, filepath.Join(projectDir, "content", "docs", "intro.md"), "# Introduction\n")
 	mustWriteFile(t, filepath.Join(projectDir, "public", "styles.css"), "body {}\n")
 	mustWriteFile(t, filepath.Join(projectDir, ".env.example"), "PORT=8080\n")
 	serverBinaryPath := filepath.Join(distDir, "server", "app")
@@ -42,6 +43,7 @@ func TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts(t *testing.T) 
 
 	for _, rel := range []string{
 		"app/page.gsx",
+		"content/docs/intro.md",
 		"public/styles.css",
 		".env.example",
 		"README.md",

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -34,6 +34,7 @@ func TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts(t *testing.T) 
 	mustWriteFile(t, filepath.Join(projectDir, "content", "docs", "intro.md"), "# Introduction\n")
 	mustWriteFile(t, filepath.Join(projectDir, "public", "styles.css"), "body {}\n")
 	mustWriteFile(t, filepath.Join(projectDir, ".env.example"), "PORT=8080\n")
+	mustWriteFile(t, filepath.Join(distDir, "content", "docs", "removed.md"), "# Removed\n")
 	serverBinaryPath := filepath.Join(distDir, "server", "app")
 	mustWriteFile(t, serverBinaryPath, "binary")
 
@@ -52,6 +53,9 @@ func TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts(t *testing.T) 
 		if _, err := os.Stat(filepath.Join(distDir, rel)); err != nil {
 			t.Fatalf("expected %s in bundle: %v", rel, err)
 		}
+	}
+	if _, err := os.Stat(filepath.Join(distDir, "content", "docs", "removed.md")); !os.IsNotExist(err) {
+		t.Fatalf("stale content file survived deployment staging: %v", err)
 	}
 
 	runScript := readFile(t, filepath.Join(distDir, "run.sh"))

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -68,6 +68,9 @@ func TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts(t *testing.T) 
 	if !strings.Contains(readme, "deployable GoSX bundle") {
 		t.Fatalf("unexpected dist README: %q", readme)
 	}
+	if !strings.Contains(readme, "`content/` contains collection documents") {
+		t.Fatalf("dist README omits staged content directory: %q", readme)
+	}
 }
 
 func TestEvaluateProjectSceneBudget(t *testing.T) {
@@ -109,6 +112,9 @@ func TestWriteBuildReadmeWithoutServerBinary(t *testing.T) {
 	}
 	if !strings.Contains(readme, "`assets/` contains immutable hashed runtime") {
 		t.Fatalf("unexpected readme content %q", readme)
+	}
+	if !strings.Contains(readme, "`content/` contains collection documents") {
+		t.Fatalf("readme omits optional content directory: %q", readme)
 	}
 }
 


### PR DESCRIPTION
## Summary
- copy the conventional project-level `content/` tree into `dist/`
- keep server-rendered and prerendered content routes on the same app-root layout in development and production
- cover content staging in the deployment-bundle regression test

## Verification
- `go test ./cmd/gosx -run '^TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts$' -count=1`
- `go test ./cmd/gosx -count=1`
- built `gotreesitter-docs` with the patched CLI: production TinyGo runtime and static export completed successfully

## Motivation
A GoSX docs app can load `content/docs` in development but the production build previously staged only `app/` and `public/`. The prerender server therefore booted with `GOSX_APP_ROOT=dist` and failed because `dist/content` was missing.