### PR TITLE
format: canonicalize v0.31.6 docs sources

### DIFF
--- a/examples/gosx-docs/app/demos/checkers/page.gsx
+++ b/examples/gosx-docs/app/demos/checkers/page.gsx
@@ -11,10 +11,12 @@ func Page() Node {
 				height="600"
 				decoding="async"
 				fetchpriority="high"
-			/>
+			 />
 			<Scene3D {...data.scene} />
 			<p class="checkers-showcase__render-note">
-				Pure-Go native preview · <a href="/checkers-native-telemetry.json">inspect telemetry</a> · live Scene3D when available
+				Pure-Go native preview ·
+				<a href="/checkers-native-telemetry.json">inspect telemetry</a>
+				· live Scene3D when available
 			</p>
 		</div>
 		<section class="checkers-showcase__intro" data-checkers-root>

--- a/examples/gosx-docs/app/demos/collab/page.gsx
+++ b/examples/gosx-docs/app/demos/collab/page.gsx
@@ -2,43 +2,43 @@ package collab
 
 func Page() Node {
 	    return <section
-		class="collab"
-		aria-label="Last-write-wins Hub synchronization demo with live presence and cursors"
-		data-initial-version={data.initialVersion}
+	    	class="collab"
+	    	aria-label="Last-write-wins Hub synchronization demo with live presence and cursors"
+	    	data-initial-version={data.initialVersion}
 	    >
-		<header class="collab__header">
-			<h1 class="collab__title">Hub Sync · LWW</h1>
-			<div class="collab__status" aria-live="polite">
-				<span id="collab-status-dot" class="collab__status-dot"></span>
-				<span id="collab-status" role="status">connecting…</span>
-				<span aria-hidden="true">·</span>
-				<span>
-					v
-					<span id="collab-version">{data.initialVersion}</span>
-				</span>
-				<span aria-hidden="true">·</span>
-				<span id="collab-presence" class="collab__presence" role="status">connecting…</span>
-			</div>
-			<span id="collab-self" class="collab__self" aria-live="polite"></span>
-		</header>
-		<div class="collab__body">
-			<div class="collab__pane collab__pane--editor">
-				<div class="collab__pane-label">SOURCE</div>
-				<div class="collab__editor-wrap">
-					<textarea id="collab-source" class="collab__source" spellcheck="false" aria-label="Markdown source">{data.initialText}</textarea>
-					<div id="collab-cursors" class="collab__cursor-layer" aria-hidden="true"></div>
-				</div>
-			</div>
-			<div class="collab__pane collab__pane--preview">
-				<div class="collab__pane-label">PREVIEW</div>
-				<div id="collab-preview" class="collab__preview"></div>
-			</div>
-		</div>
-		<footer class="collab__footer">
-			<span>
-				one shared in-memory document · last write wins · live presence and remote cursors over the hub · no CRDT, rooms, or persistence
-			</span>
-		</footer>
-		<script src="/collab-client.js" defer></script>
+	    	<header class="collab__header">
+	    		<h1 class="collab__title">Hub Sync · LWW</h1>
+	    		<div class="collab__status" aria-live="polite">
+	    			<span id="collab-status-dot" class="collab__status-dot"></span>
+	    			<span id="collab-status" role="status">connecting…</span>
+	    			<span aria-hidden="true">·</span>
+	    			<span>
+	    				v
+	    				<span id="collab-version">{data.initialVersion}</span>
+	    			</span>
+	    			<span aria-hidden="true">·</span>
+	    			<span id="collab-presence" class="collab__presence" role="status">connecting…</span>
+	    		</div>
+	    		<span id="collab-self" class="collab__self" aria-live="polite"></span>
+	    	</header>
+	    	<div class="collab__body">
+	    		<div class="collab__pane collab__pane--editor">
+	    			<div class="collab__pane-label">SOURCE</div>
+	    			<div class="collab__editor-wrap">
+	    				<textarea id="collab-source" class="collab__source" spellcheck="false" aria-label="Markdown source">{data.initialText}</textarea>
+	    				<div id="collab-cursors" class="collab__cursor-layer" aria-hidden="true"></div>
+	    			</div>
+	    		</div>
+	    		<div class="collab__pane collab__pane--preview">
+	    			<div class="collab__pane-label">PREVIEW</div>
+	    			<div id="collab-preview" class="collab__preview"></div>
+	    		</div>
+	    	</div>
+	    	<footer class="collab__footer">
+	    		<span>
+	    			one shared in-memory document · last write wins · live presence and remote cursors over the hub · no CRDT, rooms, or persistence
+	    		</span>
+	    	</footer>
+	    	<script src="/collab-client.js" defer></script>
 	    </section>
 }

--- a/examples/gosx-docs/app/demos/fluid/page.gsx
+++ b/examples/gosx-docs/app/demos/fluid/page.gsx
@@ -2,62 +2,62 @@ package fluid
 
 func Page() Node {
     return <section class="fluid" aria-label="Server-streamed velocity field">
-	<div class="fluid__frame">
-		<canvas
-			id="fluid-canvas"
-			class="fluid__canvas"
-			width={data.worldW}
-			height={data.worldH}
-			aria-label="particle flow canvas"
-		></canvas>
-		<div class="fluid__hud">
-			<div class="fluid__hud-title">VELOCITY FIELD</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">STATE</span>
-				<b class="fluid__stat-value" id="fluid-state" role="status">connecting…</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">GRID</span>
-				<b class="fluid__stat-value" id="fluid-grid">
-					{data.gridN}
-					³
-				</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">BITS</span>
-				<b class="fluid__stat-value" id="fluid-bits">{data.bitWidth}</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">TICK</span>
-				<b class="fluid__stat-value" id="fluid-tick">—</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">WIRE</span>
-				<b class="fluid__stat-value" id="fluid-wire">—</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">COMPRESSION</span>
-				<b class="fluid__stat-value" id="fluid-compression">—</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">FRAME</span>
-				<b class="fluid__stat-value" id="fluid-frame-kind">waiting</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">RATE</span>
-				<b class="fluid__stat-value" id="fluid-rate">—</b>
-			</div>
-			<div class="fluid__stat">
-				<span class="fluid__stat-label">PARTICLES</span>
-				<b class="fluid__stat-value" id="fluid-particles">0</b>
-			</div>
-		</div>
-	</div>
-	<footer class="fluid__footer">
-		<span>
-			GoSX Field → 6-bit keyframes/deltas → Hub at 20 Hz · browser decodes one slice and renders particles · drag inside the canvas for a visual-only nudge (client-side presentation effect, does not touch the server field)
-		</span>
-	</footer>
-	<script src="/fluid-client.js" defer></script>
+    	<div class="fluid__frame">
+    		<canvas
+    			id="fluid-canvas"
+    			class="fluid__canvas"
+    			width={data.worldW}
+    			height={data.worldH}
+    			aria-label="particle flow canvas"
+    		></canvas>
+    		<div class="fluid__hud">
+    			<div class="fluid__hud-title">VELOCITY FIELD</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">STATE</span>
+    				<b class="fluid__stat-value" id="fluid-state" role="status">connecting…</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">GRID</span>
+    				<b class="fluid__stat-value" id="fluid-grid">
+    					{data.gridN}
+    					³
+    				</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">BITS</span>
+    				<b class="fluid__stat-value" id="fluid-bits">{data.bitWidth}</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">TICK</span>
+    				<b class="fluid__stat-value" id="fluid-tick">—</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">WIRE</span>
+    				<b class="fluid__stat-value" id="fluid-wire">—</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">COMPRESSION</span>
+    				<b class="fluid__stat-value" id="fluid-compression">—</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">FRAME</span>
+    				<b class="fluid__stat-value" id="fluid-frame-kind">waiting</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">RATE</span>
+    				<b class="fluid__stat-value" id="fluid-rate">—</b>
+    			</div>
+    			<div class="fluid__stat">
+    				<span class="fluid__stat-label">PARTICLES</span>
+    				<b class="fluid__stat-value" id="fluid-particles">0</b>
+    			</div>
+    		</div>
+    	</div>
+    	<footer class="fluid__footer">
+    		<span>
+    			GoSX Field → 6-bit keyframes/deltas → Hub at 20 Hz · browser decodes one slice and renders particles · drag inside the canvas for a visual-only nudge (client-side presentation effect, does not touch the server field)
+    		</span>
+    	</footer>
+    	<script src="/fluid-client.js" defer></script>
     </section>
 }

--- a/examples/gosx-docs/app/demos/layout.gsx
+++ b/examples/gosx-docs/app/demos/layout.gsx
@@ -6,123 +6,130 @@ package docs
 
 func Layout() Node {
     return <div
-		class="demos-shell"
-		data-gosx-bind-source=".demo-dock__link[aria-current='page']"
-		data-gosx-bind-attr="data-demo-slug:data-demo"
-	>
-	<header class="demos-topbar">
-		<span class="demos-topbar__crumb">
-			<a href="/" class="demos-topbar__home" data-gosx-link="true">GoSX</a>
-			<span class="demos-topbar__sep" aria-hidden="true">/</span>
-			<a href="/demos" class="demos-topbar__section" data-gosx-link="true">Demos</a>
-		</span>
-		<button
-			class="demos-topbar__menu"
-			type="button"
-			aria-label="Toggle demos menu"
-			aria-controls="demo-dock"
-			aria-expanded="false"
-			data-gosx-toggle-target=".demos-body"
-			data-gosx-toggle-attribute="data-dock-open"
-		>
-			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-		</button>
-	</header>
-	<div class="demos-body">
-		<nav id="demo-dock" class="demo-dock" aria-label="Demos">
-			<ul class="demo-dock__list" role="list">
-				<Each of={Demos()} as="demo">
-					<li class="demo-dock__item" role="listitem">
-						<a
-							href={"/demos/" + demo.Slug}
-							class="demo-dock__link"
-							data-gosx-link="true"
-							data-demo={demo.Slug}
-							data-demo-title={demo.Title}
-							data-demo-lesson={demo.Lesson}
-							data-demo-facets={demoValues(demo.Facets)}
-							data-demo-source={demoSourceURL(demo.SourcePath)}
-							data-demo-source-path={demo.SourcePath}
-							data-demo-packages={demoValues(demo.Packages)}
-							data-demo-render-mode={demo.RenderMode}
-							data-demo-limitations={demo.Limitations}
-							data-gosx-toggle-close=".demos-body"
-							data-gosx-toggle-attribute="data-dock-open"
-						>
-							<span class="demo-dock__dot" aria-hidden="true"></span>
-							<span class="demo-dock__body">
-								<span class="demo-dock__title">{demo.Title}</span>
-								<span class="demo-dock__tag">{demo.Tag}</span>
-							</span>
-							<span class={"demo-dock__chip demo-dock__chip--" + demo.Status}>{demo.Status}</span>
-						</a>
-					</li>
-				</Each>
-			</ul>
-		</nav>
-		<div class="demo-viewport">
-			<Slot />
-			<footer class="demo-meta" role="contentinfo" aria-label="Demo metadata">
-				<button
-					type="button"
-					class="demo-meta__pill"
-					data-gosx-disclosure-target="#demo-details"
-					aria-controls="demo-details"
-					aria-expanded="false"
-				>How this is GoSX</button>
-			</footer>
-		</div>
-	</div>
-	<div class="demo-details-backdrop" data-gosx-disclosure-backdrop="#demo-details" hidden></div>
-	<aside
-		id="demo-details"
-		class="demo-details"
-		data-gosx-disclosure
-		data-gosx-bind-source=".demo-dock__link[aria-current='page']"
-		role="dialog"
-		aria-modal="true"
-		aria-labelledby="demo-details-title"
-		hidden
-	>
-		<header class="demo-details__header">
-			<div>
-				<p class="demo-details__eyebrow">How this is GoSX</p>
-				<h2 id="demo-details-title" class="demo-details__title" data-gosx-bind-text="data-demo-title">Demo details</h2>
-			</div>
-			<button
-				type="button"
-				class="demo-details__close"
-				data-gosx-disclosure-close="#demo-details"
-				data-gosx-disclosure-initial-focus
-				aria-label="Close demo details"
-			>×</button>
-		</header>
-		<p class="demo-details__lesson" data-gosx-bind-text="data-demo-lesson">Choose a demo to inspect how it is built.</p>
-		<dl class="demo-details__facts">
-			<div>
-				<dt>Built with</dt>
-				<dd data-gosx-bind-text="data-demo-facets">—</dd>
-			</div>
-			<div>
-				<dt>Packages</dt>
-				<dd data-gosx-bind-text="data-demo-packages">—</dd>
-			</div>
-			<div>
-				<dt>Rendering</dt>
-				<dd data-gosx-bind-text="data-demo-render-mode">—</dd>
-			</div>
-			<div>
-				<dt>Honest limits</dt>
-				<dd data-gosx-bind-text="data-demo-limitations">—</dd>
-			</div>
-		</dl>
-		<a class="demo-details__source" data-gosx-bind-attr="href:data-demo-source" target="_blank" rel="noopener noreferrer">
-			View GoSX source
-			<span aria-hidden="true">↗</span>
-		</a>
-		<code class="demo-details__path" data-gosx-bind-text="data-demo-source-path"></code>
-	</aside>
+    	class="demos-shell"
+    	data-gosx-bind-source=".demo-dock__link[aria-current='page']"
+    	data-gosx-bind-attr="data-demo-slug:data-demo"
+    >
+    	<header class="demos-topbar">
+    		<span class="demos-topbar__crumb">
+    			<a href="/" class="demos-topbar__home" data-gosx-link="true">GoSX</a>
+    			<span class="demos-topbar__sep" aria-hidden="true">/</span>
+    			<a href="/demos" class="demos-topbar__section" data-gosx-link="true">Demos</a>
+    		</span>
+    		<button
+    			class="demos-topbar__menu"
+    			type="button"
+    			aria-label="Toggle demos menu"
+    			aria-controls="demo-dock"
+    			aria-expanded="false"
+    			data-gosx-toggle-target=".demos-body"
+    			data-gosx-toggle-attribute="data-dock-open"
+    		>
+    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+    		</button>
+    	</header>
+    	<div class="demos-body">
+    		<nav id="demo-dock" class="demo-dock" aria-label="Demos">
+    			<ul class="demo-dock__list" role="list">
+    				<Each of={Demos()} as="demo">
+    					<li class="demo-dock__item" role="listitem">
+    						<a
+    							href={"/demos/" + demo.Slug}
+    							class="demo-dock__link"
+    							data-gosx-link="true"
+    							data-demo={demo.Slug}
+    							data-demo-title={demo.Title}
+    							data-demo-lesson={demo.Lesson}
+    							data-demo-facets={demoValues(demo.Facets)}
+    							data-demo-source={demoSourceURL(demo.SourcePath)}
+    							data-demo-source-path={demo.SourcePath}
+    							data-demo-packages={demoValues(demo.Packages)}
+    							data-demo-render-mode={demo.RenderMode}
+    							data-demo-limitations={demo.Limitations}
+    							data-gosx-toggle-close=".demos-body"
+    							data-gosx-toggle-attribute="data-dock-open"
+    						>
+    							<span class="demo-dock__dot" aria-hidden="true"></span>
+    							<span class="demo-dock__body">
+    								<span class="demo-dock__title">{demo.Title}</span>
+    								<span class="demo-dock__tag">{demo.Tag}</span>
+    							</span>
+    							<span class={"demo-dock__chip demo-dock__chip--" + demo.Status}>{demo.Status}</span>
+    						</a>
+    					</li>
+    				</Each>
+    			</ul>
+    		</nav>
+    		<div class="demo-viewport">
+    			<Slot />
+    			<footer class="demo-meta" role="contentinfo" aria-label="Demo metadata">
+    				<button
+    					type="button"
+    					class="demo-meta__pill"
+    					data-gosx-disclosure-target="#demo-details"
+    					aria-controls="demo-details"
+    					aria-expanded="false"
+    				>How this is GoSX</button>
+    			</footer>
+    		</div>
+    	</div>
+    	<div class="demo-details-backdrop" data-gosx-disclosure-backdrop="#demo-details" hidden></div>
+    	<aside
+    		id="demo-details"
+    		class="demo-details"
+    		data-gosx-disclosure
+    		data-gosx-bind-source=".demo-dock__link[aria-current='page']"
+    		role="dialog"
+    		aria-modal="true"
+    		aria-labelledby="demo-details-title"
+    		hidden
+    	>
+    		<header class="demo-details__header">
+    			<div>
+    				<p class="demo-details__eyebrow">How this is GoSX</p>
+    				<h2 id="demo-details-title" class="demo-details__title" data-gosx-bind-text="data-demo-title">Demo details</h2>
+    			</div>
+    			<button
+    				type="button"
+    				class="demo-details__close"
+    				data-gosx-disclosure-close="#demo-details"
+    				data-gosx-disclosure-initial-focus
+    				aria-label="Close demo details"
+    			>×</button>
+    		</header>
+    		<p class="demo-details__lesson" data-gosx-bind-text="data-demo-lesson">
+    			Choose a demo to inspect how it is built.
+    		</p>
+    		<dl class="demo-details__facts">
+    			<div>
+    				<dt>Built with</dt>
+    				<dd data-gosx-bind-text="data-demo-facets">—</dd>
+    			</div>
+    			<div>
+    				<dt>Packages</dt>
+    				<dd data-gosx-bind-text="data-demo-packages">—</dd>
+    			</div>
+    			<div>
+    				<dt>Rendering</dt>
+    				<dd data-gosx-bind-text="data-demo-render-mode">—</dd>
+    			</div>
+    			<div>
+    				<dt>Honest limits</dt>
+    				<dd data-gosx-bind-text="data-demo-limitations">—</dd>
+    			</div>
+    		</dl>
+    		<a
+    			class="demo-details__source"
+    			data-gosx-bind-attr="href:data-demo-source"
+    			target="_blank"
+    			rel="noopener noreferrer"
+    		>
+    			View GoSX source
+    			<span aria-hidden="true">↗</span>
+    		</a>
+    		<code class="demo-details__path" data-gosx-bind-text="data-demo-source-path"></code>
+    	</aside>
     </div>
 }

--- a/examples/gosx-docs/app/demos/livesim/page.gsx
+++ b/examples/gosx-docs/app/demos/livesim/page.gsx
@@ -2,48 +2,54 @@ package livesim
 
 func Page() Node {
     return <section class="livesim" aria-label="Live 2D physics sandbox">
-	<div class="livesim__frame">
-		<canvas
-			id="livesim-canvas"
-			class="livesim__canvas"
-			width={data.worldW}
-			height={data.worldH}
-			aria-label="physics canvas — click to drop a circle"
-			tabindex="0"
-			role="application"
-		></canvas>
-		<div class="livesim__hud">
-			<div class="livesim__stat">
-				<span class="livesim__stat-label">SERVER TICK</span>
-				<b class="livesim__stat-value" id="livesim-frame">0</b>
-			</div>
-			<div class="livesim__stat">
-				<span class="livesim__stat-label">RENDER</span>
-				<b class="livesim__stat-value" id="livesim-render">—</b>
-			</div>
-			<div class="livesim__stat">
-				<span class="livesim__stat-label">CIRCLES</span>
-				<b class="livesim__stat-value" id="livesim-count">0</b>
-			</div>
-			<div class="livesim__stat">
-				<span class="livesim__stat-label">STATE</span>
-				<b class="livesim__stat-value" id="livesim-state" role="status">connecting…</b>
-			</div>
-			<div class="livesim__stat">
-				<span class="livesim__stat-label">VIEWERS</span>
-				<b class="livesim__stat-value" id="livesim-viewers" role="status">1</b>
-			</div>
-			<div class="livesim__actions">
-				<button class="livesim__spawn" id="livesim-spawn" type="button">Spawn at center</button>
-				<button class="livesim__burst" id="livesim-burst" type="button">Burst</button>
-			</div>
-		</div>
-	</div>
-	<footer class="livesim__footer">
-		<span>
-			pointer, touch, or Enter/Space spawns a circle · Burst drops {data.burstMinCircles}–{data.burstMaxCircles} circles via the hub · GoSX Sim owns state at 20 Hz for up to {data.maxCircles} circles · open a second tab to see live viewer count and ghost cursors
-		</span>
-	</footer>
-	<script src="/livesim-client.js" defer></script>
+    	<div class="livesim__frame">
+    		<canvas
+    			id="livesim-canvas"
+    			class="livesim__canvas"
+    			width={data.worldW}
+    			height={data.worldH}
+    			aria-label="physics canvas — click to drop a circle"
+    			tabindex="0"
+    			role="application"
+    		></canvas>
+    		<div class="livesim__hud">
+    			<div class="livesim__stat">
+    				<span class="livesim__stat-label">SERVER TICK</span>
+    				<b class="livesim__stat-value" id="livesim-frame">0</b>
+    			</div>
+    			<div class="livesim__stat">
+    				<span class="livesim__stat-label">RENDER</span>
+    				<b class="livesim__stat-value" id="livesim-render">—</b>
+    			</div>
+    			<div class="livesim__stat">
+    				<span class="livesim__stat-label">CIRCLES</span>
+    				<b class="livesim__stat-value" id="livesim-count">0</b>
+    			</div>
+    			<div class="livesim__stat">
+    				<span class="livesim__stat-label">STATE</span>
+    				<b class="livesim__stat-value" id="livesim-state" role="status">connecting…</b>
+    			</div>
+    			<div class="livesim__stat">
+    				<span class="livesim__stat-label">VIEWERS</span>
+    				<b class="livesim__stat-value" id="livesim-viewers" role="status">1</b>
+    			</div>
+    			<div class="livesim__actions">
+    				<button class="livesim__spawn" id="livesim-spawn" type="button">Spawn at center</button>
+    				<button class="livesim__burst" id="livesim-burst" type="button">Burst</button>
+    			</div>
+    		</div>
+    	</div>
+    	<footer class="livesim__footer">
+    		<span>
+    			pointer, touch, or Enter/Space spawns a circle · Burst drops
+    			{data.burstMinCircles}
+    			–
+    			{data.burstMaxCircles}
+    			circles via the hub · GoSX Sim owns state at 20 Hz for up to
+    			{data.maxCircles}
+    			circles · open a second tab to see live viewer count and ghost cursors
+    		</span>
+    	</footer>
+    	<script src="/livesim-client.js" defer></script>
     </section>
 }

--- a/examples/gosx-docs/app/demos/playground/page.gsx
+++ b/examples/gosx-docs/app/demos/playground/page.gsx
@@ -32,8 +32,14 @@ func Page() Node {
 					title="Ctrl+Enter compiles immediately"
 				>{data.source}</textarea>
 				<div class="play__editor-meta">
-					<span class="play__editor-meta-item" data-editor-stat="lines">{data.initialLines} lines</span>
-					<span class="play__editor-meta-item" data-editor-stat="chars">{data.initialChars} chars</span>
+					<span class="play__editor-meta-item" data-editor-stat="lines">
+						{data.initialLines}
+						lines
+					</span>
+					<span class="play__editor-meta-item" data-editor-stat="chars">
+						{data.initialChars}
+						chars
+					</span>
 					<span class="play__editor-meta-item play__editor-meta-hint">Ctrl+Enter compiles now</span>
 				</div>
 				<div class="play__errors" aria-live="polite"></div>
@@ -53,7 +59,10 @@ func Page() Node {
 					</div>
 					<div class="play__stat">
 						<span class="play__stat-label">Program</span>
-						<b class="play__stat-value" data-stat="bytes">{data.initialProgramBytes} bytes</b>
+						<b class="play__stat-value" data-stat="bytes">
+							{data.initialProgramBytes}
+							bytes
+						</b>
 					</div>
 					<div class="play__stat">
 						<span class="play__stat-label">Nodes</span>

--- a/examples/gosx-docs/app/demos/scene3d-bench/page.gsx
+++ b/examples/gosx-docs/app/demos/scene3d-bench/page.gsx
@@ -137,7 +137,7 @@ func BenchOverlayScript() Node {
 	(function() {
 	  if (typeof window === "undefined") return;
 	  window.__gosx_scene3d_perf = true;
-
+	
 	  var BUF_LEN = 240;
 	  var buf = new Float64Array(BUF_LEN);
 	  var bufIdx = 0;
@@ -149,12 +149,12 @@ func BenchOverlayScript() Node {
 	  var lastRAF = 0;
 	  var detectedGPU = "unavailable";
 	  var selectedBackend = "starting";
-
+	
 	  // 16.7ms == one frame at 60fps. Used only to colour-code the p95/max/
 	  // rAF-p95 readouts; CPU submit is a fraction of a frame so this is a
 	  // guide, not a claim that the whole frame missed its budget.
 	  var FRAME_BUDGET_MS = 1000 / 60;
-
+	
 	  // FPS sparkline: a separate, longer ring buffer than rafBuf (which is
 	  // sized for the 240-sample / ~4s CPU submit window) so the sparkline can
 	  // cover roughly the last 10 seconds of rAF cadence regardless of display
@@ -166,13 +166,13 @@ func BenchOverlayScript() Node {
 	  var fpsTimeBuf = new Float64Array(FPS_BUF_LEN);
 	  var fpsIdx = 0;
 	  var fpsCount = 0;
-
+	
 	  // sessionStorage key used to hand a snapshot of this tab's CPU submit
 	  // stats to the next full-page load when the operator clicks a workload
 	  // link. Never blended into the live ring buffer — only ever shown as a
 	  // labeled "prev workload" comparison row.
 	  var PREV_SNAPSHOT_KEY = "gosx-scene3d-bench:prev-snapshot";
-
+	
 	  function push(duration) {
 	    buf[bufIdx] = duration;
 	    bufIdx = (bufIdx + 1) % BUF_LEN;
@@ -209,7 +209,7 @@ func BenchOverlayScript() Node {
 	      mean: sum / count,
 	    };
 	  }
-
+	
 	  var els = {};
 	  function mountOverlay() {
 	    els.current  = document.getElementById("bench3d-current");
@@ -247,13 +247,13 @@ func BenchOverlayScript() Node {
 	    var download = document.getElementById("bench3d-download");
 	    if (download) download.addEventListener("click", downloadSnapshot);
 	  }
-
+	
 	  function fmt(ms) {
 	    if (typeof ms !== "number" || !isFinite(ms)) return "—";
 	    if (ms < 1) return (ms * 1000).toFixed(0) + "µs";
 	    return ms.toFixed(2) + "ms";
 	  }
-
+	
 	  // barClass returns the CSS class suffix for a frame time value.
 	  function barClass(ms) {
 	    if (ms <= 8)  return "healthy";
@@ -261,7 +261,7 @@ func BenchOverlayScript() Node {
 	    if (ms <= 33) return "stretched";
 	    return "dropping";
 	  }
-
+	
 	  // budgetClass colour-codes a millisecond value against FRAME_BUDGET_MS
 	  // (16.7ms / 60fps): "calm" comfortably under budget, "warning"
 	  // approaching it, "hot" over it. Used for the p95/max/rAF-p95 stat text,
@@ -272,7 +272,7 @@ func BenchOverlayScript() Node {
 	    if (ms <= FRAME_BUDGET_MS) return "warning";
 	    return "hot";
 	  }
-
+	
 	  // fpsBarClass returns the CSS class suffix for an instantaneous fps
 	  // sample in the sparkline. Thresholds mirror the 60fps budget: healthy
 	  // near/above 60fps, sliding down through dropped-frame territory.
@@ -283,7 +283,7 @@ func BenchOverlayScript() Node {
 	    if (fps >= 24) return "stretched";
 	    return "dropping";
 	  }
-
+	
 	  // paintHistogram renders up to 60 bars into the SVG element.
 	  function paintHistogram(svg) {
 	    if (!svg || bufCount === 0) return;
@@ -292,7 +292,7 @@ func BenchOverlayScript() Node {
 	    var viewH = 40;
 	    var gap   = 1;
 	    var barW  = (viewW - (BARS - 1) * gap) / BARS;
-
+	
 	    // Collect the most-recent min(bufCount, BARS) samples in chronological order.
 	    var count = Math.min(bufCount, BARS);
 	    var samples = [];
@@ -301,18 +301,18 @@ func BenchOverlayScript() Node {
 	      var idx = ((bufIdx - 1 - i) % BUF_LEN + BUF_LEN) % BUF_LEN;
 	      samples.push(buf[idx]);
 	    }
-
+	
 	    // Find max for scaling (floor at 1ms to avoid divide-by-zero).
 	    var maxVal = 1;
 	    for (var k = 0; k < samples.length; k++) {
 	      if (samples[k] > maxVal) maxVal = samples[k];
 	    }
-
+	
 	    // Build SVG rects as a string to do a single innerHTML assignment.
 	    var svgNS = "http://www.w3.org/2000/svg";
 	    // Remove old children.
 	    while (svg.firstChild) svg.removeChild(svg.firstChild);
-
+	
 	    for (var b = 0; b < samples.length; b++) {
 	      var val = samples[b];
 	      var h   = Math.max(2, Math.round((val / maxVal) * viewH));
@@ -327,7 +327,7 @@ func BenchOverlayScript() Node {
 	      svg.appendChild(rect);
 	    }
 	  }
-
+	
 	  // paintFPSSparkline renders the last ~FPS_WINDOW_MS of instantaneous
 	  // rAF-derived fps samples as a bar sparkline, aria-hidden — the
 	  // adjacent "rAF cadence" / "rAF p95" stat rows are its text
@@ -340,7 +340,7 @@ func BenchOverlayScript() Node {
 	    var viewW = 240;
 	    var viewH = 32;
 	    var gap   = 1;
-
+	
 	    // Walk backwards from the most recent sample, stopping at the window
 	    // edge or once we run out of buffered samples.
 	    var windowSamples = [];
@@ -351,21 +351,21 @@ func BenchOverlayScript() Node {
 	    }
 	    if (windowSamples.length === 0) return;
 	    windowSamples.reverse(); // chronological order, oldest first
-
+	
 	    // Cap the bar count for render cost; keep only the most recent BARS.
 	    var samples = windowSamples.length > BARS
 	      ? windowSamples.slice(windowSamples.length - BARS)
 	      : windowSamples;
 	    var barW = (viewW - (samples.length - 1) * gap) / samples.length;
-
+	
 	    var maxVal = 1;
 	    for (var k = 0; k < samples.length; k++) {
 	      if (samples[k] > maxVal) maxVal = samples[k];
 	    }
-
+	
 	    var svgNS = "http://www.w3.org/2000/svg";
 	    while (svg.firstChild) svg.removeChild(svg.firstChild);
-
+	
 	    for (var b = 0; b < samples.length; b++) {
 	      var val = samples[b];
 	      var h   = Math.max(2, Math.round((val / maxVal) * viewH));
@@ -380,7 +380,7 @@ func BenchOverlayScript() Node {
 	      svg.appendChild(rect);
 	    }
 	  }
-
+	
 	  function updateOverlay() {
 	    var stats = computeStats();
 	    var rafStats = computeRAFStats();
@@ -401,7 +401,7 @@ func BenchOverlayScript() Node {
 	    }
 	    paintFPSSparkline(els.spark, performance.now());
 	  }
-
+	
 	  function sampleRAF(now) {
 	    if (lastRAF) {
 	      var interval = now - lastRAF;
@@ -413,7 +413,7 @@ func BenchOverlayScript() Node {
 	    lastRAF = now;
 	    requestAnimationFrame(sampleRAF);
 	  }
-
+	
 	  function snapshot() {
 	    var overlay = document.getElementById("bench3d-overlay");
 	    return {
@@ -429,13 +429,13 @@ func BenchOverlayScript() Node {
 	      userAgent: navigator.userAgent,
 	    };
 	  }
-
+	
 	  function setActionStatus(message) {
 	    if (!els.status) return;
 	    els.status.textContent = message;
 	    setTimeout(function() { if (els.status) els.status.textContent = ""; }, 1800);
 	  }
-
+	
 	  function copySnapshot() {
 	    var text = JSON.stringify(snapshot(), null, 2);
 	    if (!navigator.clipboard || !navigator.clipboard.writeText) {
@@ -446,7 +446,7 @@ func BenchOverlayScript() Node {
 	      setActionStatus("JSON copied");
 	    }, function() { setActionStatus("Copy failed"); });
 	  }
-
+	
 	  function downloadSnapshot() {
 	    var blob = new Blob([JSON.stringify(snapshot(), null, 2) + "\n"], { type: "application/json" });
 	    var url = URL.createObjectURL(blob);
@@ -457,7 +457,7 @@ func BenchOverlayScript() Node {
 	    setTimeout(function() { URL.revokeObjectURL(url); }, 0);
 	    setActionStatus("JSON downloaded");
 	  }
-
+	
 	  function onEntries(entries) {
 	    for (var i = 0; i < entries.length; i++) {
 	      var entry = entries[i];
@@ -471,7 +471,7 @@ func BenchOverlayScript() Node {
 	      performance.clearMeasures("scene3d-render");
 	    }
 	  }
-
+	
 	  function installObserver() {
 	    if (typeof PerformanceObserver !== "function") {
 	      console.warn("[bench3d] PerformanceObserver unavailable; overlay disabled");
@@ -484,17 +484,17 @@ func BenchOverlayScript() Node {
 	      console.warn("[bench3d] PerformanceObserver.observe failed:", err);
 	    }
 	  }
-
+	
 	  // detectGPU uses the renderer selected by the mounted Scene3D runtime.
 	  // A separate WebGL probe is used only for an optional renderer label.
 	  function detectGPU() {
 	    var gpuEl = document.getElementById("bench3d-gpu");
 	    var apiEl = document.getElementById("bench3d-api");
 	    if (!gpuEl && !apiEl) return;
-
+	
 	    var apiStr = "starting";
 	    var gpuStr = "unavailable";
-
+	
 	    // WebGL2 fallback — also the primary source of renderer info.
 	    var canvas = document.createElement("canvas");
 	    var gl2 = null;
@@ -519,7 +519,7 @@ func BenchOverlayScript() Node {
 	        }
 	      }
 	    }
-
+	
 	    detectedGPU = gpuStr;
 	    if (gpuEl) gpuEl.textContent = gpuStr;
 	    function syncBackend() {
@@ -541,7 +541,7 @@ func BenchOverlayScript() Node {
 	      }, 100);
 	    }
 	  }
-
+	
 	  function markActiveWorkload() {
 	    var overlay = document.getElementById("bench3d-overlay");
 	    var active = overlay ? overlay.getAttribute("data-workload") : "mixed";
@@ -552,7 +552,7 @@ func BenchOverlayScript() Node {
 	      else links[i].removeAttribute("aria-current");
 	    }
 	  }
-
+	
 	  // restorePrevSnapshot reads the CPU submit snapshot (if any) that was
 	  // saved to sessionStorage right before the operator clicked a workload
 	  // link on a previous load of this page, and shows it as a labeled
@@ -583,7 +583,7 @@ func BenchOverlayScript() Node {
 	      " (" + prev.samples + " samples)";
 	    els.prevRow.hidden = false;
 	  }
-
+	
 	  // wireWorkloadNav saves this tab's current CPU submit snapshot to
 	  // sessionStorage right before a workload link navigates away, so the
 	  // next full page load can show it via restorePrevSnapshot. This is the
@@ -611,7 +611,7 @@ func BenchOverlayScript() Node {
 	      });
 	    }
 	  }
-
+	
 	  function boot() {
 	    mountOverlay();
 	    installObserver();
@@ -622,7 +622,7 @@ func BenchOverlayScript() Node {
 	    requestAnimationFrame(sampleRAF);
 	    setInterval(updateOverlay, 250);
 	  }
-
+	
 	  if (document.readyState === "loading") {
 	    document.addEventListener("DOMContentLoaded", boot);
 	  } else {

--- a/examples/gosx-docs/app/demos/scene3d/page.gsx
+++ b/examples/gosx-docs/app/demos/scene3d/page.gsx
@@ -25,7 +25,9 @@ func Page() Node {
 			<details class="scene3d-showcase__proof">
 				<summary>What GoSX owns</summary>
 				<ul>
-					<li>Typed scene graph, stable mesh IDs, and per-mesh declarative spin</li>
+					<li>
+						Typed scene graph, stable mesh IDs, and per-mesh declarative spin
+					</li>
 					<li>
 						PBR materials and a three-point lighting rig
 					</li>

--- a/examples/gosx-docs/app/demos/water/page.gsx
+++ b/examples/gosx-docs/app/demos/water/page.gsx
@@ -2,391 +2,389 @@ package docs
 
 func Page() Node {
   return <main
-	class="water-demo"
-	data-gosx-scene3d-control-scope="true"
-	data-gosx-scene3d-panel-scope="true"
-	aria-label="GoSX water simulation demo"
+  	class="water-demo"
+  	data-gosx-scene3d-control-scope="true"
+  	data-gosx-scene3d-panel-scope="true"
+  	aria-label="GoSX water simulation demo"
   >
-	<Scene3D
-		id="water-demo-scene"
-		class="water-demo__scene"
-		width={1280}
-		height={760}
-		responsive={true}
-		fillHeight={true}
-		controls="orbit"
-		controlTargetX={0}
-		controlTargetY={-0.5}
-		controlTargetZ={0}
-		controlRotateMode="pixel-degrees"
-		controlRotateDirection="grab"
-		controlMinDistance={2}
-		controlMaxDistance={10}
-		controlPitchLimit={1.5707788735}
-		preferWebGPU={true}
-		maxDevicePixelRatio={1.6}
-		adaptiveQuality={false}
-		qualityTier="full"
-		canvasAlpha={false}
-	>
-		<Camera
-			x={1.2695827068526726}
-			y={1.1904730469627978}
-			z={3.395653196065958}
-			fov={45}
-			near={0.01}
-			far={100}
-		 />
-		<Environment
-			ambientColor="#d8edf2"
-			ambientIntensity={0.2}
-			skyColor="#89b7c5"
-			skyIntensity={0.36}
-			groundColor="#211813"
-			groundIntensity={0.24}
-			fogColor="#071217"
-			fogDensity={0.016}
-		 />
-		<WaterSystem
-			id="water-main"
-			interactionProfile="water-object-drop-orbit"
-			interactionTarget="water-main"
-			interactionObject="Sphere"
-			resolution={256}
-			surfaceResolution={201}
-			poolShape="Box"
-			poolWidth={1.0}
-			poolHeight={1.0}
-			poolLength={1.0}
-			cornerRadius={0}
-			waveSpeed={1.0}
-			damping={0.995}
-			normalScale={1.0}
-			seedDrops={20}
-			dropRadius={0.03}
-			dropStrength={0.01}
-			tileTexture="/water/tiles.jpg"
-			cubeMap="/water/"
-			shallowColor="#7ad1eb"
-			deepColor="#082e57"
-			aboveWaterColorR={0.25}
-			aboveWaterColorG={1.0}
-			aboveWaterColorB={1.25}
-			causticsResolution={1024}
-			objectTextureResolutionMode="viewport"
-			objectTexturePixelBudget={786432}
-			objectShadowResolution={1024}
-			caustics={true}
-			reflection={true}
-			refraction={true}
-			followCamera={false}
-			lightDirectionX={2}
-			lightDirectionY={2}
-			lightDirectionZ={-1}
-			activeObject="Sphere"
-			objectKind="sphere"
-			objectX={-0.4}
-			objectY={-0.75}
-			objectZ={0.2}
-			objectRadius={0.25}
-			objectDriftX={0}
-			objectDriftY={0}
-			objectDriftZ={0}
-			objectBobAmplitude={0}
-			objectBobSpeed={0}
-			objectDisplacementScale={1.0}
-			computeBackend="elio"
-			materialBackend="selena"
-			seedSelenaWGSL={data.waterSeedSelenaWGSL}
-			dropSelenaWGSL={data.waterDropSelenaWGSL}
-			displacementSelenaWGSL={data.waterDisplacementSelenaWGSL}
-			simulationSelenaWGSL={data.waterSimulationSelenaWGSL}
-			normalSelenaWGSL={data.waterNormalSelenaWGSL}
-			poolSelenaWGSL={data.waterPoolSelenaWGSL}
-			surfaceSelenaWGSL={data.waterSurfaceSelenaWGSL}
-			surfaceBelowSelenaWGSL={data.waterSurfaceBelowSelenaWGSL}
-			causticsSelenaWGSL={data.waterCausticsSelenaWGSL}
-			objectShadowSelenaWGSL={data.waterObjectShadowSelenaWGSL}
-			compoundShadowSelenaWGSL={data.waterCompoundShadowSelenaWGSL}
-			objectMeshShadowSelenaWGSL={data.waterObjectMeshShadowSelenaWGSL}
-			seedVertexGLES={data.waterSeedVertexGLES}
-			seedFragmentGLES={data.waterSeedFragmentGLES}
-			dropVertexGLES={data.waterDropVertexGLES}
-			dropFragmentGLES={data.waterDropFragmentGLES}
-			displacementVertexGLES={data.waterDisplacementVertexGLES}
-			displacementFragmentGLES={data.waterDisplacementFragmentGLES}
-			simulationVertexGLES={data.waterSimulationVertexGLES}
-			simulationFragmentGLES={data.waterSimulationFragmentGLES}
-			normalVertexGLES={data.waterNormalVertexGLES}
-			normalFragmentGLES={data.waterNormalFragmentGLES}
-			causticsVertexGLES={data.waterCausticsVertexGLES}
-			causticsFragmentGLES={data.waterCausticsFragmentGLES}
-			poolVertexGLES={data.waterPoolVertexGLES}
-			poolFragmentGLES={data.waterPoolFragmentGLES}
-			surfaceVertexGLES={data.waterSurfaceVertexGLES}
-			surfaceFragmentGLES={data.waterSurfaceFragmentGLES}
-			surfaceBelowVertexGLES={data.waterSurfaceBelowVertexGLES}
-			surfaceBelowFragmentGLES={data.waterSurfaceBelowFragmentGLES}
-			objectShadowVertexGLES={data.waterObjectShadowVertexGLES}
-			objectShadowFragmentGLES={data.waterObjectShadowFragmentGLES}
-			compoundShadowVertexGLES={data.waterCompoundShadowVertexGLES}
-			compoundShadowFragmentGLES={data.waterCompoundShadowFragmentGLES}
-			objectMeshShadowVertexGLES={data.waterObjectMeshShadowVertexGLES}
-			objectMeshShadowFragmentGLES={data.waterObjectMeshShadowFragmentGLES}
-			objectMaterialVertexGLES={data.waterObjectPassVertexGLES}
-			objectMaterialFragmentGLES={data.waterObjectPassFragmentGLES}
-			duckMaterialVertexGLES={data.waterDuckPassVertexGLES}
-			duckMaterialFragmentGLES={data.waterDuckPassFragmentGLES}
-			shaderDescriptors={data.waterShaderDescriptors}
-		 />
-		<Material
-			name="brass-glow"
-			kind="standard"
-			color="#d9974d"
-			roughness={0.34}
-			metalness={0.28}
-			emissive="#513318"
-			emissiveIntensity={0.28}
-		 />
-		<Material
-			name="water-object-material"
-			kind="custom"
-			shaderBackend="selena"
-			customVertexWGSL={data.waterObjectPassSelenaWGSL}
-			customFragmentWGSL={data.waterObjectPassSelenaWGSL}
-			shaderLayout={data.waterObjectMaterialSelenaLayout}
-			customUniforms={data.waterObjectMaterialSelenaUniforms}
-		 />
-		<Material
-			name="water-duck-material"
-			kind="custom"
-			shaderBackend="selena"
-			customVertexWGSL={data.waterDuckPassSelenaWGSL}
-			customFragmentWGSL={data.waterDuckPassSelenaWGSL}
-			shaderLayout={data.waterDuckMaterialSelenaLayout}
-			customUniforms={data.waterDuckMaterialSelenaUniforms}
-		 />
-		<Mesh
-			id="float-sphere"
-			kind="sphere"
-			radius={0.25}
-			x={-0.4}
-			y={-0.75}
-			z={0.2}
-			material="water-object-material"
-			roughness={0.32}
-			metalness={0.08}
-			wireframe={false}
-			castShadow={true}
-			spinX={0}
-			spinY={0}
-			driftX={0}
-			driftY={0}
-			driftZ={0}
-			bobAmplitude={0}
-			bobSpeed={0}
-			outlineColor="#ffe5c8"
-			outlineWidth={0.022}
-		 />
-		<Mesh
-			id="float-cube"
-			kind="box"
-			width={0.5}
-			height={0.5}
-			depth={0.5}
-			x={-0.4}
-			y={10}
-			visible={false}
-			z={0.2}
-			rotationX={0}
-			rotationY={0}
-			material="water-object-material"
-			roughness={0.42}
-			metalness={0.1}
-			wireframe={false}
-			castShadow={true}
-			spinX={0.2}
-			spinY={0.28}
-			driftX={0}
-			driftY={0}
-			driftZ={0}
-			bobAmplitude={0}
-			bobSpeed={0}
-		 />
-		<Mesh
-			id="float-torus"
-			kind="torusKnot"
-			radius={0.17}
-			tube={0.045}
-			tubularSegments={64}
-			radialSegments={8}
-			x={-0.4}
-			y={10}
-			visible={false}
-			z={0.2}
-			rotationX={1.5707963267948966}
-			material="water-object-material"
-			wireframe={false}
-			castShadow={true}
-			spinX={0}
-			spinY={0}
-			driftX={0}
-			driftY={0}
-			driftZ={0}
-			bobAmplitude={0}
-			bobSpeed={0}
-		 />
-		</Scene3D>
-	<aside
-		id="water-demo-help"
-		class="water-demo__help"
-		data-gosx-scene3d-help-panel="true"
-		aria-label="Water demo reference"
-	>
-		<h1>GoSX Water</h1>
-		<p>
-			Original author:
-			<a href="http://madebyevan.com/" target="_blank" rel="noopener noreferrer">Evan Wallace</a>
-		</p>
-		<p>
-			Ported to Three.js by
-			<a href="https://github.com/jeantimex" target="_blank" rel="noopener noreferrer">jeantimex</a>
-		</p>
-		<p>
-			<a href="https://github.com/jeantimex/threejs-water" target="_blank" rel="noopener noreferrer">jeantimex/threejs-water</a>
-		</p>
-		<p>
-			Ported to GoSX by
-			<a href="https://github.com/odvcencio" target="_blank" rel="noopener noreferrer">odvcencio</a>
-			and
-			<a href="https://github.com/m31-labs" target="_blank" rel="noopener noreferrer">M31 Labs</a>
-		</p>
-		<h2>Interactions</h2>
-		<ul>
-			<li>Draw on the water to make ripples</li>
-			<li>
-				Drag the background to rotate the camera
-			</li>
-			<li>Scroll or pinch to zoom</li>
-			<li>Press SPACEBAR to pause and unpause</li>
-			<li>
-				Drag the selected object to move it around
-			</li>
-			<li>
-				Press the L key to set the light direction
-			</li>
-			<li>Press the G key to toggle gravity</li>
-		</ul>
-		<h2>Features</h2>
-		<ul>
-				<li>Ray-marched reflections and refractions</li>
-				<li>Analytic object and pool shading</li>
-			<li>Heightfield water simulation</li>
-			<li>Soft shadows</li>
-			<li>Real-time caustics</li>
-			<li>
-					Box and rounded-box pool geometry
-			</li>
-			<li>
-				Procedural geometry and glTF model support
-			</li>
-		</ul>
-	</aside>
-	<button
-		class="water-demo__help-toggle"
-		type="button"
-		aria-controls="water-demo-help"
-		aria-expanded="false"
-		data-gosx-scene3d-panel-toggle="water-demo-help"
-	>menu</button>
-	<form
-		class="water-demo__controls"
-		data-gosx-scene3d-controls="true"
-		data-gosx-scene3d-control-form="fluid-object"
-		data-gosx-scene3d-control-subject="water-main"
-		data-gosx-scene3d-control-target="water-demo-scene"
-		data-gosx-scene3d-control-data={data.waterControlData}
-		data-gosx-scene3d-control-open="false"
-		aria-label="Water settings"
-	>
-		<div class="water-demo__controls-head">
-			<button
-				class="water-demo__controls-toggle"
-				type="button"
-				aria-expanded="false"
-				data-gosx-scene3d-control-toggle="true"
-			>Settings</button>
-			<output name="status" data-gosx-scene3d-control-status="true">Sphere</output>
-		</div>
-		<div class="water-demo__controls-body" data-gosx-scene3d-control-body="true">
-			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Scene">
-				<legend>Scene</legend>
-				<label class="water-demo__toggle">
-					<input type="checkbox" name="paused" />
-					<span>Paused</span>
-				</label>
-			</fieldset>
-			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Object">
-				<legend>Object</legend>
-				<label>
-					<span>Object</span>
-					<select name="object">
-						<option value="None">None</option>
-						<option value="Sphere" selected={true}>Sphere</option>
-						<option value="Cube">Cube</option>
-						<option value="TorusKnot">TorusKnot</option>
-						<option value="Rubber Duck">Rubber Duck</option>
-					</select>
-				</label>
-				<div class="water-demo__control-grid">
-					<label class="water-demo__toggle">
-						<input type="checkbox" name="gravity" />
-						<span>Gravity</span>
-					</label>
-					<label class="water-demo__toggle">
-						<input type="checkbox" name="densityEnabled" />
-						<span>Density</span>
-					</label>
-				</div>
-				<label data-gosx-scene3d-density-control="true">
-					<span>Density</span>
-					<input type="range" name="density" min="0.2" max="2" step="0.01" value="0.9" />
-				</label>
-			</fieldset>
-			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Pool">
-				<legend>Pool</legend>
-				<label>
-					<span>Pool Shape</span>
-					<select name="poolShape">
-						<option value="Box" selected={true}>Box</option>
-						<option value="Rounded Box">Rounded Box</option>
-					</select>
-				</label>
-				<label data-gosx-scene3d-rounded-control="true">
-					<span>Corner Radius</span>
-					<input type="range" name="cornerRadius" min="0" max="1" step="0.01" value="0.1" />
-				</label>
-				<label data-gosx-scene3d-pool-boundary-control="true">
-					<span>Pool Width</span>
-					<input type="range" name="poolWidth" min="0.5" max="3" step="0.05" value="1" />
-				</label>
-				<label data-gosx-scene3d-pool-boundary-control="true">
-					<span>Pool Depth</span>
-					<input type="range" name="poolHeight" min="0.3" max="2" step="0.05" value="1" />
-				</label>
-				<label data-gosx-scene3d-pool-boundary-control="true">
-					<span>Pool Length</span>
-					<input type="range" name="poolLength" min="0.5" max="3" step="0.05" value="1" />
-				</label>
-			</fieldset>
-			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Lights">
-				<legend>Lights</legend>
-				<label class="water-demo__toggle">
-					<input type="checkbox" name="followCamera" />
-					<span>Follow Camera</span>
-				</label>
-			</fieldset>
-		</div>
-		</form>
-	</main>
+  	<Scene3D
+  		id="water-demo-scene"
+  		class="water-demo__scene"
+  		width={1280}
+  		height={760}
+  		responsive={true}
+  		fillHeight={true}
+  		controls="orbit"
+  		controlTargetX={0}
+  		controlTargetY={-0.5}
+  		controlTargetZ={0}
+  		controlRotateMode="pixel-degrees"
+  		controlRotateDirection="grab"
+  		controlMinDistance={2}
+  		controlMaxDistance={10}
+  		controlPitchLimit={1.5707788735}
+  		preferWebGPU={true}
+  		maxDevicePixelRatio={1.6}
+  		adaptiveQuality={false}
+  		qualityTier="full"
+  		canvasAlpha={false}
+  	>
+  		<Camera
+  			x={1.2695827068526726}
+  			y={1.1904730469627978}
+  			z={3.395653196065958}
+  			fov={45}
+  			near={0.01}
+  			far={100}
+  		 />
+  		<Environment
+  			ambientColor="#d8edf2"
+  			ambientIntensity={0.2}
+  			skyColor="#89b7c5"
+  			skyIntensity={0.36}
+  			groundColor="#211813"
+  			groundIntensity={0.24}
+  			fogColor="#071217"
+  			fogDensity={0.016}
+  		 />
+  		<WaterSystem
+  			id="water-main"
+  			interactionProfile="water-object-drop-orbit"
+  			interactionTarget="water-main"
+  			interactionObject="Sphere"
+  			resolution={256}
+  			surfaceResolution={201}
+  			poolShape="Box"
+  			poolWidth={1.0}
+  			poolHeight={1.0}
+  			poolLength={1.0}
+  			cornerRadius={0}
+  			waveSpeed={1.0}
+  			damping={0.995}
+  			normalScale={1.0}
+  			seedDrops={20}
+  			dropRadius={0.03}
+  			dropStrength={0.01}
+  			tileTexture="/water/tiles.jpg"
+  			cubeMap="/water/"
+  			shallowColor="#7ad1eb"
+  			deepColor="#082e57"
+  			aboveWaterColorR={0.25}
+  			aboveWaterColorG={1.0}
+  			aboveWaterColorB={1.25}
+  			causticsResolution={1024}
+  			objectTextureResolutionMode="viewport"
+  			objectTexturePixelBudget={786432}
+  			objectShadowResolution={1024}
+  			caustics={true}
+  			reflection={true}
+  			refraction={true}
+  			followCamera={false}
+  			lightDirectionX={2}
+  			lightDirectionY={2}
+  			lightDirectionZ={-1}
+  			activeObject="Sphere"
+  			objectKind="sphere"
+  			objectX={-0.4}
+  			objectY={-0.75}
+  			objectZ={0.2}
+  			objectRadius={0.25}
+  			objectDriftX={0}
+  			objectDriftY={0}
+  			objectDriftZ={0}
+  			objectBobAmplitude={0}
+  			objectBobSpeed={0}
+  			objectDisplacementScale={1.0}
+  			computeBackend="elio"
+  			materialBackend="selena"
+  			seedSelenaWGSL={data.waterSeedSelenaWGSL}
+  			dropSelenaWGSL={data.waterDropSelenaWGSL}
+  			displacementSelenaWGSL={data.waterDisplacementSelenaWGSL}
+  			simulationSelenaWGSL={data.waterSimulationSelenaWGSL}
+  			normalSelenaWGSL={data.waterNormalSelenaWGSL}
+  			poolSelenaWGSL={data.waterPoolSelenaWGSL}
+  			surfaceSelenaWGSL={data.waterSurfaceSelenaWGSL}
+  			surfaceBelowSelenaWGSL={data.waterSurfaceBelowSelenaWGSL}
+  			causticsSelenaWGSL={data.waterCausticsSelenaWGSL}
+  			objectShadowSelenaWGSL={data.waterObjectShadowSelenaWGSL}
+  			compoundShadowSelenaWGSL={data.waterCompoundShadowSelenaWGSL}
+  			objectMeshShadowSelenaWGSL={data.waterObjectMeshShadowSelenaWGSL}
+  			seedVertexGLES={data.waterSeedVertexGLES}
+  			seedFragmentGLES={data.waterSeedFragmentGLES}
+  			dropVertexGLES={data.waterDropVertexGLES}
+  			dropFragmentGLES={data.waterDropFragmentGLES}
+  			displacementVertexGLES={data.waterDisplacementVertexGLES}
+  			displacementFragmentGLES={data.waterDisplacementFragmentGLES}
+  			simulationVertexGLES={data.waterSimulationVertexGLES}
+  			simulationFragmentGLES={data.waterSimulationFragmentGLES}
+  			normalVertexGLES={data.waterNormalVertexGLES}
+  			normalFragmentGLES={data.waterNormalFragmentGLES}
+  			causticsVertexGLES={data.waterCausticsVertexGLES}
+  			causticsFragmentGLES={data.waterCausticsFragmentGLES}
+  			poolVertexGLES={data.waterPoolVertexGLES}
+  			poolFragmentGLES={data.waterPoolFragmentGLES}
+  			surfaceVertexGLES={data.waterSurfaceVertexGLES}
+  			surfaceFragmentGLES={data.waterSurfaceFragmentGLES}
+  			surfaceBelowVertexGLES={data.waterSurfaceBelowVertexGLES}
+  			surfaceBelowFragmentGLES={data.waterSurfaceBelowFragmentGLES}
+  			objectShadowVertexGLES={data.waterObjectShadowVertexGLES}
+  			objectShadowFragmentGLES={data.waterObjectShadowFragmentGLES}
+  			compoundShadowVertexGLES={data.waterCompoundShadowVertexGLES}
+  			compoundShadowFragmentGLES={data.waterCompoundShadowFragmentGLES}
+  			objectMeshShadowVertexGLES={data.waterObjectMeshShadowVertexGLES}
+  			objectMeshShadowFragmentGLES={data.waterObjectMeshShadowFragmentGLES}
+  			objectMaterialVertexGLES={data.waterObjectPassVertexGLES}
+  			objectMaterialFragmentGLES={data.waterObjectPassFragmentGLES}
+  			duckMaterialVertexGLES={data.waterDuckPassVertexGLES}
+  			duckMaterialFragmentGLES={data.waterDuckPassFragmentGLES}
+  			shaderDescriptors={data.waterShaderDescriptors}
+  		 />
+  		<Material
+  			name="brass-glow"
+  			kind="standard"
+  			color="#d9974d"
+  			roughness={0.34}
+  			metalness={0.28}
+  			emissive="#513318"
+  			emissiveIntensity={0.28}
+  		 />
+  		<Material
+  			name="water-object-material"
+  			kind="custom"
+  			shaderBackend="selena"
+  			customVertexWGSL={data.waterObjectPassSelenaWGSL}
+  			customFragmentWGSL={data.waterObjectPassSelenaWGSL}
+  			shaderLayout={data.waterObjectMaterialSelenaLayout}
+  			customUniforms={data.waterObjectMaterialSelenaUniforms}
+  		 />
+  		<Material
+  			name="water-duck-material"
+  			kind="custom"
+  			shaderBackend="selena"
+  			customVertexWGSL={data.waterDuckPassSelenaWGSL}
+  			customFragmentWGSL={data.waterDuckPassSelenaWGSL}
+  			shaderLayout={data.waterDuckMaterialSelenaLayout}
+  			customUniforms={data.waterDuckMaterialSelenaUniforms}
+  		 />
+  		<Mesh
+  			id="float-sphere"
+  			kind="sphere"
+  			radius={0.25}
+  			x={-0.4}
+  			y={-0.75}
+  			z={0.2}
+  			material="water-object-material"
+  			roughness={0.32}
+  			metalness={0.08}
+  			wireframe={false}
+  			castShadow={true}
+  			spinX={0}
+  			spinY={0}
+  			driftX={0}
+  			driftY={0}
+  			driftZ={0}
+  			bobAmplitude={0}
+  			bobSpeed={0}
+  			outlineColor="#ffe5c8"
+  			outlineWidth={0.022}
+  		 />
+  		<Mesh
+  			id="float-cube"
+  			kind="box"
+  			width={0.5}
+  			height={0.5}
+  			depth={0.5}
+  			x={-0.4}
+  			y={10}
+  			visible={false}
+  			z={0.2}
+  			rotationX={0}
+  			rotationY={0}
+  			material="water-object-material"
+  			roughness={0.42}
+  			metalness={0.1}
+  			wireframe={false}
+  			castShadow={true}
+  			spinX={0.2}
+  			spinY={0.28}
+  			driftX={0}
+  			driftY={0}
+  			driftZ={0}
+  			bobAmplitude={0}
+  			bobSpeed={0}
+  		 />
+  		<Mesh
+  			id="float-torus"
+  			kind="torusKnot"
+  			radius={0.17}
+  			tube={0.045}
+  			tubularSegments={64}
+  			radialSegments={8}
+  			x={-0.4}
+  			y={10}
+  			visible={false}
+  			z={0.2}
+  			rotationX={1.5707963267948966}
+  			material="water-object-material"
+  			wireframe={false}
+  			castShadow={true}
+  			spinX={0}
+  			spinY={0}
+  			driftX={0}
+  			driftY={0}
+  			driftZ={0}
+  			bobAmplitude={0}
+  			bobSpeed={0}
+  		 />
+  	</Scene3D>
+  	<aside
+  		id="water-demo-help"
+  		class="water-demo__help"
+  		data-gosx-scene3d-help-panel="true"
+  		aria-label="Water demo reference"
+  	>
+  		<h1>GoSX Water</h1>
+  		<p>
+  			Original author:
+  			<a href="http://madebyevan.com/" target="_blank" rel="noopener noreferrer">Evan Wallace</a>
+  		</p>
+  		<p>
+  			Ported to Three.js by
+  			<a href="https://github.com/jeantimex" target="_blank" rel="noopener noreferrer">jeantimex</a>
+  		</p>
+  		<p>
+  			<a href="https://github.com/jeantimex/threejs-water" target="_blank" rel="noopener noreferrer">jeantimex/threejs-water</a>
+  		</p>
+  		<p>
+  			Ported to GoSX by
+  			<a href="https://github.com/odvcencio" target="_blank" rel="noopener noreferrer">odvcencio</a>
+  			and
+  			<a href="https://github.com/m31-labs" target="_blank" rel="noopener noreferrer">M31 Labs</a>
+  		</p>
+  		<h2>Interactions</h2>
+  		<ul>
+  			<li>Draw on the water to make ripples</li>
+  			<li>
+  				Drag the background to rotate the camera
+  			</li>
+  			<li>Scroll or pinch to zoom</li>
+  			<li>Press SPACEBAR to pause and unpause</li>
+  			<li>
+  				Drag the selected object to move it around
+  			</li>
+  			<li>
+  				Press the L key to set the light direction
+  			</li>
+  			<li>Press the G key to toggle gravity</li>
+  		</ul>
+  		<h2>Features</h2>
+  		<ul>
+  			<li>Ray-marched reflections and refractions</li>
+  			<li>Analytic object and pool shading</li>
+  			<li>Heightfield water simulation</li>
+  			<li>Soft shadows</li>
+  			<li>Real-time caustics</li>
+  			<li>Box and rounded-box pool geometry</li>
+  			<li>
+  				Procedural geometry and glTF model support
+  			</li>
+  		</ul>
+  	</aside>
+  	<button
+  		class="water-demo__help-toggle"
+  		type="button"
+  		aria-controls="water-demo-help"
+  		aria-expanded="false"
+  		data-gosx-scene3d-panel-toggle="water-demo-help"
+  	>menu</button>
+  	<form
+  		class="water-demo__controls"
+  		data-gosx-scene3d-controls="true"
+  		data-gosx-scene3d-control-form="fluid-object"
+  		data-gosx-scene3d-control-subject="water-main"
+  		data-gosx-scene3d-control-target="water-demo-scene"
+  		data-gosx-scene3d-control-data={data.waterControlData}
+  		data-gosx-scene3d-control-open="false"
+  		aria-label="Water settings"
+  	>
+  		<div class="water-demo__controls-head">
+  			<button
+  				class="water-demo__controls-toggle"
+  				type="button"
+  				aria-expanded="false"
+  				data-gosx-scene3d-control-toggle="true"
+  			>Settings</button>
+  			<output name="status" data-gosx-scene3d-control-status="true">Sphere</output>
+  		</div>
+  		<div class="water-demo__controls-body" data-gosx-scene3d-control-body="true">
+  			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Scene">
+  				<legend>Scene</legend>
+  				<label class="water-demo__toggle">
+  					<input type="checkbox" name="paused" />
+  					<span>Paused</span>
+  				</label>
+  			</fieldset>
+  			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Object">
+  				<legend>Object</legend>
+  				<label>
+  					<span>Object</span>
+  					<select name="object">
+  						<option value="None">None</option>
+  						<option value="Sphere" selected={true}>Sphere</option>
+  						<option value="Cube">Cube</option>
+  						<option value="TorusKnot">TorusKnot</option>
+  						<option value="Rubber Duck">Rubber Duck</option>
+  					</select>
+  				</label>
+  				<div class="water-demo__control-grid">
+  					<label class="water-demo__toggle">
+  						<input type="checkbox" name="gravity" />
+  						<span>Gravity</span>
+  					</label>
+  					<label class="water-demo__toggle">
+  						<input type="checkbox" name="densityEnabled" />
+  						<span>Density</span>
+  					</label>
+  				</div>
+  				<label data-gosx-scene3d-density-control="true">
+  					<span>Density</span>
+  					<input type="range" name="density" min="0.2" max="2" step="0.01" value="0.9" />
+  				</label>
+  			</fieldset>
+  			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Pool">
+  				<legend>Pool</legend>
+  				<label>
+  					<span>Pool Shape</span>
+  					<select name="poolShape">
+  						<option value="Box" selected={true}>Box</option>
+  						<option value="Rounded Box">Rounded Box</option>
+  					</select>
+  				</label>
+  				<label data-gosx-scene3d-rounded-control="true">
+  					<span>Corner Radius</span>
+  					<input type="range" name="cornerRadius" min="0" max="1" step="0.01" value="0.1" />
+  				</label>
+  				<label data-gosx-scene3d-pool-boundary-control="true">
+  					<span>Pool Width</span>
+  					<input type="range" name="poolWidth" min="0.5" max="3" step="0.05" value="1" />
+  				</label>
+  				<label data-gosx-scene3d-pool-boundary-control="true">
+  					<span>Pool Depth</span>
+  					<input type="range" name="poolHeight" min="0.3" max="2" step="0.05" value="1" />
+  				</label>
+  				<label data-gosx-scene3d-pool-boundary-control="true">
+  					<span>Pool Length</span>
+  					<input type="range" name="poolLength" min="0.5" max="3" step="0.05" value="1" />
+  				</label>
+  			</fieldset>
+  			<fieldset class="water-demo__control-group" data-gosx-scene3d-control-group="Lights">
+  				<legend>Lights</legend>
+  				<label class="water-demo__toggle">
+  					<input type="checkbox" name="followCamera" />
+  					<span>Follow Camera</span>
+  				</label>
+  			</fieldset>
+  		</div>
+  	</form>
+  </main>
 }

--- a/examples/gosx-docs/app/layout.gsx
+++ b/examples/gosx-docs/app/layout.gsx
@@ -37,30 +37,115 @@ func Layout() Node {
 				<div class="nav-group">
 					<span class="nav-group__label">Start</span>
 					<a href="/" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Overview</a>
-					<a href="/docs/getting-started" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Getting Started</a>
+					<a
+						href="/docs/getting-started"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Getting Started</a>
 				</div>
 				<div class="nav-group">
 					<span class="nav-group__label">Reference</span>
-					<a href="/docs/routing" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Routing</a>
-					<a href="/docs/forms" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Forms</a>
-					<a href="/docs/auth" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Auth</a>
-					<a href="/docs/islands" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Islands</a>
-					<a href="/docs/signals" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Signals</a>
-					<a href="/docs/engines" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Engines</a>
-					<a href="/docs/scene3d" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">3D Engine</a>
-					<a href="/docs/hubs" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Hubs & CRDT</a>
-					<a href="/docs/runtime" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Runtime</a>
-					<a href="/docs/images" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Images</a>
-					<a href="/docs/text-layout" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Text Layout</a>
-					<a href="/docs/motion" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Motion</a>
-					<a href="/docs/streaming" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Streaming</a>
-					<a href="/docs/compiler" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Compiler</a>
-					<a href="/docs/deployment" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Deployment</a>
+					<a
+						href="/docs/routing"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Routing</a>
+					<a
+						href="/docs/forms"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Forms</a>
+					<a
+						href="/docs/auth"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Auth</a>
+					<a
+						href="/docs/islands"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Islands</a>
+					<a
+						href="/docs/signals"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Signals</a>
+					<a
+						href="/docs/engines"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Engines</a>
+					<a
+						href="/docs/scene3d"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>3D Engine</a>
+					<a
+						href="/docs/hubs"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Hubs & CRDT</a>
+					<a
+						href="/docs/runtime"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Runtime</a>
+					<a
+						href="/docs/images"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Images</a>
+					<a
+						href="/docs/text-layout"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Text Layout</a>
+					<a
+						href="/docs/motion"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Motion</a>
+					<a
+						href="/docs/streaming"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Streaming</a>
+					<a
+						href="/docs/compiler"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Compiler</a>
+					<a
+						href="/docs/deployment"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Deployment</a>
 				</div>
 				<div class="nav-group">
 					<span class="nav-group__label">Demos</span>
 					<a href="/demos" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Explore all demos</a>
-					<a href="/demos/water" data-gosx-link="true" data-gosx-disclosure-close="#nav-overlay" class="nav-link">Water Lab</a>
+					<a
+						href="/demos/water"
+						data-gosx-link="true"
+						data-gosx-disclosure-close="#nav-overlay"
+						class="nav-link"
+					>Water Lab</a>
 				</div>
 			</div>
 		</div>

--- a/examples/gosx-docs/app/page.gsx
+++ b/examples/gosx-docs/app/page.gsx
@@ -10,7 +10,9 @@ func Page() Node {
 				<div class="hero__lockup">
 					<p class="hero__kicker kicker">Go-authored from request to GPU</p>
 					<h1 id="home-title" class="hero__title chrome-text">GoSX</h1>
-					<p class="hero__tagline">Build server-rendered applications, interactive tools, realtime systems, and GPU scenes in Go&mdash;without a JavaScript app toolchain.</p>
+					<p class="hero__tagline">
+						Build server-rendered applications, interactive tools, realtime systems, and GPU scenes in Go&mdash;without a JavaScript app toolchain.
+					</p>
 					<div class="hero__actions">
 						<a href="/docs/getting-started" data-gosx-link="true" class="btn btn--gold">Start with GoSX</a>
 						<a href="/demos" data-gosx-link="true" class="btn btn--ghost">See it running</a>
@@ -26,17 +28,30 @@ func Page() Node {
 				<span class="hero__scroll-indicator"></span>
 			</div>
 		</section>
-
 		<section class="runtime-map" aria-labelledby="runtime-map-title">
 			<div class="section-shell">
-				<header class="section-heading" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+				<header
+					class="section-heading"
+					data-gosx-motion
+					data-gosx-motion-trigger="view"
+					data-gosx-motion-preset="slide-up"
+				>
 					<p class="kicker">The execution model</p>
-					<h2 id="runtime-map-title">Five surfaces. Use only what the feature needs.</h2>
-					<p>A GoSX page starts on the server. Interactivity, graphics, and shared state are explicit upgrades&mdash;not a runtime tax paid by every route.</p>
+					<h2 id="runtime-map-title">
+						Five surfaces. Use only what the feature needs.
+					</h2>
+					<p>
+						A GoSX page starts on the server. Interactivity, graphics, and shared state are explicit upgrades&mdash;not a runtime tax paid by every route.
+					</p>
 				</header>
 				<ol class="runtime-map__list">
 					<Each of={data.runtimeSurfaces} as="surface">
-						<li class="runtime-card" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+						<li
+							class="runtime-card"
+							data-gosx-motion
+							data-gosx-motion-trigger="view"
+							data-gosx-motion-preset="slide-up"
+						>
 							<div class="runtime-card__head">
 								<span class="runtime-card__num" aria-hidden="true">{surface.num}</span>
 								<h3>{surface.name}</h3>
@@ -48,19 +63,35 @@ func Page() Node {
 				</ol>
 			</div>
 		</section>
-
 		<section class="gpu-story" aria-labelledby="gpu-story-title">
 			<div class="gpu-story__inner section-shell">
-				<div class="gpu-story__copy" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+				<div
+					class="gpu-story__copy"
+					data-gosx-motion
+					data-gosx-motion-trigger="view"
+					data-gosx-motion-preset="slide-up"
+				>
 					<p class="kicker">Scene3D + Selena</p>
-					<h2 id="gpu-story-title">One scene graph. One shader source. Two GPU backends.</h2>
-					<p>Scene3D lowers typed Go scenes into shared SceneIR. Selena compiles each authored <code>.sel</code> shader to WGSL for WebGPU and GLES for WebGL2. GoSX selects and drives the backend; the demo does not carry a second hand-written WebGL implementation.</p>
+					<h2 id="gpu-story-title">
+						One scene graph. One shader source. Two GPU backends.
+					</h2>
+					<p>
+						Scene3D lowers typed Go scenes into shared SceneIR. Selena compiles each authored
+						<code>.sel</code>
+						shader to WGSL for WebGPU and GLES for WebGL2. GoSX selects and drives the backend; the demo does not carry a second hand-written WebGL implementation.
+					</p>
 					<div class="gpu-story__actions">
 						<a href="/demos/water" data-gosx-link="true" class="showcase__link">Run the water system</a>
 						<a href="/docs/scene3d" data-gosx-link="true" class="showcase__link">Read the Scene3D model</a>
 					</div>
 				</div>
-				<div class="pipeline" aria-label="GoSX graphics pipeline" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+				<div
+					class="pipeline"
+					aria-label="GoSX graphics pipeline"
+					data-gosx-motion
+					data-gosx-motion-trigger="view"
+					data-gosx-motion-preset="slide-up"
+				>
 					<div class="pipeline__source">
 						<span class="pipeline__label">Author once</span>
 						<strong>Go scene + Selena shader</strong>
@@ -78,33 +109,53 @@ func Page() Node {
 							<small>GLES render + ping-pong</small>
 						</div>
 					</div>
-					<footer class="pipeline__footer">Shared bindings &middot; native harness evidence &middot; no demo JavaScript</footer>
+					<footer class="pipeline__footer">
+						Shared bindings &middot; native harness evidence &middot; no demo JavaScript
+					</footer>
 				</div>
 			</div>
 		</section>
-
 		<section class="paths" aria-labelledby="paths-title">
 			<div class="section-shell">
-				<header class="section-heading" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+				<header
+					class="section-heading"
+					data-gosx-motion
+					data-gosx-motion-trigger="view"
+					data-gosx-motion-preset="slide-up"
+				>
 					<p class="kicker">Explore by outcome</p>
-					<h2 id="paths-title">Start with the kind of system you are building.</h2>
+					<h2 id="paths-title">
+						Start with the kind of system you are building.
+					</h2>
 				</header>
 				<div class="paths__grid">
 					<Each of={data.paths} as="path">
-						<article class="path-card" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+						<article
+							class="path-card"
+							data-gosx-motion
+							data-gosx-motion-trigger="view"
+							data-gosx-motion-preset="slide-up"
+						>
 							<span class="path-card__index" aria-hidden="true">{path.num}</span>
 							<h3>{path.title}</h3>
 							<p>{path.body}</p>
 							<span class="path-card__tools">{path.tools}</span>
-							<a href={path.href} data-gosx-link="true" class="path-card__link">Explore {path.title}</a>
+							<a href={path.href} data-gosx-link="true" class="path-card__link">
+								Explore
+								{path.title}
+							</a>
 						</article>
 					</Each>
 				</div>
 			</div>
 		</section>
-
 		<section class="proof" aria-labelledby="proof-title">
-			<div class="proof__inner section-shell" data-gosx-motion data-gosx-motion-trigger="view" data-gosx-motion-preset="slide-up">
+			<div
+				class="proof__inner section-shell"
+				data-gosx-motion
+				data-gosx-motion-trigger="view"
+				data-gosx-motion-preset="slide-up"
+			>
 				<div>
 					<p class="kicker">The compact version</p>
 					<h2 id="proof-title" class="proof__heading">A platform with explicit boundaries.</h2>


### PR DESCRIPTION
Follow-up to v0.31.6: run the GoSX formatter over the 11 GSX files reported by CI.

Validation: `make fmt-check`; `go test ./examples/gosx-docs/...`.