### PR TITLE
release(release): Release v0.35.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 ## Unreleased
 
+## v0.35.9 (2026-07-26)
+
+Scene3D custom post-process passes now execute. `customPost`, `toneMapping`,
+and `colorGrade` never ran on either backend, so any app that authored one
+received nothing at all.
+
+- `normalizeScenePostEffect` forced the effect kind to lower case. That rewrote
+  `customPost` to `custompost`, `toneMapping` to `tonemapping`, and `colorGrade`
+  to `colorgrade`. Both backends dispatch with `switch (effect.kind)` and `===`
+  against camelCase constants, so all three kinds fell through to
+  `default: break;`. The effect stayed in scene state, the post chain still ran,
+  and the mount attributes still counted the effect. Zero pixels were written.
+  Only the all-lowercase kinds survived: `bloom`, `ssao`, `dof`, `fxaa`, and
+  `vignette`.
+- The normalizer now folds case for matching only, then returns the exact
+  spelling both backends dispatch on. An unknown kind keeps the author's
+  spelling, so a newer backend still receives it.
+- The planner emits `colorGrade` for `color-grade`, `color-grading`, and
+  `colorgrade`. The CSS `--scene-filter` path writes straight into scene state
+  and skips the normalizer, so the hyphenated spelling left that pass unmatched
+  as well.
+- WebGL now assigns the return value of `applyCustomPost` unconditionally. The
+  helper returns `null` to report that the pass already drew to the default
+  framebuffer. The old `if (next !== null)` guard dropped that signal, so the
+  closing `blitToScreen` painted the unprocessed scene over the pass output. A
+  trailing custom pass wrote no visible pixels even when it compiled and drew
+  correctly.
+- WebGPU passes `packSelenaUniforms` into `wgpuCreatePostProcessor` as a
+  callback. The uniform packer lives in a sibling closure, not an enclosing one,
+  so the previous bare call raised a `ReferenceError`. The customPost case was
+  unreachable, which hid the defect.
+- New regression tests drive the real author path on both backends: props to
+  `createSceneState` to bundle to `renderer.render`. They assert that the pass
+  reaches shader creation and that it is drawn with its own pipeline.
+  `scripts/forced-red-custompost.go` reads back canvas pixels under SwiftShader
+  and confirms that a forced-red custom pass is the only draw that reaches the
+  canvas.
+
+Scene3D debug tooling:
+
+- `gosx visual --require-backend` accepts `webgpu`, `webgl`, or `any-gpu`. It
+  reads the `data-gosx-scene3d-backend` attributes after the settle wait and
+  fails the capture before any pixel comparison when a mount missed the
+  requirement. The error names each failing mount, separates a Canvas2D
+  fallback from a wrong GPU family, and prints the headless Chrome flags that a
+  software GPU needs.
+- `window.__gosx_scene3d_require_gpu` lets a custom capture harness refuse the
+  Canvas2D fallback without disabling the WebGL path, because WebGL is also a
+  real GPU backend.
+- A new `/docs/debugging-scene3d` page describes the four tiers of Scene3D debug
+  tooling: the CPU reference renderer, the state and draw recorder, the live
+  inspector, and the compositor diagnostics.
+
+Upgrade note: an app that authors `customPost`, `toneMapping`, or `colorGrade`
+receives those passes for the first time on this release. Review the visual
+result before you ship.
+
 ## v0.35.8 (2026-07-26)
 
 WebGPU mesh rendering now preserves authored two-sided materials and reports

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.35.8**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.35.9**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -789,7 +789,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.35.8**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.35.9**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.35.8"
+const Current = "v0.35.9"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.35.8"
+const Number = "0.35.9"


### PR DESCRIPTION
## Summary

Bump version to v0.35.9 and update release documentation. This release resolves critical bugs in Scene3D post-process passes (`customPost`, `toneMapping`, `colorGrade`) that were previously dropped due to case-mismatch bugs in the normalizer and dispatcher, along with WebGL/WebGPU pipeline signal handling fixes. It also introduces new debug tooling and automated capture requirements for verifying GPU backend execution.

## Changes

- Bump version constant and documentation to v0.35.9.
- Document fixes for Scene3D custom post-process passes (customPost, toneMapping, colorGrade) that were previously dropped due to case-sensitivity bugs in the normalizer and dispatcher.
- Resolve WebGL applyCustomPost return value handling so it correctly signals when a pass draws to the default framebuffer.
- Fix WebGPU uniform packing by passing packSelenaUniforms as a callback to wgpuCreatePostProcessor to resolve a ReferenceError.
- Add regression tests validating customPost execution on both WebGL and WebGPU backends, including a forced-red canvas pixel check.
- Introduce gosx visual --require-backend CLI flag and window.__gosx_scene3d_require_gpu API to enforce GPU backend requirements during automated captures.
- Add /docs/debugging-scene3d page outlining Scene3D debug tooling tiers.

## Testing

- Run unit and integration tests via `go test ./...`.
- Execute `scripts/forced-red-custompost.go` under SwiftShader to verify custom post passes render correctly to the canvas.
- Test `gosx visual --require-backend` flags manually to ensure they correctly reject mismatches and provide actionable error output.

## Review Focus

Focus on the case-normalization logic for scene post-effects and the WebGL/WebGPU pass pipeline signals.