### PR TITLE
bump: Bump version to v0.29.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+## v0.29.5 (2026-07-10)
+
+Production Scene3D, audio, collaboration hardening, and deployable content
+collections. This release banks the full post-v0.29.4 range and makes the
+gotreesitter documentation bundle self-contained in production.
+
+- Shipped the performant Scene3D water demo with honest WebGPU/WebGL backend
+  behavior, one lifecycle-aware scheduler, bounded simulation/caustics work,
+  lazy Duck/glTF loading, production bundle gates, visual baselines, and
+  hardware frame-time certification.
+- Added the `scene.GameplayPostFX()` preset, real FXAA in both browser
+  renderers, GPU-skinned Selena materials on WebGL, and typed scene audio,
+  bus, clip, cue, and synth-patch authoring surfaces.
+- Added live per-frame Selena context uniforms for camera, directional light,
+  and ambient state, plus the `scene.Props.Audio` manifest seam used by the
+  mounted client audio engine.
+- Added inbound CRDT binary authorization while preserving authorized sync and
+  read-only broadcast behavior.
+- Stabilized hub, scheduler, and canvas lifecycle tests around protocol and
+  completion barriers instead of sleeps or scheduler-yield assumptions.
+- Fixed deployment bundles to stage a conventional project-level `content/`
+  tree beside `app/` and `public/`, so server-rendered and prerendered content
+  routes resolve from the same app-root layout in development and production.
+
 ## v0.29.4 (2026-07-06)
 
 Fix: Scene3D client bootstrap dropped instanced-mesh cull fields —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v0.29.5 (2026-07-10)
+## v0.29.5 (2026-07-11)
 
 Production Scene3D, audio, collaboration hardening, and deployable content
 collections. This release banks the full post-v0.29.4 range and makes the

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.29.4**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.29.5**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -722,7 +722,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.29.4**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.29.5**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.29.4"
+const Current = "v0.29.5"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.29.4"
+const Number = "0.29.5"


### PR DESCRIPTION
## Summary

Prepare GoSX v0.29.5 and bank the complete post-v0.29.4 range: production Scene3D water, gameplay post-FX and audio, live Selena context, collaboration authorization, asynchronous test hardening, and deployable content collections.

## Changes

- bump `internal/version` and both README release declarations to v0.29.5
- document the shipped water demo and its lifecycle, lazy-load, backend-honesty, bundle, visual, and hardware performance gates
- document real WebGPU/WebGL FXAA, GPU-skinned Selena, typed audio authoring, live context uniforms, and `scene.Props.Audio`
- document inbound CRDT binary authorization and the protocol/completion-based CI stabilization work
- document project-level `content/` staging so production documentation routes share the development app-root layout

## Validation

- `make GO=/home/draco/go/bin/go1.26.0 release-gate` — version, README, changelog, replace-directive, filename, and module-zip checks all pass
- `go test ./cmd/gosx -run '^TestStageDeploymentBundleCopiesRuntimeDirsAndWritesArtifacts$' -count=1`
- PR #39 production docs proof: all 14 content files staged byte-for-byte and packaged routes `/`, `/docs/introduction`, and `/docs/performance` returned HTTP 200
- `git diff --check`

## Stack

Stacked on #39 (`codex/build-stage-content`) so the tag cannot land without the deployment-content fix it documents.
