### PR TITLE
fix(ci): Add Go setup to js-tests and gate e2e behind build tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,8 +80,10 @@ jobs:
       - name: Build CLI
         run: make build-cli
 
-  # js-tests: Node only, no Go/TinyGo/Chrome setup. This is the fastest
-  # feedback loop (~32s) and must not sit behind the multi-minute Go job.
+  # js-tests: Node for `node --test`, plus Go — `make test-js` also runs
+  # `cd cmd/buildbootstrap && go run . --check` (the bundle staleness gate),
+  # which needs a Go toolchain. No TinyGo/Chrome setup: nothing here shells
+  # out to either.
   js-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -89,6 +91,12 @@ jobs:
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
 
       # Node is only needed as a bare runtime for `node --test` (stdlib-only
       # JS unit tests). There are no npm dependencies to install.

--- a/e2e/render_chromedp_test.go
+++ b/e2e/render_chromedp_test.go
@@ -1,3 +1,5 @@
+//go:build e2e
+
 package e2e
 
 import (


### PR DESCRIPTION
## Summary

Fix the CI pipeline by adding the missing Go toolchain setup to the js-tests job, which is required for the bundle staleness check. Additionally, gate the e2e chromedp test behind a build tag to exclude it from standard test runs.

## Changes

- Add `actions/setup-go` to the `js-tests` job so `make test-js` can execute the Go-based bundle staleness check.
- Add `//go:build e2e` build tag to `e2e/render_chromedp_test.go` to exclude it from standard `go test` runs.

## Testing

- Run `make test-js` locally to verify the Go setup requirement is met.
- Trigger the CI workflow and confirm the `js-tests` job completes successfully.
- Run `go test ./e2e/...` locally and verify the chromedp test is skipped without the `e2e` build tag.