### PR TITLE
bump: release v0.35.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,45 @@
 
 ## Unreleased
 
+## v0.35.10 (2026-07-26)
+
+WebGL custom post-process passes received no reserved auto-uniforms. The pass
+read `time` as 0 on every frame, so each time-driven effect stayed inert. A
+Selena post pass that fades in, flows, or animates showed a static first frame.
+
+- `applyCustomPost` in `client/js/bootstrap-src/16-scene-webgl.js` read only the
+  author-supplied `effect.uniforms` map. Reserved auto-uniforms are not in that
+  map. The pass therefore received 0 for `time`, `mvp`, `modelMatrix`,
+  `normalMatrix`, and the context-class names `cameraPos`, `sunDir`, `sunColor`,
+  and `ambient`.
+- v0.35.9 made this defect reachable. Before v0.35.9 the post effect kind was
+  folded to lower case, so `customPost` matched no backend case and the pass
+  never ran. The uniform defect was present but unreachable.
+- The WebGL mesh path and the WebGPU post path always resolved these names. The
+  mesh path calls `selenaUniformValue` through `uploadSelenaUniforms`. The
+  WebGPU post path calls `sceneSelenaUniformValue` through
+  `sceneSelenaUniformData`. Only the WebGL post path skipped the resolver.
+- `createScenePostProcessor` now accepts the renderer's Selena uniform resolver
+  as a parameter, and the render loop supplies `selenaUniformValue`. This
+  matches the WebGPU side, where `wgpuCreatePostProcessor` already accepts
+  `sceneSelenaUniformData`.
+- `applyCustomPost` now resolves every declared uniform block field through that
+  resolver. Precedence is unchanged: reserved names resolve first, then the
+  author map, then the compiled layout defaults, then a typed zero. A declared
+  `param time` ships a compiled default of 0 inside `customUniforms`. Reserved
+  names resolve first so that default cannot shadow the clock.
+- Compiled layout defaults now apply to custom post fields that the author does
+  not set. The old code skipped such a field, and GLSL then read 0.
+- Uniform upload is now driven by the declared field type through a shared
+  `sceneSelenaUploadUniform` helper. The old post-path code chose the upload
+  call from the JavaScript shape of the value, so a `vec3` field that held a
+  bare number went out as a scalar. The mesh path and the post path now share
+  one upload function and cannot diverge again.
+- Added a regression test that asserts uniform CONTENT, not dispatch. It mounts
+  a WebGL scene with a `customPost` effect, advances the clock, and requires a
+  nonzero `time` that tracks `performance.now()`. Earlier tests asserted only
+  that the pass dispatched, which is how this defect stayed hidden.
+
 ## v0.35.9 (2026-07-26)
 
 Scene3D custom post-process passes now execute. `customPost`, `toneMapping`,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write components in `.gsx` — Go with embedded markup — compile through a real compiler pipeline, render on the server by default, hydrate interactive islands with WebAssembly. No JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.35.9**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.35.10**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -789,7 +789,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.35.9**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.35.10**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,8 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.35.9"
+const Current = "v0.35.10"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.35.9"
+const Number = "0.35.10"


### PR DESCRIPTION
## Summary

Bumps the project version to v0.35.10 and publishes the corresponding release notes. This update includes changelog documentation for a critical fix where custom WebGL post-process passes failed to resolve reserved auto-uniforms like `time` and lighting data, which caused time-driven effects to render statically. The release standardizes uniform upload logic and introduces a content-focused regression test.

## Changes

- Update version constant in `internal/version/version.go` to v0.35.10
- Sync current release mentions in `README.md`
- Publish the v0.35.10 release notes in `CHANGELOG.md`, covering the post-process auto-uniform fix and associated refactorings