### PR TITLE
Release GoSX v0.35.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 ## Unreleased
 
+## v0.35.4 (2026-07-23)
+
+Scene3D camera depth, culling, and orbit controls now use the same forward-Z
+convention across WebGL, WebGPU, and runtime control state.
+
+- Fixes camera-space depth parity so WebGL and WebGPU cull against the same
+  near/far rules and keep visible nodes consistent.
+- Tightens depth assertion coverage for the transformed draw plan and both
+  renderer paths.
+- Aligns orbit camera state with the corrected Z convention so signal-backed
+  and pointer-driven orbit controls report matching camera positions.
+
 ## v0.35.3 (2026-07-22)
 
 GoSX now waits until after the first paint before it starts the initial

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.35.3**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.35.4**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -789,7 +789,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.35.3**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.35.4**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.35.3"
+const Current = "v0.35.4"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.35.3"
+const Number = "0.35.4"


### PR DESCRIPTION
## Summary
- set GoSX release truth to v0.35.4
- add v0.35.4 changelog entry
- update README current release references

## Verification
- go run ./cmd/gosx release check
- make release-gate
- cd cmd/buildbootstrap && go run . --check
- make verify-danmuji
- go test ./cmd/gosx ./internal/version
