### PR TITLE
docs: README refresh for v0.31.x — water, runtime surfaces, native scene tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ count    // local to the declaring island
 
 **Managed Motion** — `server.Motion`, `ctx.Motion`, and the `.gsx` `<Motion />` builtin expose server-authored motion presets that run on the shared bootstrap layer. Preset, trigger, duration, delay, easing, reduced-motion policy, and distance all stay in one declarative contract.
 
+**Runtime Surfaces** — `gosx.RuntimeSurface`, `gosx.Action`, and `gosx.Region` describe progressive-enhancement contracts in server HTML (`data-gosx-runtime-surface`), and the shared bootstrap owns discovery, navigation remounting, scoped DOM/query/fetch/listen access, stream-template consumption, and disposal — so rich pages register framework-managed behavior instead of shipping bespoke script tags.
+
 ## Engines
 
 For work that doesn't fit the island model — canvas rendering, WebGL, background computation:
@@ -409,10 +411,12 @@ scene.Props{
 - **Instancing** — `InstancedMesh` renders repeated geometry through WebGPU instance-rate vertex buffers and WebGL2 `drawArraysInstanced`, with per-instance transforms, colors, material passes, receive shadows, and WebGPU instanced shadow casters
 - **World primitives** — helper lines, thick world lines, wire overlays, grids, axes, clip-space guides, and textured plane surfaces render on WebGPU through dedicated color, screen-space line-expansion, and surface-texture pipelines; dashed line styles remain the explicit WebGL2 compatibility escape hatch
 - **Particles** — GPU-computed particle systems via `ComputeParticles` with emitter, forces, and material
+- **Water** — `WaterSystem` GPU heightfield simulation with box/rounded pool shapes, caustics, reflection, refraction, projected object optics, drop/orbit/object-drag interaction, independent surface mesh topology, and adaptive quality profiles — WebGPU-first with a WebGL path rendered from the same authored Selena sources
 - **Environment** — ambient, hemisphere, sky/ground, cubemap IBL, exposure, fog, tonemapping
 - **WebGPU presentation** — tier-aware 4x MSAA render targets with resolve-to-canvas/post-FX targets, adapter feature/limit negotiation for timestamp queries, shader-f16, indirect first-instance, compressed textures, subgroups, manifest-driven `requiredFeatures` / `requiredLimits` negotiation, opt-in adapter `powerPreference`, opt-in canvas `alphaMode` / `colorSpace` / `toneMapping`, and diagnostics exposed for tooling through `data-gosx-scene3d-webgpu-*` mount attributes, plus shared SceneIR parity across WebGPU, WebGL2, and headless backends
 - **Post-processing** — `SSAO`, `DOF`, `Bloom`, `Tonemap` (ACES / Reinhard / Filmic), `Vignette`, `ColorGrade`, FXAA 3.11, RGB9E5/HDR intermediate selection, HDR10 presentation when supported, composable chain, with backend-specific passes skipped gracefully when unavailable
 - **Editor/debug surfaces** — `AxesHelper`, `GridHelper`, `BoxHelper`, `BoundingBoxHelper`, `SkeletonHelper`, visual `TransformControls`, selected mesh outline styling, dashed/solid line materials, and opt-in `Stats` overlay
+- **Native preview & certification** — `scene/preview` renders typed scenes to PNG with no browser or GPU (thumbnails, docs images, deterministic visual tests), and `scene/harness` certifies contract evidence — frame hashes, coverage, Selena artifact hashes, exact BVH ray/drag traces — into schema-versioned JSON reports suitable for agent-operated authoring workflows
 - **Shadow pixel cap** — v0.15.0's `Shadows.MaxPixels` caps each shadow map (default 1024²), preventing multi-megabyte-per-light allocations when individual lights request large shadow sizes
 - **Compression & LOD** — per-component scalar quantization with delta encoding, progressive streaming, camera-distance-based LOD switching via `scene.Compression`, plus conventional discrete mesh/model swaps via `scene.LODGroup`
 - **Transitions** — declarative enter/exit/state transitions on any scene node via `InState` / `OutState` / `Live`
@@ -524,6 +528,15 @@ gosx build --msix [app]               # Stage and package Windows MSIX output
 gosx build --sign --msix [app]        # Sign MSIX via signtool
 gosx build --appinstaller <uri> [app] # Emit AppInstaller update feed XML
 gosx assets plan [path...]            # Inspect 3D/game assets and planned build optimizations
+gosx scene render [--out image.png] <scene-file>
+                                      # Render a typed scene natively to PNG (no browser or GPU)
+gosx scene inspect [--cert] [--budget file] <file-or-dir>...
+                                      # Authoring report: surface, assets, memory, fallbacks, budgets
+gosx scene validate [--strict] <file-or-dir>...
+                                      # Structured schema diagnostics for scene documents
+gosx scene certify [--backend webgpu|webgl|canvas2d] <scene-file>
+                                      # Backend capability certification report
+gosx scene schema [--out path]        # Emit the SceneIR JSON schema
 gosx export [app]                     # Pre-render static pages to dist/static/
 gosx compile [file.gsx]               # Compile .gsx to IR
 gosx check [file.gsx]                 # Parse and validate


### PR DESCRIPTION
Surgical README updates covering features that shipped in v0.31.6–v0.31.15 but weren't yet documented:

- **Water** bullet in the Scene3D feature surface (WaterSystem heightfield sim, caustics/reflection/refraction, interaction, adaptive quality, Selena-authored cross-backend)
- **Native preview & certification** bullet (scene/preview PNG rendering, scene/harness contract-evidence certification)
- **Runtime Surfaces** entry under Server Features (RuntimeSurface/Action/Region, data-gosx-runtime-surface contract)
- **gosx scene** subcommands in the CLI block (render/inspect/validate/certify/schema, signatures verified against cmd/gosx/scene.go)

No code changes.
