### PR TITLE
fix(wasm): exclude host-only IR lowering from TinyGo client build

### DIFF
--- a/cmd/gosx/tinygo_build_test.go
+++ b/cmd/gosx/tinygo_build_test.go
@@ -136,6 +136,51 @@ func TestTinyGoWASMDependencyClosurePrunesHostShaderCompiler(t *testing.T) {
 	}
 }
 
+// TestTinyGoWASMDependencyClosureExcludesGoTreeSitterAndGob is a regression
+// pin for the R2 "unreachable" trap that fired on every /admin/editor load
+// in production (sassafras / handoff-26-wasm-trap investigation).
+//
+// Root cause: engine/surface/lowering.go and ir/lower.go had no build
+// constraint excluding them from the WASM client, even though both are
+// host/build-time-only (their only callers — engine/surface/discover.go,
+// compile.go, lsp/symbols.go — are all already `!js`/`!tinygo`). Importing
+// either pulled github.com/odvcencio/gotreesitter (and its encoding/gob
+// dependency, used by its embedded-grammar loader) into every TinyGo build
+// of client/wasm. TinyGo's internal/reflectlite has a known gap —
+// AssignableTo/Implements against a non-empty interface panics
+// ("reflect: unimplemented: AssignableTo with interface") — that gob's
+// type-info machinery (mustGetTypeInfo -> userType -> implementsInterface)
+// trips during WASM boot, before any hydrate call. Combined with this
+// build's `-panic=trap` TinyGo flag, that unrecoverable panic silently
+// compiled to a bare `unreachable` WASM trap on every production page load.
+//
+// This test would have failed red before the fix (gotreesitter present as
+// an external module dependency of the TinyGo client/wasm closure) and is
+// green after (see engine/surface/lowering.go and ir/lower.go's
+// `!js`/`!tinygo` tags). tinyGoWASMDependencyClosure separates in-module
+// gosx packages from external modules — gotreesitter is a third-party
+// module (github.com/odvcencio/gotreesitter), so it shows up in the
+// `modules` return value, not `packages` (which only reflects packages
+// within m31labs.dev/gosx itself — see TestTinyGoWASMDependencyClosure
+// PrunesHostShaderCompiler's m31labs.dev/selena check for the same
+// pattern). encoding/gob is Go standard library, which
+// tinyGoWASMDependencyClosure filters out of both return values entirely
+// (`pkg.Standard` short-circuit) — gotreesitter's absence is what actually
+// matters here, since gob only entered the graph transitively through it.
+func TestTinyGoWASMDependencyClosureExcludesGoTreeSitterAndGob(t *testing.T) {
+	t.Setenv("GOSX_TINYGO_FULL_RUNTIME", "")
+
+	_, modules, err := tinyGoWASMDependencyClosure(".", tinyGoWASMTags()...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, module := range modules {
+		if module.Path == "github.com/odvcencio/gotreesitter" {
+			t.Fatalf("TinyGo WASM closure unexpectedly includes gotreesitter (R2 unreachable-trap regression — it drags in encoding/gob, which trips TinyGo's internal/reflectlite AssignableTo-with-interface gap): %+v", module)
+		}
+	}
+}
+
 func TestStandardGoWASMOptIsOptIn(t *testing.T) {
 	t.Setenv("GOSX_GO_WASM_OPT", "")
 	if standardGoWASMOptEnabled() {

--- a/engine/surface/lowering.go
+++ b/engine/surface/lowering.go
@@ -1,7 +1,32 @@
+//go:build !js
+
 // Bytecode lowering for engine surfaces (Slice X.D — AST-compiler
 // initiative). Wraps ir/golower so engine/surface/discover.go can route
 // annotation-free surface declarations to the shared-VM bytecode path
 // per ADR 0003.
+//
+// Host-only (like discover.go, its sole caller): LowerToBytecode compiles
+// .gsx source into bytecode at build time via ir/golower, which pulls in
+// ir (and, transitively, gotreesitter for CST parsing — see ir/lower.go).
+// The WASM client only ever hydrates the already-compiled bytecode this
+// produces (client/bridge/bridge_engine_surface.go's decodeEngineSurfaceProgram
+// documents the JSON this emits, but never calls LowerToBytecode itself); it
+// has no legitimate reason to link the .gsx compiler or gotreesitter at all
+// — compile_stub_tinygo.go states exactly this intent for gosx.Compile, but
+// this file (lacking any exclusion) was the leak: TinyGo links gotreesitter
+// transitively through ir -> ir/lower.go, and something in that linked-in
+// grammar-loading path (encoding/gob's type-info construction against a
+// non-empty interface) trips TinyGo's internal/reflectlite gap
+// ("AssignableTo with interface" is unimplemented for interfaces with
+// methods — see /usr/local/lib/tinygo/src/internal/reflectlite/type.go)
+// during WASM boot, before any hydrate call — an unrecoverable panic that,
+// combined with this build's -panic=trap, silently traps as a bare
+// `unreachable` on every /admin/editor load. Excluding this file from js
+// builds (matching discover.go's existing `!js` tag) removes the entire
+// gotreesitter/gob chain from the WASM client, since neither of the other
+// engine/surface files the client imports (canvas_host_impl.go, vm_host.go,
+// context_host.go, surface.go, wrap.go, registry.go, head_assets.go,
+// annotation.go) reference ir or gotreesitter.
 //
 // JS-side bootstrap wiring note: the bytecode dispatcher reads
 // data-gosx-engine-bytecode from the rendered <canvas> placeholder

--- a/ir/goident.go
+++ b/ir/goident.go
@@ -1,0 +1,32 @@
+package ir
+
+// isValidGoIdent, isGoIdentStart, and isGoIdentContinue are plain string
+// helpers with no gotreesitter dependency. They live in their own
+// unconstrained file (rather than lower.go, which is `!tinygo` — see that
+// file's doc comment) because validate.go (always built, including under
+// TinyGo) needs isValidGoIdent too.
+func isValidGoIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		if i == 0 {
+			if !isGoIdentStart(r) {
+				return false
+			}
+		} else {
+			if !isGoIdentContinue(r) {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+func isGoIdentStart(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
+}
+
+func isGoIdentContinue(r rune) bool {
+	return isGoIdentStart(r) || (r >= '0' && r <= '9')
+}

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1,3 +1,29 @@
+//go:build !tinygo
+
+// Lower (this file) is the CST-to-IR compiler step: it is host/build-time
+// -only tooling (its only callers are compile.go's gosx.Compile and
+// lsp/symbols.go — never client/wasm at runtime, which only ever hydrates
+// already-lowered IR/bytecode). It is excluded from TinyGo builds for the
+// same reason compile.go/grammar.go/grammargen_aliases.go/gsx_attr_scanner.go
+// are (see compile_stub_tinygo.go): its gotreesitter dependency is not
+// TinyGo-clean. Specifically, gotreesitter transitively pulls in
+// encoding/gob (via its embedded-grammar loader), and TinyGo's
+// internal/reflectlite has a known, unimplemented gap —
+// `AssignableTo`/`Implements` against a non-empty interface panics
+// ("reflect: unimplemented: AssignableTo with interface") — that gob's
+// type-info machinery (mustGetTypeInfo -> userType -> implementsInterface)
+// trips during WASM boot. Before this fix, this file had NO build
+// constraint, so importing the `ir` package for its data types (Program,
+// etc. — needed by client/wasm's dependency graph via engine/surface) also
+// linked gotreesitter into every TinyGo build of client/wasm, regardless of
+// whether Lower() was ever called. Combined with the production build's
+// `-panic=trap` TinyGo flag, that panic silently traps as a bare WASM
+// `unreachable` on every /admin/editor load, before any hydrate call.
+// The standard (non-TinyGo) `go build GOOS=js GOARCH=wasm` test/dev build is
+// unaffected either way — it keeps the real compiler (64-bit int, so
+// grammargen compiles) as client/wasm's own tests rely on genuinely
+// compiling .gsx snippets.
+
 package ir
 
 import (
@@ -1005,34 +1031,6 @@ func (l *lowerer) lowerEngineSurface(comp *Component) {
 
 	comp.EngineSurface = true
 	comp.SurfaceHandlers = handlers
-}
-
-// isValidGoIdent reports whether s is a valid (non-empty) Go identifier.
-// It does not check for reserved keywords — that is fine at this stage.
-func isValidGoIdent(s string) bool {
-	if s == "" {
-		return false
-	}
-	for i, r := range s {
-		if i == 0 {
-			if !isGoIdentStart(r) {
-				return false
-			}
-		} else {
-			if !isGoIdentContinue(r) {
-				return false
-			}
-		}
-	}
-	return true
-}
-
-func isGoIdentStart(r rune) bool {
-	return (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || r == '_'
-}
-
-func isGoIdentContinue(r rune) bool {
-	return isGoIdentStart(r) || (r >= '0' && r <= '9')
 }
 
 // findGSXReturn searches a function body for a return statement containing GSX.


### PR DESCRIPTION
The production TinyGo client build pulled gotreesitter+encoding/gob via ir/lower.go and engine/surface/lowering.go (host-tooling-only code with no build constraints). TinyGo's internal/reflectlite lacks AssignableTo for non-empty interfaces; gob's type-info machinery trips it at WASM boot, and -panic=trap compiles that to a silent 'unreachable' on every editor load. Fix: !js / !tinygo constraints + goident.go extraction. New regression test asserts the TinyGo dependency closure excludes gotreesitter/gob (red pre-fix). go test ./... green (~330 pkgs), npm test:js 458/458, 3/3 clean loads post-fix vs 3/3 trapped pre-fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)