### PR TITLE
release(version): Release v0.35.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 ## Unreleased
 
+## v0.35.8 (2026-07-26)
+
+WebGPU mesh rendering now preserves authored two-sided materials and reports
+enough telemetry to distinguish submitted work from CPU view culling.
+
+- Double-sided mesh objects select a no-cull WebGPU pipeline. The behavior
+  applies to standard materials, custom Selena materials, and skinned Selena
+  meshes; other objects retain back-face culling.
+- Scene3D WebGPU telemetry separates bundled mesh objects, submitted mesh draw
+  calls, and objects rejected by CPU frustum culling. Diagnostics can now tell
+  whether missing geometry was culled before submission instead of treating
+  every bundled object as a draw call.
+- Selena pipeline caches include the cull mode, preventing one mesh's
+  double-sided setting from leaking into another mesh that shares a material.
+- CI installs Go in the JavaScript job and excludes the browser-only
+  `chromedp` integration test from ordinary unit runs, making the required
+  checks reproducible on clean runners.
+
 ## v0.35.7 (2026-07-25)
 
 Declarative motion can now split text and stagger the reveal across the pieces.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.35.7**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.35.8**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -789,7 +789,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.35.7**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.35.8**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.35.7"
+const Current = "v0.35.8"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.35.7"
+const Number = "0.35.8"


### PR DESCRIPTION
## Summary

- bump the canonical GoSX version to v0.35.8
- document double-sided WebGPU mesh rendering and split draw/cull telemetry
- include the skinned Selena correction and CI runner reliability fixes

## Validation

- `make release-gate`
- `git diff --check`