### PR TITLE
[Stack 1/11] add(core): 3D physics and compact VM values

### DIFF
--- a/client/bridge/bridge.go
+++ b/client/bridge/bridge.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"m31labs.dev/gosx/client/enginevm"
 	"m31labs.dev/gosx/client/videosync"
 	"m31labs.dev/gosx/client/vm"
 	rootengine "m31labs.dev/gosx/engine"
@@ -17,7 +16,7 @@ import (
 type Bridge struct {
 	islands        map[string]*vm.Island
 	computeIslands map[string]struct{}
-	engines        map[string]*enginevm.Runtime
+	engines        map[string]*vm.SceneAdapter
 	// boards holds canvas2d adapter instances (Phase 2). Typed as the
 	// Reconciler interface so the islands-only build can elide the concrete
 	// *vm.CanvasBoardAdapter from the binary entirely; the full build's
@@ -166,7 +165,7 @@ func New() *Bridge {
 	b := &Bridge{
 		islands:        make(map[string]*vm.Island),
 		computeIslands: make(map[string]struct{}),
-		engines:        make(map[string]*enginevm.Runtime),
+		engines:        make(map[string]*vm.SceneAdapter),
 		boards:         make(map[string]vm.Reconciler),
 		reconcilers:    make(map[string]vm.Reconciler),
 		engineSurfaces: make(map[string]any),
@@ -279,7 +278,7 @@ func (b *Bridge) HydrateEngine(id, componentName, propsJSON string, programData 
 		b.DisposeEngine(id)
 	}
 
-	runtime := enginevm.New(prog, propsJSON)
+	runtime := vm.NewSceneAdapter(prog, propsJSON)
 	connectSharedEngineSignals(runtime, b.store, prog.Signals)
 	b.engines[id] = runtime
 	b.reconcilers[id] = runtime
@@ -374,12 +373,13 @@ func (b *Bridge) RenderEngine(id string, width, height int, timeSeconds float64)
 }
 
 // MarshalPatches serializes patch ops to JSON for the JS patch applier.
+//
+// The encoder is hand-rolled and byte-identical to encoding/json — see
+// patch_json.go for why, and patch_json_test.go for the equality proof. The
+// error return stays for source compatibility; this path cannot fail.
 func MarshalPatches(patches []vm.PatchOp) (string, error) {
-	data, err := json.Marshal(patches)
-	if err != nil {
-		return "", err
-	}
-	return string(data), nil
+	buf := make([]byte, 0, patchesJSONSize(patches))
+	return string(appendPatchesJSON(buf, patches)), nil
 }
 
 // DisposeIsland cleans up an island and unsubscribes from all shared signals.
@@ -443,7 +443,7 @@ func (b *Bridge) ReconcilerCount() int {
 // LookupReconciler returns the reconciler registered under id, if any. The
 // returned value satisfies the vm.Reconciler lifecycle interface; callers
 // that need surface-specific behavior (PatchOp emission, Command emission)
-// must type-assert to *vm.Island or *enginevm.Runtime.
+// must type-assert to *vm.Island or *vm.SceneAdapter.
 func (b *Bridge) LookupReconciler(id string) (vm.Reconciler, bool) {
 	r, ok := b.reconcilers[id]
 	return r, ok
@@ -487,7 +487,7 @@ func sharedSignalDefs(prog *program.Program) []program.SignalDef {
 	return defs
 }
 
-func connectSharedEngineSignals(runtime *enginevm.Runtime, store *Store, defs []program.SignalDef) {
+func connectSharedEngineSignals(runtime *vm.SceneAdapter, store *Store, defs []program.SignalDef) {
 	for _, def := range defs {
 		if !isSharedSignal(def.Name) {
 			continue

--- a/client/bridge/bridge_aliases_test.go
+++ b/client/bridge/bridge_aliases_test.go
@@ -20,8 +20,8 @@ func TestStoreSetSurfaceEventReadableViaSceneAlias(t *testing.T) {
 	if !ok {
 		t.Fatalf("legacy $scene.event.selectedID lookup failed after $surface.event.selectedID write")
 	}
-	if got.Str != "rect-42" {
-		t.Errorf("alias read = %q, want %q", got.Str, "rect-42")
+	if got.Text() != "rect-42" {
+		t.Errorf("alias read = %q, want %q", got.Text(), "rect-42")
 	}
 }
 
@@ -37,8 +37,8 @@ func TestStoreSetSceneAliasReachesSurfaceTarget(t *testing.T) {
 	if !ok {
 		t.Fatalf("$surface.event lookup failed after $scene.event write")
 	}
-	if got.Str != "legacy-id" {
-		t.Errorf("canonical read = %q, want %q", got.Str, "legacy-id")
+	if got.Text() != "legacy-id" {
+		t.Errorf("canonical read = %q, want %q", got.Text(), "legacy-id")
 	}
 }
 
@@ -62,7 +62,7 @@ func TestStoreSignalAliasNotifiesLegacySubscriber(t *testing.T) {
 	if fired == 0 {
 		t.Fatalf("legacy subscriber did not fire when $surface.event.selectedID was written")
 	}
-	if v := legacySig.Get().Str; v != "hit" {
+	if v := legacySig.Get().Text(); v != "hit" {
 		t.Errorf("legacy signal value after canonical write = %q, want %q", v, "hit")
 	}
 }
@@ -87,7 +87,7 @@ func TestStoreNonAliasNamesAreUnaffected(t *testing.T) {
 	store := NewStore()
 	store.Set("$custom.counter", vm.IntVal(42))
 	got, ok := store.Get("$custom.counter")
-	if !ok || got.Num != 42 {
+	if !ok || got.Number() != 42 {
 		t.Errorf("custom signal lost through alias path: ok=%v got=%v", ok, got)
 	}
 }
@@ -105,8 +105,8 @@ func TestStoreAliasTableMatchesADR0007(t *testing.T) {
 			t.Errorf("legacy lookup %q failed after canonical %q write", legacy, canonical)
 			continue
 		}
-		if got.Str != legacy {
-			t.Errorf("legacy lookup %q = %q, want %q", legacy, got.Str, legacy)
+		if got.Text() != legacy {
+			t.Errorf("legacy lookup %q = %q, want %q", legacy, got.Text(), legacy)
 		}
 	}
 }

--- a/client/bridge/bridge_canvasboard_event_full.go
+++ b/client/bridge/bridge_canvasboard_event_full.go
@@ -270,7 +270,7 @@ func (b *Bridge) canvasBoardApplyNav(adapter *vm.CanvasBoardAdapter, dir CanvasN
 	}
 	current := ""
 	if cur, ok := store.Get("$surface.event.selectedID"); ok {
-		current = cur.Str
+		current = cur.Text()
 	}
 	next := adapter.NavFrom(current, canvasNavDirString(dir))
 	if next == "" {

--- a/client/bridge/bridge_canvasboard_event_test.go
+++ b/client/bridge/bridge_canvasboard_event_test.go
@@ -189,16 +189,16 @@ func TestCanvasBoardEventPickWritesSelectedID(t *testing.T) {
 	if !ok {
 		t.Fatalf("$surface.event.selectedID not written")
 	}
-	if got.Str != "node-A" {
-		t.Errorf("selectedID = %q, want node-A", got.Str)
+	if got.Text() != "node-A" {
+		t.Errorf("selectedID = %q, want node-A", got.Text())
 	}
 	// Legacy alias must forward (ADR 0007).
-	if legacy, ok := store.Get("$scene.event.selectedID"); !ok || legacy.Str != "node-A" {
-		t.Errorf("legacy $scene.event.selectedID = (%q,%v), want node-A", legacy.Str, ok)
+	if legacy, ok := store.Get("$scene.event.selectedID"); !ok || legacy.Text() != "node-A" {
+		t.Errorf("legacy $scene.event.selectedID = (%q,%v), want node-A", legacy.Text(), ok)
 	}
 	target, _ := store.Get("$surface.event.targetID")
-	if target.Str != "node-A" {
-		t.Errorf("targetID = %q, want node-A", target.Str)
+	if target.Text() != "node-A" {
+		t.Errorf("targetID = %q, want node-A", target.Text())
 	}
 
 	// A pick over empty space clears the selection.
@@ -206,8 +206,8 @@ func TestCanvasBoardEventPickWritesSelectedID(t *testing.T) {
 		t.Fatalf("pick miss event: %v", err)
 	}
 	cleared, _ := store.Get("$surface.event.selectedID")
-	if cleared.Str != "" {
-		t.Errorf("selectedID after miss = %q, want empty", cleared.Str)
+	if cleared.Text() != "" {
+		t.Errorf("selectedID after miss = %q, want empty", cleared.Text())
 	}
 }
 
@@ -222,8 +222,8 @@ func TestCanvasBoardEventPickPointerSignals(t *testing.T) {
 	}
 	store := b.GetStore()
 	px, ok := store.Get("$surface.event.pointerX")
-	if !ok || px.Num != 150 {
-		t.Errorf("pointerX = (%v,%v), want 150", px.Num, ok)
+	if !ok || px.Number() != 150 {
+		t.Errorf("pointerX = (%v,%v), want 150", px.Number(), ok)
 	}
 	if _, ok := store.Get("$surface.event.revision"); !ok {
 		t.Errorf("revision not written on pick")
@@ -304,12 +304,12 @@ func TestCanvasBoardEventMarqueeWritesSelectedIDs(t *testing.T) {
 	if !ok {
 		t.Fatalf("$surface.event.selectedIDs not written")
 	}
-	if ids.Str != "node-A,node-B" {
-		t.Errorf("selectedIDs = %q, want \"node-A,node-B\"", ids.Str)
+	if ids.Text() != "node-A,node-B" {
+		t.Errorf("selectedIDs = %q, want \"node-A,node-B\"", ids.Text())
 	}
 	primary, _ := store.Get("$surface.event.selectedID")
-	if primary.Str != "node-A" {
-		t.Errorf("primary selectedID = %q, want node-A (first of the marquee set)", primary.Str)
+	if primary.Text() != "node-A" {
+		t.Errorf("primary selectedID = %q, want node-A (first of the marquee set)", primary.Text())
 	}
 }
 
@@ -324,18 +324,18 @@ func TestCanvasBoardEventMarqueeEmptyClears(t *testing.T) {
 	store := b.GetStore()
 	// First select something.
 	_ = b.CanvasBoardEvent("board-mqc", CanvasBoardEventMarquee, []float64{0, 0, 600, 400, 600, 400}, "")
-	if got, _ := store.Get("$surface.event.selectedIDs"); got.Str == "" {
+	if got, _ := store.Get("$surface.event.selectedIDs"); got.Text() == "" {
 		t.Fatalf("precondition: expected a selection before clear")
 	}
 	// A zero-area marquee clears.
 	if err := b.CanvasBoardEvent("board-mqc", CanvasBoardEventMarquee, []float64{0, 0, 0, 0, 600, 400}, ""); err != nil {
 		t.Fatalf("clear marquee: %v", err)
 	}
-	if got, _ := store.Get("$surface.event.selectedIDs"); got.Str != "" {
-		t.Errorf("selectedIDs after clear = %q, want empty", got.Str)
+	if got, _ := store.Get("$surface.event.selectedIDs"); got.Text() != "" {
+		t.Errorf("selectedIDs after clear = %q, want empty", got.Text())
 	}
-	if got, _ := store.Get("$surface.event.selectedID"); got.Str != "" {
-		t.Errorf("selectedID after clear = %q, want empty", got.Str)
+	if got, _ := store.Get("$surface.event.selectedID"); got.Text() != "" {
+		t.Errorf("selectedID after clear = %q, want empty", got.Text())
 	}
 }
 
@@ -358,8 +358,8 @@ func TestCanvasBoardEventNavWritesSelectedID(t *testing.T) {
 		t.Fatalf("nav event: %v", err)
 	}
 	got, _ := store.Get("$surface.event.selectedID")
-	if got.Str != "R" {
-		t.Errorf("selectedID after nav right = %q, want R", got.Str)
+	if got.Text() != "R" {
+		t.Errorf("selectedID after nav right = %q, want R", got.Text())
 	}
 }
 
@@ -377,8 +377,8 @@ func TestCanvasBoardEventNavFromEmptyPicksFirst(t *testing.T) {
 		t.Fatalf("nav event: %v", err)
 	}
 	got, _ := store.Get("$surface.event.selectedID")
-	if got.Str != "high" {
-		t.Errorf("selectedID after nav from empty = %q, want high (topmost-leftmost)", got.Str)
+	if got.Text() != "high" {
+		t.Errorf("selectedID after nav from empty = %q, want high (topmost-leftmost)", got.Text())
 	}
 }
 
@@ -399,8 +399,8 @@ func TestCanvasBoardEventNavNoNeighborKeepsSelection(t *testing.T) {
 		t.Fatalf("nav event: %v", err)
 	}
 	got, _ := store.Get("$surface.event.selectedID")
-	if got.Str != "C" {
-		t.Errorf("selectedID after no-neighbor nav = %q, want unchanged C", got.Str)
+	if got.Text() != "C" {
+		t.Errorf("selectedID after no-neighbor nav = %q, want unchanged C", got.Text())
 	}
 }
 

--- a/client/bridge/bridge_test.go
+++ b/client/bridge/bridge_test.go
@@ -193,10 +193,10 @@ func TestSetSharedSignalJSON(t *testing.T) {
 	if val.Type != program.TypeAny {
 		t.Fatalf("expected any type, got %d", val.Type)
 	}
-	if got := val.Fields["count"].Num; got != 2 {
+	if got := val.Map()["count"].Number(); got != 2 {
 		t.Fatalf("expected count=2, got %v", got)
 	}
-	if got := val.Fields["members"].Items[1].Str; got != "b" {
+	if got := val.Map()["members"].List()[1].Text(); got != "b" {
 		t.Fatalf("expected member b, got %q", got)
 	}
 }
@@ -216,10 +216,10 @@ func TestSetSharedSignalBatchJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("expected pointer signal value")
 	}
-	if got := pointer.Fields["x"].Num; got != 12.5 {
+	if got := pointer.Map()["x"].Number(); got != 12.5 {
 		t.Fatalf("expected x=12.5, got %v", got)
 	}
-	if got := pointer.Fields["y"].Num; got != -3 {
+	if got := pointer.Map()["y"].Number(); got != -3 {
 		t.Fatalf("expected y=-3, got %v", got)
 	}
 
@@ -227,8 +227,8 @@ func TestSetSharedSignalBatchJSON(t *testing.T) {
 	if !ok {
 		t.Fatal("expected key signal value")
 	}
-	if !keyboard.Fields["space"].Bool {
-		t.Fatalf("expected space=true, got %#v", keyboard.Fields["space"])
+	if !keyboard.Map()["space"].Truth() {
+		t.Fatalf("expected space=true, got %#v", keyboard.Map()["space"])
 	}
 }
 

--- a/client/bridge/patch_json.go
+++ b/client/bridge/patch_json.go
@@ -1,0 +1,186 @@
+package bridge
+
+import (
+	"strconv"
+	"unicode/utf8"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// Hand-rolled JSON encoding for []vm.PatchOp.
+//
+// Every reconcile ships its op list across the WASM boundary as a JSON string.
+// Measured on the js/wasm target with a 100-row list build (800 ops, 43,681
+// bytes), the old encoding/json call took about 380 microseconds, while the
+// string copy across syscall/js took 5 and the browser's JSON.parse took 168.
+// The encode, not the boundary, was the cost. This encoder brings it to about
+// 151 microseconds, and the one-op batch a counter click produces from 650
+// nanoseconds to 237.
+//
+// The output stays byte-identical to encoding/json's, so patch.js, the runtime
+// tests and every recorded fixture keep working. patch_json_test.go pins that
+// equality against a randomized corpus.
+
+const lowerHex = "0123456789abcdef"
+
+// lineSeparator and paragraphSeparator are valid inside a JSON string but
+// break a JavaScript source literal, so encoding/json escapes both.
+const (
+	lineSeparator      = '\u2028'
+	paragraphSeparator = '\u2029'
+)
+
+// appendPatchesJSON writes the JSON array form of patches into out.
+//
+// Field order and omission rules follow the struct tags on vm.PatchOp:
+// kind and path always appear; tag, text, attrName and children appear only
+// when non-empty.
+func appendPatchesJSON(out []byte, patches []vm.PatchOp) []byte {
+	if patches == nil {
+		return append(out, "null"...)
+	}
+	out = append(out, '[')
+	for i := range patches {
+		if i > 0 {
+			out = append(out, ',')
+		}
+		out = appendPatchOpJSON(out, &patches[i])
+	}
+	return append(out, ']')
+}
+
+// patchesJSONSize estimates the encoded length so the buffer needs no regrow.
+//
+// The walk touches lengths only, never string contents, so it costs a few
+// nanoseconds per op. Escaping can still push a payload past the estimate; that
+// costs one grow, which the previous fixed guess paid on every batch.
+func patchesJSONSize(patches []vm.PatchOp) int {
+	// Two brackets, plus one comma between each pair of ops.
+	total := 2 + len(patches)
+	for i := range patches {
+		op := &patches[i]
+		// {"kind":NNN,"path":"..."} — 22 bytes of frame.
+		total += 22 + len(op.Path)
+		if op.Tag != "" {
+			total += 9 + len(op.Tag)
+		}
+		if op.Text != "" {
+			total += 10 + len(op.Text)
+		}
+		if op.AttrName != "" {
+			total += 14 + len(op.AttrName)
+		}
+		if n := len(op.Children); n > 0 {
+			total += 14 + 8*n
+		}
+	}
+	return total
+}
+
+func appendPatchOpJSON(out []byte, op *vm.PatchOp) []byte {
+	out = append(out, `{"kind":`...)
+	out = strconv.AppendUint(out, uint64(op.Kind), 10)
+	out = append(out, `,"path":`...)
+	out = appendJSONString(out, op.Path)
+	if op.Tag != "" {
+		out = append(out, `,"tag":`...)
+		out = appendJSONString(out, op.Tag)
+	}
+	if op.Text != "" {
+		out = append(out, `,"text":`...)
+		out = appendJSONString(out, op.Text)
+	}
+	if op.AttrName != "" {
+		out = append(out, `,"attrName":`...)
+		out = appendJSONString(out, op.AttrName)
+	}
+	if len(op.Children) > 0 {
+		out = append(out, `,"children":[`...)
+		for i, child := range op.Children {
+			if i > 0 {
+				out = append(out, ',')
+			}
+			out = strconv.AppendInt(out, int64(child), 10)
+		}
+		out = append(out, ']')
+	}
+	return append(out, '}')
+}
+
+// jsonSafeByte reports whether a byte below 0x80 can go into a JSON string
+// unescaped.
+//
+// The set matches encoding/json's htmlSafeSet: printable ASCII minus the quote
+// and the backslash, minus '<', '>' and '&'. encoding/json escapes those three
+// by default so a patch payload cannot break out of a <script> block, and the
+// output must match byte for byte.
+func jsonSafeByte(b byte) bool {
+	if b < 0x20 {
+		return false
+	}
+	switch b {
+	case '"', '\\', '<', '>', '&':
+		return false
+	}
+	return true
+}
+
+// appendJSONString writes s as a quoted JSON string, matching
+// encoding/json.Marshal with HTML escaping left on.
+func appendJSONString(out []byte, s string) []byte {
+	out = append(out, '"')
+	start := 0
+	for i := 0; i < len(s); {
+		b := s[i]
+		if b < utf8.RuneSelf {
+			if jsonSafeByte(b) {
+				i++
+				continue
+			}
+			out = append(out, s[start:i]...)
+			switch b {
+			case '\\', '"':
+				out = append(out, '\\', b)
+			case '\b':
+				out = append(out, '\\', 'b')
+			case '\f':
+				out = append(out, '\\', 'f')
+			case '\n':
+				out = append(out, '\\', 'n')
+			case '\r':
+				out = append(out, '\\', 'r')
+			case '\t':
+				out = append(out, '\\', 't')
+			default:
+				// Control bytes other than \b, \f, \n, \r and \t, plus
+				// <, > and &.
+				out = append(out, '\\', 'u', '0', '0', lowerHex[b>>4], lowerHex[b&0xF])
+			}
+			i++
+			start = i
+			continue
+		}
+		r, size := utf8.DecodeRuneInString(s[i:])
+		if r == utf8.RuneError && size == 1 {
+			// Invalid UTF-8 becomes an escaped replacement character, as
+			// encoding/json does.
+			out = append(out, s[start:i]...)
+			out = append(out, `\ufffd`...)
+			i += size
+			start = i
+			continue
+		}
+		if r == lineSeparator || r == paragraphSeparator {
+			// Line and paragraph separators are valid JSON but break a
+			// JavaScript source literal, so encoding/json escapes them.
+			out = append(out, s[start:i]...)
+			out = append(out, '\\', 'u', '2', '0', '2', lowerHex[r&0xF])
+			i += size
+			start = i
+			continue
+		}
+		i += size
+	}
+	out = append(out, s[start:]...)
+	return append(out, '"')
+}

--- a/client/bridge/patch_json_test.go
+++ b/client/bridge/patch_json_test.go
@@ -1,0 +1,199 @@
+package bridge
+
+import (
+	"encoding/json"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/client/vm"
+)
+
+// TestMarshalPatchesMatchesEncodingJSON pins the hand-rolled encoder to
+// encoding/json byte for byte.
+//
+// patch.js, runtime.test.js and recorded fixtures all read this exact text, so a
+// single escaping difference is a wire break. Any change to appendPatchesJSON
+// must keep this test green.
+func TestMarshalPatchesMatchesEncodingJSON(t *testing.T) {
+	cases := map[string][]vm.PatchOp{
+		"nil":   nil,
+		"empty": {},
+		"set text": {
+			{Kind: vm.PatchSetText, Path: "1/0", Text: "42"},
+		},
+		"empty path and empty text": {
+			{Kind: vm.PatchSetText, Path: "", Text: ""},
+		},
+		"every field": {
+			{
+				Kind:     vm.PatchCreateElement,
+				Path:     "0/12/3",
+				Tag:      "li",
+				Text:     "row",
+				AttrName: "data-row",
+				Children: []int{0, 7, 42},
+			},
+		},
+		"html in text": {
+			{Kind: vm.PatchSetText, Path: "0", Text: `<strong class="x">a & b</strong>`},
+		},
+		"quotes and backslashes": {
+			{Kind: vm.PatchSetAttr, Path: "0", AttrName: "title", Text: `he said "hi\there"`},
+		},
+		"control characters": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "a\tb\nc\rd\x00e\x1ff\x7fg"},
+		},
+		"bell and form feed": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "\a\b\f\v"},
+		},
+		"multibyte and emoji": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "héllo wörld — 日本語 🎉"},
+		},
+		"line and paragraph separators": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "a b c"},
+		},
+		"invalid utf8": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "ok\xff\xfe\x80bad"},
+		},
+		"lone surrogate bytes": {
+			{Kind: vm.PatchSetText, Path: "0", Text: "\xed\xa0\x80"},
+		},
+		"negative and large children": {
+			{Kind: vm.PatchReorder, Path: "0", Children: []int{-1, 0, 65535, 1000000}},
+		},
+		"empty children slice stays omitted": {
+			{Kind: vm.PatchReorder, Path: "0", Children: []int{}},
+		},
+		"high kind value": {
+			{Kind: vm.PatchKind(200), Path: "0"},
+		},
+		"multi op batch": {
+			{Kind: vm.PatchRemoveElement, Path: "0/3"},
+			{Kind: vm.PatchCreateText, Path: "0", Text: "x", Children: []int{3}},
+			{Kind: vm.PatchRemoveAttr, Path: "0/3", AttrName: "hidden"},
+			{Kind: vm.PatchSetValue, Path: "0/4", AttrName: "value", Text: "typed"},
+		},
+	}
+
+	for name, ops := range cases {
+		t.Run(name, func(t *testing.T) {
+			want, err := json.Marshal(ops)
+			if err != nil {
+				t.Fatalf("encoding/json failed: %v", err)
+			}
+			got, err := MarshalPatches(ops)
+			if err != nil {
+				t.Fatalf("MarshalPatches failed: %v", err)
+			}
+			if got != string(want) {
+				t.Errorf("encoder diverged\n got: %s\nwant: %s", got, want)
+			}
+		})
+	}
+}
+
+// TestMarshalPatchesMatchesEncodingJSONRandomized runs the same equality check
+// over a randomized corpus, so escaping paths the table misses still get hit.
+func TestMarshalPatchesMatchesEncodingJSONRandomized(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260726))
+	for round := 0; round < 3000; round++ {
+		ops := make([]vm.PatchOp, rng.Intn(4))
+		for i := range ops {
+			ops[i] = vm.PatchOp{
+				Kind:     vm.PatchKind(rng.Intn(12)),
+				Path:     randomPatchText(rng),
+				Tag:      randomPatchText(rng),
+				Text:     randomPatchText(rng),
+				AttrName: randomPatchText(rng),
+			}
+			if n := rng.Intn(4); n > 0 {
+				ops[i].Children = make([]int, n)
+				for j := range ops[i].Children {
+					ops[i].Children[j] = rng.Intn(2000) - 500
+				}
+			}
+		}
+		want, err := json.Marshal(ops)
+		if err != nil {
+			t.Fatalf("round %d: encoding/json failed: %v", round, err)
+		}
+		got, err := MarshalPatches(ops)
+		if err != nil {
+			t.Fatalf("round %d: MarshalPatches failed: %v", round, err)
+		}
+		if got != string(want) {
+			t.Fatalf("round %d: encoder diverged\n got: %s\nwant: %s", round, got, want)
+		}
+	}
+}
+
+// randomPatchText builds a short string from a pool that spans safe ASCII,
+// escape-forcing bytes, multi-byte runes and invalid UTF-8.
+func randomPatchText(rng *rand.Rand) string {
+	pool := []string{
+		"", "a", "0/1", "div", "data-x", " ", "\t", "\n", "\r", "\x00", "\x0b",
+		"\x1f", "\x7f", `"`, `\`, "<", ">", "&", "é", "日", "🎉", " ",
+		" ", "\xff", "\x80", "\xed\xa0\x80", "\xc3", "ok",
+	}
+	var b strings.Builder
+	for n := rng.Intn(6); n > 0; n-- {
+		b.WriteString(pool[rng.Intn(len(pool))])
+	}
+	return b.String()
+}
+
+// --- benchmarks ---
+
+func benchPatchListBuild(rows, cells int) []vm.PatchOp {
+	ops := make([]vm.PatchOp, 0, rows*(2+cells*2))
+	for r := 0; r < rows; r++ {
+		rowPath := "0/" + strconv.Itoa(r)
+		ops = append(ops,
+			vm.PatchOp{Kind: vm.PatchCreateElement, Path: "0", Tag: "li", Children: []int{r}},
+			vm.PatchOp{Kind: vm.PatchSetAttr, Path: rowPath, AttrName: "data-row", Text: strconv.Itoa(r)},
+		)
+		for c := 0; c < cells; c++ {
+			cellPath := rowPath + "/" + strconv.Itoa(c)
+			ops = append(ops,
+				vm.PatchOp{Kind: vm.PatchCreateElement, Path: rowPath, Tag: "span", Children: []int{c}},
+				vm.PatchOp{Kind: vm.PatchCreateText, Path: cellPath, Text: "r" + strconv.Itoa(r) + "c" + strconv.Itoa(c), Children: []int{0}},
+			)
+		}
+	}
+	return ops
+}
+
+func BenchmarkMarshalPatchesCounter(b *testing.B) {
+	ops := []vm.PatchOp{{Kind: vm.PatchSetText, Path: "1/0", Text: "42"}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := MarshalPatches(ops); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalPatchesListBuild(b *testing.B) {
+	ops := benchPatchListBuild(100, 3)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := MarshalPatches(ops); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMarshalPatchesListBuildEncodingJSON(b *testing.B) {
+	ops := benchPatchListBuild(100, 3)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := json.Marshal(ops); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/client/vm/canvas_board_adapter_test.go
+++ b/client/vm/canvas_board_adapter_test.go
@@ -518,7 +518,7 @@ func TestCanvasBoardAdapterLifecycleMirrorsSceneAdapter(t *testing.T) {
 
 	sceneVal := scene.EvalExpr(islandprogram.ExprID(0))
 	boardVal := board.EvalExpr(islandprogram.ExprID(0))
-	if sceneVal.Num != boardVal.Num {
+	if sceneVal.num != boardVal.num {
 		t.Errorf("EvalExpr divergence: scene=%v board=%v", sceneVal, boardVal)
 	}
 

--- a/client/vm/clip_motion.go
+++ b/client/vm/clip_motion.go
@@ -224,13 +224,6 @@ func positioned(track *motion.Track) motion.Positioned {
 	}
 }
 
-func lastTime(times []float64) float64 {
-	if len(times) == 0 {
-		return 0
-	}
-	return times[len(times)-1]
-}
-
 // vec3Track builds an ArityVec3 keyframe track from a stride-3 channel.
 func vec3Track(ch rootengine.RenderAnimationChannel, ref, prop string, stride int) *motion.Track {
 	n := frameCount(ch, stride)

--- a/client/vm/closure.go
+++ b/client/vm/closure.go
@@ -44,20 +44,17 @@ import (
 // evaluate them defensively (the lowerer always emits literals, but
 // dynamic operands shouldn't crash the VM) and feed the resulting
 // names into ClosureVal.
-func (vm *VM) evalClosureExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpClosure {
-		return Value{}, false
-	}
+func (vm *VM) closureValue(e *program.Expr) Value {
 	captured := make([]string, 0, len(e.Operands))
 	for _, op := range e.Operands {
 		nameVal := vm.Eval(op)
-		if nameVal.Str != "" {
-			captured = append(captured, nameVal.Str)
+		if name := nameVal.text(); name != "" {
+			captured = append(captured, name)
 		}
 	}
 	// Snapshot the caller's frame pointer. nil is OK — closures
 	// declared at handler scope with no enclosing locals are valid.
-	return ClosureVal(e.Value, captured, vm.frame), true
+	return ClosureVal(e.Value, captured, vm.frame)
 }
 
 // invokeClosureFromIndirectCall handles the Y.D OpIndirectCall path
@@ -71,12 +68,16 @@ func (vm *VM) evalClosureExpr(e program.Expr) (Value, bool) {
 // the ClosureVal. The captured-frame bridge is installed by wrapping
 // the fresh callee frame's `parent` slot — see frame.go's parent
 // lookup chain.
-func (vm *VM) invokeClosureFromIndirectCall(cv Value, args []Value, e program.Expr) Value {
-	def, ok := vm.funcs[cv.closure.funcName]
+func (vm *VM) invokeClosureFromIndirectCall(cv Value, args []Value, e *program.Expr) Value {
+	ref := cv.closureRefOf()
+	if ref == nil {
+		return ZeroValue(program.TypeAny)
+	}
+	def, ok := vm.funcs[ref.funcName]
 	if !ok {
 		vm.recordExprDiagnostic(
 			"unknown_closure_func",
-			"closure refers to unregistered FuncDef "+cv.closure.funcName,
+			"closure refers to unregistered FuncDef "+ref.funcName,
 			e.Op,
 			e.Value,
 		)
@@ -99,7 +100,7 @@ func (vm *VM) invokeClosureFromIndirectCall(cv Value, args []Value, e program.Ex
 	}
 
 	prevFrame := vm.frame
-	closureFrame := newClosureFrame(cv.closure)
+	closureFrame := newClosureFrame(ref)
 	vm.frame = closureFrame
 	vm.callDepth++
 	defer func() {
@@ -120,8 +121,8 @@ func (vm *VM) invokeClosureFromIndirectCall(cv Value, args []Value, e program.Ex
 	var result Value
 	for _, bodyID := range def.Body {
 		result = vm.Eval(bodyID)
-		if result.Control == ControlReturn {
-			result.Control = ControlNone
+		if result.Control() == ControlReturn {
+			result = result.WithControl(ControlNone)
 			break
 		}
 	}
@@ -164,8 +165,8 @@ func (vm *VM) InvokeClosure(cv Value, args []Value) Value {
 	if !IsClosure(cv) {
 		return ZeroValue(program.TypeAny)
 	}
-	synthetic := program.Expr{Op: program.OpIndirectCall, Value: cv.closure.funcName}
-	return vm.invokeClosureFromIndirectCall(cv, args, synthetic)
+	synthetic := program.Expr{Op: program.OpIndirectCall, Value: ClosureFuncName(cv)}
+	return vm.invokeClosureFromIndirectCall(cv, args, &synthetic)
 }
 
 // itoa is a tiny helper so closure.go doesn't pull strconv (keeps the

--- a/client/vm/closure_dispatch_test.go
+++ b/client/vm/closure_dispatch_test.go
@@ -62,8 +62,8 @@ func TestVM_OpClosureInvokeRunsBody(t *testing.T) {
 		t.Fatalf("OpClosure did not yield a ClosureVal")
 	}
 	got := vm.InvokeClosure(cv, []Value{IntVal(7)})
-	if int(got.Num) != 14 {
-		t.Errorf("InvokeClosure(7) = %v, want 14", got.Num)
+	if int(got.num) != 14 {
+		t.Errorf("InvokeClosure(7) = %v, want 14", got.num)
 	}
 }
 
@@ -105,8 +105,8 @@ func TestVM_ClosureCaptureByReferenceWriteback(t *testing.T) {
 	if !ok {
 		t.Fatalf("parent frame lost n after closure invocations")
 	}
-	if int(got.Num) != 3 {
-		t.Errorf("parent n = %v, want 3 (closure writes did not propagate)", got.Num)
+	if int(got.num) != 3 {
+		t.Errorf("parent n = %v, want 3 (closure writes did not propagate)", got.num)
 	}
 }
 
@@ -136,11 +136,11 @@ func TestVM_ClosureShadowingParamWinsOverCapture(t *testing.T) {
 	vm := NewVM(prog, nil)
 	cv := ClosureVal("__y_g_shadow", []string{"x"}, parent)
 	got := vm.InvokeClosure(cv, []Value{IntVal(5)})
-	if int(got.Num) != 5 {
-		t.Errorf("shadowing: got %v, want 5 (the parameter, not the captured 100)", got.Num)
+	if int(got.num) != 5 {
+		t.Errorf("shadowing: got %v, want 5 (the parameter, not the captured 100)", got.num)
 	}
-	if v, _ := parent.get("x"); int(v.Num) != 100 {
-		t.Errorf("parent x mutated despite param shadow: %v, want 100", v.Num)
+	if v, _ := parent.get("x"); int(v.num) != 100 {
+		t.Errorf("parent x mutated despite param shadow: %v, want 100", v.num)
 	}
 }
 

--- a/client/vm/closure_test.go
+++ b/client/vm/closure_test.go
@@ -55,14 +55,14 @@ func TestClosureValCaptureByReference(t *testing.T) {
 	// must see the update.
 	f.set("y", IntVal(20))
 
-	got, ok := cv.closure.frame.get("y")
+	got, ok := cv.closureRefOf().frame.get("y")
 	if !ok {
 		t.Fatalf("captured frame does not have y")
 	}
-	if int(got.Num) != 20 {
-		t.Errorf("captured y = %v, want 20 (capture-by-reference broken)", got.Num)
+	if int(got.num) != 20 {
+		t.Errorf("captured y = %v, want 20 (capture-by-reference broken)", got.num)
 	}
-	if !cv.closure.captured["y"] {
+	if !cv.closureRefOf().captured["y"] {
 		t.Errorf("captured set does not record y")
 	}
 }

--- a/client/vm/composite_test.go
+++ b/client/vm/composite_test.go
@@ -38,14 +38,14 @@ func TestOpCompositeStructPositional(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(4)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("OpComposite struct: Fields nil; got %+v", got)
 	}
-	if got.Fields["X"].Num != 3.5 {
-		t.Errorf("Fields[X] = %f, want 3.5", got.Fields["X"].Num)
+	if got.Map()["X"].num != 3.5 {
+		t.Errorf("Fields[X] = %f, want 3.5", got.Map()["X"].num)
 	}
-	if got.Fields["Y"].Num != 1.25 {
-		t.Errorf("Fields[Y] = %f, want 1.25", got.Fields["Y"].Num)
+	if got.Map()["Y"].num != 1.25 {
+		t.Errorf("Fields[Y] = %f, want 1.25", got.Map()["Y"].num)
 	}
 }
 
@@ -69,11 +69,11 @@ func TestOpCompositeSliceMaterialization(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(6)
-	if len(got.Items) != 3 {
-		t.Fatalf("Items length = %d, want 3", len(got.Items))
+	if len(got.List()) != 3 {
+		t.Fatalf("Items length = %d, want 3", len(got.List()))
 	}
-	if got.Items[0].Str != "alpha" || got.Items[2].Str != "gamma" {
-		t.Errorf("Items = %+v, want [alpha beta gamma]", got.Items)
+	if got.List()[0].Text() != "alpha" || got.List()[2].Text() != "gamma" {
+		t.Errorf("Items = %+v, want [alpha beta gamma]", got.List())
 	}
 }
 
@@ -94,11 +94,11 @@ func TestOpCompositeMapMaterialization(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(4)
-	if got.Fields == nil || len(got.Fields) != 2 {
-		t.Fatalf("Fields = %+v, want 2 entries", got.Fields)
+	if got.Map() == nil || len(got.Map()) != 2 {
+		t.Fatalf("Fields = %+v, want 2 entries", got.Map())
 	}
-	if got.Fields["x"].Num != 1.5 || got.Fields["y"].Num != 2.5 {
-		t.Errorf("Fields = %+v, want {x:1.5, y:2.5}", got.Fields)
+	if got.Map()["x"].num != 1.5 || got.Map()["y"].num != 2.5 {
+		t.Errorf("Fields = %+v, want {x:1.5, y:2.5}", got.Map())
 	}
 }
 
@@ -112,11 +112,11 @@ func TestOpCompositeEmptyStruct(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(0)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("empty struct should still allocate Fields, got %+v", got)
 	}
-	if len(got.Fields) != 0 {
-		t.Errorf("empty struct Fields = %d entries, want 0", len(got.Fields))
+	if len(got.Map()) != 0 {
+		t.Errorf("empty struct Fields = %d entries, want 0", len(got.Map()))
 	}
 }
 
@@ -135,7 +135,7 @@ func TestOpCompositeOddOperandsDiagnostic(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(1)
-	if got.Fields != nil {
+	if got.Map() != nil {
 		t.Errorf("malformed OpComposite should fall back to zero Any, got %+v", got)
 	}
 	diags := machine.Diagnostics()
@@ -153,7 +153,7 @@ func TestOpCompositeUnknownKindDiagnostic(t *testing.T) {
 	prog := &program.Program{Exprs: exprs}
 	machine := NewVM(prog, nil)
 	got := machine.Eval(0)
-	if got.Fields != nil || got.Items != nil {
+	if got.Map() != nil || got.List() != nil {
 		t.Errorf("unknown OpComposite kind should fall back to zero Any, got %+v", got)
 	}
 	diags := machine.Diagnostics()

--- a/client/vm/diagnostics.go
+++ b/client/vm/diagnostics.go
@@ -77,7 +77,7 @@ func (vm *VM) recordExprDiagnostic(code, message string, op program.OpCode, valu
 	})
 }
 
-func (vm *VM) recordMissingOperands(e program.Expr, want int) {
+func (vm *VM) recordMissingOperands(e *program.Expr, want int) {
 	vm.recordExprDiagnostic(
 		"missing_operands",
 		fmt.Sprintf("opcode %d requires at least %d operands, got %d", e.Op, want, len(e.Operands)),
@@ -86,7 +86,7 @@ func (vm *VM) recordMissingOperands(e program.Expr, want int) {
 	)
 }
 
-func (vm *VM) requireOperands(e program.Expr, want int) bool {
+func (vm *VM) requireOperands(e *program.Expr, want int) bool {
 	if len(e.Operands) >= want {
 		return true
 	}

--- a/client/vm/frame.go
+++ b/client/vm/frame.go
@@ -47,23 +47,6 @@ func newClosureFrame(cr *closureRef) *frame {
 	}
 }
 
-// has reports whether name has been declared in this frame.
-// For closure frames, captured names report as declared whenever the
-// captured frame has them, so OpLocalGet hits the captured-bridge
-// path instead of producing a missing-frame diagnostic.
-func (f *frame) has(name string) bool {
-	if f == nil {
-		return false
-	}
-	if _, ok := f.locals[name]; ok {
-		return true
-	}
-	if f.captured != nil && f.captured.captured[name] && f.captured.frame != nil {
-		return f.captured.frame.has(name)
-	}
-	return false
-}
-
 // get returns the current value of name and whether it was declared.
 // Reads of undeclared locals return the zero Value with ok=false so
 // the caller can surface a missing_local diagnostic. For closure

--- a/client/vm/fuzz_test.go
+++ b/client/vm/fuzz_test.go
@@ -1,0 +1,205 @@
+// FuzzVMEvalNeverPanics pins the VM's "panic-free contract" (see
+// vm.go's Eval doc comment) with a native Go fuzz target.
+//
+// The VM is the one package in this repository that promises never
+// to panic. Every other opcode evaluator degrades to a zero Value
+// plus a structured Diagnostic instead. Yet before this file
+// existed, no fuzz target exercised that promise. An ad-hoc version
+// of exactly this harness found the SliceVal/SubstringVal
+// negative-end bounds bug (see value_test.go's
+// TestSliceValNegativeEndDoesNotPanic) in seconds across 400,000
+// random programs.
+//
+// The fuzzer builds a random but acyclic program.Expr graph. Node
+// i's operands only ever reference nodes 0..i-1. So the graph is a
+// DAG by construction, and Eval can never recurse into a cycle
+// through it. (Self-referential *values*, as opposed to expression
+// graphs, are a separate concern.
+// TestValueStringSelfReferentialArrayDoesNotOverflow and its
+// neighbors in value_test.go and json_test.go cover that case.)
+// Every opcode the VM defines gets picked with equal probability.
+// So a newly added opcode is automatically included without this
+// file changing.
+
+package vm
+
+import (
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+	"m31labs.dev/gosx/signal"
+)
+
+// fuzzMaxNodes bounds how large a single generated program can be.
+// This keeps one fuzz iteration fast, even combined with Eval's own
+// depth cap (maxEvalDepth) and the loop step budget (loops.go).
+const fuzzMaxNodes = 64
+
+// fuzzMaxOperandsPerExpr bounds how many operands a single generated
+// Expr can carry. The real opcodes need at most 4 (OpFor), so this
+// covers every shape while keeping the DAG shallow enough to stay
+// fast.
+const fuzzMaxOperandsPerExpr = 4
+
+func FuzzVMEvalNeverPanics(f *testing.F) {
+	f.Add(int64(1), 8, "9e999")
+	f.Add(int64(2), 20, "-1")
+	f.Add(int64(3), 0, "")
+	f.Add(int64(4), 50, "NaN")
+	f.Add(int64(5), 12, "1e300")
+	f.Add(int64(6), 3, "struct:Fuzz")
+	f.Add(int64(7), 40, "slice")
+
+	f.Fuzz(func(t *testing.T, seed int64, rawNodeCount int, litSeed string) {
+		if len(litSeed) > 64 {
+			litSeed = litSeed[:64] // bound pathologically huge literal strings
+		}
+		rng := rand.New(rand.NewSource(seed ^ int64(rawNodeCount)))
+		prog := fuzzBuildProgram(rng, rawNodeCount, litSeed)
+
+		m := NewVM(prog, map[string]Value{"fuzzProp": IntVal(1)})
+		m.SetSignal("fuzzSignal", signal.New(IntVal(0)))
+		m.SetForCap(1000) // keep OpFor/OpForRange bodies bounded and fast
+
+		for id := range prog.Exprs {
+			evalFuzzNode(t, m, id, prog.Exprs[id])
+		}
+	})
+}
+
+// evalFuzzNode evaluates one node. It turns any panic into a
+// t.Fatal that carries the offending opcode. So a fuzz failure's
+// corpus entry comes with an immediately actionable message,
+// instead of just a raw stack trace. go test's native fuzzing still
+// treats this as a failure. It still saves and minimizes the
+// corpus entry, because t.Fatal marks the (*testing.T) as failed
+// either way.
+func evalFuzzNode(t *testing.T, m *VM, id int, e program.Expr) {
+	t.Helper()
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Eval(%d) panicked on opcode %d (value %q, operands %v): %v", id, e.Op, e.Value, e.Operands, r)
+		}
+	}()
+	_ = m.Eval(program.ExprID(id))
+}
+
+// fuzzBuildProgram builds a random program.Program whose Exprs form
+// a DAG. Every Expr's operands reference strictly earlier indices.
+// So there is no cycle for Eval to recurse through.
+func fuzzBuildProgram(rng *rand.Rand, rawNodeCount int, litSeed string) *program.Program {
+	n := rawNodeCount % fuzzMaxNodes
+	if n < 0 {
+		n = -n
+	}
+	n++ // always at least 1 node
+
+	exprs := make([]program.Expr, n)
+	for i := 0; i < n; i++ {
+		exprs[i] = fuzzRandomExpr(rng, i, litSeed)
+	}
+	return &program.Program{
+		Name:  "fuzz",
+		Exprs: exprs,
+		// A bounded, non-default MaxCallDepth keeps any OpIndirectCall
+		// fast to fail. The generator may produce one, but it never
+		// resolves, since this fuzzer builds no Funcs. It still
+		// exercises the unknown_user_function diagnostic path.
+		MaxCallDepth: 32,
+	}
+}
+
+// fuzzOpCodeCount is the number of opcodes program.go defines,
+// computed once from the contiguous iota range [OpLitString,
+// OpClosure]. Every opcode is reachable through fuzzRandomExpr with
+// equal probability. A newly added opcode extends this range
+// automatically, as long as it keeps the iota block contiguous.
+const fuzzOpCodeCount = int(program.OpClosure) + 1
+
+// fuzzExprTypeCount mirrors fuzzOpCodeCount for program.ExprType.
+const fuzzExprTypeCount = int(program.TypeAny) + 1
+
+func fuzzRandomExpr(rng *rand.Rand, idx int, litSeed string) program.Expr {
+	e := program.Expr{
+		Op:    program.OpCode(rng.Intn(fuzzOpCodeCount)),
+		Type:  program.ExprType(rng.Intn(fuzzExprTypeCount)),
+		Value: fuzzRandomValue(rng, litSeed),
+	}
+
+	maxOperands := idx
+	if maxOperands > fuzzMaxOperandsPerExpr {
+		maxOperands = fuzzMaxOperandsPerExpr
+	}
+	if maxOperands <= 0 {
+		return e
+	}
+	count := rng.Intn(maxOperands + 1)
+	if count == 0 {
+		return e
+	}
+	e.Operands = make([]program.ExprID, count)
+	for i := range e.Operands {
+		// Strictly less than idx: this is what makes the graph acyclic.
+		e.Operands[i] = program.ExprID(rng.Intn(idx))
+	}
+	return e
+}
+
+// fuzzRandomValue returns e.Value for a generated node. The pool
+// mixes several categories:
+//
+//   - Numeric and boolean edge cases that stress literal parsing
+//     and float-to-int casts. These are the exact shape that caused
+//     the SliceVal / SubstringVal crashes in value.go.
+//   - Composite-literal kind tags. OpComposite dispatches on
+//     e.Value for these.
+//   - Collection-scoped identifier names: _item, _index, and _key.
+//   - The fuzzer-controlled litSeed. This lets Go's built-in
+//     mutator explore literal strings that neither this list nor a
+//     human would think to write by hand.
+func fuzzRandomValue(rng *rand.Rand, litSeed string) string {
+	choices := []string{
+		"", "0", "-1", "1", "true", "false",
+		"9e999", "-9e999", "1e300", "-1e300",
+		"NaN", "Inf", "+Inf", "-Inf", "3.14", "-3.14",
+		"slice", "map", "struct:Fuzz",
+		"x", "i", "_item", "_index", "_key", "n",
+		litSeed,
+	}
+	return choices[rng.Intn(len(choices))]
+}
+
+// TestFuzzVMEvalNeverPanicsSeedCorpusReplays runs the fuzz
+// function's own seed corpus as a regular test. So `go test` (with
+// no -fuzz flag) still exercises these specific edge cases on every
+// ordinary CI run. It does not depend on someone remembering to run
+// `make test-fuzz-smoke`.
+func TestFuzzVMEvalNeverPanicsSeedCorpusReplays(t *testing.T) {
+	seeds := []struct {
+		seed      int64
+		nodeCount int
+		lit       string
+	}{
+		{1, 8, "9e999"},
+		{2, 20, "-1"},
+		{3, 0, ""},
+		{4, 50, "NaN"},
+		{5, 12, "1e300"},
+		{6, 3, "struct:Fuzz"},
+		{7, 40, "slice"},
+	}
+	for i, s := range seeds {
+		t.Run(fmt.Sprintf("seed_%d", i), func(t *testing.T) {
+			rng := rand.New(rand.NewSource(s.seed ^ int64(s.nodeCount)))
+			prog := fuzzBuildProgram(rng, s.nodeCount, s.lit)
+			m := NewVM(prog, map[string]Value{"fuzzProp": IntVal(1)})
+			m.SetSignal("fuzzSignal", signal.New(IntVal(0)))
+			m.SetForCap(1000)
+			for id := range prog.Exprs {
+				evalFuzzNode(t, m, id, prog.Exprs[id])
+			}
+		})
+	}
+}

--- a/client/vm/host_call.go
+++ b/client/vm/host_call.go
@@ -99,10 +99,7 @@ func (vm *VM) LookupHost(name string) (HostReceiver, bool) {
 // for the given identifier) record a `host_unbound` diagnostic and
 // likewise yield the zero value so handler bodies continue to
 // evaluate the rest of their statements.
-func (vm *VM) evalHostCallExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpHostCall {
-		return Value{}, false
-	}
+func (vm *VM) hostCallValue(e *program.Expr) Value {
 	dot := strings.IndexByte(e.Value, '.')
 	if dot <= 0 || dot == len(e.Value)-1 {
 		vm.recordExprDiagnostic(
@@ -111,7 +108,7 @@ func (vm *VM) evalHostCallExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 	recvName := e.Value[:dot]
 	methodName := e.Value[dot+1:]
@@ -125,7 +122,7 @@ func (vm *VM) evalHostCallExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 	args := make([]Value, len(e.Operands))
 	for i, op := range e.Operands {
@@ -139,9 +136,9 @@ func (vm *VM) evalHostCallExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
-	return result, true
+	return result
 }
 
 // --- Test helper: HostRecorder ---

--- a/client/vm/host_call_test.go
+++ b/client/vm/host_call_test.go
@@ -56,11 +56,11 @@ func TestEvalHostCallEvaluatesArgsInSourceOrder(t *testing.T) {
 	if len(args) != 2 {
 		t.Fatalf("expected 2 args; got %d", len(args))
 	}
-	if args[0].Num != 1.5 {
-		t.Errorf("args[0] = %f, want 1.5", args[0].Num)
+	if args[0].num != 1.5 {
+		t.Errorf("args[0] = %f, want 1.5", args[0].num)
 	}
-	if args[1].Num != 2.5 {
-		t.Errorf("args[1] = %f, want 2.5", args[1].Num)
+	if args[1].num != 2.5 {
+		t.Errorf("args[1] = %f, want 2.5", args[1].num)
 	}
 }
 
@@ -79,8 +79,8 @@ func TestEvalHostCallReturnValue(t *testing.T) {
 	}
 	vm.BindHost("c", rec)
 	got := vm.Eval(0)
-	if int(got.Num) != 800 {
-		t.Errorf("c.Width() returned %d, want 800", int(got.Num))
+	if int(got.num) != 800 {
+		t.Errorf("c.Width() returned %d, want 800", int(got.num))
 	}
 }
 

--- a/client/vm/intrinsics.go
+++ b/client/vm/intrinsics.go
@@ -108,7 +108,7 @@ func IntrinsicNames() []string {
 // dispatched (whether or not the intrinsic errored — errors are
 // surfaced via diagnostics), or (zero, false) when no intrinsic is
 // registered under the name.
-func (vm *VM) callIntrinsic(e program.Expr) (Value, bool) {
+func (vm *VM) callIntrinsic(e *program.Expr) (Value, bool) {
 	fn, ok := LookupIntrinsic(e.Value)
 	if !ok {
 		return Value{}, false

--- a/client/vm/intrinsics_math.go
+++ b/client/vm/intrinsics_math.go
@@ -39,7 +39,7 @@ func mathUnary(fn func(float64) float64) Intrinsic {
 		if len(args) != 1 {
 			return Value{}, errors.New("math: function expects 1 argument")
 		}
-		return FloatVal(fn(args[0].Num)), nil
+		return FloatVal(fn(args[0].num)), nil
 	}
 }
 
@@ -51,6 +51,6 @@ func mathBinary(fn func(float64, float64) float64) Intrinsic {
 		if len(args) != 2 {
 			return Value{}, errors.New("math: function expects 2 arguments")
 		}
-		return FloatVal(fn(args[0].Num, args[1].Num)), nil
+		return FloatVal(fn(args[0].num, args[1].num)), nil
 	}
 }

--- a/client/vm/intrinsics_math_test.go
+++ b/client/vm/intrinsics_math_test.go
@@ -14,72 +14,72 @@ func TestMathSin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if math.Abs(v.Num-1.0) > 1e-9 {
-		t.Errorf("math.Sin(π/2) = %f, want 1.0", v.Num)
+	if math.Abs(v.num-1.0) > 1e-9 {
+		t.Errorf("math.Sin(π/2) = %f, want 1.0", v.num)
 	}
 }
 
 func TestMathCos(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Cos")
 	v, _ := fn([]Value{FloatVal(0)})
-	if math.Abs(v.Num-1.0) > 1e-9 {
-		t.Errorf("math.Cos(0) = %f, want 1.0", v.Num)
+	if math.Abs(v.num-1.0) > 1e-9 {
+		t.Errorf("math.Cos(0) = %f, want 1.0", v.num)
 	}
 }
 
 func TestMathSqrt(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Sqrt")
 	v, _ := fn([]Value{FloatVal(16)})
-	if v.Num != 4 {
-		t.Errorf("math.Sqrt(16) = %f, want 4", v.Num)
+	if v.num != 4 {
+		t.Errorf("math.Sqrt(16) = %f, want 4", v.num)
 	}
 }
 
 func TestMathAbs(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Abs")
 	v, _ := fn([]Value{FloatVal(-3.5)})
-	if v.Num != 3.5 {
-		t.Errorf("math.Abs(-3.5) = %f, want 3.5", v.Num)
+	if v.num != 3.5 {
+		t.Errorf("math.Abs(-3.5) = %f, want 3.5", v.num)
 	}
 }
 
 func TestMathFloor(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Floor")
 	v, _ := fn([]Value{FloatVal(3.9)})
-	if v.Num != 3 {
-		t.Errorf("math.Floor(3.9) = %f, want 3", v.Num)
+	if v.num != 3 {
+		t.Errorf("math.Floor(3.9) = %f, want 3", v.num)
 	}
 }
 
 func TestMathCeil(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Ceil")
 	v, _ := fn([]Value{FloatVal(3.1)})
-	if v.Num != 4 {
-		t.Errorf("math.Ceil(3.1) = %f, want 4", v.Num)
+	if v.num != 4 {
+		t.Errorf("math.Ceil(3.1) = %f, want 4", v.num)
 	}
 }
 
 func TestMathAtan2(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Atan2")
 	v, _ := fn([]Value{FloatVal(1), FloatVal(0)})
-	if math.Abs(v.Num-math.Pi/2) > 1e-9 {
-		t.Errorf("math.Atan2(1,0) = %f, want π/2", v.Num)
+	if math.Abs(v.num-math.Pi/2) > 1e-9 {
+		t.Errorf("math.Atan2(1,0) = %f, want π/2", v.num)
 	}
 }
 
 func TestMathMax(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Max")
 	v, _ := fn([]Value{FloatVal(3), FloatVal(7)})
-	if v.Num != 7 {
-		t.Errorf("math.Max(3,7) = %f, want 7", v.Num)
+	if v.num != 7 {
+		t.Errorf("math.Max(3,7) = %f, want 7", v.num)
 	}
 }
 
 func TestMathMin(t *testing.T) {
 	fn, _ := LookupIntrinsic("math.Min")
 	v, _ := fn([]Value{FloatVal(3), FloatVal(7)})
-	if v.Num != 3 {
-		t.Errorf("math.Min(3,7) = %f, want 3", v.Num)
+	if v.num != 3 {
+		t.Errorf("math.Min(3,7) = %f, want 3", v.num)
 	}
 }
 
@@ -89,8 +89,8 @@ func TestMathPi(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if v.Num != math.Pi {
-		t.Errorf("math.Pi = %f, want %f", v.Num, math.Pi)
+	if v.num != math.Pi {
+		t.Errorf("math.Pi = %f, want %f", v.num, math.Pi)
 	}
 }
 

--- a/client/vm/intrinsics_rand.go
+++ b/client/vm/intrinsics_rand.go
@@ -42,7 +42,7 @@ func init() {
 		if len(args) != 1 {
 			return Value{}, errors.New("rand.Intn expects 1 argument")
 		}
-		n := int(args[0].Num)
+		n := int(args[0].num)
 		if n <= 0 {
 			return Value{}, errors.New("rand.Intn: n must be > 0")
 		}
@@ -54,7 +54,7 @@ func init() {
 		if len(args) != 1 {
 			return Value{}, errors.New("rand.Seed expects 1 argument")
 		}
-		seed := int64(args[0].Num)
+		seed := int64(args[0].num)
 		randMu.Lock()
 		defer randMu.Unlock()
 		randSrc = rand.New(rand.NewSource(seed))

--- a/client/vm/intrinsics_rand_test.go
+++ b/client/vm/intrinsics_rand_test.go
@@ -14,8 +14,8 @@ func TestRandSeedThenFloat64IsDeterministic(t *testing.T) {
 	_, _ = seed([]Value{IntVal(42)})
 	c, _ := flt(nil)
 	d, _ := flt(nil)
-	if a.Num != c.Num || b.Num != d.Num {
-		t.Errorf("seeded sequence not reproducible: (%f,%f) vs (%f,%f)", a.Num, b.Num, c.Num, d.Num)
+	if a.num != c.num || b.num != d.num {
+		t.Errorf("seeded sequence not reproducible: (%f,%f) vs (%f,%f)", a.num, b.num, c.num, d.num)
 	}
 }
 
@@ -28,8 +28,8 @@ func TestRandIntnRange(t *testing.T) {
 		if err != nil {
 			t.Fatalf("err: %v", err)
 		}
-		if v.Num < 0 || v.Num >= 10 {
-			t.Errorf("rand.Intn(10) out of range: %f", v.Num)
+		if v.num < 0 || v.num >= 10 {
+			t.Errorf("rand.Intn(10) out of range: %f", v.num)
 		}
 	}
 }

--- a/client/vm/intrinsics_sort.go
+++ b/client/vm/intrinsics_sort.go
@@ -52,16 +52,17 @@ func init() {
 // from _items when the surrounding call is sort.Slice. This matches
 // how Go's sort.Slice closure is reinvoked over the in-place mutated
 // slice. Returns the sorted array as a new Value.
-func (vm *VM) sortSliceValue(e program.Expr) Value {
+func (vm *VM) sortSliceValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ArrayVal(nil)
 	}
 	coll := vm.Eval(e.Operands[0])
-	if coll.Items == nil {
+	if !coll.isList() {
 		return coll
 	}
-	items := make([]Value, len(coll.Items))
-	copy(items, coll.Items)
+	source := coll.list()
+	items := make([]Value, len(source))
+	copy(items, source)
 
 	bodyID := e.Operands[1]
 	restore := vm.captureProps([]string{"_i", "_j", "_items"})
@@ -72,7 +73,7 @@ func (vm *VM) sortSliceValue(e program.Expr) Value {
 		vm.props["_i"] = IntVal(i)
 		vm.props["_j"] = IntVal(j)
 		vm.props["_items"] = ArrayVal(working)
-		return vm.Eval(bodyID).Bool
+		return vm.Eval(bodyID).Truth()
 	})
 	return ArrayVal(items)
 }

--- a/client/vm/intrinsics_sort_test.go
+++ b/client/vm/intrinsics_sort_test.go
@@ -39,12 +39,12 @@ func TestSortSliceAscending(t *testing.T) {
 	})
 	vm := NewVM(prog, props)
 	got := vm.Eval(7)
-	if len(got.Items) != 3 {
-		t.Fatalf("sort.Slice result len = %d, want 3", len(got.Items))
+	if len(got.List()) != 3 {
+		t.Fatalf("sort.Slice result len = %d, want 3", len(got.List()))
 	}
-	if int(got.Items[0].Num) != 1 || int(got.Items[1].Num) != 2 || int(got.Items[2].Num) != 3 {
+	if int(got.List()[0].num) != 1 || int(got.List()[1].num) != 2 || int(got.List()[2].num) != 3 {
 		t.Errorf("sorted = [%f %f %f], want [1 2 3]",
-			got.Items[0].Num, got.Items[1].Num, got.Items[2].Num)
+			got.List()[0].num, got.List()[1].num, got.List()[2].num)
 	}
 }
 
@@ -68,15 +68,15 @@ func TestSortSliceStability(t *testing.T) {
 	})
 	vm := NewVM(prog, props)
 	got := vm.Eval(2)
-	if len(got.Items) != 3 {
-		t.Fatalf("len = %d", len(got.Items))
+	if len(got.List()) != 3 {
+		t.Fatalf("len = %d", len(got.List()))
 	}
-	if got.Items[0].Fields["tag"].Str != "a" ||
-		got.Items[1].Fields["tag"].Str != "b" ||
-		got.Items[2].Fields["tag"].Str != "c" {
+	if got.List()[0].Map()["tag"].Text() != "a" ||
+		got.List()[1].Map()["tag"].Text() != "b" ||
+		got.List()[2].Map()["tag"].Text() != "c" {
 		t.Errorf("stability broken; got tags %q %q %q",
-			got.Items[0].Fields["tag"].Str,
-			got.Items[1].Fields["tag"].Str,
-			got.Items[2].Fields["tag"].Str)
+			got.List()[0].Map()["tag"].Text(),
+			got.List()[1].Map()["tag"].Text(),
+			got.List()[2].Map()["tag"].Text())
 	}
 }

--- a/client/vm/intrinsics_strconv.go
+++ b/client/vm/intrinsics_strconv.go
@@ -17,13 +17,13 @@ func init() {
 		if len(args) != 1 {
 			return Value{}, errors.New("strconv.Itoa expects 1 argument")
 		}
-		return StringVal(strconv.Itoa(int(args[0].Num))), nil
+		return StringVal(strconv.Itoa(int(args[0].num))), nil
 	})
 	RegisterIntrinsic("strconv.Atoi", func(args []Value) (Value, error) {
 		if len(args) != 1 {
 			return Value{}, errors.New("strconv.Atoi expects 1 argument")
 		}
-		n, err := strconv.Atoi(args[0].Str)
+		n, err := strconv.Atoi(args[0].text())
 		if err != nil {
 			return Value{}, err
 		}
@@ -36,17 +36,17 @@ func init() {
 		}
 		// fmt byte is encoded as a single-char string.
 		var format byte = 'g'
-		if args[1].Str != "" {
-			format = args[1].Str[0]
+		if spec := args[1].text(); spec != "" {
+			format = spec[0]
 		}
-		return StringVal(strconv.FormatFloat(args[0].Num, format, int(args[2].Num), int(args[3].Num))), nil
+		return StringVal(strconv.FormatFloat(args[0].num, format, int(args[2].num), int(args[3].num))), nil
 	})
 	RegisterIntrinsic("strconv.ParseFloat", func(args []Value) (Value, error) {
 		// Go signature: ParseFloat(s string, bitSize int)
 		if len(args) != 2 {
 			return Value{}, errors.New("strconv.ParseFloat expects 2 arguments")
 		}
-		f, err := strconv.ParseFloat(args[0].Str, int(args[1].Num))
+		f, err := strconv.ParseFloat(args[0].text(), int(args[1].num))
 		if err != nil {
 			return Value{}, err
 		}

--- a/client/vm/intrinsics_strconv_test.go
+++ b/client/vm/intrinsics_strconv_test.go
@@ -7,8 +7,8 @@ import (
 func TestStrconvItoa(t *testing.T) {
 	fn, _ := LookupIntrinsic("strconv.Itoa")
 	v, _ := fn([]Value{IntVal(42)})
-	if v.Str != "42" {
-		t.Errorf("Itoa(42) = %q, want 42", v.Str)
+	if v.Text() != "42" {
+		t.Errorf("Itoa(42) = %q, want 42", v.Text())
 	}
 }
 
@@ -18,8 +18,8 @@ func TestStrconvAtoiOK(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if int(v.Num) != 42 {
-		t.Errorf("Atoi(\"42\") = %f, want 42", v.Num)
+	if int(v.num) != 42 {
+		t.Errorf("Atoi(\"42\") = %f, want 42", v.num)
 	}
 }
 
@@ -37,8 +37,8 @@ func TestStrconvFormatFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if v.Str != "3.14" {
-		t.Errorf("FormatFloat = %q, want 3.14", v.Str)
+	if v.Text() != "3.14" {
+		t.Errorf("FormatFloat = %q, want 3.14", v.Text())
 	}
 }
 
@@ -48,7 +48,7 @@ func TestStrconvParseFloat(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if v.Num != 2.5 {
-		t.Errorf("ParseFloat(\"2.5\") = %f, want 2.5", v.Num)
+	if v.num != 2.5 {
+		t.Errorf("ParseFloat(\"2.5\") = %f, want 2.5", v.num)
 	}
 }

--- a/client/vm/intrinsics_strings.go
+++ b/client/vm/intrinsics_strings.go
@@ -37,7 +37,7 @@ func stringsUnary(fn func(string) string) Intrinsic {
 		if len(args) != 1 {
 			return Value{}, errors.New("strings: function expects 1 argument")
 		}
-		return StringVal(fn(args[0].Str)), nil
+		return StringVal(fn(args[0].text())), nil
 	}
 }
 
@@ -47,7 +47,7 @@ func stringsPredicate(fn func(string, string) bool) Intrinsic {
 		if len(args) != 2 {
 			return Value{}, errors.New("strings: predicate expects 2 arguments")
 		}
-		return BoolVal(fn(args[0].Str, args[1].Str)), nil
+		return BoolVal(fn(args[0].text(), args[1].text())), nil
 	}
 }
 
@@ -55,7 +55,7 @@ func intrinsicStringsSplit(args []Value) (Value, error) {
 	if len(args) != 2 {
 		return Value{}, errors.New("strings.Split expects 2 arguments")
 	}
-	parts := strings.Split(args[0].Str, args[1].Str)
+	parts := strings.Split(args[0].text(), args[1].text())
 	items := make([]Value, len(parts))
 	for i, p := range parts {
 		items[i] = StringVal(p)
@@ -68,14 +68,15 @@ func intrinsicStringsJoin(args []Value) (Value, error) {
 		return Value{}, errors.New("strings.Join expects 2 arguments")
 	}
 	src := args[0]
-	if src.Items == nil {
+	if !src.isList() {
 		return StringVal(""), nil
 	}
-	parts := make([]string, len(src.Items))
-	for i, v := range src.Items {
+	items := src.list()
+	parts := make([]string, len(items))
+	for i, v := range items {
 		parts[i] = v.String()
 	}
-	return StringVal(strings.Join(parts, args[1].Str)), nil
+	return StringVal(strings.Join(parts, args[1].text())), nil
 }
 
 func intrinsicStringsReplace(args []Value) (Value, error) {
@@ -84,9 +85,9 @@ func intrinsicStringsReplace(args []Value) (Value, error) {
 	// args; with 3 args we treat it as ReplaceAll (n = -1).
 	switch len(args) {
 	case 3:
-		return StringVal(strings.ReplaceAll(args[0].Str, args[1].Str, args[2].Str)), nil
+		return StringVal(strings.ReplaceAll(args[0].text(), args[1].text(), args[2].text())), nil
 	case 4:
-		return StringVal(strings.Replace(args[0].Str, args[1].Str, args[2].Str, int(args[3].Num))), nil
+		return StringVal(strings.Replace(args[0].text(), args[1].text(), args[2].text(), int(args[3].num))), nil
 	default:
 		return Value{}, errors.New("strings.Replace expects 3 or 4 arguments")
 	}

--- a/client/vm/intrinsics_strings_test.go
+++ b/client/vm/intrinsics_strings_test.go
@@ -10,8 +10,8 @@ func TestStringsSplit(t *testing.T) {
 	if err != nil {
 		t.Fatalf("err: %v", err)
 	}
-	if len(v.Items) != 3 || v.Items[0].Str != "a" || v.Items[1].Str != "b" || v.Items[2].Str != "c" {
-		t.Errorf("Split = %+v, want [a b c]", v.Items)
+	if len(v.List()) != 3 || v.List()[0].Text() != "a" || v.List()[1].Text() != "b" || v.List()[2].Text() != "c" {
+		t.Errorf("Split = %+v, want [a b c]", v.List())
 	}
 }
 
@@ -21,16 +21,16 @@ func TestStringsJoin(t *testing.T) {
 		ArrayVal([]Value{StringVal("a"), StringVal("b"), StringVal("c")}),
 		StringVal("-"),
 	})
-	if v.Str != "a-b-c" {
-		t.Errorf("Join = %q, want %q", v.Str, "a-b-c")
+	if v.Text() != "a-b-c" {
+		t.Errorf("Join = %q, want %q", v.Text(), "a-b-c")
 	}
 }
 
 func TestStringsTrimSpace(t *testing.T) {
 	fn, _ := LookupIntrinsic("strings.TrimSpace")
 	v, _ := fn([]Value{StringVal("  hi  ")})
-	if v.Str != "hi" {
-		t.Errorf("TrimSpace = %q, want %q", v.Str, "hi")
+	if v.Text() != "hi" {
+		t.Errorf("TrimSpace = %q, want %q", v.Text(), "hi")
 	}
 }
 
@@ -38,12 +38,12 @@ func TestStringsToLowerUpper(t *testing.T) {
 	low, _ := LookupIntrinsic("strings.ToLower")
 	up, _ := LookupIntrinsic("strings.ToUpper")
 	v, _ := low([]Value{StringVal("HeLLo")})
-	if v.Str != "hello" {
-		t.Errorf("ToLower = %q", v.Str)
+	if v.Text() != "hello" {
+		t.Errorf("ToLower = %q", v.Text())
 	}
 	v, _ = up([]Value{StringVal("HeLLo")})
-	if v.Str != "HELLO" {
-		t.Errorf("ToUpper = %q", v.Str)
+	if v.Text() != "HELLO" {
+		t.Errorf("ToUpper = %q", v.Text())
 	}
 }
 
@@ -51,13 +51,13 @@ func TestStringsReplaceVariants(t *testing.T) {
 	fn, _ := LookupIntrinsic("strings.Replace")
 	// 3 args → ReplaceAll
 	v, _ := fn([]Value{StringVal("a-b-a"), StringVal("a"), StringVal("X")})
-	if v.Str != "X-b-X" {
-		t.Errorf("ReplaceAll = %q, want X-b-X", v.Str)
+	if v.Text() != "X-b-X" {
+		t.Errorf("ReplaceAll = %q, want X-b-X", v.Text())
 	}
 	// 4 args → Replace with n
 	v, _ = fn([]Value{StringVal("a-b-a"), StringVal("a"), StringVal("X"), IntVal(1)})
-	if v.Str != "X-b-a" {
-		t.Errorf("Replace(n=1) = %q, want X-b-a", v.Str)
+	if v.Text() != "X-b-a" {
+		t.Errorf("Replace(n=1) = %q, want X-b-a", v.Text())
 	}
 }
 
@@ -66,15 +66,15 @@ func TestStringsContainsPrefixSuffix(t *testing.T) {
 	p, _ := LookupIntrinsic("strings.HasPrefix")
 	s, _ := LookupIntrinsic("strings.HasSuffix")
 	v, _ := c([]Value{StringVal("foobar"), StringVal("oob")})
-	if !v.Bool {
+	if !v.Truth() {
 		t.Error("Contains(foobar, oob) should be true")
 	}
 	v, _ = p([]Value{StringVal("foobar"), StringVal("foo")})
-	if !v.Bool {
+	if !v.Truth() {
 		t.Error("HasPrefix(foobar, foo) should be true")
 	}
 	v, _ = s([]Value{StringVal("foobar"), StringVal("bar")})
-	if !v.Bool {
+	if !v.Truth() {
 		t.Error("HasSuffix(foobar, bar) should be true")
 	}
 }

--- a/client/vm/intrinsics_test.go
+++ b/client/vm/intrinsics_test.go
@@ -17,7 +17,7 @@ func TestRegistryLookupRoundTrip(t *testing.T) {
 		if len(args) != 1 {
 			return Value{}, nil
 		}
-		return IntVal(int(args[0].Num) * 2), nil
+		return IntVal(int(args[0].num) * 2), nil
 	})
 
 	fn, ok := r.Lookup("test.Double")
@@ -28,8 +28,8 @@ func TestRegistryLookupRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("intrinsic err: %v", err)
 	}
-	if int(v.Num) != 14 {
-		t.Fatalf("test.Double(7) = %f, want 14", v.Num)
+	if int(v.num) != 14 {
+		t.Fatalf("test.Double(7) = %f, want 14", v.num)
 	}
 }
 
@@ -48,7 +48,7 @@ func TestOpCallDispatchesIntrinsic(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	got := vm.Eval(1)
-	if got.Type != program.TypeFloat || got.Num != 0 {
+	if got.Type != program.TypeFloat || got.num != 0 {
 		t.Fatalf("math.Sin(0) via OpCall = %+v, want FloatVal(0)", got)
 	}
 }

--- a/client/vm/island.go
+++ b/client/vm/island.go
@@ -18,9 +18,17 @@ var _ Reconciler = (*Island)(nil)
 type Island struct {
 	vm       *VM
 	program  *program.Program
-	id       string
 	prev     *ResolvedTree // previous tree for reconciliation
 	handlers map[string]*program.Handler
+
+	// reuse carries the per-program static analysis and the previous
+	// walk's snapshot, so a reconcile can copy the subtrees that nothing
+	// changed instead of evaluating them. nil disables the optimisation
+	// and restores whole-tree evaluation. See reuse.go.
+	reuse *islandReuse
+	// reuseBuilt records that the analysis already ran, so a program that
+	// cannot benefit is analysed once instead of on every reconcile.
+	reuseBuilt bool
 
 	// PatchCallback is called when shared signals trigger a re-render.
 	// Set by the bridge to push patches to JS.
@@ -58,7 +66,37 @@ func (island *Island) CheckHydration(serverTree *ResolvedTree) []string {
 func (island *Island) SetSharedSignal(name string, sig *signal.Signal[Value]) {
 	island.vm.SetSignal(name, sig)
 	// Re-evaluate the initial tree with the shared signal's current value
-	island.prev = island.vm.EvalTree()
+	island.prev = island.evalTree()
+}
+
+// ensureReuse runs the subtree-reuse analysis once, on the first reconcile.
+//
+// Building it in NewIsland would charge every server-side render for an
+// optimisation only an interactive island can use. Building it here charges
+// the first event instead, and every event after that reads the result.
+func (island *Island) ensureReuse() {
+	if island.reuseBuilt {
+		return
+	}
+	island.reuseBuilt = true
+	island.reuse = newIslandReuse(island.program)
+}
+
+// evalTree builds the next resolved tree. It hands the VM the subtree-reuse
+// context first, so the walk copies the subtrees whose inputs did not change
+// and evaluates the rest.
+//
+// The snapshot refresh runs before the walk. Read refresh's doc comment for
+// why that order is the safe one.
+func (island *Island) evalTree() *ResolvedTree {
+	reuse := island.reuse
+	if reuse == nil {
+		return island.vm.EvalTree()
+	}
+	dirty := reuse.refresh(island.vm)
+	reuse.begin(island.vm, island.prev, dirty)
+	defer reuse.end(island.vm)
+	return island.vm.EvalTree()
 }
 
 // EvalExpr evaluates an expression by ID in this island's VM.
@@ -96,7 +134,11 @@ func NewIsland(prog *program.Program, propsJSON string) *Island {
 		handlers: handlerMap(prog),
 	}
 
-	island.prev = vm.EvalTree()
+	// The first tree has nothing to reuse, so the analysis stays unbuilt
+	// here. An island that renders once and never receives an event — the
+	// server-side path through ResolveInitialTree — then pays nothing for
+	// subtree reuse at all. Reconcile builds the analysis on first use.
+	island.prev = island.evalTree()
 	return island
 }
 
@@ -118,6 +160,12 @@ func (island *Island) SwapProgram(prog *program.Program) []PatchOp {
 	island.vm.SwapProgram(prog)
 	island.program = prog
 	island.handlers = handlerMap(prog)
+	// The old analysis described the old bytecode, and the old spans point
+	// into a tree the old node table produced. Both go away with the swap.
+	// The rebuilt state starts unprimed, so the first walk after a swap
+	// evaluates every node.
+	island.reuse = nil
+	island.reuseBuilt = false
 	return island.Reconcile()
 }
 
@@ -148,8 +196,32 @@ func (island *Island) Dispatch(handlerName string, eventDataJSON string) []Patch
 }
 
 // Reconcile evaluates the current tree and diffs against the previous tree.
+//
+// The walk no longer evaluates every node. Route (b) of the old design note
+// shipped: reuse.go computes, per program node, the set of signals and props
+// its subtree reads, and the walk copies a subtree out of island.prev when
+// none of those inputs changed. A counter increment now evaluates one
+// expression node and copies the three elements around it.
+//
+// Two limits stay, both deliberate:
+//
+//   - A node inside a forEach body is never reused, because the VM rebinds
+//     `_item` and the `as`/`index` names per iteration and the same program
+//     node resolves to different content each pass. Making that case work
+//     needs a per-iteration identity, not a per-node one.
+//   - A subtree containing any impure opcode is never reused. isPureOp in
+//     reuse.go holds the contract, and an unlisted opcode is impure, so the
+//     safe direction is the default.
+//
+// Route (a) of the old note, skipping evaluation of Program.StaticMask
+// subtrees, is now redundant. The mask means "this one node is static" — it
+// is populated by populateStaticMask in ir/island.go straight from each
+// source node's IsStatic flag, with no subtree rollup — so it could not have
+// carried a whole subtree by itself. The read-set analysis proves the same
+// property for a subtree and covers the dynamic-but-unchanged case too.
 func (island *Island) Reconcile() []PatchOp {
-	next := island.vm.EvalTree()
+	island.ensureReuse()
+	next := island.evalTree()
 	ops := ReconcileTrees(island.prev, next, island.program.StaticMask)
 	island.prev = next
 	return ops

--- a/client/vm/island_test.go
+++ b/client/vm/island_test.go
@@ -133,7 +133,7 @@ func TestReentrantBatch(t *testing.T) {
 		})
 	})
 
-	if !s.Get().Eq(IntVal(2)).Bool {
+	if !s.Get().Eq(IntVal(2)).Truth() {
 		t.Fatalf("expected 2 after nested batch, got %v", s.Get())
 	}
 }

--- a/client/vm/json.go
+++ b/client/vm/json.go
@@ -22,30 +22,44 @@ func ValueFromJSON(raw string) (Value, error) {
 
 // ToAny converts a VM value back into plain Go values suitable for JSON marshaling.
 func (v Value) ToAny() any {
-	if v.Items != nil {
-		items := make([]any, len(v.Items))
-		for i := range v.Items {
-			items[i] = v.Items[i].ToAny()
+	return v.toAnyAtDepth(0)
+}
+
+// toAnyAtDepth mirrors the depth guard in Value.String and
+// Value.Eq. A Value can contain itself, built through OpIndexSet or
+// OpFieldSet's in-place mutation. Such a Value must degrade to a
+// sentinel instead of recursing until the goroutine stack
+// overflows.
+func (v Value) toAnyAtDepth(depth int) any {
+	if depth > maxValueRecursionDepth {
+		return cycleSentinel
+	}
+	if v.isList() {
+		src := v.list()
+		items := make([]any, len(src))
+		for i := range src {
+			items[i] = src[i].toAnyAtDepth(depth + 1)
 		}
 		return items
 	}
-	if v.Fields != nil {
-		fields := make(map[string]any, len(v.Fields))
-		for key, field := range v.Fields {
-			fields[key] = field.ToAny()
+	if v.isMap() {
+		src := v.dict()
+		fields := make(map[string]any, len(src))
+		for key, field := range src {
+			fields[key] = field.toAnyAtDepth(depth + 1)
 		}
 		return fields
 	}
 
 	switch v.Type {
 	case program.TypeString:
-		return v.Str
+		return v.text()
 	case program.TypeBool:
-		return v.Bool
+		return v.truth()
 	case program.TypeInt:
-		return int(v.Num)
+		return int(v.num)
 	case program.TypeFloat:
-		return v.Num
+		return v.num
 	default:
 		return nil
 	}

--- a/client/vm/json_test.go
+++ b/client/vm/json_test.go
@@ -1,0 +1,41 @@
+package vm
+
+import "testing"
+
+// TestValueToAnySelfReferentialArrayDoesNotOverflow mirrors the
+// String() / Eq() cycle-safety regressions in value_test.go for the
+// JSON marshal path. ToAny recurses over Items exactly like
+// String() did before the fix. So a self-referential array, built
+// through OpIndexSet's in-place mutation (see lhs_set.go), would
+// recurse until the goroutine stack overflowed. That is a fatal
+// error, not a panic, so recover() could never catch it.
+func TestValueToAnySelfReferentialArrayDoesNotOverflow(t *testing.T) {
+	arr := ArrayVal([]Value{{}})
+	arr.List()[0] = arr
+
+	got := arr.ToAny()
+
+	// The depth guard does not fire on the first recursion. It fires
+	// only after maxValueRecursionDepth levels. So walk down the
+	// nested []any{[]any{...}} chain the cycle produces, and confirm
+	// the recursion is bounded. Within a small multiple of
+	// maxValueRecursionDepth steps, the walk must reach the cycle
+	// sentinel. An unguarded ToAny would instead keep producing
+	// another []any forever, until the goroutine stack overflowed.
+	steps := 0
+	for steps <= maxValueRecursionDepth+2 {
+		items, ok := got.([]any)
+		if !ok {
+			if s, ok := got.(string); ok && s == cycleSentinel {
+				return
+			}
+			t.Fatalf("ToAny() cycle walk step %d = %#v (%T), want []any or the cycle sentinel %q", steps, got, got, cycleSentinel)
+		}
+		if len(items) != 1 {
+			t.Fatalf("ToAny() cycle walk step %d returned %d items, want 1", steps, len(items))
+		}
+		got = items[0]
+		steps++
+	}
+	t.Fatalf("ToAny() on a self-referential array never reached the cycle sentinel within %d steps; the depth guard did not fire", steps)
+}

--- a/client/vm/lhs_set.go
+++ b/client/vm/lhs_set.go
@@ -45,17 +45,6 @@ import (
 // Returns (value, true) for any LHS-set opcode (value is the assigned
 // RHS, mirroring OpAssign's return so callers can chain through an
 // OpSeq). Returns (Value{}, false) for any other opcode.
-func (vm *VM) evalLHSSetExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpFieldSet:
-		return vm.fieldSetValue(e), true
-	case program.OpIndexSet:
-		return vm.indexSetValue(e), true
-	default:
-		return Value{}, false
-	}
-}
-
 // fieldSetValue evaluates `target.<Value> = Operands[1]` and writes
 // the assigned value into Operands[0]'s Fields map in place. The field
 // name lives in Value because it's always a compile-time identifier in
@@ -77,13 +66,13 @@ func (vm *VM) evalLHSSetExpr(e program.Expr) (Value, bool) {
 // Go maps are reference types. If the caller obtained `target` via
 // OpLocalGet (a Value-by-value copy), the Fields map inside that copy
 // still points at the same underlying storage as the original.
-func (vm *VM) fieldSetValue(e program.Expr) Value {
+func (vm *VM) fieldSetValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ZeroValue(program.TypeAny)
 	}
 	target := vm.Eval(e.Operands[0])
 	value := vm.Eval(e.Operands[1])
-	if target.Fields == nil {
+	if !target.SetField(e.Value, value) {
 		vm.recordExprDiagnostic(
 			"field_set_non_struct",
 			fmt.Sprintf("OpFieldSet target field %q evaluates to a Value with no Fields map (Value type %d)", e.Value, target.Type),
@@ -96,7 +85,6 @@ func (vm *VM) fieldSetValue(e program.Expr) Value {
 		// caller. Drop the write but keep the panic-free contract.
 		return value
 	}
-	target.Fields[e.Value] = value
 	return value
 }
 
@@ -118,7 +106,7 @@ func (vm *VM) fieldSetValue(e program.Expr) Value {
 // ArrayVal (Items non-nil, Fields nil) — those go through Items. A
 // Value can't legally have both populated in the supported subset, so
 // "Items first if non-nil" is unambiguous.
-func (vm *VM) indexSetValue(e program.Expr) Value {
+func (vm *VM) indexSetValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 3) {
 		return ZeroValue(program.TypeAny)
 	}
@@ -127,21 +115,40 @@ func (vm *VM) indexSetValue(e program.Expr) Value {
 	value := vm.Eval(e.Operands[2])
 
 	switch {
-	case target.Items != nil:
-		idx := int(key.Num)
-		if idx < 0 || idx >= len(target.Items) {
+	case target.isList():
+		items := target.list()
+		idx := int(key.num)
+		if idx < 0 || idx >= len(items) {
 			vm.recordExprDiagnostic(
 				"index_set_out_of_range",
-				fmt.Sprintf("OpIndexSet index %d out of range [0,%d)", idx, len(target.Items)),
+				fmt.Sprintf("OpIndexSet index %d out of range [0,%d)", idx, len(items)),
 				e.Op,
 				e.Value,
 			)
 			return value
 		}
-		target.Items[idx] = value
+		if valueAliasesItems(value, items) {
+			// `arr[idx] = arr` (or any value that aliases the exact
+			// same backing array as target) builds a Value that
+			// contains itself. The write still goes through. Y.C's
+			// in-place-mutation contract is deliberate — see the file
+			// header. But String, Eq, and ToAny would otherwise
+			// recurse forever over the cycle. Those three walkers
+			// carry their own depth guard (value.go's
+			// maxValueRecursionDepth). It degrades to a sentinel
+			// instead of crashing. This diagnostic just makes the
+			// cycle visible at its origin.
+			vm.recordExprDiagnostic(
+				"self_referential_value",
+				"OpIndexSet wrote a value that aliases its own target array, creating a cycle",
+				e.Op,
+				e.Value,
+			)
+		}
+		items[idx] = value
 		return value
-	case target.Fields != nil:
-		target.Fields[key.String()] = value
+	case target.isMap():
+		target.dict()[key.String()] = value
 		return value
 	default:
 		vm.recordExprDiagnostic(
@@ -152,4 +159,19 @@ func (vm *VM) indexSetValue(e program.Expr) Value {
 		)
 		return value
 	}
+}
+
+// valueAliasesItems reports whether value's Items slice shares the
+// exact same backing array as target. In other words, it reports
+// whether value is an alias of the array target belongs to. This
+// check catches `arr[idx] = arr` at the point of the write. Comparing
+// lengths plus the address of the first element needs no reflect or
+// unsafe dependency, and it never flags two distinct arrays that
+// merely hold equal contents.
+func valueAliasesItems(value Value, target []Value) bool {
+	items := value.list()
+	if items == nil || len(target) == 0 || len(items) != len(target) {
+		return false
+	}
+	return &items[0] == &target[0]
 }

--- a/client/vm/lhs_set_test.go
+++ b/client/vm/lhs_set_test.go
@@ -47,13 +47,13 @@ func TestOpFieldSetWritesIntoExistingObject(t *testing.T) {
 		"Y": FloatVal(2),
 	}))
 	got := machine.Eval(6)
-	if got.Num != 99 {
-		t.Errorf("v.X after FieldSet = %f, want 99", got.Num)
+	if got.num != 99 {
+		t.Errorf("v.X after FieldSet = %f, want 99", got.num)
 	}
 	// Confirm the original map was mutated, not a copy.
 	v, _ := machine.frame.get("v")
-	if v.Fields["X"].Num != 99 {
-		t.Errorf("frame.v.Fields[X] = %f, want 99 (in-place mutation broken)", v.Fields["X"].Num)
+	if v.Map()["X"].num != 99 {
+		t.Errorf("frame.v.Fields[X] = %f, want 99 (in-place mutation broken)", v.Map()["X"].num)
 	}
 }
 
@@ -74,8 +74,8 @@ func TestOpFieldSetOnNonStructDiagnoses(t *testing.T) {
 	machine := NewVM(prog, nil)
 	machine.frame = newFrame()
 	got := machine.Eval(2)
-	if int(got.Num) != 42 {
-		t.Errorf("OpFieldSet on non-struct returned %f, want 42 (assigned value)", got.Num)
+	if int(got.num) != 42 {
+		t.Errorf("OpFieldSet on non-struct returned %f, want 42 (assigned value)", got.num)
 	}
 	diags := machine.Diagnostics()
 	found := false
@@ -116,12 +116,12 @@ func TestOpIndexSetWritesIntoSliceInPlace(t *testing.T) {
 	machine.frame.declare("s")
 	machine.frame.set("s", ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3)}))
 	got := machine.Eval(7)
-	if int(got.Num) != 9 {
-		t.Errorf("s[1] after IndexSet = %d, want 9", int(got.Num))
+	if int(got.num) != 9 {
+		t.Errorf("s[1] after IndexSet = %d, want 9", int(got.num))
 	}
 	v, _ := machine.frame.get("s")
-	if int(v.Items[1].Num) != 9 {
-		t.Errorf("frame.s.Items[1] = %d, want 9 (in-place mutation broken)", int(v.Items[1].Num))
+	if int(v.List()[1].num) != 9 {
+		t.Errorf("frame.s.Items[1] = %d, want 9 (in-place mutation broken)", int(v.List()[1].num))
 	}
 }
 
@@ -152,8 +152,8 @@ func TestOpIndexSetWritesIntoMapInPlace(t *testing.T) {
 	// Start with an empty map; IndexSet should create the key.
 	machine.frame.set("m", ObjectVal(map[string]Value{}))
 	got := machine.Eval(7)
-	if int(got.Num) != 5 {
-		t.Errorf("m[\"k\"] after IndexSet = %d, want 5", int(got.Num))
+	if int(got.num) != 5 {
+		t.Errorf("m[\"k\"] after IndexSet = %d, want 5", int(got.num))
 	}
 }
 

--- a/client/vm/loops.go
+++ b/client/vm/loops.go
@@ -3,11 +3,28 @@
 // collection { body }`. Both are bounded by a safety cap so a runaway
 // loop in lowered Go can't lock up the shared client WASM.
 //
-// The cap is per-VM (defaults to 1<<20 = 1M iterations); call
-// VM.SetForCap to raise or lower it. Hitting the cap produces a
-// structured diagnostic (loop_cap_exceeded) and the loop terminates
-// at the current iteration. The convention is "fail visibly under
-// stress" — we never silently truncate output.
+// The cap (default 1<<20 = 1,048,576) applies at two levels:
+//
+//  1. Per loop: no single OpFor / OpForRange runs more than the
+//     cap's worth of iterations. Hitting this alone produces a
+//     loop_cap_exceeded diagnostic.
+//  2. Per dispatch, across every nested loop: forValue and
+//     forRangeValue charge each iteration against one VM-wide
+//     counter, vm.loopSteps. This applies at any nesting depth. Eval
+//     resets the counter at the start of each top-level dispatch.
+//     Two nested loops can each stay under the per-loop cap, yet
+//     still multiply past any single loop's cap. Two loops capped at
+//     1<<20 each permit up to 1<<40 total body evaluations with no
+//     aggregate check. That is far too much work for one dispatch.
+//     Once the shared counter exceeds the cap, a
+//     loop_step_budget_exceeded diagnostic fires once. Every loop,
+//     at every nesting depth, then stops on its next iteration
+//     check.
+//
+// SetForCap raises or lowers the single knob both levels share. The
+// convention throughout is "fail visibly under stress". A loop that
+// hits either cap stops and records a diagnostic. It never silently
+// truncates its output or runs forever.
 
 package vm
 
@@ -17,13 +34,19 @@ import (
 	"m31labs.dev/gosx/island/program"
 )
 
-// defaultForCap bounds OpFor / OpForRange iterations per call. Chosen
-// so trivial bounded loops never trip it and pathological infinite
-// loops surface quickly (~ms wall clock for a tight body).
+// defaultForCap bounds OpFor / OpForRange iterations, both per loop
+// and in aggregate across every loop nested inside one dispatch (see
+// the file header). It is not a wall-clock guarantee. A tight body
+// can still take a perceptible amount of time to run the full cap.
+// But it does bound the total number of body evaluations a
+// dispatch's loops can ever perform. This closes the per-loop-only
+// cap's nested-multiplication gap.
 const defaultForCap = 1 << 20
 
-// SetForCap sets the per-loop iteration cap for this VM. A value of 0
-// or less resets to the default.
+// SetForCap sets the iteration cap for this VM. Both the per-loop
+// bound (effectiveForCap) and the per-dispatch aggregate bound
+// (charged by chargeLoopStep) share this one value. A value of 0 or
+// less resets to the default.
 func (vm *VM) SetForCap(n int) {
 	if n <= 0 {
 		vm.forCap = defaultForCap
@@ -41,6 +64,38 @@ func (vm *VM) effectiveForCap() int {
 	return vm.forCap
 }
 
+// chargeLoopStep charges one iteration against the VM-wide loop
+// step budget. Every OpFor / OpForRange loop active in the current
+// top-level dispatch shares this budget, including loops nested
+// inside other loops.
+//
+// Eval resets the budget at the start of each fresh dispatch, when
+// evalDepth transitions from 0. So the bound is "total loop work
+// per dispatch", not "total loop work for the VM's lifetime".
+//
+// Returns true once the budget is exhausted. The caller (forValue
+// or forRangeValue) must then stop iterating immediately, without
+// running the iteration that triggered this. Every enclosing loop
+// must also stop on its own next check. This is why loopBudgetHit
+// is sticky, rather than reset per loop.
+func (vm *VM) chargeLoopStep(e *program.Expr) bool {
+	if vm.loopBudgetHit {
+		return true
+	}
+	vm.loopSteps++
+	if vm.loopSteps <= vm.effectiveForCap() {
+		return false
+	}
+	vm.loopBudgetHit = true
+	vm.recordExprDiagnostic(
+		"loop_step_budget_exceeded",
+		fmt.Sprintf("total loop steps across nested loops exceeded the per-dispatch budget of %d; aborting", vm.effectiveForCap()),
+		e.Op,
+		e.Value,
+	)
+	return true
+}
+
 // forValue evaluates an OpFor expression. Operands order:
 //
 //	[0] init — evaluated once before the loop.
@@ -50,7 +105,7 @@ func (vm *VM) effectiveForCap() int {
 //
 // Any missing operand is treated as a noop. This lets the lowerer omit
 // init/post when the Go source omits them.
-func (vm *VM) forValue(e program.Expr) Value {
+func (vm *VM) forValue(e *program.Expr) Value {
 	if len(e.Operands) < 4 {
 		vm.recordExprDiagnostic(
 			"missing_operands",
@@ -65,18 +120,23 @@ func (vm *VM) forValue(e program.Expr) Value {
 	cap := vm.effectiveForCap()
 	var last Value
 	for i := 0; i < cap; i++ {
-		if !vm.Eval(e.Operands[1]).Bool {
+		if vm.loopBudgetHit {
+			return last
+		}
+		if !vm.Eval(e.Operands[1]).Truth() {
+			return last
+		}
+		if vm.chargeLoopStep(e) {
 			return last
 		}
 		last = vm.Eval(e.Operands[3])
-		switch last.Control {
+		switch last.Control() {
 		case ControlBreak:
-			last.Control = ControlNone
-			return last
+			return last.WithControl(ControlNone)
 		case ControlReturn:
 			return last // propagate to enclosing EvalWithFrame
 		case ControlContinue:
-			last.Control = ControlNone
+			last = last.WithControl(ControlNone)
 		}
 		vm.Eval(e.Operands[2])
 	}
@@ -99,7 +159,7 @@ func (vm *VM) forValue(e program.Expr) Value {
 // collection is empty. Honors the same iteration cap as OpFor for
 // pathological inputs (a million-element array is allowed; a billion
 // surfaces the diagnostic).
-func (vm *VM) forRangeValue(e program.Expr) Value {
+func (vm *VM) forRangeValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ZeroValue(program.TypeAny)
 	}
@@ -112,8 +172,9 @@ func (vm *VM) forRangeValue(e program.Expr) Value {
 
 	var last Value
 	switch {
-	case coll.Items != nil:
-		n := len(coll.Items)
+	case coll.isList():
+		items := coll.list()
+		n := len(items)
 		if n > cap {
 			vm.recordExprDiagnostic(
 				"loop_cap_exceeded",
@@ -124,25 +185,31 @@ func (vm *VM) forRangeValue(e program.Expr) Value {
 			n = cap
 		}
 		for i := 0; i < n; i++ {
+			if vm.loopBudgetHit {
+				return last
+			}
+			if vm.chargeLoopStep(e) {
+				return last
+			}
 			vm.props["_index"] = IntVal(i)
-			vm.props["_item"] = coll.Items[i]
+			vm.props["_item"] = items[i]
 			vm.props["_key"] = IntVal(i)
 			last = vm.Eval(body)
-			switch last.Control {
+			switch last.Control() {
 			case ControlBreak:
-				last.Control = ControlNone
-				return last
+				return last.WithControl(ControlNone)
 			case ControlReturn:
 				return last
 			case ControlContinue:
-				last.Control = ControlNone
+				last = last.WithControl(ControlNone)
 			}
 		}
-	case coll.Fields != nil:
+	case coll.isMap():
 		// Iterate map fields in sorted-key order so the lowered
 		// program behaves deterministically (Go's range-over-map is
 		// randomized; the bytecode runtime is the gentler default).
-		keys := sortedEachFieldKeys(coll.Fields)
+		fields := coll.dict()
+		keys := sortedEachFieldKeys(fields)
 		n := len(keys)
 		if n > cap {
 			vm.recordExprDiagnostic(
@@ -154,19 +221,24 @@ func (vm *VM) forRangeValue(e program.Expr) Value {
 			n = cap
 		}
 		for i := 0; i < n; i++ {
+			if vm.loopBudgetHit {
+				return last
+			}
+			if vm.chargeLoopStep(e) {
+				return last
+			}
 			k := keys[i]
 			vm.props["_key"] = StringVal(k)
-			vm.props["_item"] = coll.Fields[k]
+			vm.props["_item"] = fields[k]
 			vm.props["_index"] = IntVal(i)
 			last = vm.Eval(body)
-			switch last.Control {
+			switch last.Control() {
 			case ControlBreak:
-				last.Control = ControlNone
-				return last
+				return last.WithControl(ControlNone)
 			case ControlReturn:
 				return last
 			case ControlContinue:
-				last.Control = ControlNone
+				last = last.WithControl(ControlNone)
 			}
 		}
 	default:

--- a/client/vm/loops_test.go
+++ b/client/vm/loops_test.go
@@ -1,0 +1,230 @@
+// Tests for OpFor / OpForRange (loops.go). Before this file existed,
+// no test in the repository exercised either opcode directly against
+// the VM. The per-loop cap and the per-dispatch step budget were both
+// unverified.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+	"m31labs.dev/gosx/signal"
+)
+
+// buildCountingForProgram returns a program computing:
+//
+//	for i := 0; i < limit; i++ { n = n + 1 }
+//
+// as OpFor bytecode, plus the ExprID of the OpFor node itself.
+func buildCountingForProgram(limit int) (*program.Program, program.ExprID) {
+	exprs := []program.Expr{
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},             // 0: init value
+		{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{0}},     // 1: init: i = 0
+		{Op: program.OpLocalGet, Value: "i"},                                  // 2
+		{Op: program.OpLitInt, Value: itoaTest(limit), Type: program.TypeInt}, // 3
+		{Op: program.OpLt, Operands: []program.ExprID{2, 3}},                  // 4: cond: i < limit
+		{Op: program.OpLocalGet, Value: "i"},                                  // 5
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},             // 6
+		{Op: program.OpAdd, Operands: []program.ExprID{5, 6}},                 // 7: i+1
+		{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{7}},     // 8: post: i = i+1
+		{Op: program.OpSignalGet, Value: "n", Type: program.TypeInt},          // 9
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},             // 10
+		{Op: program.OpAdd, Operands: []program.ExprID{9, 10}},                // 11: n+1
+		{Op: program.OpSignalSet, Value: "n", Operands: []program.ExprID{11}}, // 12: body: n = n+1
+		{Op: program.OpFor, Operands: []program.ExprID{1, 4, 8, 12}},          // 13
+	}
+	return progFromExprs(exprs), 13
+}
+
+// itoaTest is a tiny decimal formatter so this file has no extra
+// import beyond what's already here.
+func itoaTest(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	digits := []byte{}
+	for n > 0 {
+		digits = append([]byte{byte('0' + n%10)}, digits...)
+		n /= 10
+	}
+	return string(digits)
+}
+
+// TestForValueRunsExpectedIterations is the basic sanity test OpFor
+// never had: a bounded `for i := 0; i < 3; i++` must run exactly 3
+// times.
+func TestForValueRunsExpectedIterations(t *testing.T) {
+	prog, forID := buildCountingForProgram(3)
+	vm := NewVM(prog, nil)
+	sig := signal.New(IntVal(0))
+	vm.SetSignal("n", sig)
+
+	vm.EvalWithFrame(forID)
+
+	if int(sig.Get().num) != 3 {
+		t.Fatalf("n after for i:=0;i<3;i++ = %v, want 3", sig.Get().num)
+	}
+	if len(vm.Diagnostics()) != 0 {
+		t.Fatalf("bounded loop should not emit diagnostics, got %+v", vm.Diagnostics())
+	}
+}
+
+// TestForValuePerLoopCapExceeded pins the existing (pre-existing,
+// previously untested) per-loop cap: an unconditionally-true loop
+// stops at SetForCap's value and records loop_cap_exceeded.
+func TestForValuePerLoopCapExceeded(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpSeq},                                                  // 0: noop init/post
+		{Op: program.OpLitBool, Value: "true"},                               // 1: cond, always true
+		{Op: program.OpSignalGet, Value: "n", Type: program.TypeInt},         // 2
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},            // 3
+		{Op: program.OpAdd, Operands: []program.ExprID{2, 3}},                // 4
+		{Op: program.OpSignalSet, Value: "n", Operands: []program.ExprID{4}}, // 5: body
+		{Op: program.OpFor, Operands: []program.ExprID{0, 1, 0, 5}},          // 6
+	}
+	vm := NewVM(progFromExprs(exprs), nil)
+	sig := signal.New(IntVal(0))
+	vm.SetSignal("n", sig)
+	vm.SetForCap(4)
+
+	vm.Eval(6)
+
+	if int(sig.Get().num) != 4 {
+		t.Fatalf("n after infinite loop capped at 4 = %v, want 4", sig.Get().num)
+	}
+	requireDiag(t, vm, "loop_cap_exceeded")
+}
+
+// TestNestedForLoopsShareOneStepBudget is the regression test for
+// the bug this file exists to fix. Two nested, unconditionally-true
+// OpFor loops each stay within their own per-loop cap. But together
+// they used to multiply to cap*cap total body evaluations, with
+// nothing bounding the total.
+//
+// With SetForCap(5), the pre-fix VM ran the inner loop to completion
+// (5 iterations) on every one of the outer loop's 5 iterations. That
+// is 25 total increments of n, none of it caught by any diagnostic.
+//
+// The fix charges every iteration of every loop, at any nesting
+// depth, against one shared per-dispatch budget. So the total
+// across both loops must stay at or under the cap, and a
+// loop_step_budget_exceeded diagnostic must fire.
+func TestNestedForLoopsShareOneStepBudget(t *testing.T) {
+	const cap = 5
+	exprs := []program.Expr{
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},         // 0: shared init value
+		{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{0}}, // 1: outer init: i = 0
+		{Op: program.OpLitBool, Value: "true"},                            // 2: outer cond
+		{Op: program.OpLocalGet, Value: "i"},                              // 3
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},         // 4
+		{Op: program.OpAdd, Operands: []program.ExprID{3, 4}},             // 5: i+1
+		{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{5}}, // 6: outer post
+
+		{Op: program.OpAssign, Value: "j", Operands: []program.ExprID{0}},  // 7: inner init: j = 0
+		{Op: program.OpLitBool, Value: "true"},                             // 8: inner cond
+		{Op: program.OpLocalGet, Value: "j"},                               // 9
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},          // 10
+		{Op: program.OpAdd, Operands: []program.ExprID{9, 10}},             // 11: j+1
+		{Op: program.OpAssign, Value: "j", Operands: []program.ExprID{11}}, // 12: inner post
+
+		{Op: program.OpSignalGet, Value: "n", Type: program.TypeInt},          // 13
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},             // 14
+		{Op: program.OpAdd, Operands: []program.ExprID{13, 14}},               // 15: n+1
+		{Op: program.OpSignalSet, Value: "n", Operands: []program.ExprID{15}}, // 16: innermost body
+
+		{Op: program.OpFor, Operands: []program.ExprID{7, 8, 12, 16}}, // 17: inner for
+		{Op: program.OpFor, Operands: []program.ExprID{1, 2, 6, 17}},  // 18: outer for, body = inner for
+	}
+	vm := NewVM(progFromExprs(exprs), nil)
+	sig := signal.New(IntVal(0))
+	vm.SetSignal("n", sig)
+	vm.SetForCap(cap)
+
+	vm.EvalWithFrame(18)
+
+	total := int(sig.Get().num)
+	if total > cap {
+		t.Fatalf("nested loops incremented n %d times with a per-dispatch budget of %d; the aggregate step budget did not bound the total", total, cap)
+	}
+	if total >= cap*cap {
+		t.Fatalf("nested loops incremented n %d times, which is the unbounded cap*cap=%d blowup the fix must prevent", total, cap*cap)
+	}
+	requireDiag(t, vm, "loop_step_budget_exceeded")
+}
+
+// TestSetForCapAppliesToFreshDispatch verifies SetForCap has a real,
+// exercised effect: lowering the cap to 1 must stop even a single
+// unconditionally-true loop after exactly 1 iteration.
+func TestSetForCapAppliesToFreshDispatch(t *testing.T) {
+	exprs := []program.Expr{
+		{Op: program.OpSeq},                                                  // 0: noop
+		{Op: program.OpLitBool, Value: "true"},                               // 1: cond
+		{Op: program.OpSignalGet, Value: "n", Type: program.TypeInt},         // 2
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},            // 3
+		{Op: program.OpAdd, Operands: []program.ExprID{2, 3}},                // 4
+		{Op: program.OpSignalSet, Value: "n", Operands: []program.ExprID{4}}, // 5
+		{Op: program.OpFor, Operands: []program.ExprID{0, 1, 0, 5}},          // 6
+	}
+	vm := NewVM(progFromExprs(exprs), nil)
+	sig := signal.New(IntVal(0))
+	vm.SetSignal("n", sig)
+	vm.SetForCap(1)
+
+	vm.Eval(6)
+
+	if int(sig.Get().num) != 1 {
+		t.Fatalf("n with SetForCap(1) = %v, want exactly 1", sig.Get().num)
+	}
+}
+
+// TestForRangeSharesStepBudgetWithOpFor verifies OpForRange charges
+// against the same per-dispatch budget as OpFor. This test nests the
+// loops the other way around: an OpFor loop whose body is an
+// OpForRange over a slice.
+func TestForRangeSharesStepBudgetWithOpFor(t *testing.T) {
+	const cap = 6
+	// items := []int{0,0,0,0,0,0,0,0,0,0} (10 items, an ordinary slice
+	// literal — no loop cap applies to building it, only to iterating
+	// it).
+	pairs := make([]program.ExprID, 0, 20)
+	exprs := []program.Expr{
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt}, // 0: shared init/value
+	}
+	for i := 0; i < 10; i++ {
+		pairs = append(pairs, 0, 0)
+	}
+	exprs = append(exprs, program.Expr{Op: program.OpComposite, Value: "slice", Operands: pairs}) // 1: items
+	itemsID := program.ExprID(1)
+
+	exprs = append(exprs,
+		program.Expr{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{0}}, // 2: outer init
+		program.Expr{Op: program.OpLitBool, Value: "true"},                            // 3: outer cond
+		program.Expr{Op: program.OpLocalGet, Value: "i"},                              // 4
+		program.Expr{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},         // 5
+		program.Expr{Op: program.OpAdd, Operands: []program.ExprID{4, 5}},             // 6
+		program.Expr{Op: program.OpAssign, Value: "i", Operands: []program.ExprID{6}}, // 7: outer post
+
+		program.Expr{Op: program.OpSignalGet, Value: "n", Type: program.TypeInt},          // 8
+		program.Expr{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},             // 9
+		program.Expr{Op: program.OpAdd, Operands: []program.ExprID{8, 9}},                 // 10
+		program.Expr{Op: program.OpSignalSet, Value: "n", Operands: []program.ExprID{10}}, // 11: range body
+
+		program.Expr{Op: program.OpForRange, Operands: []program.ExprID{itemsID, 11}}, // 12: for range items
+	)
+	forRangeID := program.ExprID(12)
+	exprs = append(exprs, program.Expr{Op: program.OpFor, Operands: []program.ExprID{2, 3, 7, forRangeID}}) // 13: outer for
+
+	vm := NewVM(progFromExprs(exprs), nil)
+	sig := signal.New(IntVal(0))
+	vm.SetSignal("n", sig)
+	vm.SetForCap(cap)
+
+	vm.EvalWithFrame(program.ExprID(13))
+
+	total := int(sig.Get().num)
+	if total > cap {
+		t.Fatalf("OpFor-over-OpForRange incremented n %d times with a per-dispatch budget of %d", total, cap)
+	}
+	requireDiag(t, vm, "loop_step_budget_exceeded")
+}

--- a/client/vm/make.go
+++ b/client/vm/make.go
@@ -34,15 +34,12 @@ import (
 // (ArrayVal). Unknown tags record an "invalid_make" diagnostic and
 // fall back to the zero Any value so the VM's panic-free contract
 // holds.
-func (vm *VM) evalMakeExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpMake {
-		return Value{}, false
-	}
+func (vm *VM) makeValue(e *program.Expr) Value {
 	switch e.Value {
 	case "map":
-		return ObjectVal(map[string]Value{}), true
+		return ObjectVal(map[string]Value{})
 	case "slice":
-		return vm.makeSlice(e), true
+		return vm.makeSlice(e)
 	default:
 		vm.recordExprDiagnostic(
 			"invalid_make",
@@ -50,7 +47,7 @@ func (vm *VM) evalMakeExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 }
 
@@ -59,7 +56,7 @@ func (vm *VM) evalMakeExpr(e program.Expr) (Value, bool) {
 // diagnostic and fall back to a zero-length slice — the engine-surface
 // authoring contract is permissive about runtime type errors so the VM
 // stays panic-free (matches the Y.A / Y.C convention).
-func (vm *VM) makeSlice(e program.Expr) Value {
+func (vm *VM) makeSlice(e *program.Expr) Value {
 	if len(e.Operands) == 0 {
 		// `make([]T)` is not valid Go syntactically, but `make([]T, 0)`
 		// produces an empty slice — preserve that even if the lowerer
@@ -67,7 +64,7 @@ func (vm *VM) makeSlice(e program.Expr) Value {
 		return ArrayVal([]Value{})
 	}
 	lenVal := vm.Eval(e.Operands[0])
-	n := int(lenVal.Num)
+	n := int(lenVal.num)
 	if n < 0 {
 		vm.recordExprDiagnostic(
 			"invalid_make",

--- a/client/vm/make_test.go
+++ b/client/vm/make_test.go
@@ -23,11 +23,11 @@ func TestEvalOpMakeEmptyMap(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(0)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("OpMake(map) should return a Value with a non-nil Fields map")
 	}
-	if len(got.Fields) != 0 {
-		t.Errorf("OpMake(map) should be empty; got %d entries", len(got.Fields))
+	if len(got.Map()) != 0 {
+		t.Errorf("OpMake(map) should be empty; got %d entries", len(got.Map()))
 	}
 }
 
@@ -43,11 +43,11 @@ func TestEvalOpMakeSizedSlice(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(1)
-	if got.Items == nil {
+	if got.List() == nil {
 		t.Fatalf("OpMake(slice, 5) should return a Value with a non-nil Items slice")
 	}
-	if len(got.Items) != 5 {
-		t.Errorf("OpMake(slice, 5) len = %d, want 5", len(got.Items))
+	if len(got.List()) != 5 {
+		t.Errorf("OpMake(slice, 5) len = %d, want 5", len(got.List()))
 	}
 }
 
@@ -63,11 +63,11 @@ func TestEvalOpMakeEmptySlice(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(1)
-	if got.Items == nil {
+	if got.List() == nil {
 		t.Errorf("OpMake(slice, 0) should still allocate a non-nil empty slice")
 	}
-	if len(got.Items) != 0 {
-		t.Errorf("OpMake(slice, 0) len = %d, want 0", len(got.Items))
+	if len(got.List()) != 0 {
+		t.Errorf("OpMake(slice, 0) len = %d, want 0", len(got.List()))
 	}
 }
 
@@ -83,8 +83,8 @@ func TestEvalOpMakeNegativeLength(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(1)
-	if len(got.Items) != 0 {
-		t.Errorf("OpMake(slice, -3) should clamp to len=0; got len=%d", len(got.Items))
+	if len(got.List()) != 0 {
+		t.Errorf("OpMake(slice, -3) should clamp to len=0; got len=%d", len(got.List()))
 	}
 	// A diagnostic should have been recorded — the VM's recordExprDiagnostic
 	// surface is internal to the test scope; we verify the safe-output
@@ -101,11 +101,11 @@ func TestEvalOpMakeUnknownKindTag(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(0)
-	if got.Fields != nil {
-		t.Errorf("OpMake(\"chan\") should NOT return a populated Fields map; got %v", got.Fields)
+	if got.Map() != nil {
+		t.Errorf("OpMake(\"chan\") should NOT return a populated Fields map; got %v", got.Map())
 	}
-	if got.Items != nil {
-		t.Errorf("OpMake(\"chan\") should NOT return a populated Items slice; got %v", got.Items)
+	if got.List() != nil {
+		t.Errorf("OpMake(\"chan\") should NOT return a populated Items slice; got %v", got.List())
 	}
 }
 
@@ -123,8 +123,8 @@ func TestEvalOpMakeMapIsFreshAllocation(t *testing.T) {
 	vm := NewVM(prog, nil)
 	a := vm.Eval(0)
 	b := vm.Eval(0)
-	a.Fields["k"] = StringVal("from-a")
-	if _, ok := b.Fields["k"]; ok {
+	a.Map()["k"] = StringVal("from-a")
+	if _, ok := b.Map()["k"]; ok {
 		t.Errorf("each OpMake(map) eval must allocate a fresh Fields map; got aliased storage")
 	}
 }

--- a/client/vm/map_lookup_bench_test.go
+++ b/client/vm/map_lookup_bench_test.go
@@ -1,9 +1,16 @@
-// Slice Y.B — benchmark for OpMapLookup. The Y.B handler runs once per
+// Slice Y.B — benchmarks for OpMapLookup. The Y.B handler runs once per
 // comma-ok map index in lowered Go (`v, ok := m[k]`), so its cost is
 // scaled by handler invocation count. Target: a single lookup against
 // a 100-entry map should run in well under 1 µs so a draw handler that
 // fires 60 times/second with a few dozen lookups never approaches
 // frame budget.
+//
+// The earlier version of BenchmarkMapLookupHit pointed the lookup at an
+// OpComposite, so every iteration re-materialized the whole 100-entry map and
+// the benchmark reported about 14 µs — the cost of building the map, not of
+// reading it. The lookup benchmarks below hold the map in a prop, which is what
+// a real handler does, and a separate benchmark keeps the materialization cost
+// visible under its own name.
 
 package vm
 
@@ -14,40 +21,95 @@ import (
 	"m31labs.dev/gosx/island/program"
 )
 
-// BenchmarkMapLookupHit measures the steady-state cost of a present-key
-// lookup against a 100-entry ObjectVal-backed map. The setup pre-builds
-// the lookup program once so the bench loop measures only Eval + the
-// ObjectVal wrapper allocation.
+// BenchmarkMapLookupHit measures a present-key lookup against a 100-entry
+// ObjectVal held in a prop. The loop times Eval plus the ObjectVal wrapper.
 func BenchmarkMapLookupHit(b *testing.B) {
-	prog, lookupID := buildBenchLookup(100, "key_50")
-	vm := NewVM(prog, nil)
+	machine, lookupID := newBenchLookupVM(100, "key_50")
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		got := vm.Eval(lookupID)
-		if got.Fields["ok"].Bool != true {
+		got := machine.Eval(lookupID)
+		if !got.Map()["ok"].Truth() {
 			b.Fatalf("expected hit, got %+v", got)
 		}
 	}
 }
 
-// BenchmarkMapLookupMiss measures the absent-key path. Should be
-// indistinguishable from the hit path — both branches do one
-// map-Fields read plus the wrapper allocation.
+// BenchmarkMapLookupMiss measures the absent-key path. It should be
+// indistinguishable from the hit path — both branches do one map-Fields read
+// plus the wrapper allocation.
 func BenchmarkMapLookupMiss(b *testing.B) {
-	prog, lookupID := buildBenchLookup(100, "key_999")
-	vm := NewVM(prog, nil)
+	machine, lookupID := newBenchLookupVM(100, "key_999")
+	b.ReportAllocs()
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		got := vm.Eval(lookupID)
-		if got.Fields["ok"].Bool != false {
+		got := machine.Eval(lookupID)
+		if got.Map()["ok"].Truth() {
 			b.Fatalf("expected miss, got %+v", got)
 		}
 	}
 }
 
+// BenchmarkMapCompositeThenLookup100 keeps the old shape under an honest name:
+// it materializes a 100-entry map composite and then reads one key.
+func BenchmarkMapCompositeThenLookup100(b *testing.B) {
+	prog, lookupID := buildBenchLookup(100, "key_50")
+	machine := NewVM(prog, nil)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		got := machine.Eval(lookupID)
+		if !got.Map()["ok"].Truth() {
+			b.Fatalf("expected hit, got %+v", got)
+		}
+	}
+}
+
+// TestMapLookupStaysCheap pins the allocation count of one lookup.
+//
+// The doc comment above states a sub-microsecond target. Wall time flakes on a
+// shared machine, so the assertion pins the allocation count instead: the
+// lookup must not touch the map's size. Two allocations cover the result
+// ObjectVal — the Fields map plus its bucket — and nothing else.
+func TestMapLookupStaysCheap(t *testing.T) {
+	machine, lookupID := newBenchLookupVM(100, "key_50")
+	// Warm the VM so first-call lazy work does not land in the measurement.
+	machine.Eval(lookupID)
+
+	const maxAllocs = 3
+	got := testing.AllocsPerRun(200, func() {
+		result := machine.Eval(lookupID)
+		if !result.Map()["ok"].Truth() {
+			t.Fatal("expected a hit")
+		}
+	})
+	if got > maxAllocs {
+		t.Errorf("OpMapLookup against a 100-entry map allocated %.0f objects, want at most %d; "+
+			"a lookup must not scale with map size", got, maxAllocs)
+	}
+}
+
+// newBenchLookupVM builds a VM whose single OpMapLookup reads a 100-entry map
+// held in the "m" prop. This is the shape a lowered handler produces.
+func newBenchLookupVM(n int, key string) (*VM, program.ExprID) {
+	prog := &program.Program{}
+	mapID := program.ExprID(len(prog.Exprs))
+	prog.Exprs = append(prog.Exprs, program.Expr{Op: program.OpPropGet, Value: "m", Type: program.TypeAny})
+	keyID := program.ExprID(len(prog.Exprs))
+	prog.Exprs = append(prog.Exprs, program.Expr{Op: program.OpLitString, Value: key, Type: program.TypeString})
+	lookupID := program.ExprID(len(prog.Exprs))
+	prog.Exprs = append(prog.Exprs, program.Expr{Op: program.OpMapLookup, Operands: []program.ExprID{mapID, keyID}})
+
+	fields := make(map[string]Value, n)
+	for i := 0; i < n; i++ {
+		fields["key_"+strconv.Itoa(i)] = IntVal(i)
+	}
+	return NewVM(prog, map[string]Value{"m": ObjectVal(fields)}), lookupID
+}
+
 // buildBenchLookup pre-builds a program whose single OpMapLookup
 // targets an N-entry map composite literal. Returns the program and
-// the ExprID of the lookup so the bench loop only times Eval.
+// the ExprID of the lookup.
 func buildBenchLookup(n int, key string) (*program.Program, program.ExprID) {
 	prog := &program.Program{}
 	var entryIDs []program.ExprID

--- a/client/vm/map_lookup_test.go
+++ b/client/vm/map_lookup_test.go
@@ -42,14 +42,14 @@ func TestMapLookupPresent(t *testing.T) {
 	prog, id := buildLookupProgram([][2]string{{"hit", "1.5"}, {"miss", "0"}}, "hit")
 	vm := NewVM(prog, nil)
 	got := vm.Eval(id)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("expected ObjectVal with Fields; got %+v", got)
 	}
-	if got.Fields["ok"].Bool != true {
-		t.Errorf("ok = %v, want true", got.Fields["ok"].Bool)
+	if got.Map()["ok"].Truth() != true {
+		t.Errorf("ok = %v, want true", got.Map()["ok"].Truth())
 	}
-	if got.Fields["value"].Num != 1.5 {
-		t.Errorf("value = %f, want 1.5", got.Fields["value"].Num)
+	if got.Map()["value"].num != 1.5 {
+		t.Errorf("value = %f, want 1.5", got.Map()["value"].num)
 	}
 }
 
@@ -57,15 +57,15 @@ func TestMapLookupAbsent(t *testing.T) {
 	prog, id := buildLookupProgram([][2]string{{"hit", "1.5"}}, "miss")
 	vm := NewVM(prog, nil)
 	got := vm.Eval(id)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("expected ObjectVal with Fields; got %+v", got)
 	}
-	if got.Fields["ok"].Bool != false {
-		t.Errorf("ok = %v, want false", got.Fields["ok"].Bool)
+	if got.Map()["ok"].Truth() != false {
+		t.Errorf("ok = %v, want false", got.Map()["ok"].Truth())
 	}
 	// Missing-key value is the zero Any — Num is 0, Str is empty.
-	v := got.Fields["value"]
-	if v.Num != 0 || v.Str != "" {
+	v := got.Map()["value"]
+	if v.num != 0 || v.Text() != "" {
 		t.Errorf("absent value = %+v, want zero", v)
 	}
 }
@@ -92,7 +92,7 @@ func TestMapLookupOnNonMap(t *testing.T) {
 	vm := NewVM(prog, nil)
 	vm.diagnosticSink = func(d Diagnostic) { diags = append(diags, d) }
 	got := vm.Eval(lookupID)
-	if got.Fields == nil || got.Fields["ok"].Bool != false {
+	if got.Map() == nil || got.Map()["ok"].Truth() != false {
 		t.Errorf("non-map lookup yielded %+v, want {value: zero, ok: false}", got)
 	}
 	if len(diags) == 0 {
@@ -121,10 +121,10 @@ func TestMapLookupOperandCount(t *testing.T) {
 
 	vm := NewVM(prog, nil)
 	got := vm.Eval(lookupID)
-	if got.Fields == nil {
+	if got.Map() == nil {
 		t.Fatalf("expected ObjectVal even on operand-shortage; got %+v", got)
 	}
-	if got.Fields["ok"].Bool != false {
-		t.Errorf("ok = %v, want false on operand-shortage", got.Fields["ok"].Bool)
+	if got.Map()["ok"].Truth() != false {
+		t.Errorf("ok = %v, want false on operand-shortage", got.Map()["ok"].Truth())
 	}
 }

--- a/client/vm/ops.go
+++ b/client/vm/ops.go
@@ -23,5 +23,13 @@ const (
 	PatchReplaceElement                  // Replace an element node.
 	PatchReorder                         // Reorder children of a node.
 	PatchSetValue                        // Set the value property of a node.
-	PatchSetHTML                         // Set innerHTML (for highlighted content).
+
+	// PatchSetHTML is receive-only. No Go code emits it, and the reconciler
+	// never will: patch.js sanitizes kind 9 by assigning op.text as text
+	// content, so it cannot inject markup, and runtime.test.js pins that
+	// behaviour. The constant stays because the JS applier still accepts the
+	// kind, and a protocol number must not be silently reused for something
+	// else. Removing it means removing the JS branch and its test in the same
+	// change.
+	PatchSetHTML
 )

--- a/client/vm/reconcile.go
+++ b/client/vm/reconcile.go
@@ -72,7 +72,7 @@ func reconcileNodePair(ops *[]PatchOp, prev, next *ResolvedTree, prevIdx, nextId
 		appendReplaceSubtree(ops, next, nextIdx, path)
 		return
 	}
-	reconcileElementNodePair(ops, prev, next, pair.prev, pair.next, nextIdx, path, staticMask)
+	reconcileElementNodePair(ops, prev, next, pair.prev, pair.next, path, staticMask)
 }
 
 type resolvedNodePair struct {
@@ -128,7 +128,7 @@ func reconcileLeafNodePair(ops *[]PatchOp, pn, nn *ResolvedNode, next *ResolvedT
 	}
 }
 
-func reconcileElementNodePair(ops *[]PatchOp, prev, next *ResolvedTree, pn, nn *ResolvedNode, nextIdx int, path string, staticMask []bool) {
+func reconcileElementNodePair(ops *[]PatchOp, prev, next *ResolvedTree, pn, nn *ResolvedNode, path string, staticMask []bool) {
 	if pn.Text != nn.Text && (pn.Text != "" || nn.Text != "") {
 		appendTextPatch(ops, path, nn.Text)
 	}
@@ -310,7 +310,13 @@ func reorderIndices(current, desired []string) []int {
 	return reorderedIndices(indexByKey, desired)
 }
 
+// stringSlicesEqual reports whether two string slices hold the same values in
+// the same order. It checks the lengths itself: the only caller guards them
+// today, but a future caller must not be able to turn this into an index panic.
 func stringSlicesEqual(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
 	for i := range left {
 		if left[i] != right[i] {
 			return false
@@ -349,26 +355,26 @@ func reorderedIndices(indexByKey map[string]int, desired []string) []int {
 // falls back to a plain index-positional diff.
 func reconcilePositionalChildren(ops *[]PatchOp, prev, next *ResolvedTree, pn, nn *ResolvedNode, path string, staticMask []bool) {
 	pc, nc := pn.Children, nn.Children
-	prevHas, prevUnique := childIdentitySet(prev, pc)
-	nextHas, nextUnique := childIdentitySet(next, nc)
-
-	if !prevUnique || !nextUnique {
+	if !childIdentitiesUnique(prev, pc) || !childIdentitiesUnique(next, nc) {
 		reconcileIndexPositional(ops, prev, next, pc, nc, path, staticMask)
 		return
 	}
 
+	prevLookup := newChildIdentityLookup(prev, pc)
+	nextLookup := newChildIdentityLookup(next, nc)
+
 	i, j, d := 0, 0, 0
 	for i < len(pc) && j < len(nc) {
-		pid := childIdentity(prev, pc[i])
-		nid := childIdentity(next, nc[j])
+		pid, _ := childIdentity(prev, pc[i])
+		nid, _ := childIdentity(next, nc[j])
 		switch {
 		case pid == nid:
 			reconcileNodePair(ops, prev, next, pc[i], nc[j], childPath(path, d), staticMask)
 			i, j, d = i+1, j+1, d+1
-		case !nextHas[pid]:
+		case !nextLookup.has(pid):
 			appendRemoveChild(ops, childPath(path, d)) // prev child gone; successor shifts to d
 			i++
-		case !prevHas[nid]:
+		case !prevLookup.has(nid):
 			appendCreateSubtree(ops, next, nc[j], path, d) // next child is new
 			j, d = j+1, d+1
 		default:
@@ -405,39 +411,125 @@ func reconcileIndexPositional(ops *[]PatchOp, prev, next *ResolvedTree, pc, nc [
 	}
 }
 
-func childIdentity(tree *ResolvedTree, idx int) string {
-	n := resolvedNodeAt(tree, idx)
-	if n == nil {
-		return ""
-	}
-	if n.Key != "" {
-		return "k:" + n.Key
-	}
-	if n.HasSource && n.Source >= 0 {
-		return "s:" + strconv.Itoa(n.Source)
-	}
-	return ""
+// childID identifies one sibling for identity-aware diffing.
+//
+// A non-empty key identifies the node; otherwise the program node index does.
+// The struct is comparable, so identity checks need no string building. The
+// previous shape returned "k:"+Key or "s:"+itoa(Source), which allocated one
+// string per child, per side, on every event.
+type childID struct {
+	key    string
+	source int
 }
 
-// childIdentitySet returns the set of non-empty child identities and whether
-// every child had a distinct, non-empty identity (the precondition for
-// identity-aware diffing).
-func childIdentitySet(tree *ResolvedTree, indices []int) (map[string]bool, bool) {
+// childIdentity returns the identity of a sibling plus whether it has one.
+func childIdentity(tree *ResolvedTree, idx int) (childID, bool) {
+	n := resolvedNodeAt(tree, idx)
+	if n == nil {
+		return childID{}, false
+	}
+	if n.Key != "" {
+		return childID{key: n.Key}, true
+	}
+	if n.HasSource && n.Source >= 0 {
+		return childID{source: n.source1()}, true
+	}
+	return childID{}, false
+}
+
+// source1 shifts the program node index by one so that source 0 never collides
+// with the zero childID, which stands for "no identity".
+func (node *ResolvedNode) source1() int {
+	return node.Source + 1
+}
+
+// childIdentityScanLimit is the sibling count above which building a map beats
+// scanning the child list. Below it the scan wins, because it allocates nothing.
+//
+// Sibling groups with distinct identities are handwritten markup — a handful of
+// elements. A forEach row set shares one program source, so its identities
+// repeat and childIdentitiesUnique rejects it on the second child. A list long
+// enough to reach the map branch is therefore rare.
+const childIdentityScanLimit = 16
+
+// childIdentitiesUnique reports whether every child in indices carries a
+// distinct, non-empty identity. That is the precondition for identity-aware
+// diffing; a false answer sends the caller to the index-positional walk.
+func childIdentitiesUnique(tree *ResolvedTree, indices []int) bool {
+	// An empty list is trivially unique. A single child is NOT: it may carry no
+	// identity at all, and that must still send the caller to the index walk,
+	// because the identity walk would treat the missing identity as absent from
+	// the other side and emit a remove plus a create instead of an in-place
+	// reconcile.
 	if len(indices) == 0 {
-		return nil, true
+		return true
 	}
-	set := make(map[string]bool, len(indices))
-	unique := true
+	if len(indices) > childIdentityScanLimit {
+		seen := make(map[childID]struct{}, len(indices))
+		for _, idx := range indices {
+			id, ok := childIdentity(tree, idx)
+			if !ok {
+				return false
+			}
+			if _, exists := seen[id]; exists {
+				return false
+			}
+			seen[id] = struct{}{}
+		}
+		return true
+	}
+	for i, idx := range indices {
+		id, ok := childIdentity(tree, idx)
+		if !ok {
+			return false
+		}
+		for _, prior := range indices[:i] {
+			if other, priorOK := childIdentity(tree, prior); priorOK && other == id {
+				return false
+			}
+		}
+	}
+	return true
+}
+
+// childIdentityLookup answers "does this sibling list contain that identity".
+//
+// Short lists scan the tree directly and allocate nothing. Long lists build a map
+// once so the merge walk stays linear. The struct holds no inline array, so it
+// returns through the caller's frame with no heap traffic.
+type childIdentityLookup struct {
+	tree    *ResolvedTree
+	indices []int
+	set     map[childID]struct{} // nil in scanning mode
+}
+
+// newChildIdentityLookup prepares membership answers for one sibling list. Call
+// it only after childIdentitiesUnique has passed.
+func newChildIdentityLookup(tree *ResolvedTree, indices []int) childIdentityLookup {
+	if len(indices) <= childIdentityScanLimit {
+		return childIdentityLookup{tree: tree, indices: indices}
+	}
+	set := make(map[childID]struct{}, len(indices))
 	for _, idx := range indices {
-		id := childIdentity(tree, idx)
-		if id == "" || set[id] {
-			unique = false
-		}
-		if id != "" {
-			set[id] = true
+		if id, ok := childIdentity(tree, idx); ok {
+			set[id] = struct{}{}
 		}
 	}
-	return set, unique
+	return childIdentityLookup{tree: tree, indices: indices, set: set}
+}
+
+// has reports whether the sibling list carries id.
+func (l childIdentityLookup) has(id childID) bool {
+	if l.set != nil {
+		_, ok := l.set[id]
+		return ok
+	}
+	for _, idx := range l.indices {
+		if other, ok := childIdentity(l.tree, idx); ok && other == id {
+			return true
+		}
+	}
+	return false
 }
 
 func appendReplaceSubtree(ops *[]PatchOp, tree *ResolvedTree, nodeIdx int, path string) {

--- a/client/vm/reconcile_test.go
+++ b/client/vm/reconcile_test.go
@@ -938,3 +938,51 @@ func TestReconcileNoKeysUnchanged(t *testing.T) {
 		t.Fatalf("expected 0 ops for unchanged tree, got %d", len(ops))
 	}
 }
+
+// TestSingleChildWithoutIdentityUsesIndexWalk pins the one-child edge case.
+//
+// A lone child with no key and no program source has no identity. The identity
+// walk would then read it as absent from the other side and emit a remove plus a
+// create, where the index walk reconciles it in place. childIdentitiesUnique must
+// therefore reject a single identity-less child, not wave it through.
+func TestSingleChildWithoutIdentityUsesIndexWalk(t *testing.T) {
+	prev := &ResolvedTree{Nodes: []ResolvedNode{
+		{Tag: "div", HasSource: true, Source: 0, Children: []int{1}},
+		{Tag: "span", HasSource: false, Text: "old"},
+	}}
+	next := &ResolvedTree{Nodes: []ResolvedNode{
+		{Tag: "div", HasSource: true, Source: 0, Children: []int{1}},
+		{Tag: "span", HasSource: false, Text: "new"},
+	}}
+
+	ops := ReconcileTrees(prev, next, nil)
+	for _, op := range ops {
+		if op.Kind == PatchRemoveElement || op.Kind == PatchCreateElement {
+			t.Fatalf("an identity-less single child must reconcile in place, got %+v in %+v", op, ops)
+		}
+	}
+	if len(ops) != 1 || ops[0].Kind != PatchSetText || ops[0].Path != "0" || ops[0].Text != "new" {
+		t.Fatalf("expected one SetText at path 0, got %+v", ops)
+	}
+}
+
+// TestSingleChildIdentityMismatchStillReplaces confirms the index walk keeps
+// working when a lone identity-less child has more siblings on the next side.
+func TestSingleChildWithoutIdentityAgainstLongerNextList(t *testing.T) {
+	prev := &ResolvedTree{Nodes: []ResolvedNode{
+		{Tag: "ul", HasSource: true, Source: 0, Children: []int{1}},
+		{Tag: "li", HasSource: false, Text: "only"},
+	}}
+	next := &ResolvedTree{Nodes: []ResolvedNode{
+		{Tag: "ul", HasSource: true, Source: 0, Children: []int{1, 2}},
+		{Tag: "li", HasSource: false, Text: "first"},
+		{Tag: "li", HasSource: false, Text: "second"},
+	}}
+
+	ops := ReconcileTrees(prev, next, nil)
+	for _, op := range ops {
+		if op.Kind == PatchRemoveElement {
+			t.Fatalf("the shared prefix must reconcile in place, got a remove in %+v", ops)
+		}
+	}
+}

--- a/client/vm/reconciler.go
+++ b/client/vm/reconciler.go
@@ -14,7 +14,7 @@ import (
 //
 // Implementations:
 //   - *Island in this package (DOM patches)
-//   - *enginevm.Runtime in client/enginevm (engine commands)
+//   - *SceneAdapter in this package (engine commands)
 type Reconciler interface {
 	// Dispose releases any retained reconciliation state.
 	Dispose()

--- a/client/vm/reconciler_test.go
+++ b/client/vm/reconciler_test.go
@@ -28,7 +28,7 @@ func TestReconcilerInterfaceShape(t *testing.T) {
 	r.Dispose()
 	got := r.EvalExpr(7)
 	want := IntVal(7)
-	if got.Type != want.Type || got.Num != want.Num {
+	if got.Type != want.Type || got.num != want.num {
 		t.Errorf("EvalExpr returned %v, want %v", got, want)
 	}
 	r.SetSharedSignal("x", signal.New(IntVal(1)))

--- a/client/vm/resolved.go
+++ b/client/vm/resolved.go
@@ -58,7 +58,7 @@ func materializeDOMAttrs(attrs []ResolvedAttr, events []ResolvedEvent) []Resolve
 	for _, event := range events {
 		eventType := eventAttrType(event.Name)
 		out = append(out, ResolvedAttr{
-			Name:  "data-gosx-on-" + eventType,
+			Name:  eventMarkerAttr(eventType),
 			Value: event.Handler,
 		})
 		if eventType == "click" {
@@ -69,6 +69,36 @@ func materializeDOMAttrs(attrs []ResolvedAttr, events []ResolvedEvent) []Resolve
 		}
 	}
 	return out
+}
+
+// eventMarkerAttr returns the data-gosx-on-<type> attribute name the browser
+// reconciler reads.
+//
+// Every reconcile rebuilds the attribute list of every element that carries an
+// event, and the concatenation allocated a fresh string each time. The eight
+// names below cover every event the lowerer emits today, so the hot path now
+// returns a constant.
+func eventMarkerAttr(eventType string) string {
+	switch eventType {
+	case "click":
+		return "data-gosx-on-click"
+	case "input":
+		return "data-gosx-on-input"
+	case "change":
+		return "data-gosx-on-change"
+	case "submit":
+		return "data-gosx-on-submit"
+	case "keydown":
+		return "data-gosx-on-keydown"
+	case "keyup":
+		return "data-gosx-on-keyup"
+	case "focus":
+		return "data-gosx-on-focus"
+	case "blur":
+		return "data-gosx-on-blur"
+	default:
+		return "data-gosx-on-" + eventType
+	}
 }
 
 func eventAttrType(name string) string {

--- a/client/vm/reuse.go
+++ b/client/vm/reuse.go
@@ -1,0 +1,562 @@
+package vm
+
+import "m31labs.dev/gosx/island/program"
+
+// Subtree reuse — route (b) of the Reconcile design note in island.go.
+//
+// Every event used to evaluate a complete new tree and throw away the parts
+// that could not have changed. This file makes the walk skip those parts.
+//
+// The idea in three steps:
+//
+//  1. At program load, compute for every program node the set of reactive
+//     inputs (signals and props) that its whole subtree reads. Call it the
+//     read set. Compute it only when every expression in the subtree is
+//     PURE, which means its result depends on nothing but its operands and
+//     those named inputs.
+//  2. Before each reconcile, compare the current value of every watched
+//     input against the value it held at the end of the previous walk. The
+//     inputs that differ form the write set.
+//  3. During the walk, when a node's read set does not meet the write set,
+//     copy the node's resolved subtree out of the previous tree instead of
+//     evaluating it.
+//
+// Step 2 compares values instead of recording writes. That choice matters:
+// a signal can be written from a handler, from the shared-signal store, from
+// a host receiver, or from a bridge callback. A write recorder must know
+// every one of those paths, and a path it does not know produces a node that
+// silently stops updating. A value comparison knows none of them and still
+// catches all of them.
+//
+// The comparison only works for scalar payloads. A composite Value (array,
+// object, closure) is mutated in place by OpFieldSet and OpIndexSet, so the
+// snapshot would alias the mutated storage and always compare equal. Any
+// watched input holding a composite is therefore marked dirty on every
+// reconcile. See sampleValue.
+//
+// What is deliberately NOT reused:
+//
+//   - Nodes inside a forEach body. The VM rebinds `_item`, `_index` and the
+//     `as`/`index` names per iteration, so the same program node resolves to
+//     different content in each pass. Reuse is gated on "singleton": the node
+//     is reached exactly once from the root and no ancestor is a forEach.
+//     TestForEachNodeUpdatesThroughReboundProp pins this.
+//   - Text and expression nodes. mergeAdjacentText concatenates a run of
+//     sibling text nodes into the first one, in place. Reusing a node whose
+//     Text was already merged would concatenate the same text twice. Only
+//     element nodes carry a Tag, and merging never touches them.
+//   - Any subtree containing an impure opcode. isPureOp lists the opcodes
+//     that qualify. A new opcode is impure until it is added there, so
+//     forgetting to update the list costs speed, never correctness.
+
+// maxWatchedInputs is the number of distinct signals and props one program
+// may read before subtree reuse turns itself off. The read set is a bitmask
+// in one machine word, so 64 is the natural cap. Islands read far fewer than
+// this; a program above the cap simply evaluates its whole tree as before.
+const maxWatchedInputs = 64
+
+// maxReuseWalkDepth bounds the static analysis walks over the node and
+// expression graphs. The lowerer emits a tree, so the bound never fires on
+// well-formed input. It stops a hand-built or corrupted program from
+// recursing without end at plan time.
+const maxReuseWalkDepth = 512
+
+// watchKind distinguishes the two namespaces a pure expression can read.
+type watchKind uint8
+
+const (
+	// watchSignal names a reactive signal read through OpSignalGet.
+	watchSignal watchKind = iota
+	// watchProp names an island prop read through OpPropGet.
+	watchProp
+)
+
+// watchKey identifies one reactive input.
+type watchKey struct {
+	kind watchKind
+	name string
+}
+
+// nodeReuseInfo is the per-program-node result of the static analysis.
+type nodeReuseInfo struct {
+	// mask holds one bit per watched input the node's subtree reads.
+	mask uint64
+	// reusable reports whether the node's resolved subtree may be copied
+	// from the previous tree when mask does not meet the write set.
+	reusable bool
+}
+
+// reusePlan is the static analysis of one program. It is computed once per
+// program and is read-only afterwards, so an Island may keep it across
+// reconciles and a SwapProgram simply builds a new one.
+type reusePlan struct {
+	watch []watchKey
+	index map[watchKey]int
+	nodes []nodeReuseInfo
+	exprs []exprReuseInfo
+	// full is true when at least one node is reusable. A plan with no
+	// reusable node saves nothing and is dropped by newReusePlan.
+	full bool
+}
+
+// exprReuseInfo memoizes the analysis of one expression.
+type exprReuseInfo struct {
+	mask  uint64
+	pure  bool
+	done  bool
+	busy  bool
+	valid bool
+}
+
+// nodeSpan records where a program node's resolved subtree landed in a tree.
+// The subtree is contiguous: appendResolvedNode writes the node first and
+// every descendant after it, so [start, end) covers the whole subtree.
+type nodeSpan struct {
+	start int32
+	end   int32
+	valid bool
+}
+
+// treeReuse is the per-walk state the VM reads while building a tree. The
+// Island owns it and re-points its fields on every reconcile, so the walk
+// allocates nothing for the bookkeeping.
+type treeReuse struct {
+	plan *reusePlan
+	// prev is the tree the previous walk produced. Reused subtrees are
+	// copied out of it.
+	prev *ResolvedTree
+	// prevSpans locates each reusable node's subtree inside prev.
+	prevSpans []nodeSpan
+	// spans records the same for the tree being built now.
+	spans []nodeSpan
+	// dirty holds one bit per watched input whose value changed.
+	dirty uint64
+	// hits counts the subtrees the last walk copied instead of
+	// evaluating. Tests read it to prove that reuse fired; nothing in the
+	// runtime path depends on it.
+	hits int
+}
+
+// newReusePlan analyses prog and returns a plan, or nil when subtree reuse
+// cannot help. A nil plan makes every reconcile evaluate the whole tree, so
+// returning nil is always safe.
+func newReusePlan(prog *program.Program) *reusePlan {
+	if prog == nil || len(prog.Nodes) == 0 || int(prog.Root) >= len(prog.Nodes) {
+		return nil
+	}
+	plan := &reusePlan{
+		index: make(map[watchKey]int),
+		nodes: make([]nodeReuseInfo, len(prog.Nodes)),
+		exprs: make([]exprReuseInfo, len(prog.Exprs)),
+	}
+	singleton := planSingletons(prog)
+	for id := range prog.Nodes {
+		mask, pure := plan.nodeInfo(prog, program.NodeID(id), 0)
+		reusable := pure && singleton[id] && prog.Nodes[id].Kind == program.NodeElement
+		plan.nodes[id] = nodeReuseInfo{mask: mask, reusable: reusable}
+		if reusable {
+			plan.full = true
+		}
+	}
+	if !plan.full || len(plan.watch) > maxWatchedInputs {
+		return nil
+	}
+	return plan
+}
+
+// planSingletons marks the program nodes that the walk from Root reaches
+// exactly once with no forEach ancestor. Those are the only nodes whose
+// resolved subtree occupies one predictable place in the tree.
+func planSingletons(prog *program.Program) []bool {
+	singleton := make([]bool, len(prog.Nodes))
+	visited := make([]bool, len(prog.Nodes))
+	var poison func(id program.NodeID, depth int)
+	poison = func(id program.NodeID, depth int) {
+		if int(id) >= len(prog.Nodes) || depth > maxReuseWalkDepth || !singleton[id] {
+			return
+		}
+		singleton[id] = false
+		for _, child := range prog.Nodes[id].Children {
+			poison(child, depth+1)
+		}
+	}
+	var walk func(id program.NodeID, inLoop bool, depth int)
+	walk = func(id program.NodeID, inLoop bool, depth int) {
+		if int(id) >= len(prog.Nodes) || depth > maxReuseWalkDepth {
+			return
+		}
+		if visited[id] {
+			// A second path reaches this node, so it resolves more than
+			// once and its subtree loses its single home in the tree.
+			poison(id, depth)
+			return
+		}
+		visited[id] = true
+		singleton[id] = !inLoop
+		node := prog.Nodes[id]
+		childInLoop := inLoop || node.Kind == program.NodeForEach
+		for _, child := range node.Children {
+			walk(child, childInLoop, depth+1)
+		}
+	}
+	walk(prog.Root, false, 0)
+	return singleton
+}
+
+// nodeInfo returns the read set of the subtree rooted at id, and whether
+// every expression in that subtree is pure.
+func (plan *reusePlan) nodeInfo(prog *program.Program, id program.NodeID, depth int) (uint64, bool) {
+	if int(id) >= len(prog.Nodes) || depth > maxReuseWalkDepth {
+		return 0, false
+	}
+	node := prog.Nodes[id]
+	var mask uint64
+	// Every node kind that carries an expression stores it in the same
+	// field: NodeExpr's content, NodeForEach's collection, NodeConditional's
+	// condition. NodeElement and NodeText leave it at zero, and expression 0
+	// is a legal ID, so read it only for the kinds that use it.
+	switch node.Kind {
+	case program.NodeExpr, program.NodeForEach, program.NodeConditional:
+		exprMask, pure := plan.exprInfo(prog, node.Expr, depth+1)
+		if !pure {
+			return 0, false
+		}
+		mask |= exprMask
+	}
+	for _, attr := range node.Attrs {
+		if attr.Kind != program.AttrExpr {
+			continue
+		}
+		exprMask, pure := plan.exprInfo(prog, attr.Expr, depth+1)
+		if !pure {
+			return 0, false
+		}
+		mask |= exprMask
+	}
+	for _, child := range node.Children {
+		childMask, pure := plan.nodeInfo(prog, child, depth+1)
+		if !pure {
+			return 0, false
+		}
+		mask |= childMask
+	}
+	return mask, true
+}
+
+// exprInfo returns the read set of the expression tree rooted at id, and
+// whether every opcode in it is pure. Results are memoized because the same
+// expression is often shared by several nodes.
+func (plan *reusePlan) exprInfo(prog *program.Program, id program.ExprID, depth int) (uint64, bool) {
+	if int(id) >= len(prog.Exprs) || depth > maxReuseWalkDepth {
+		return 0, false
+	}
+	slot := &plan.exprs[id]
+	if slot.done {
+		return slot.mask, slot.pure
+	}
+	if slot.busy {
+		// An expression that reaches itself cannot be proved pure.
+		return 0, false
+	}
+	slot.busy = true
+	mask, pure := plan.exprInfoUncached(prog, id, depth)
+	slot.busy = false
+	slot.mask = mask
+	slot.pure = pure
+	slot.done = true
+	return mask, pure
+}
+
+func (plan *reusePlan) exprInfoUncached(prog *program.Program, id program.ExprID, depth int) (uint64, bool) {
+	expr := &prog.Exprs[id]
+	switch expr.Op {
+	case program.OpSignalGet:
+		return plan.watchBit(watchKey{kind: watchSignal, name: expr.Value})
+	case program.OpPropGet:
+		return plan.watchBit(watchKey{kind: watchProp, name: expr.Value})
+	}
+	if !isPureOp(expr.Op) {
+		return 0, false
+	}
+	var mask uint64
+	for _, operand := range expr.Operands {
+		operandMask, pure := plan.exprInfo(prog, operand, depth+1)
+		if !pure {
+			return 0, false
+		}
+		mask |= operandMask
+	}
+	return mask, true
+}
+
+// watchBit assigns key a bit position, creating it on first use. It returns
+// an impure result once the program passes maxWatchedInputs, which switches
+// reuse off for the whole program.
+func (plan *reusePlan) watchBit(key watchKey) (uint64, bool) {
+	if key.name == "" {
+		return 0, false
+	}
+	pos, ok := plan.index[key]
+	if !ok {
+		if len(plan.watch) >= maxWatchedInputs {
+			return 0, false
+		}
+		pos = len(plan.watch)
+		plan.watch = append(plan.watch, key)
+		plan.index[key] = pos
+	}
+	return uint64(1) << uint(pos), true
+}
+
+// isPureOp reports whether an opcode's result depends only on its operands.
+//
+// Read the list as a contract, not as an optimisation table. An opcode
+// belongs here only when re-evaluating it with the same watched inputs
+// produces the same Value and records no diagnostic. Everything absent from
+// the list is treated as impure, so a new opcode is safe by default and only
+// loses the reuse win until someone adds it.
+//
+// Four groups are deliberately excluded:
+//
+//   - Writers (OpSignalSet, OpAssign, OpFieldSet, OpIndexSet, the local and
+//     loop opcodes). They change state, so skipping them changes behaviour.
+//   - Scope rebinders (OpMap, OpFilter, OpFind, OpForRange, OpClosure, the
+//     call opcodes). They bind `_item` and friends, so a read set built from
+//     names alone would miss what the body actually depends on.
+//   - Ambient readers (OpEventGet, OpHostCall). Their result changes with
+//     state this analysis does not watch.
+//   - OpSignalUpdate, which both reads and writes.
+func isPureOp(op program.OpCode) bool {
+	switch op {
+	case program.OpLitString, program.OpLitInt, program.OpLitFloat, program.OpLitBool,
+		program.OpAdd, program.OpSub, program.OpMul, program.OpDiv, program.OpMod, program.OpNeg,
+		program.OpEq, program.OpNeq, program.OpLt, program.OpGt, program.OpLte, program.OpGte,
+		program.OpAnd, program.OpOr, program.OpNot,
+		program.OpConcat, program.OpFormat, program.OpCond,
+		program.OpIndex, program.OpLen,
+		program.OpSlice, program.OpAppend, program.OpContains,
+		program.OpToUpper, program.OpToLower, program.OpTrim, program.OpSplit, program.OpJoin,
+		program.OpReplace, program.OpSubstring, program.OpStartsWith, program.OpEndsWith,
+		program.OpToString, program.OpToInt, program.OpToFloat, program.OpToRunes,
+		program.OpMapLookup:
+		return true
+	default:
+		return false
+	}
+}
+
+// watchSample is the comparable snapshot of one watched input. It copies the
+// scalar payload out of the Value instead of holding the Value, so a stale
+// snapshot never keeps an object alive and never aliases mutable storage.
+type watchSample struct {
+	present bool
+	// stable is false for a composite or closure payload. Those mutate in
+	// place, so a snapshot of them proves nothing and the input counts as
+	// dirty on every reconcile.
+	stable  bool
+	typ     program.ExprType
+	num     float64
+	str     string
+	boolean bool
+}
+
+// sampleValue snapshots v. present reports whether the input existed at all;
+// a missing input counts as dirty so that a transient loop binding, which is
+// absent between reconciles, never looks unchanged.
+func sampleValue(v Value, present bool) watchSample {
+	if !present {
+		return watchSample{}
+	}
+	if v.isList() || v.isMap() || v.closureRefOf() != nil {
+		return watchSample{present: true}
+	}
+	return watchSample{
+		present: true,
+		stable:  true,
+		typ:     v.Type,
+		num:     v.num,
+		str:     v.text(),
+		boolean: v.truth(),
+	}
+}
+
+// sampleDiffers reports whether the input changed between two snapshots, or
+// whether either snapshot is one this analysis cannot trust.
+func sampleDiffers(prev, cur watchSample) bool {
+	if !prev.present || !cur.present || !prev.stable || !cur.stable {
+		return true
+	}
+	return prev != cur
+}
+
+// currentWatchSample reads the live value of one watched input.
+func (vm *VM) currentWatchSample(key watchKey) watchSample {
+	switch key.kind {
+	case watchSignal:
+		sig, ok := vm.signals[key.name]
+		if !ok || sig == nil {
+			return watchSample{}
+		}
+		return sampleValue(sig.Get(), true)
+	default:
+		v, ok := vm.props[key.name]
+		return sampleValue(v, ok)
+	}
+}
+
+// autoKeyProps are the two props resolveElementNode reads outside any
+// expression, to synthesize a node key. They are not part of any read set,
+// so a change in either forces a full re-evaluation.
+var autoKeyProps = [2]string{"_key", "_index"}
+
+// islandReuse is the Island-owned state that carries subtree reuse across
+// reconciles.
+type islandReuse struct {
+	plan *reusePlan
+	// snap holds the value of every watched input at the start of the
+	// previous walk.
+	snap []watchSample
+	// autoKeySnap holds the same for the two auto-key props.
+	autoKeySnap [2]watchSample
+	// primed is false until the first walk has filled snap.
+	primed bool
+	// ctx is handed to the VM for the duration of one walk.
+	ctx treeReuse
+	// spansA and spansB alternate: one holds the previous walk's spans
+	// while the other records the current walk's. Alternating them keeps
+	// the reconcile free of a per-event allocation.
+	spansA []nodeSpan
+	spansB []nodeSpan
+}
+
+// newIslandReuse builds the reuse state for prog, or nil when the program
+// cannot benefit.
+func newIslandReuse(prog *program.Program) *islandReuse {
+	plan := newReusePlan(prog)
+	if plan == nil {
+		return nil
+	}
+	return &islandReuse{
+		plan:   plan,
+		snap:   make([]watchSample, len(plan.watch)),
+		spansA: make([]nodeSpan, len(prog.Nodes)),
+		spansB: make([]nodeSpan, len(prog.Nodes)),
+	}
+}
+
+// refresh compares every watched input against the previous snapshot,
+// updates the snapshot, and returns the write set.
+//
+// The snapshot is taken BEFORE the walk on purpose. An impure expression
+// evaluated during the walk may write a signal; taking the snapshot first
+// means the next reconcile sees that write and re-evaluates. Taking it after
+// would hide the write.
+func (r *islandReuse) refresh(vm *VM) uint64 {
+	var dirty uint64
+	for i, key := range r.plan.watch {
+		cur := vm.currentWatchSample(key)
+		if !r.primed || sampleDiffers(r.snap[i], cur) {
+			dirty |= uint64(1) << uint(i)
+		}
+		r.snap[i] = cur
+	}
+	for i, name := range autoKeyProps {
+		v, ok := vm.props[name]
+		cur := sampleValue(v, ok)
+		// Absent on both sides is the normal case for an island that is
+		// not rendered inside a list. Treat it as unchanged, and treat any
+		// presence or value change as a full invalidation.
+		changed := cur != r.autoKeySnap[i]
+		r.autoKeySnap[i] = cur
+		if r.primed && changed {
+			dirty = ^uint64(0)
+		}
+	}
+	if !r.primed {
+		dirty = ^uint64(0)
+	}
+	return dirty
+}
+
+// begin points the VM at this walk's reuse context and returns it so the
+// caller can hand it back with end.
+func (r *islandReuse) begin(vm *VM, prev *ResolvedTree, dirty uint64) {
+	r.spansA, r.spansB = r.spansB, r.spansA
+	clear(r.spansA)
+	r.ctx.plan = r.plan
+	r.ctx.prev = prev
+	r.ctx.prevSpans = r.spansB
+	r.ctx.spans = r.spansA
+	r.ctx.dirty = dirty
+	r.ctx.hits = 0
+	if !r.primed || prev == nil {
+		// Nothing trustworthy to copy from on the first walk.
+		r.ctx.prev = nil
+	}
+	vm.reuse = &r.ctx
+}
+
+// end detaches the reuse context and marks the snapshot usable.
+func (r *islandReuse) end(vm *VM) {
+	vm.reuse = nil
+	r.ctx.prev = nil
+	r.primed = true
+}
+
+// reuseResolvedNode copies the subtree of program node nodeID out of the
+// previous tree when nothing it reads has changed. It returns the index of
+// the copied root and true on success.
+//
+// Index remapping: the copied nodes carry child indices that point into the
+// previous tree. When the subtree lands at the same index it held before,
+// which is the common case because nothing ahead of it changed shape, the
+// indices already agree and even the Children slices are shared. Otherwise
+// each Children slice is rebuilt with the offset applied.
+func (vm *VM) reuseResolvedNode(tree *ResolvedTree, nodeID int) (int, bool) {
+	r := vm.reuse
+	if r == nil || r.prev == nil || r.plan == nil {
+		return 0, false
+	}
+	if nodeID < 0 || nodeID >= len(r.plan.nodes) || nodeID >= len(r.prevSpans) {
+		return 0, false
+	}
+	info := r.plan.nodes[nodeID]
+	if !info.reusable || info.mask&r.dirty != 0 {
+		return 0, false
+	}
+	span := r.prevSpans[nodeID]
+	if !span.valid || span.start < 0 || span.end < span.start || int(span.end) > len(r.prev.Nodes) {
+		return 0, false
+	}
+	base := len(tree.Nodes)
+	tree.Nodes = append(tree.Nodes, r.prev.Nodes[span.start:span.end]...)
+	if delta := base - int(span.start); delta != 0 {
+		for i := base; i < len(tree.Nodes); i++ {
+			node := &tree.Nodes[i]
+			if len(node.Children) == 0 {
+				continue
+			}
+			shifted := make([]int, len(node.Children))
+			for j, child := range node.Children {
+				shifted[j] = child + delta
+			}
+			node.Children = shifted
+		}
+	}
+	vm.recordReuseSpan(nodeID, base, len(tree.Nodes))
+	r.hits++
+	return base, true
+}
+
+// recordReuseSpan notes where a reusable node's subtree landed so the next
+// walk can copy it.
+func (vm *VM) recordReuseSpan(nodeID, start, end int) {
+	r := vm.reuse
+	if r == nil || nodeID < 0 || nodeID >= len(r.spans) {
+		return
+	}
+	if nodeID >= len(r.plan.nodes) || !r.plan.nodes[nodeID].reusable {
+		return
+	}
+	r.spans[nodeID] = nodeSpan{start: int32(start), end: int32(end), valid: true}
+}

--- a/client/vm/reuse_fuzz_test.go
+++ b/client/vm/reuse_fuzz_test.go
@@ -1,0 +1,236 @@
+// FuzzIslandReuseMatchesFullEval pins the one property subtree reuse must
+// never break: the tree a reconcile produces with reuse switched on has to
+// equal the tree a full walk produces.
+//
+// That property is worth fuzzing because the failure mode is silent. A read
+// set that misses one input, a span that points at the wrong range, or an
+// index that is not shifted, all produce a tree that still renders. It is
+// just stale, or subtly mis-linked, and no assertion in a hand-written test
+// happens to look at that node.
+//
+// The generator emits only expressions the reuse plan calls pure, because a
+// full re-walk is the oracle here and an impure expression would move the
+// oracle. Lowered island node content is drawn from that same set, so the
+// restriction costs no coverage of the code under test. Handlers do the
+// writing: each one sets a signal, which is what makes the next reconcile
+// interesting.
+//
+// The seed corpus runs as a normal test under `go test`, so the shapes below
+// are checked on every build even without -fuzz.
+
+package vm
+
+import (
+	"math/rand"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// fuzzReuseMaxNodes bounds the generated node table. Reuse decisions are per
+// node, so a few dozen nodes already cover deep nesting, sibling shifts and
+// loop bodies. A bigger table only makes each execution slower.
+const fuzzReuseMaxNodes = 24
+
+// fuzzReuseMaxSteps bounds the dispatch sequence per execution.
+const fuzzReuseMaxSteps = 6
+
+// fuzzReuseExprs is the fixed expression table every generated program
+// shares. Keeping it fixed means the fuzzer explores tree SHAPES, which is
+// where the span and index bookkeeping lives, instead of re-exploring the
+// expression evaluator that FuzzVMEvalNeverPanics already covers.
+//
+// Index map:
+//
+//	0  count signal          6  count + 1
+//	1  label signal          7  label + name prop
+//	2  name prop             8  row prop (bound by a forEach)
+//	3  items prop            9  row + label
+//	4  "x" literal          10  count > 1        (conditional test)
+//	5  1 literal            11  label + "x"
+func fuzzReuseExprs() []program.Expr {
+	return []program.Expr{
+		{Op: program.OpSignalGet, Value: "count", Type: program.TypeInt},                                    // 0
+		{Op: program.OpSignalGet, Value: "label", Type: program.TypeString},                                 // 1
+		{Op: program.OpPropGet, Value: "name", Type: program.TypeString},                                    // 2
+		{Op: program.OpPropGet, Value: "items", Type: program.TypeAny},                                      // 3
+		{Op: program.OpLitString, Value: "x", Type: program.TypeString},                                     // 4
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},                                           // 5
+		{Op: program.OpAdd, Operands: []program.ExprID{0, 5}, Type: program.TypeInt},                        // 6
+		{Op: program.OpConcat, Operands: []program.ExprID{1, 2}, Type: program.TypeString},                  // 7
+		{Op: program.OpPropGet, Value: "row", Type: program.TypeString},                                     // 8
+		{Op: program.OpConcat, Operands: []program.ExprID{8, 1}, Type: program.TypeString},                  // 9
+		{Op: program.OpGt, Operands: []program.ExprID{0, 5}, Type: program.TypeBool},                        // 10
+		{Op: program.OpConcat, Operands: []program.ExprID{1, 4}, Type: program.TypeString},                  // 11
+		{Op: program.OpSignalSet, Operands: []program.ExprID{6}, Value: "count", Type: program.TypeInt},     // 12
+		{Op: program.OpSignalSet, Operands: []program.ExprID{11}, Value: "label", Type: program.TypeString}, // 13
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},                                           // 14
+	}
+}
+
+// fuzzReuseContentExprs are the expression IDs a text-producing node may use.
+var fuzzReuseContentExprs = []program.ExprID{0, 1, 2, 4, 6, 7, 8, 9, 11}
+
+// fuzzReuseHandlers name the two writers the dispatch loop picks between.
+var fuzzReuseHandlers = []string{"bump", "relabel"}
+
+func FuzzIslandReuseMatchesFullEval(f *testing.F) {
+	f.Add(int64(1), 6, 3)
+	f.Add(int64(2), 12, 5)
+	f.Add(int64(3), 1, 1)
+	f.Add(int64(4), 24, 6)
+	f.Add(int64(5), 3, 0)
+	f.Add(int64(6), 18, 4)
+	f.Add(int64(7), 9, 2)
+
+	f.Fuzz(func(t *testing.T, seed int64, rawNodeCount int, rawSteps int) {
+		rng := rand.New(rand.NewSource(seed ^ int64(rawNodeCount)))
+		prog := fuzzBuildIslandProgram(rng, rawNodeCount)
+
+		island := NewIsland(prog, `{"name":"n","items":["a","b","c"]}`)
+		if island == nil {
+			t.Fatal("NewIsland returned nil")
+		}
+
+		steps := boundedFuzzCount(rawSteps, fuzzReuseMaxSteps)
+		for step := 0; step <= steps; step++ {
+			island.Dispatch(fuzzReuseHandlers[rng.Intn(len(fuzzReuseHandlers))], "{}")
+			want := fullEvalTree(island)
+			if !treesEqual(island.prev, want) {
+				t.Fatalf("step %d: the reused tree differs from a full evaluation\n"+
+					" reused: %s\n   full: %s", step,
+					describeFuzzTree(island.prev), describeFuzzTree(want))
+			}
+		}
+	})
+}
+
+// boundedFuzzCount folds an arbitrary int into [0, limit].
+func boundedFuzzCount(raw, limit int) int {
+	if raw < 0 {
+		raw = -raw
+	}
+	if raw < 0 { // math.MinInt negates to itself
+		return 0
+	}
+	return raw % (limit + 1)
+}
+
+// fuzzBuildIslandProgram builds a random node tree over the fixed expression
+// table. Children always reference strictly higher node IDs, so the graph is
+// acyclic by construction and every node is reached at most once.
+func fuzzBuildIslandProgram(rng *rand.Rand, rawNodeCount int) *program.Program {
+	count := boundedFuzzCount(rawNodeCount, fuzzReuseMaxNodes) + 1
+	nodes := make([]program.Node, count)
+
+	// Walk backwards so a node can only adopt children built after it.
+	for id := count - 1; id >= 0; id-- {
+		nodes[id] = fuzzRandomIslandNode(rng, id, count)
+	}
+	// The root must be able to hold children, otherwise most generated
+	// trees collapse to a single node and the shape coverage is wasted.
+	if nodes[0].Kind != program.NodeElement {
+		nodes[0] = program.Node{Kind: program.NodeElement, Tag: "div", Children: nodes[0].Children}
+	}
+
+	return &program.Program{
+		Name:  "fuzz-island",
+		Nodes: nodes,
+		Root:  0,
+		Exprs: fuzzReuseExprs(),
+		Signals: []program.SignalDef{
+			{Name: "count", Type: program.TypeInt, Init: program.ExprID(14)},
+			{Name: "label", Type: program.TypeString, Init: program.ExprID(4)},
+		},
+		Handlers: []program.Handler{
+			{Name: "bump", Body: []program.ExprID{12}},
+			{Name: "relabel", Body: []program.ExprID{13}},
+		},
+	}
+}
+
+func fuzzRandomIslandNode(rng *rand.Rand, id, count int) program.Node {
+	children := fuzzRandomChildren(rng, id, count)
+	switch rng.Intn(6) {
+	case 0:
+		return program.Node{Kind: program.NodeText, Text: "t"}
+	case 1:
+		return program.Node{
+			Kind: program.NodeExpr,
+			Expr: fuzzReuseContentExprs[rng.Intn(len(fuzzReuseContentExprs))],
+		}
+	case 2:
+		return program.Node{Kind: program.NodeFragment, Children: children}
+	case 3:
+		return program.Node{
+			Kind:     program.NodeConditional,
+			Expr:     10,
+			Attrs:    []program.Attr{{Kind: program.AttrExpr, Name: "fallback", Expr: 4}},
+			Children: children,
+		}
+	case 4:
+		return program.Node{
+			Kind:     program.NodeForEach,
+			Expr:     3,
+			Attrs:    []program.Attr{{Kind: program.AttrStatic, Name: "as", Value: "row"}},
+			Children: children,
+		}
+	default:
+		node := program.Node{Kind: program.NodeElement, Tag: "div", Children: children}
+		switch rng.Intn(3) {
+		case 0:
+			node.Attrs = []program.Attr{{Kind: program.AttrStatic, Name: "class", Value: "c"}}
+		case 1:
+			node.Attrs = []program.Attr{
+				{Kind: program.AttrExpr, Name: "title", Expr: fuzzReuseContentExprs[rng.Intn(len(fuzzReuseContentExprs))]},
+				{Kind: program.AttrEvent, Name: "click", Event: "bump"},
+			}
+		}
+		return node
+	}
+}
+
+// fuzzRandomChildren picks up to three children from the IDs after id.
+func fuzzRandomChildren(rng *rand.Rand, id, count int) []program.NodeID {
+	available := count - id - 1
+	if available <= 0 {
+		return nil
+	}
+	n := rng.Intn(4)
+	if n > available {
+		n = available
+	}
+	if n == 0 {
+		return nil
+	}
+	children := make([]program.NodeID, 0, n)
+	next := id + 1
+	for i := 0; i < n && next < count; i++ {
+		children = append(children, program.NodeID(next))
+		next += 1 + rng.Intn(2)
+	}
+	return children
+}
+
+// describeFuzzTree renders a tree compactly so a failure message shows the
+// shape that broke instead of a page of struct dumps.
+func describeFuzzTree(tree *ResolvedTree) string {
+	if tree == nil {
+		return "<nil>"
+	}
+	out := make([]byte, 0, len(tree.Nodes)*16)
+	for i := range tree.Nodes {
+		node := &tree.Nodes[i]
+		out = append(out, '[')
+		out = append(out, node.Tag...)
+		out = append(out, '"')
+		out = append(out, node.Text...)
+		out = append(out, '"')
+		for _, child := range node.Children {
+			out = append(out, ' ')
+			out = append(out, byte('0'+child%10))
+		}
+		out = append(out, ']')
+	}
+	return string(out)
+}

--- a/client/vm/reuse_test.go
+++ b/client/vm/reuse_test.go
@@ -1,0 +1,492 @@
+package vm
+
+import (
+	"reflect"
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+	"m31labs.dev/gosx/signal"
+)
+
+// treesEqual compares two resolved trees by content. Subtree reuse must
+// produce exactly the tree a full evaluation produces, so every test that
+// exercises reuse checks the result against a fresh full walk.
+func treesEqual(left, right *ResolvedTree) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	if len(left.Nodes) != len(right.Nodes) {
+		return false
+	}
+	for i := range left.Nodes {
+		if !nodesEqual(&left.Nodes[i], &right.Nodes[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func nodesEqual(left, right *ResolvedNode) bool {
+	return left.Source == right.Source &&
+		left.HasSource == right.HasSource &&
+		left.Tag == right.Tag &&
+		left.Text == right.Text &&
+		left.Key == right.Key &&
+		reflect.DeepEqual(left.Attrs, right.Attrs) &&
+		reflect.DeepEqual(left.Events, right.Events) &&
+		reflect.DeepEqual(left.Children, right.Children)
+}
+
+// fullEvalTree walks the program with reuse switched off, which is the
+// oracle every reuse test compares against.
+func fullEvalTree(island *Island) *ResolvedTree {
+	saved := island.vm.reuse
+	island.vm.reuse = nil
+	tree := island.vm.EvalTree()
+	island.vm.reuse = saved
+	return tree
+}
+
+func reuseHits(island *Island) int {
+	if island.reuse == nil {
+		return 0
+	}
+	return island.reuse.ctx.hits
+}
+
+func TestReconcileReusesUnchangedElementSubtrees(t *testing.T) {
+	island := NewIsland(program.CounterProgram(), `{}`)
+	// The analysis is built on the first reconcile and the snapshot is
+	// primed by it, so the first event still evaluates the whole tree.
+	island.Dispatch("increment", "{}")
+	if island.reuse == nil {
+		t.Fatal("counter program should get a reuse plan")
+	}
+
+	patches := island.Dispatch("increment", "{}")
+
+	if hits := reuseHits(island); hits != 2 {
+		t.Errorf("reused subtrees = %d, want 2 (both buttons); the counter's "+
+			"root and its display node read the count signal, the buttons do not", hits)
+	}
+	if got := counterDisplayText(island.prev); got != "2" {
+		t.Fatalf("display after two increments = %q, want %q", got, "2")
+	}
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("reused tree differs from a full evaluation")
+	}
+	if len(patches) != 1 || patches[0].Kind != PatchSetText || patches[0].Text != "2" {
+		t.Fatalf("patches = %#v, want one SetText(\"2\")", patches)
+	}
+}
+
+func TestReconcileWithoutChangeReusesWholeTree(t *testing.T) {
+	island := NewIsland(program.CounterProgram(), `{}`)
+	island.Reconcile() // builds the analysis and primes the snapshot
+
+	patches := island.Reconcile()
+
+	if len(patches) != 0 {
+		t.Fatalf("patches from an unchanged reconcile = %#v, want none", patches)
+	}
+	if hits := reuseHits(island); hits != 1 {
+		t.Errorf("reused subtrees = %d, want 1 (the whole root copies in one step)", hits)
+	}
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("reused tree differs from a full evaluation")
+	}
+}
+
+func TestReconcileReuseMatchesFullEvalOverManyDispatches(t *testing.T) {
+	island := NewIsland(program.CounterProgram(), `{}`)
+	for step := 0; step < 8; step++ {
+		if step%3 == 0 {
+			island.Dispatch("decrement", "{}")
+		} else {
+			island.Dispatch("increment", "{}")
+		}
+		if !treesEqual(island.prev, fullEvalTree(island)) {
+			t.Fatalf("step %d: reused tree differs from a full evaluation", step)
+		}
+	}
+	if got := counterDisplayText(island.prev); got != "2" {
+		t.Fatalf("display after 8 dispatches = %q, want %q", got, "2")
+	}
+}
+
+// listSuffixProgram builds the shape that breaks a careless read-set walk.
+//
+//	<ul>                        element, reached once, so a reuse candidate
+//	  <ForEach items as row>    collection is a PROP, so it never changes
+//	    <li>{row + suffix}</li> content reads a SIGNAL through the rebound prop
+//
+// The <ul> holds no expression of its own. Its read set has to come from the
+// forEach body, one scope down, or the <ul> looks unchanged when the suffix
+// signal moves and the whole list silently stops updating.
+func listSuffixProgram() *program.Program {
+	return &program.Program{
+		Name: "ListSuffix",
+		Nodes: []program.Node{
+			{ // 0: <ul>
+				Kind:     program.NodeElement,
+				Tag:      "ul",
+				Children: []program.NodeID{1},
+			},
+			{ // 1: forEach over the "items" prop
+				Kind: program.NodeForEach,
+				Expr: 0,
+				Attrs: []program.Attr{
+					{Kind: program.AttrStatic, Name: "as", Value: "row"},
+				},
+				Children: []program.NodeID{2},
+			},
+			{ // 2: <li>
+				Kind:     program.NodeElement,
+				Tag:      "li",
+				Children: []program.NodeID{3},
+			},
+			{ // 3: {row + suffix}
+				Kind: program.NodeExpr,
+				Expr: 1,
+			},
+		},
+		Root: 0,
+		Exprs: []program.Expr{
+			{Op: program.OpPropGet, Value: "items", Type: program.TypeAny},                                      // 0
+			{Op: program.OpConcat, Operands: []program.ExprID{2, 3}},                                            // 1
+			{Op: program.OpPropGet, Value: "row", Type: program.TypeString},                                     // 2
+			{Op: program.OpSignalGet, Value: "suffix", Type: program.TypeString},                                // 3
+			{Op: program.OpLitString, Value: "!", Type: program.TypeString},                                     // 4
+			{Op: program.OpLitString, Value: "?", Type: program.TypeString},                                     // 5
+			{Op: program.OpSignalSet, Operands: []program.ExprID{5}, Value: "suffix", Type: program.TypeString}, // 6
+		},
+		Signals: []program.SignalDef{
+			{Name: "suffix", Type: program.TypeString, Init: program.ExprID(4)},
+		},
+		Handlers: []program.Handler{
+			{Name: "swap", Body: []program.ExprID{6}},
+		},
+	}
+}
+
+func listItemTexts(tree *ResolvedTree) []string {
+	if tree == nil || len(tree.Nodes) == 0 {
+		return nil
+	}
+	var texts []string
+	for _, itemIdx := range tree.Nodes[0].Children {
+		item := tree.Nodes[itemIdx]
+		if len(item.Children) == 0 {
+			continue
+		}
+		texts = append(texts, tree.Nodes[item.Children[0]].Text)
+	}
+	return texts
+}
+
+// TestForEachNodeUpdatesThroughReboundProp is the regression guard route (b)
+// needs. The forEach collection never changes, so only the read set carried
+// up from the loop body can tell the walk that the list is stale.
+func TestForEachNodeUpdatesThroughReboundProp(t *testing.T) {
+	island := NewIsland(listSuffixProgram(), `{"items": ["a", "b"]}`)
+
+	before := listItemTexts(island.prev)
+	if !reflect.DeepEqual(before, []string{"a!", "b!"}) {
+		t.Fatalf("initial list = %v, want [a! b!]", before)
+	}
+
+	island.Dispatch("swap", "{}")
+
+	after := listItemTexts(island.prev)
+	if !reflect.DeepEqual(after, []string{"a?", "b?"}) {
+		t.Fatalf("list after the suffix signal changed = %v, want [a? b?]; the "+
+			"<ul> was reused even though its forEach body reads the signal "+
+			"through the rebound `row` prop", after)
+	}
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("reused tree differs from a full evaluation")
+	}
+}
+
+// TestForEachDeletesScopedPropsItCreated pins the scope contract a forEach
+// owes every node after it.
+//
+// FuzzIslandReuseMatchesFullEval found this. restoreProps used to put back
+// only the names that already existed, so `_item`, `_index`, `_key` and the
+// `as` name survived the loop. autoKey reads `_index`, which meant a plain
+// element rendered after a list picked up a key built from the list's last
+// index, and the key changed again the next time the list length changed.
+func TestForEachDeletesScopedPropsItCreated(t *testing.T) {
+	island := NewIsland(listSuffixProgram(), `{"items": ["a", "b"]}`)
+
+	for _, name := range []string{"_item", "_index", "_key", "row", "rowKey"} {
+		if _, ok := island.vm.props[name]; ok {
+			t.Errorf("prop %q survived the forEach that bound it; a name absent "+
+				"before the loop must be absent after it", name)
+		}
+	}
+	if island.prev.Nodes[0].Key != "" {
+		t.Errorf("root key = %q, want empty; the root is not inside the list",
+			island.prev.Nodes[0].Key)
+	}
+}
+
+// TestForEachBodyIsNeverReusable pins the gate that makes the case above
+// safe. A loop body resolves once per iteration, so it has no single home in
+// the tree to copy from.
+func TestForEachBodyIsNeverReusable(t *testing.T) {
+	plan := newReusePlan(listSuffixProgram())
+	if plan == nil {
+		t.Fatal("list program should get a reuse plan")
+	}
+	if !plan.nodes[0].reusable {
+		t.Error("node 0 <ul> should be reusable: it is reached once, outside any loop")
+	}
+	if plan.nodes[2].reusable {
+		t.Error("node 2 <li> must not be reusable: it sits inside a forEach body")
+	}
+	if plan.nodes[0].mask == 0 {
+		t.Error("node 0 <ul> read set is empty; it must carry the suffix signal " +
+			"that its forEach body reads")
+	}
+	if plan.nodes[0].mask != plan.nodes[2].mask|plan.nodes[1].mask {
+		t.Errorf("node 0 read set %b should cover its whole subtree", plan.nodes[0].mask)
+	}
+}
+
+// objectSignalProgram reads one field of an object-valued signal. Handlers
+// mutate that object in place, which no snapshot can detect by comparison.
+func objectSignalProgram() *program.Program {
+	return &program.Program{
+		Name: "ObjectSignal",
+		Nodes: []program.Node{
+			{Kind: program.NodeElement, Tag: "div", Children: []program.NodeID{1}},
+			{Kind: program.NodeExpr, Expr: 0},
+		},
+		Root: 0,
+		Exprs: []program.Expr{
+			{Op: program.OpIndex, Operands: []program.ExprID{1, 2}, Type: program.TypeString}, // 0
+			{Op: program.OpSignalGet, Value: "state", Type: program.TypeAny},                  // 1
+			{Op: program.OpLitString, Value: "label", Type: program.TypeString},               // 2
+			{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},                         // 3
+		},
+		Signals: []program.SignalDef{
+			{Name: "state", Type: program.TypeAny, Init: program.ExprID(3)},
+		},
+	}
+}
+
+// TestReuseTreatsCompositeSignalAsAlwaysDirty covers the in-place mutation
+// contract. OpFieldSet writes through the same map every alias holds, so a
+// value snapshot of an object signal always compares equal to itself.
+func TestReuseTreatsCompositeSignalAsAlwaysDirty(t *testing.T) {
+	island := NewIsland(objectSignalProgram(), `{}`)
+	fields := map[string]Value{"label": StringVal("first")}
+	island.vm.SetSignal("state", signal.New(ObjectVal(fields)))
+	island.Reconcile()
+
+	if got := island.prev.Nodes[1].Text; got != "first" {
+		t.Fatalf("text = %q, want %q", got, "first")
+	}
+
+	// Mutate through the shared map, exactly as OpFieldSet does.
+	fields["label"] = StringVal("second")
+	island.Reconcile()
+
+	if got := island.prev.Nodes[1].Text; got != "second" {
+		t.Fatalf("text after an in-place field write = %q, want %q; a composite "+
+			"signal must count as dirty on every reconcile", got, "second")
+	}
+}
+
+// TestReuseFollowsPropChanges covers the second watched namespace. Props are
+// set once at construction for most islands, but SetProp is a public seam.
+func TestReuseFollowsPropChanges(t *testing.T) {
+	prog := &program.Program{
+		Name: "PropText",
+		Nodes: []program.Node{
+			{Kind: program.NodeElement, Tag: "div", Children: []program.NodeID{1}},
+			{Kind: program.NodeExpr, Expr: 0},
+		},
+		Root: 0,
+		Exprs: []program.Expr{
+			{Op: program.OpPropGet, Value: "label", Type: program.TypeString},
+		},
+	}
+	island := NewIsland(prog, `{"label": "before"}`)
+	if got := island.prev.Nodes[1].Text; got != "before" {
+		t.Fatalf("initial text = %q, want %q", got, "before")
+	}
+
+	island.vm.SetProp("label", StringVal("after"))
+	patches := island.Reconcile()
+
+	if got := island.prev.Nodes[1].Text; got != "after" {
+		t.Fatalf("text after the prop changed = %q, want %q", got, "after")
+	}
+	if len(patches) != 1 {
+		t.Fatalf("patches = %#v, want one", patches)
+	}
+}
+
+// conditionalShiftProgram places a conditional ahead of a reusable sibling,
+// so toggling the condition moves the sibling to a different index.
+func conditionalShiftProgram() *program.Program {
+	return &program.Program{
+		Name: "ConditionalShift",
+		Nodes: []program.Node{
+			{Kind: program.NodeElement, Tag: "div", Children: []program.NodeID{1, 3}},
+			{ // 1: conditional on the "shown" signal
+				Kind:     program.NodeConditional,
+				Expr:     0,
+				Children: []program.NodeID{2},
+			},
+			{Kind: program.NodeElement, Tag: "b", Children: []program.NodeID{5}}, // 2
+			{Kind: program.NodeElement, Tag: "span", Children: []program.NodeID{4}},
+			{Kind: program.NodeText, Text: "tail"}, // 4
+			{Kind: program.NodeText, Text: "head"}, // 5
+		},
+		Root: 0,
+		Exprs: []program.Expr{
+			{Op: program.OpSignalGet, Value: "shown", Type: program.TypeBool},                                // 0
+			{Op: program.OpLitBool, Value: "true", Type: program.TypeBool},                                   // 1
+			{Op: program.OpLitBool, Value: "false", Type: program.TypeBool},                                  // 2
+			{Op: program.OpSignalSet, Operands: []program.ExprID{2}, Value: "shown", Type: program.TypeBool}, // 3
+			{Op: program.OpSignalSet, Operands: []program.ExprID{1}, Value: "shown", Type: program.TypeBool}, // 4
+		},
+		Signals: []program.SignalDef{
+			{Name: "shown", Type: program.TypeBool, Init: program.ExprID(1)},
+		},
+		Handlers: []program.Handler{
+			{Name: "hide", Body: []program.ExprID{3}},
+			{Name: "show", Body: []program.ExprID{4}},
+		},
+	}
+}
+
+// TestReuseRemapsChildrenWhenIndicesShift exercises the offset path. The
+// copied subtree carries child indices from the previous tree, so a subtree
+// that lands somewhere else has to rebuild them.
+func TestReuseRemapsChildrenWhenIndicesShift(t *testing.T) {
+	island := NewIsland(conditionalShiftProgram(), `{}`)
+	if len(island.prev.Nodes) != 5 {
+		t.Fatalf("initial tree size = %d, want 5 (div, b, head, span, tail)", len(island.prev.Nodes))
+	}
+
+	island.Dispatch("hide", "{}")
+
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("tree after the conditional collapsed differs from a full evaluation")
+	}
+	root := island.prev.Nodes[0]
+	if len(root.Children) != 1 {
+		t.Fatalf("root children = %v, want one (the span)", root.Children)
+	}
+	span := island.prev.Nodes[root.Children[0]]
+	if span.Tag != "span" || len(span.Children) != 1 {
+		t.Fatalf("reused span = %#v, want a span with one child", span)
+	}
+	if got := island.prev.Nodes[span.Children[0]].Text; got != "tail" {
+		t.Fatalf("reused span child text = %q, want %q; the copied child index "+
+			"was not shifted to the new tree", got, "tail")
+	}
+
+	island.Dispatch("show", "{}")
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("tree after the conditional reopened differs from a full evaluation")
+	}
+}
+
+// TestReusePlanRejectsImpureSubtrees pins the purity contract. An opcode
+// whose result depends on state the plan does not watch must switch reuse
+// off for every element above it.
+func TestReusePlanRejectsImpureSubtrees(t *testing.T) {
+	prog := &program.Program{
+		Name: "EventText",
+		Nodes: []program.Node{
+			{Kind: program.NodeElement, Tag: "div", Children: []program.NodeID{1}},
+			{Kind: program.NodeExpr, Expr: 0},
+		},
+		Root: 0,
+		Exprs: []program.Expr{
+			{Op: program.OpEventGet, Value: "key", Type: program.TypeString},
+		},
+	}
+	if plan := newReusePlan(prog); plan != nil {
+		t.Fatalf("a program whose only element reads event data must not get a "+
+			"reuse plan; got reusable=%v", plan.nodes[0].reusable)
+	}
+}
+
+func TestIsPureOpDefaultsToImpure(t *testing.T) {
+	impure := []program.OpCode{
+		program.OpSignalSet, program.OpSignalUpdate, program.OpAssign,
+		program.OpLocalGet, program.OpLocalSet, program.OpLocalDecl,
+		program.OpFieldSet, program.OpIndexSet,
+		program.OpCall, program.OpIndirectCall, program.OpHostCall, program.OpClosure,
+		program.OpEventGet, program.OpMake, program.OpSeq,
+		program.OpFor, program.OpForRange, program.OpReturn, program.OpBreak, program.OpContinue,
+		program.OpMap, program.OpFilter, program.OpFind, program.OpComposite, program.OpRange,
+	}
+	for _, op := range impure {
+		if isPureOp(op) {
+			t.Errorf("opcode %v is listed as pure; it writes state, rebinds a scope, "+
+				"or reads state the reuse plan does not watch", op)
+		}
+	}
+	if !isPureOp(program.OpAdd) || !isPureOp(program.OpConcat) {
+		t.Error("arithmetic and concatenation must stay pure")
+	}
+}
+
+func TestReusePlanRejectsTooManyWatchedInputs(t *testing.T) {
+	prog := &program.Program{
+		Name:  "WideRead",
+		Nodes: []program.Node{{Kind: program.NodeElement, Tag: "div"}},
+		Root:  0,
+	}
+	// One element whose text concatenates more distinct signals than the
+	// read-set bitmask can hold.
+	concat := program.Expr{Op: program.OpConcat}
+	for i := 0; i <= maxWatchedInputs; i++ {
+		name := "s" + string(rune('a'+i%26)) + string(rune('a'+i/26))
+		prog.Exprs = append(prog.Exprs, program.Expr{Op: program.OpSignalGet, Value: name, Type: program.TypeString})
+		concat.Operands = append(concat.Operands, program.ExprID(i))
+	}
+	prog.Exprs = append(prog.Exprs, concat)
+	prog.Nodes = append(prog.Nodes, program.Node{Kind: program.NodeExpr, Expr: program.ExprID(len(prog.Exprs) - 1)})
+	prog.Nodes[0].Children = []program.NodeID{1}
+
+	if plan := newReusePlan(prog); plan != nil {
+		t.Fatal("a program reading more inputs than the bitmask holds must fall " +
+			"back to full evaluation")
+	}
+}
+
+func TestReusePlanSurvivesCyclicNodeGraph(t *testing.T) {
+	prog := &program.Program{
+		Name: "Cyclic",
+		Nodes: []program.Node{
+			{Kind: program.NodeElement, Tag: "div", Children: []program.NodeID{1}},
+			{Kind: program.NodeElement, Tag: "span", Children: []program.NodeID{0}},
+		},
+		Root: 0,
+	}
+	// The walks must terminate. The result only has to be safe, not clever.
+	_ = newReusePlan(prog)
+}
+
+func TestSwapProgramDropsStaleReuseState(t *testing.T) {
+	island := NewIsland(program.CounterProgram(), `{}`)
+	island.Dispatch("increment", "{}")
+
+	island.SwapProgram(program.FormProgram())
+
+	if !treesEqual(island.prev, fullEvalTree(island)) {
+		t.Fatal("tree after a program swap differs from a full evaluation")
+	}
+	if hits := reuseHits(island); hits != 0 {
+		t.Errorf("reused subtrees right after a swap = %d, want 0; the previous "+
+			"tree belongs to the old node table", hits)
+	}
+}

--- a/client/vm/safety_test.go
+++ b/client/vm/safety_test.go
@@ -1,0 +1,137 @@
+// Regression tests for the panic-free-contract crash bugs fixed
+// alongside this file: OpSlice / OpSubstring bounds clamping (value.go
+// SliceVal / SubstringVal), and Eval's own recursion depth guard.
+// These build the exact opcode graphs the bug report reproduced
+// against. value_test.go and json_test.go cover the same fixes at
+// the Value method level directly.
+
+package vm
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/island/program"
+)
+
+// TestVMOpSliceEmptyArrayNegativeEndDoesNotPanic reproduces
+// `items[0:len(items)-1]` where items is an empty array. end
+// evaluates to -1 through ordinary OpLen/OpSub bytecode, not a
+// hand-constructed negative literal. Before the fix this panicked
+// inside SliceVal with "slice bounds out of range [:-1]".
+func TestVMOpSliceEmptyArrayNegativeEndDoesNotPanic(t *testing.T) {
+	prog := progFromExprs([]program.Expr{
+		{Op: program.OpComposite, Value: "slice"},                  // 0: items := []T{} (empty)
+		{Op: program.OpLen, Operands: []program.ExprID{0}},         // 1: len(items) == 0
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},  // 2
+		{Op: program.OpSub, Operands: []program.ExprID{1, 2}},      // 3: len(items)-1 == -1
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},  // 4: start
+		{Op: program.OpSlice, Operands: []program.ExprID{0, 4, 3}}, // 5: items[0:len(items)-1]
+	})
+	vm := NewVM(prog, nil)
+	got := vm.Eval(5)
+	if len(got.List()) != 0 {
+		t.Fatalf("items[0:len(items)-1] on empty items = %+v, want 0 items", got)
+	}
+}
+
+// TestVMOpSubstringEmptyStringNegativeEndDoesNotPanic reproduces
+// `name[0:len(name)-1]` where name is "". Before the fix this panicked
+// inside SubstringVal the same way SliceVal did.
+func TestVMOpSubstringEmptyStringNegativeEndDoesNotPanic(t *testing.T) {
+	prog := progFromExprs([]program.Expr{
+		{Op: program.OpLitString, Value: "", Type: program.TypeString}, // 0: name := ""
+		{Op: program.OpLen, Operands: []program.ExprID{0}},             // 1: len(name) == 0
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},      // 2
+		{Op: program.OpSub, Operands: []program.ExprID{1, 2}},          // 3: len(name)-1 == -1
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},      // 4: start
+		{Op: program.OpSubstring, Operands: []program.ExprID{0, 4, 3}}, // 5: name[0:len(name)-1]
+	})
+	vm := NewVM(prog, nil)
+	got := vm.Eval(5)
+	if got.Text() != "" {
+		t.Fatalf("name[0:len(name)-1] on empty name = %q, want \"\"", got.Text())
+	}
+}
+
+// TestVMOpSliceFloatOverflowEndDoesNotPanic reproduces the "end
+// becomes +Inf" path. It uses a genuine runtime float overflow
+// (OpMul on two large literals), not a hand-built literal.
+// 1e300*1e300 exceeds float64's range. IEEE 754 rounds that to
+// +Inf, matching how a surface expression like `1e300 * scale`
+// could overflow at runtime. int(+Inf) is MinInt64 on amd64. Before
+// the fix, this reached v.Items[start:end] as a negative index and
+// panicked with "slice bounds out of range
+// [:-9223372036854775808]".
+func TestVMOpSliceFloatOverflowEndDoesNotPanic(t *testing.T) {
+	prog := progFromExprs([]program.Expr{
+		{Op: program.OpLitFloat, Value: "1e300", Type: program.TypeFloat},                 // 0
+		{Op: program.OpLitFloat, Value: "1e300", Type: program.TypeFloat},                 // 1
+		{Op: program.OpMul, Operands: []program.ExprID{0, 1}},                             // 2: +Inf
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},                         // 3: composite index 0
+		{Op: program.OpLitInt, Value: "10", Type: program.TypeInt},                        // 4: composite value 0
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},                         // 5: composite index 1
+		{Op: program.OpLitInt, Value: "20", Type: program.TypeInt},                        // 6: composite value 1
+		{Op: program.OpComposite, Value: "slice", Operands: []program.ExprID{3, 4, 5, 6}}, // 7: [10, 20]
+		{Op: program.OpLitInt, Value: "0", Type: program.TypeInt},                         // 8: start
+		{Op: program.OpSlice, Operands: []program.ExprID{7, 8, 2}},                        // 9: arr[0:+Inf]
+	})
+	vm := NewVM(prog, nil)
+	got := vm.Eval(9)
+	if len(got.List()) != 2 || int(got.List()[0].num) != 10 || int(got.List()[1].num) != 20 {
+		t.Fatalf("arr[0:+Inf] = %+v, want the full [10, 20] array (end clamped to len)", got)
+	}
+}
+
+// TestEvalSelfReferentialExprDoesNotOverflow reproduces an
+// expression graph whose first operand refers to itself. It has no
+// OpIndirectCall or closure frame anywhere in it. So
+// Program.MaxCallDepth (Y.D) cannot bound this recursion, because
+// it never calls a function. Before Eval grew its own depth guard,
+// this ran until the goroutine stack overflowed with a fatal
+// (unrecoverable) error.
+//
+// Only the first operand self-refers. The second is a plain
+// literal. So the recursion is linear, not exponential, and the
+// test completes quickly even while it exercises the full depth
+// cap.
+//
+// The result's exact value isn't meaningful here. Once the guard
+// fires at maxEvalDepth, the zero it returns for the innermost call
+// flows back up through maxEvalDepth Add() calls against the
+// literal operand. It lands on some large but finite float. What
+// matters is that Eval returns at all, instead of crashing, and
+// records the eval_depth_exceeded diagnostic exactly once.
+func TestEvalSelfReferentialExprDoesNotOverflow(t *testing.T) {
+	prog := progFromExprs([]program.Expr{
+		{Op: program.OpAdd, Operands: []program.ExprID{0, 1}}, // 0: refers to itself + a literal
+		{Op: program.OpLitInt, Value: "1", Type: program.TypeInt},
+	})
+	vm := NewVM(prog, nil)
+	vm.Eval(0) // must return, not crash
+	requireDiag(t, vm, "eval_depth_exceeded")
+}
+
+// TestEvalDeepButFiniteExprStillEvaluates guards against an
+// overcorrection. A legitimately deep, but finite and non-cyclic,
+// chain of nested OpAdd expressions sits well under maxEvalDepth.
+// It must still evaluate to the correct value, rather than getting
+// cut off by the new depth guard.
+func TestEvalDeepButFiniteExprStillEvaluates(t *testing.T) {
+	const depth = 500
+	exprs := make([]program.Expr, 0, depth+1)
+	exprs = append(exprs, program.Expr{Op: program.OpLitInt, Value: "1", Type: program.TypeInt}) // 0
+	for i := 1; i <= depth; i++ {
+		exprs = append(exprs, program.Expr{
+			Op:       program.OpAdd,
+			Operands: []program.ExprID{program.ExprID(i - 1), 0}, // running += 1, depth deep
+		})
+	}
+	vm := NewVM(progFromExprs(exprs), nil)
+	got := vm.Eval(program.ExprID(depth))
+	if int(got.num) != depth+1 {
+		t.Fatalf("deep-but-finite chain = %d, want %d", int(got.num), depth+1)
+	}
+	if len(vm.Diagnostics()) != 0 {
+		t.Fatalf("deep-but-finite chain should not trip the depth guard, got diagnostics: %+v", vm.Diagnostics())
+	}
+}

--- a/client/vm/scene_adapter.go
+++ b/client/vm/scene_adapter.go
@@ -258,42 +258,44 @@ func resolveProps(machine *VM, props map[string]islandprogram.ExprID) map[string
 }
 
 func valueToAny(value Value) any {
-	if value.Fields != nil {
-		out := make(map[string]any, len(value.Fields))
-		keys := make([]string, 0, len(value.Fields))
-		for key := range value.Fields {
+	if value.isMap() {
+		fields := value.dict()
+		out := make(map[string]any, len(fields))
+		keys := make([]string, 0, len(fields))
+		for key := range fields {
 			keys = append(keys, key)
 		}
 		sort.Strings(keys)
 		for _, key := range keys {
-			out[key] = valueToAny(value.Fields[key])
+			out[key] = valueToAny(fields[key])
 		}
 		return out
 	}
-	if value.Items != nil {
-		out := make([]any, len(value.Items))
-		for i, item := range value.Items {
+	if value.isList() {
+		items := value.list()
+		out := make([]any, len(items))
+		for i, item := range items {
 			out[i] = valueToAny(item)
 		}
 		return out
 	}
 	switch value.Type {
 	case islandprogram.TypeString:
-		return value.Str
+		return value.text()
 	case islandprogram.TypeBool:
-		return value.Bool
+		return value.truth()
 	case islandprogram.TypeInt:
-		return int(value.Num)
+		return int(value.num)
 	case islandprogram.TypeFloat:
-		return value.Num
+		return value.num
 	default:
-		if value.Str != "" {
-			return value.Str
+		if text := value.text(); text != "" {
+			return text
 		}
-		if value.Bool {
+		if value.truth() {
 			return true
 		}
-		return value.Num
+		return value.num
 	}
 }
 

--- a/client/vm/scene_resolver.go
+++ b/client/vm/scene_resolver.go
@@ -307,11 +307,6 @@ type point3 struct {
 	Z float64
 }
 
-type projectedLine struct {
-	From rootengine.RenderPoint
-	To   rootengine.RenderPoint
-}
-
 type sceneAppendResult struct {
 	Bounds     rootengine.RenderBounds
 	HasBounds  bool

--- a/client/vm/sequencing_test.go
+++ b/client/vm/sequencing_test.go
@@ -37,7 +37,7 @@ func TestOpSeqReturnsLastValue(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	got := vm.EvalWithFrame(7)
-	if got.Type != program.TypeInt || int(got.Num) != 3 {
+	if got.Type != program.TypeInt || int(got.num) != 3 {
 		t.Fatalf("OpSeq result = %+v, want IntVal(3)", got)
 	}
 }
@@ -56,11 +56,11 @@ func TestOpSeqWritesSignal(t *testing.T) {
 	sig := signal.New(IntVal(0))
 	vm.SetSignal("count", sig)
 	got := vm.EvalWithFrame(3)
-	if got.Type != program.TypeInt || int(got.Num) != 7 {
+	if got.Type != program.TypeInt || int(got.num) != 7 {
 		t.Fatalf("OpSeq with signal target = %+v, want IntVal(7)", got)
 	}
-	if int(sig.Get().Num) != 7 {
-		t.Fatalf("signal.Get = %f, want 7", sig.Get().Num)
+	if int(sig.Get().num) != 7 {
+		t.Fatalf("signal.Get = %f, want 7", sig.Get().num)
 	}
 }
 
@@ -77,7 +77,7 @@ func TestOpLocalDeclThenAssignThenGet(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	got := vm.EvalWithFrame(4)
-	if got.Type != program.TypeInt || int(got.Num) != 5 {
+	if got.Type != program.TypeInt || int(got.num) != 5 {
 		t.Fatalf("local x = %+v, want IntVal(5)", got)
 	}
 }
@@ -90,7 +90,7 @@ func TestOpLocalGetMissingProducesDiagnostic(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	got, diags := vm.EvalWithDiagnostics(0)
-	if got.Type != program.TypeAny || got.Num != 0 || got.Str != "" || got.Bool {
+	if got.Type != program.TypeAny || got.num != 0 || got.Text() != "" || got.Truth() {
 		t.Fatalf("missing local should return zero value, got %+v", got)
 	}
 	if len(diags) != 1 || diags[0].Code != "missing_local" {
@@ -130,17 +130,17 @@ func TestEvalWithFrameIsIsolated(t *testing.T) {
 	// Outer frame writes x = 1.
 	vm.frame = newFrame()
 	vm.Eval(2)
-	if v, ok := vm.frame.get("x"); !ok || int(v.Num) != 1 {
+	if v, ok := vm.frame.get("x"); !ok || int(v.num) != 1 {
 		t.Fatalf("outer frame x = %+v ok=%v, want IntVal(1)", v, ok)
 	}
 
 	// Inner EvalWithFrame writes x = 99. Outer x must remain 1.
 	inner := vm.EvalWithFrame(3)
-	if int(inner.Num) != 99 {
+	if int(inner.num) != 99 {
 		t.Fatalf("inner assign returned %+v, want IntVal(99)", inner)
 	}
 
-	if v, ok := vm.frame.get("x"); !ok || int(v.Num) != 1 {
+	if v, ok := vm.frame.get("x"); !ok || int(v.num) != 1 {
 		t.Fatalf("outer frame x after inner EvalWithFrame = %+v ok=%v, want IntVal(1)", v, ok)
 	}
 }
@@ -176,10 +176,10 @@ func TestOpAssignFallsThroughToSignal(t *testing.T) {
 
 	// Even with an active frame, signal takes precedence.
 	got := vm.EvalWithFrame(1)
-	if int(got.Num) != 42 {
+	if int(got.num) != 42 {
 		t.Fatalf("assign returned %+v, want IntVal(42)", got)
 	}
-	if int(sig.Get().Num) != 42 {
-		t.Fatalf("signal not updated: got %f, want 42", sig.Get().Num)
+	if int(sig.Get().num) != 42 {
+		t.Fatalf("signal not updated: got %f, want 42", sig.Get().num)
 	}
 }

--- a/client/vm/swap_test.go
+++ b/client/vm/swap_test.go
@@ -88,24 +88,24 @@ func TestVMSwapProgramMergesSignalByName(t *testing.T) {
 	InitSignals(vm, swapProgA())
 
 	// count starts at 3 (A's init).
-	if got := vm.Eval(0); got.Num != 3 {
-		t.Fatalf("initial count = %v, want 3", got.Num)
+	if got := vm.Eval(0); got.num != 3 {
+		t.Fatalf("initial count = %v, want 3", got.num)
 	}
 	// Run A's handler once: count 3 -> 4.
 	vm.EvalWithFrame(4)
-	if got := vm.signals["count"].Get(); got.Num != 4 {
-		t.Fatalf("after A bump, count = %v, want 4", got.Num)
+	if got := vm.signals["count"].Get(); got.num != 4 {
+		t.Fatalf("after A bump, count = %v, want 4", got.num)
 	}
 
 	// Swap to B. Same signal name => live value 4 is kept, init 99 ignored.
 	vm.SwapProgram(swapProgB())
-	if got := vm.signals["count"].Get(); got.Num != 4 {
-		t.Fatalf("after swap to B, count = %v, want 4 (merge-by-name kept live value)", got.Num)
+	if got := vm.signals["count"].Get(); got.num != 4 {
+		t.Fatalf("after swap to B, count = %v, want 4 (merge-by-name kept live value)", got.num)
 	}
 	// B's handler is now active: count = count + 10 => 14.
 	vm.EvalWithFrame(4)
-	if got := vm.signals["count"].Get(); got.Num != 14 {
-		t.Fatalf("after B bump, count = %v, want 14 (new handler active)", got.Num)
+	if got := vm.signals["count"].Get(); got.num != 14 {
+		t.Fatalf("after B bump, count = %v, want 14 (new handler active)", got.num)
 	}
 	// The new program is installed (exprs swapped).
 	if vm.program.Name != "B" {
@@ -121,15 +121,15 @@ func TestVMSwapProgramMergesSignalByName(t *testing.T) {
 func TestIslandSwapProgramKeepsStateNewHandlerReconciles(t *testing.T) {
 	island := NewIsland(swapProgA(), `{}`)
 	island.Dispatch("bump", "{}") // count 3 -> 4 under A
-	if got := island.vm.signals["count"].Get(); got.Num != 4 {
-		t.Fatalf("pre-swap count = %v, want 4", got.Num)
+	if got := island.vm.signals["count"].Get(); got.num != 4 {
+		t.Fatalf("pre-swap count = %v, want 4", got.num)
 	}
 
 	island.SwapProgram(swapProgB())
 
 	// Merge-by-name kept the live value across the swap.
-	if got := island.vm.signals["count"].Get(); got.Num != 4 {
-		t.Fatalf("post-swap count = %v, want 4 (state preserved)", got.Num)
+	if got := island.vm.signals["count"].Get(); got.num != 4 {
+		t.Fatalf("post-swap count = %v, want 4 (state preserved)", got.num)
 	}
 	// The handler map was rebuilt against B; the rendered tree reflects the
 	// reconcile (display node shows the live value 4).
@@ -138,8 +138,8 @@ func TestIslandSwapProgramKeepsStateNewHandlerReconciles(t *testing.T) {
 	}
 	// B's handler body is the active one: count = count + 10 => 14.
 	island.Dispatch("bump", "{}")
-	if got := island.vm.signals["count"].Get(); got.Num != 14 {
-		t.Fatalf("post-swap bump count = %v, want 14 (new handler active)", got.Num)
+	if got := island.vm.signals["count"].Get(); got.num != 14 {
+		t.Fatalf("post-swap bump count = %v, want 14 (new handler active)", got.num)
 	}
 	if got := counterFirstNodeText(island.prev); got != "14" {
 		t.Fatalf("post-bump display = %q, want \"14\"", got)
@@ -170,8 +170,8 @@ func TestVMSwapProgramRenamedSignalCleanReinit(t *testing.T) {
 	if !ok {
 		t.Fatal("tally signal missing after swap to C")
 	}
-	if got := tally.Get(); got.Num != 0 {
-		t.Fatalf("tally = %v, want 0 (clean re-init)", got.Num)
+	if got := tally.Get(); got.num != 0 {
+		t.Fatalf("tally = %v, want 0 (clean re-init)", got.num)
 	}
 	// Old signal removed — no stale "count" lingering.
 	if _, ok := vm.signals["count"]; ok {

--- a/client/vm/testdata/fuzz/FuzzIslandReuseMatchesFullEval/bce71438f7323d78
+++ b/client/vm/testdata/fuzz/FuzzIslandReuseMatchesFullEval/bce71438f7323d78
@@ -1,0 +1,4 @@
+go test fuzz v1
+int64(-84)
+int(110)
+int(5)

--- a/client/vm/user_fn_calls.go
+++ b/client/vm/user_fn_calls.go
@@ -60,11 +60,7 @@ import (
 // a fresh frame that bridges captured names through to the enclosing
 // frame for Go's capture-by-reference semantics. Otherwise the
 // existing Y.D path runs.
-func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpIndirectCall {
-		return Value{}, false
-	}
-
+func (vm *VM) indirectCallValue(e *program.Expr) Value {
 	// Slice Y.G — closure-aware path. If a local with this name holds a
 	// ClosureVal, dispatch through it instead of looking up the FuncDef
 	// registry. Evaluate args in the caller's frame BEFORE pushing the
@@ -75,7 +71,7 @@ func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
 			for i, opID := range e.Operands {
 				args[i] = vm.Eval(opID)
 			}
-			return vm.invokeClosureFromIndirectCall(local, args, e), true
+			return vm.invokeClosureFromIndirectCall(local, args, e)
 		}
 	}
 
@@ -87,7 +83,7 @@ func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 
 	// Cap recursion depth so a runaway call sequence is panic-free.
@@ -104,7 +100,7 @@ func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 
 	// Step 1: evaluate arguments in the CALLER's frame.
@@ -148,8 +144,8 @@ func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
 	var result Value
 	for _, bodyID := range def.Body {
 		result = vm.Eval(bodyID)
-		if result.Control == ControlReturn {
-			result.Control = ControlNone
+		if result.Control() == ControlReturn {
+			result = result.WithControl(ControlNone)
 			break
 		}
 	}
@@ -159,5 +155,5 @@ func (vm *VM) evalIndirectCallExpr(e program.Expr) (Value, bool) {
 	// carrier (lowered by lowerMultiReturn — see ir/golower for the
 	// `__ret_<i>` keying contract). Pass it through unchanged so the
 	// caller's lowerMultiAssign reads it via OpIndex.
-	return result, true
+	return result
 }

--- a/client/vm/user_fn_calls_test.go
+++ b/client/vm/user_fn_calls_test.go
@@ -28,8 +28,8 @@ func TestEvalIndirectCallZeroArg(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(3)
-	if got.Str != "hi" {
-		t.Errorf("OpIndirectCall greet() = %q, want %q", got.Str, "hi")
+	if got.Text() != "hi" {
+		t.Errorf("OpIndirectCall greet() = %q, want %q", got.Text(), "hi")
 	}
 }
 
@@ -53,8 +53,8 @@ func TestEvalIndirectCallSingleParam(t *testing.T) {
 	}
 	vm := NewVM(prog, nil)
 	got := vm.Eval(6)
-	if int(got.Num) != 42 {
-		t.Errorf("double(21) = %d, want 42", int(got.Num))
+	if int(got.num) != 42 {
+		t.Errorf("double(21) = %d, want 42", int(got.num))
 	}
 }
 

--- a/client/vm/value.go
+++ b/client/vm/value.go
@@ -5,32 +5,273 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unsafe"
 
 	"m31labs.dev/gosx/island/program"
 )
 
 // Value is the runtime representation of all values in the island expression VM.
+//
+// Value is a tagged union of 32 bytes. Every VM method takes and returns a
+// Value by value, so one binary operation copies the struct three times. The
+// earlier struct-of-fields layout held a string header, a slice header, a map
+// word, a closure word, a float and three tag bytes side by side. That cost 72
+// bytes and flattened to 11 leaf fields, which is past the amd64 register
+// limit, so the compiler passed every Value through memory.
+//
+// The union stores one pointer word plus one length word, and a tag byte tells
+// you what they mean. Value now flattens to 4 integer-class leaf fields plus
+// one float, so a receiver and one Value argument both ride in registers.
+//
+// Read the "Value representation" note at the bottom of this file for the
+// full migration history and for the rules a new field must follow.
 type Value struct {
-	Type   program.ExprType
-	Str    string
-	Num    float64
-	Bool   bool
-	Items  []Value
-	Fields map[string]Value
+	// noCompare keeps Value non-comparable. The pre-union layout held a
+	// map field, so Go refused to compare a Value, and two behaviours grew
+	// to depend on that.
+	//
+	// signal.New installs a == based change test for every comparable type
+	// and installs none for the rest. On a union, == compares the payload
+	// POINTER. OpIndexSet and OpFieldSet then mutate the array or the map
+	// behind that pointer IN PLACE, so == reports "unchanged" for a Value
+	// whose contents just changed, and the signal never notifies. Use Eq,
+	// which walks the payload, whenever you need to compare two Values.
+	//
+	// The generic fallback in signal.defaultEqual also boxes both operands,
+	// which costs one allocation per Set for a 32-byte struct.
+	//
+	// The field costs no bytes. It is first, so it adds no tail padding,
+	// and a zero-length array takes no argument register.
+	noCompare [0]func()
 
-	// Control is a non-zero unwind sentinel emitted by OpReturn /
-	// OpBreak / OpContinue (Slice X.C). OpSeq, OpFor, OpForRange, and
-	// EvalWithFrame check this field after each operand evaluation and
-	// stop propagating accordingly. Regular evaluation never reads or
-	// writes Control, so existing programs and tests are unaffected.
-	Control ControlSignal
+	// ptr holds the single pointer payload. What it points to depends on
+	// the kind bits of tag:
+	//
+	//   kindScalar   nil
+	//   kindString   the first byte of the string
+	//   kindArray    the first element of the array
+	//   kindMap      the map header word
+	//   kindClosure  the *closureRef
+	//
+	// An empty string or an empty array keeps whatever data pointer the
+	// original header carried, which the runtime may report as nil. Read
+	// n, never ptr, to learn the length.
+	//
+	// The field keeps pointer type so the garbage collector scans it and
+	// keeps the payload alive.
+	ptr unsafe.Pointer
 
-	// closure carries the captured-frame reference for ClosureVal
-	// (Slice Y.G). It is unexported so JSON marshal / equality / String
-	// formatting all skip it — closures only exist in-VM and never
-	// cross the wire. ClosureVal() / IsClosure() are the public seams.
-	// nil for every non-closure Value.
-	closure *closureRef
+	// n is the string byte count for kindString and the element count for
+	// kindArray. Every other kind leaves it at 0.
+	n int
+
+	// num is the float payload. Int-typed Values carry their integer here
+	// too. It stays a real field because arithmetic reads it on every
+	// step, and because a float field costs a float register, not one of
+	// the scarce integer registers.
+	num float64
+
+	// Type is the static expression type the lowerer assigned. It steers
+	// String, ToIntVal and the arithmetic promotion rules. It is separate
+	// from the kind bits: Neg, for example, returns a numeric Value that
+	// keeps a TypeString tag.
+	Type program.ExprType
+
+	// tag packs three things that used to be three separate bytes: the
+	// payload kind, the boolean payload, and the control signal. Packing
+	// them keeps the leaf-field count at 4 integer-class fields, which is
+	// what lets two Values pass in registers. Read it through kind(),
+	// Truth() and Control().
+	tag uint8
+}
+
+// valueKind names which payload ptr and n hold. It occupies the low three
+// bits of Value.tag.
+type valueKind uint8
+
+const (
+	// kindScalar marks a Value with no pointer payload: the zero Value, a
+	// number, or a boolean.
+	kindScalar valueKind = iota
+	// kindString marks a text payload in ptr and n.
+	kindString
+	// kindArray marks an array payload in ptr and n.
+	kindArray
+	// kindMap marks an object payload in ptr.
+	kindMap
+	// kindClosure marks a *closureRef in ptr.
+	kindClosure
+)
+
+const (
+	// tagKindMask selects the payload kind, bits 0 to 2.
+	tagKindMask uint8 = 0x07
+	// tagTruthBit holds the boolean payload, bit 3.
+	tagTruthBit uint8 = 0x08
+	// tagControlShift moves the control signal into bits 4 and 5.
+	tagControlShift = 4
+	// tagControlMask selects the control signal, bits 4 and 5.
+	tagControlMask uint8 = 0x30
+)
+
+// --- Payload accessors ---
+//
+// Every accessor comes in two forms.
+//
+// The unexported form takes a POINTER receiver. Inside this package almost
+// every caller holds an addressable Value, so a pointer receiver inlines to a
+// single load. Use it on every hot path.
+//
+// The exported form takes a value receiver, because the seam that code outside
+// this package uses must work on any Value expression.
+//
+// Do not call an exported accessor from a hot path inside this package. The
+// inliner materializes one 32-byte copy per nested value-receiver call, and it
+// cannot fold the copies away once the Value lives in a stack slot. Chaining
+// two of them inside stringAtDepth cost 5x on BenchmarkValueIntToString.
+
+// kind reports which payload ptr and n hold.
+func (v *Value) kind() valueKind { return valueKind(v.tag & tagKindMask) }
+
+// isList reports whether v carries an array payload.
+func (v *Value) isList() bool { return v.tag&tagKindMask == uint8(kindArray) }
+
+// isMap reports whether v carries an object payload.
+func (v *Value) isMap() bool { return v.tag&tagKindMask == uint8(kindMap) }
+
+// text returns the string payload, or "" when v holds no text.
+func (v *Value) text() string {
+	if v.tag&tagKindMask != uint8(kindString) {
+		return ""
+	}
+	return unsafe.String((*byte)(v.ptr), v.n)
+}
+
+// list returns the array payload, or nil when v holds no array.
+func (v *Value) list() []Value {
+	if v.tag&tagKindMask != uint8(kindArray) {
+		return nil
+	}
+	return unsafe.Slice((*Value)(v.ptr), v.n)
+}
+
+// dict returns the object payload, or nil when v holds no object.
+func (v *Value) dict() map[string]Value {
+	if v.tag&tagKindMask != uint8(kindMap) {
+		return nil
+	}
+	// Copy ptr into a local, then read the local as a map. A map value is
+	// one pointer word, so the copy reproduces the original map, and every
+	// write through the result reaches the same object.
+	// TestMapFitsOnePointerWord pins the width this depends on.
+	p := v.ptr
+	return *(*map[string]Value)(unsafe.Pointer(&p))
+}
+
+// truth returns the boolean payload.
+func (v *Value) truth() bool { return v.tag&tagTruthBit != 0 }
+
+// control returns the unwind sentinel v carries.
+func (v *Value) control() ControlSignal {
+	return ControlSignal((v.tag & tagControlMask) >> tagControlShift)
+}
+
+// closureRefOf returns the closure bookkeeping v carries, or nil.
+func (v *Value) closureRefOf() *closureRef {
+	if v.tag&tagKindMask != uint8(kindClosure) {
+		return nil
+	}
+	return (*closureRef)(v.ptr)
+}
+
+// --- Reader seams (stage 1 of the tagged-union migration) ---
+//
+// These methods return exactly what the five payload fields used to hold.
+// They exist so that code outside this package never names a field. A tagged
+// union cannot expose five overlapping fields, so every read goes through a
+// method. Read the "Value representation" note at the bottom of this file for
+// the full plan.
+
+// Text returns the string payload. It is the raw text, NOT the formatted
+// form. Use String() when you want any Value rendered as text.
+//
+// The returned string aliases the bytes the Value was built from. Go strings
+// are immutable, so no caller can write through the alias.
+func (v Value) Text() string { return v.text() }
+
+// Number returns the float payload. Int-typed Values carry their integer
+// in the same field, so read Number() and convert at the call site.
+func (v Value) Number() float64 { return v.num }
+
+// Truth returns the boolean payload. It is the raw boolean, NOT a
+// truthiness test over the whole Value.
+func (v Value) Truth() bool { return v.truth() }
+
+// List returns the array payload. The returned slice aliases the Value's
+// storage, so a write through it is visible to every Value that shares the
+// same array. That is the documented in-place mutation contract; see
+// lhs_set.go. Use SetIndex to write one element.
+//
+// The slice has capacity equal to its length. Append to it and you get a
+// fresh array, never a write into shared storage.
+func (v Value) List() []Value { return v.list() }
+
+// Map returns the object payload. The returned map aliases the Value's
+// storage, so a write through it is visible to every Value that shares the
+// same object. Use SetField to write one field.
+func (v Value) Map() map[string]Value { return v.dict() }
+
+// IsList reports whether v carries an array payload.
+func (v Value) IsList() bool { return v.isList() }
+
+// IsMap reports whether v carries an object payload.
+func (v Value) IsMap() bool { return v.isMap() }
+
+// Control returns the unwind sentinel the Value carries. It is
+// ControlNone for every Value that regular evaluation produces.
+func (v Value) Control() ControlSignal { return v.control() }
+
+// WithControl returns a copy of v that carries the control signal c. The
+// payload does not change. Use it where the old layout assigned to the
+// Control field.
+func (v Value) WithControl(c ControlSignal) Value {
+	v.tag = (v.tag &^ tagControlMask) | (uint8(c)<<tagControlShift)&tagControlMask
+	return v
+}
+
+// --- Writer seams (stage 3 of the tagged-union migration) ---
+//
+// OpFieldSet and OpIndexSet mutate the collection in place. Hosts that
+// populate a struct-shaped Value do the same. Both need a seam that survives
+// the layout change, because a union stores the collection behind one word
+// and cannot hand back an addressable map or slice field.
+
+// SetField writes val into v's object payload under name. It reports
+// whether the write landed. A Value with no object payload returns false
+// and drops the write, which keeps the panic-free contract.
+//
+// The write is in place. Every Value that shares the same object sees it.
+// That is deliberate: composite values are reference-shared in this VM, and
+// host receivers rely on it to fill a caller-supplied props struct.
+func (v Value) SetField(name string, val Value) bool {
+	fields := v.dict()
+	if fields == nil {
+		return false
+	}
+	fields[name] = val
+	return true
+}
+
+// SetIndex writes val into v's array payload at index i. It reports whether
+// the write landed. An out-of-range index, or a Value with no array payload,
+// returns false and drops the write. The array never grows.
+func (v Value) SetIndex(i int, val Value) bool {
+	items := v.list()
+	if items == nil || i < 0 || i >= len(items) {
+		return false
+	}
+	items[i] = val
+	return true
 }
 
 // closureRef carries the runtime bookkeeping for a ClosureVal: which
@@ -52,43 +293,47 @@ type closureRef struct {
 //
 // funcName is the FuncDef registered by the lowerer for the anonymous
 // body. captured names the variables the body references that are NOT
-// its own parameters or fresh declarations (i.e., the closed-over
-// locals). frame is the caller's *frame at OpClosure-evaluation time —
-// the closure forwards reads and writes for any captured name through
-// this exact frame, giving Go's variable-capture semantics.
+// its own parameters or fresh declarations, that is, the closed-over
+// locals. frame is the caller's *frame at OpClosure-evaluation time. The
+// closure forwards reads and writes for any captured name through this
+// exact frame, giving Go's variable-capture semantics.
 func ClosureVal(funcName string, captured []string, frame *frame) Value {
 	capMap := make(map[string]bool, len(captured))
 	for _, name := range captured {
 		capMap[name] = true
 	}
+	ref := &closureRef{
+		funcName: funcName,
+		captured: capMap,
+		frame:    frame,
+	}
 	return Value{
 		Type: program.TypeAny,
-		closure: &closureRef{
-			funcName: funcName,
-			captured: capMap,
-			frame:    frame,
-		},
+		ptr:  unsafe.Pointer(ref),
+		tag:  uint8(kindClosure),
 	}
 }
 
 // IsClosure reports whether v is a ClosureVal produced by OpClosure.
 // Hosts and the VM use this to decide whether to dispatch into the
-// closure-aware path of OpIndirectCall vs the regular user-function
+// closure-aware path of OpIndirectCall or the regular user-function
 // path.
 func IsClosure(v Value) bool {
-	return v.closure != nil
+	return v.kind() == kindClosure
 }
 
 // ClosureFuncName returns the synthetic FuncDef name carried by v if
 // v is a ClosureVal, otherwise "".
 func ClosureFuncName(v Value) string {
-	if v.closure == nil {
+	ref := v.closureRefOf()
+	if ref == nil {
 		return ""
 	}
-	return v.closure.funcName
+	return ref.funcName
 }
 
-// ControlSignal is the sentinel kind carried in Value.Control.
+// ControlSignal is the sentinel kind a Value carries. Read it with
+// Control() and set it with WithControl().
 type ControlSignal uint8
 
 const (
@@ -105,33 +350,64 @@ const (
 )
 
 // ArrayVal creates an array Value from a slice of Values.
+//
+// A nil slice produces a Value that is NOT a list, which matches the
+// pre-union layout where a nil Items field read as "no array payload".
+// FilterFunc and the other array builders depend on that.
 func ArrayVal(items []Value) Value {
-	return Value{Type: program.TypeAny, Items: items}
+	if items == nil {
+		return Value{Type: program.TypeAny}
+	}
+	return Value{
+		Type: program.TypeAny,
+		ptr:  unsafe.Pointer(unsafe.SliceData(items)),
+		n:    len(items),
+		tag:  uint8(kindArray),
+	}
 }
 
 // ObjectVal creates an object Value.
+//
+// A nil map produces a Value that is NOT a map, which matches the
+// pre-union layout where a nil Fields field read as "no object payload".
 func ObjectVal(fields map[string]Value) Value {
-	return Value{Type: program.TypeAny, Fields: fields}
+	if fields == nil {
+		return Value{Type: program.TypeAny}
+	}
+	return Value{
+		Type: program.TypeAny,
+		ptr:  *(*unsafe.Pointer)(unsafe.Pointer(&fields)),
+		tag:  uint8(kindMap),
+	}
 }
 
 // StringVal creates a string Value.
 func StringVal(s string) Value {
-	return Value{Type: program.TypeString, Str: s}
+	return Value{
+		Type: program.TypeString,
+		ptr:  unsafe.Pointer(unsafe.StringData(s)),
+		n:    len(s),
+		tag:  uint8(kindString),
+	}
 }
 
 // IntVal creates an integer Value.
 func IntVal(n int) Value {
-	return Value{Type: program.TypeInt, Num: float64(n)}
+	return Value{Type: program.TypeInt, num: float64(n)}
 }
 
 // FloatVal creates a float Value.
 func FloatVal(f float64) Value {
-	return Value{Type: program.TypeFloat, Num: f}
+	return Value{Type: program.TypeFloat, num: f}
 }
 
 // BoolVal creates a boolean Value.
 func BoolVal(b bool) Value {
-	return Value{Type: program.TypeBool, Bool: b}
+	v := Value{Type: program.TypeBool}
+	if b {
+		v.tag = tagTruthBit
+	}
+	return v
 }
 
 // ZeroValue returns the zero Value for the given type.
@@ -158,239 +434,303 @@ func (v Value) Add(b Value) Value {
 		return StringVal(v.String() + b.String())
 	}
 	if isInt(v, b) {
-		return Value{Type: program.TypeInt, Num: float64(int64(v.Num) + int64(b.Num))}
+		return Value{Type: program.TypeInt, num: float64(int64(v.num) + int64(b.num))}
 	}
-	return Value{Type: program.TypeFloat, Num: v.Num + b.Num}
+	return Value{Type: program.TypeFloat, num: v.num + b.num}
 }
 
 // Sub returns a - b.
 func (v Value) Sub(b Value) Value {
 	if isInt(v, b) {
-		return Value{Type: program.TypeInt, Num: float64(int64(v.Num) - int64(b.Num))}
+		return Value{Type: program.TypeInt, num: float64(int64(v.num) - int64(b.num))}
 	}
-	return Value{Type: program.TypeFloat, Num: v.Num - b.Num}
+	return Value{Type: program.TypeFloat, num: v.num - b.num}
 }
 
 // Mul returns a * b.
 func (v Value) Mul(b Value) Value {
 	if isInt(v, b) {
-		return Value{Type: program.TypeInt, Num: float64(int64(v.Num) * int64(b.Num))}
+		return Value{Type: program.TypeInt, num: float64(int64(v.num) * int64(b.num))}
 	}
-	return Value{Type: program.TypeFloat, Num: v.Num * b.Num}
+	return Value{Type: program.TypeFloat, num: v.num * b.num}
 }
 
 // Div returns a / b. Division by zero returns 0.
 func (v Value) Div(b Value) Value {
 	if isInt(v, b) {
-		if int64(b.Num) == 0 {
-			return Value{Type: program.TypeInt, Num: 0}
+		if int64(b.num) == 0 {
+			return Value{Type: program.TypeInt, num: 0}
 		}
-		return Value{Type: program.TypeInt, Num: float64(int64(v.Num) / int64(b.Num))}
+		return Value{Type: program.TypeInt, num: float64(int64(v.num) / int64(b.num))}
 	}
-	if b.Num == 0 {
-		return Value{Type: resultType(v, b), Num: 0}
+	if b.num == 0 {
+		return Value{Type: resultType(v, b), num: 0}
 	}
-	return Value{Type: program.TypeFloat, Num: v.Num / b.Num}
+	return Value{Type: program.TypeFloat, num: v.num / b.num}
 }
 
 // Mod returns a % b.
 func (v Value) Mod(b Value) Value {
 	if isInt(v, b) {
-		if int64(b.Num) == 0 {
-			return Value{Type: program.TypeInt, Num: 0}
+		if int64(b.num) == 0 {
+			return Value{Type: program.TypeInt, num: 0}
 		}
-		return Value{Type: program.TypeInt, Num: float64(int64(v.Num) % int64(b.Num))}
+		return Value{Type: program.TypeInt, num: float64(int64(v.num) % int64(b.num))}
 	}
-	return Value{Type: program.TypeFloat, Num: math.Mod(v.Num, b.Num)}
+	return Value{Type: program.TypeFloat, num: math.Mod(v.num, b.num)}
 }
 
-// Neg returns -v.
+// Neg returns -v. The result keeps v's static type and drops any pointer
+// payload, which matches the pre-union behaviour of building a fresh
+// struct with only Type and Num set.
 func (v Value) Neg() Value {
-	return Value{Type: v.Type, Num: -v.Num}
+	return Value{Type: v.Type, num: -v.num}
 }
 
 // --- Comparisons --- all return BoolVal
 
+// maxValueRecursionDepth bounds the recursion String, Eq, and ToAny
+// use to walk the array and object payloads. The VM's in-place mutation
+// contract (see lhs_set.go) lets OpIndexSet / OpFieldSet build a Value
+// that contains itself (for example, `arr[0] = arr`). Go's recover()
+// cannot catch a stack-overflow fatal error. These three walkers
+// must stop on their own before they reach one.
+//
+// A depth cap does this without a visited-set allocation on every
+// call. A genuine cycle keeps recursing past any legitimate nesting
+// depth. So the cap only ever fires on a cycle, or on a
+// pathologically deep (but not cyclic) structure. Either way,
+// degrading to a sentinel beats a crash.
+const maxValueRecursionDepth = 1000
+
+// cycleSentinel is the string these walkers substitute for a Value
+// that recurses past maxValueRecursionDepth.
+const cycleSentinel = "<cycle>"
+
 // Eq returns whether v == b.
 func (v Value) Eq(b Value) Value {
+	return eqAtDepth(v, b, 0)
+}
+
+func eqAtDepth(v, b Value, depth int) Value {
+	if depth > maxValueRecursionDepth {
+		return BoolVal(false)
+	}
 	// Array comparison
-	if v.Items != nil || b.Items != nil {
-		if len(v.Items) != len(b.Items) {
+	if v.isList() || b.isList() {
+		left, right := v.list(), b.list()
+		if len(left) != len(right) {
 			return BoolVal(false)
 		}
-		for i := range v.Items {
-			if !v.Items[i].Eq(b.Items[i]).Bool {
+		for i := range left {
+			if eq := eqAtDepth(left[i], right[i], depth+1); !eq.truth() {
 				return BoolVal(false)
 			}
 		}
 		return BoolVal(true)
 	}
-	if v.Fields != nil || b.Fields != nil {
-		if len(v.Fields) != len(b.Fields) {
+	if v.isMap() || b.isMap() {
+		left, right := v.dict(), b.dict()
+		if len(left) != len(right) {
 			return BoolVal(false)
 		}
-		for key, val := range v.Fields {
-			other, ok := b.Fields[key]
-			if !ok || !val.Eq(other).Bool {
+		for key, val := range left {
+			other, ok := right[key]
+			if !ok {
+				return BoolVal(false)
+			}
+			if eq := eqAtDepth(val, other, depth+1); !eq.truth() {
 				return BoolVal(false)
 			}
 		}
 		return BoolVal(true)
 	}
 	if v.Type == program.TypeString || b.Type == program.TypeString {
-		return BoolVal(v.Str == b.Str)
+		return BoolVal(v.text() == b.text())
 	}
 	if v.Type == program.TypeBool || b.Type == program.TypeBool {
-		return BoolVal(v.Bool == b.Bool)
+		return BoolVal(v.truth() == b.truth())
 	}
-	return BoolVal(v.Num == b.Num)
+	return BoolVal(v.num == b.num)
 }
 
 // Neq returns whether v != b.
 func (v Value) Neq(b Value) Value {
 	r := v.Eq(b)
-	r.Bool = !r.Bool
-	return r
+	return BoolVal(!r.truth())
 }
 
 // Lt returns whether v < b.
 func (v Value) Lt(b Value) Value {
-	return BoolVal(v.Num < b.Num)
+	return BoolVal(v.num < b.num)
 }
 
 // Gt returns whether v > b.
 func (v Value) Gt(b Value) Value {
-	return BoolVal(v.Num > b.Num)
+	return BoolVal(v.num > b.num)
 }
 
 // Lte returns whether v <= b.
 func (v Value) Lte(b Value) Value {
-	return BoolVal(v.Num <= b.Num)
+	return BoolVal(v.num <= b.num)
 }
 
 // Gte returns whether v >= b.
 func (v Value) Gte(b Value) Value {
-	return BoolVal(v.Num >= b.Num)
+	return BoolVal(v.num >= b.num)
 }
 
 // --- Boolean ops ---
 
 // And returns v && b.
 func (v Value) And(b Value) Value {
-	return BoolVal(v.Bool && b.Bool)
+	return BoolVal(v.truth() && b.truth())
 }
 
 // Or returns v || b.
 func (v Value) Or(b Value) Value {
-	return BoolVal(v.Bool || b.Bool)
+	return BoolVal(v.truth() || b.truth())
 }
 
 // Not returns !v.
 func (v Value) Not() Value {
-	return BoolVal(!v.Bool)
+	return BoolVal(!v.truth())
 }
 
 // --- String ops ---
 
 // Concat returns the string concatenation of v and b.
 func (v Value) Concat(b Value) Value {
-	return StringVal(v.Str + b.Str)
+	return StringVal(v.text() + b.text())
 }
 
-// Len returns the length of a string or array Value as an int.
+// Len returns the length of a string, array, or object Value as an int.
 func (v Value) Len() int {
-	if v.Items != nil {
-		return len(v.Items)
+	switch v.kind() {
+	case kindString, kindArray:
+		return v.n
+	case kindMap:
+		return len(v.dict())
+	default:
+		return 0
 	}
-	if v.Fields != nil {
-		return len(v.Fields)
-	}
-	return len(v.Str)
 }
 
 // String converts any Value to its string representation.
 //
 // The scalar paths use strconv directly instead of fmt.Sprintf so that
-// an int-typed signal (by far the most common case, e.g. counter values)
-// renders without the fmt format-state scratch allocation. Runs once per
-// expression evaluation touching any int/float signal — in a typical
-// counter island with a "{count}" display that's N calls per reconcile.
+// an int-typed signal (by far the most common case, for example a counter
+// value) renders without the fmt format-state scratch allocation. Runs once
+// per expression evaluation touching any int or float signal. In a typical
+// counter island with a "{count}" display that is N calls per reconcile.
 func (v Value) String() string {
-	if v.Items != nil {
-		parts := make([]string, len(v.Items))
-		for i, item := range v.Items {
-			parts[i] = item.String()
-		}
-		return "[" + strings.Join(parts, ", ") + "]"
+	return v.stringAtDepth(0)
+}
+
+// stringAtDepth renders v. It keeps only the scalar cases in its own body and
+// hands the two collection cases to a helper each.
+//
+// The split is a performance decision, not a style one. A scalar Value is by
+// far the common case, and the helpers need a make, a sort and a
+// strings.Builder. Keeping those in this function gave it a 590-byte frame,
+// and the callee spends its prologue spilling five register arguments into a
+// frame that large. Moving them out shrinks the frame the scalar path pays for.
+func (v Value) stringAtDepth(depth int) string {
+	if depth > maxValueRecursionDepth {
+		return cycleSentinel
 	}
-	if v.Fields != nil {
-		keys := make([]string, 0, len(v.Fields))
-		for key := range v.Fields {
-			keys = append(keys, key)
-		}
-		sort.Strings(keys)
-		var b strings.Builder
-		b.Grow(2 + len(keys)*16)
-		b.WriteByte('{')
-		for i, key := range keys {
-			if i > 0 {
-				b.WriteString(", ")
-			}
-			b.WriteString(key)
-			b.WriteByte(':')
-			b.WriteString(v.Fields[key].String())
-		}
-		b.WriteByte('}')
-		return b.String()
+	if v.isList() {
+		return v.arrayStringAtDepth(depth)
+	}
+	if v.isMap() {
+		return v.objectStringAtDepth(depth)
 	}
 	switch v.Type {
 	case program.TypeString:
-		return v.Str
+		return v.text()
 	case program.TypeInt:
-		return strconv.FormatInt(int64(v.Num), 10)
+		return strconv.FormatInt(int64(v.num), 10)
 	case program.TypeFloat:
-		return strconv.FormatFloat(v.Num, 'g', -1, 64)
+		return strconv.FormatFloat(v.num, 'g', -1, 64)
 	case program.TypeBool:
-		if v.Bool {
+		if v.truth() {
 			return "true"
 		}
 		return "false"
 	default:
-		return strconv.FormatFloat(v.Num, 'g', -1, 64)
+		return strconv.FormatFloat(v.num, 'g', -1, 64)
 	}
+}
+
+// arrayStringAtDepth renders an array payload as "[a, b, c]".
+func (v Value) arrayStringAtDepth(depth int) string {
+	items := v.list()
+	parts := make([]string, len(items))
+	for i := range items {
+		parts[i] = items[i].stringAtDepth(depth + 1)
+	}
+	return "[" + strings.Join(parts, ", ") + "]"
+}
+
+// objectStringAtDepth renders an object payload as "{k:v, k:v}". Keys sort so
+// that the output is stable across runs.
+func (v Value) objectStringAtDepth(depth int) string {
+	fields := v.dict()
+	keys := make([]string, 0, len(fields))
+	for key := range fields {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	b.Grow(2 + len(keys)*16)
+	b.WriteByte('{')
+	for i, key := range keys {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(key)
+		b.WriteByte(':')
+		field := fields[key]
+		b.WriteString(field.stringAtDepth(depth + 1))
+	}
+	b.WriteByte('}')
+	return b.String()
 }
 
 // IndexVal returns an indexed element from an array, object, or string.
 func (v Value) IndexVal(index Value) Value {
-	if v.Items != nil {
-		idx := int(index.Num)
-		if idx < 0 || idx >= len(v.Items) {
+	if v.isList() {
+		items := v.list()
+		idx := int(index.num)
+		if idx < 0 || idx >= len(items) {
 			return ZeroValue(program.TypeAny)
 		}
-		return v.Items[idx]
+		return items[idx]
 	}
-	if v.Fields != nil {
-		if field, ok := v.Fields[index.String()]; ok {
+	if v.isMap() {
+		if field, ok := v.dict()[index.String()]; ok {
 			return field
 		}
 		return ZeroValue(program.TypeAny)
 	}
 	if v.Type == program.TypeString {
-		idx := int(index.Num)
-		if idx < 0 || idx >= len(v.Str) {
+		text := v.text()
+		idx := int(index.num)
+		if idx < 0 || idx >= len(text) {
 			return ZeroValue(program.TypeString)
 		}
-		return StringVal(v.Str[idx : idx+1])
+		return StringVal(text[idx : idx+1])
 	}
 	return ZeroValue(program.TypeAny)
 }
 
 // --- Array methods ---
 
-// AppendVal returns a new Value with elem appended to Items.
+// AppendVal returns a new Value with elem appended to the array payload.
 func (v Value) AppendVal(elem Value) Value {
-	newItems := make([]Value, len(v.Items), len(v.Items)+1)
-	copy(newItems, v.Items)
+	items := v.list()
+	newItems := make([]Value, len(items), len(items)+1)
+	copy(newItems, items)
 	newItems = append(newItems, elem)
 	return ArrayVal(newItems)
 }
@@ -398,7 +738,7 @@ func (v Value) AppendVal(elem Value) Value {
 // FilterFunc returns a new array Value containing only items for which pred returns true.
 func (v Value) FilterFunc(pred func(Value) bool) Value {
 	var result []Value
-	for _, item := range v.Items {
+	for _, item := range v.list() {
 		if pred(item) {
 			result = append(result, item)
 		}
@@ -408,8 +748,9 @@ func (v Value) FilterFunc(pred func(Value) bool) Value {
 
 // MapFunc returns a new array Value with fn applied to each item.
 func (v Value) MapFunc(fn func(Value, int) Value) Value {
-	result := make([]Value, len(v.Items))
-	for i, item := range v.Items {
+	items := v.list()
+	result := make([]Value, len(items))
+	for i, item := range items {
 		result[i] = fn(item, i)
 	}
 	return ArrayVal(result)
@@ -417,7 +758,7 @@ func (v Value) MapFunc(fn func(Value, int) Value) Value {
 
 // FindFunc returns the first item for which pred returns true, or ZeroValue.
 func (v Value) FindFunc(pred func(Value) bool) Value {
-	for _, item := range v.Items {
+	for _, item := range v.list() {
 		if pred(item) {
 			return item
 		}
@@ -425,11 +766,26 @@ func (v Value) FindFunc(pred func(Value) bool) Value {
 	return ZeroValue(program.TypeAny)
 }
 
-// SliceVal returns Items[start:end] with bounds clamping.
+// SliceVal returns the array payload from start to end with bounds clamping.
+//
+// Both bounds clamp into [0, n] before the start-over-end swap runs.
+// The end bound needs a low-side clamp too (end < 0 -> 0), not only
+// a high-side clamp (end > n -> n). A negative end reaches the swap
+// step as a smaller-than-start value. That used to send a negative
+// index straight into the array slice expression, which panicked.
+// Clamping end into range first keeps every later step working on
+// values already inside [0, n].
 func (v Value) SliceVal(start, end int) Value {
-	n := len(v.Items)
+	items := v.list()
+	n := len(items)
 	if start < 0 {
 		start = 0
+	}
+	if start > n {
+		start = n
+	}
+	if end < 0 {
+		end = 0
 	}
 	if end > n {
 		end = n
@@ -438,27 +794,29 @@ func (v Value) SliceVal(start, end int) Value {
 		start = end
 	}
 	newItems := make([]Value, end-start)
-	copy(newItems, v.Items[start:end])
+	copy(newItems, items[start:end])
 	return ArrayVal(newItems)
 }
 
-// ContainsVal checks if elem is in Items (array) or if elem.Str is a substring of v.Str (string).
+// ContainsVal reports whether elem is in the array payload, or whether
+// elem's text is a substring of v's text.
 func (v Value) ContainsVal(elem Value) Value {
-	if v.Items != nil {
-		for _, item := range v.Items {
-			if item.Eq(elem).Bool {
+	if v.isList() {
+		for _, item := range v.list() {
+			if r := item.Eq(elem); r.truth() {
 				return BoolVal(true)
 			}
 		}
 		return BoolVal(false)
 	}
-	return BoolVal(strings.Contains(v.Str, elem.Str))
+	return BoolVal(strings.Contains(v.text(), elem.text()))
 }
 
-// JoinVal joins Items as strings with the given separator.
+// JoinVal joins the array payload as strings with the given separator.
 func (v Value) JoinVal(sep string) Value {
-	parts := make([]string, len(v.Items))
-	for i, item := range v.Items {
+	items := v.list()
+	parts := make([]string, len(items))
+	for i, item := range items {
 		parts[i] = item.String()
 	}
 	return StringVal(strings.Join(parts, sep))
@@ -466,24 +824,24 @@ func (v Value) JoinVal(sep string) Value {
 
 // --- String methods ---
 
-// ToUpper returns a new Value with v.Str uppercased.
+// ToUpper returns a new Value with the text payload uppercased.
 func (v Value) ToUpper() Value {
-	return StringVal(strings.ToUpper(v.Str))
+	return StringVal(strings.ToUpper(v.text()))
 }
 
-// ToLower returns a new Value with v.Str lowercased.
+// ToLower returns a new Value with the text payload lowercased.
 func (v Value) ToLower() Value {
-	return StringVal(strings.ToLower(v.Str))
+	return StringVal(strings.ToLower(v.text()))
 }
 
-// TrimVal returns a new Value with whitespace trimmed from v.Str.
+// TrimVal returns a new Value with whitespace trimmed from the text payload.
 func (v Value) TrimVal() Value {
-	return StringVal(strings.TrimSpace(v.Str))
+	return StringVal(strings.TrimSpace(v.text()))
 }
 
-// SplitVal splits v.Str by sep and returns an ArrayVal of StringVals.
+// SplitVal splits the text payload by sep and returns an ArrayVal of StringVals.
 func (v Value) SplitVal(sep string) Value {
-	parts := strings.Split(v.Str, sep)
+	parts := strings.Split(v.text(), sep)
 	items := make([]Value, len(parts))
 	for i, p := range parts {
 		items[i] = StringVal(p)
@@ -491,16 +849,29 @@ func (v Value) SplitVal(sep string) Value {
 	return ArrayVal(items)
 }
 
-// ReplaceVal returns a new Value with all occurrences of old replaced by new in v.Str.
+// ReplaceVal returns a new Value with all occurrences of old replaced by new
+// in the text payload.
 func (v Value) ReplaceVal(old, new string) Value {
-	return StringVal(strings.ReplaceAll(v.Str, old, new))
+	return StringVal(strings.ReplaceAll(v.text(), old, new))
 }
 
-// SubstringVal returns v.Str[start:end] with bounds clamping.
+// SubstringVal returns the text payload from start to end with bounds clamping.
+//
+// Mirrors SliceVal's clamp order. Both sides of end clamp into
+// [0, n] before the start-over-end swap runs. A negative end (for
+// example, from `s[0:len(s)-1]` on an empty string) never reaches
+// the string-slice expression as a negative index.
 func (v Value) SubstringVal(start, end int) Value {
-	n := len(v.Str)
+	text := v.text()
+	n := len(text)
 	if start < 0 {
 		start = 0
+	}
+	if start > n {
+		start = n
+	}
+	if end < 0 {
+		end = 0
 	}
 	if end > n {
 		end = n
@@ -508,44 +879,47 @@ func (v Value) SubstringVal(start, end int) Value {
 	if start > end {
 		start = end
 	}
-	return StringVal(v.Str[start:end])
+	return StringVal(text[start:end])
 }
 
-// StartsWithVal returns BoolVal indicating whether v.Str starts with prefix.Str.
+// StartsWithVal reports whether v's text starts with prefix's text.
 func (v Value) StartsWithVal(prefix Value) Value {
-	return BoolVal(strings.HasPrefix(v.Str, prefix.Str))
+	return BoolVal(strings.HasPrefix(v.text(), prefix.text()))
 }
 
-// EndsWithVal returns BoolVal indicating whether v.Str ends with suffix.Str.
+// EndsWithVal reports whether v's text ends with suffix's text.
 func (v Value) EndsWithVal(suffix Value) Value {
-	return BoolVal(strings.HasSuffix(v.Str, suffix.Str))
+	return BoolVal(strings.HasSuffix(v.text(), suffix.text()))
 }
 
 // --- Type conversions ---
 
 // ToStringVal converts any Value to a StringVal.
 //
-// Slice Y.E.3: when v is an ArrayVal whose Items are all StringVals
+// Slice Y.E.3: when v is an ArrayVal whose items are all StringVals
 // (the shape produced by `[]rune(s)` via OpToRunes), the conversion
-// concatenates the items — mirroring Go's `string([]rune{...})` which
+// concatenates the items, mirroring Go's `string([]rune{...})` which
 // joins the runes back into a string. This is what makes the
 // graph_surface.go pattern `string([]rune(label)[:22])` produce a
 // truncated label rather than the debug-formatted `"[h, e, l, l, o]"`
 // shape that the array's String() form returns.
 func (v Value) ToStringVal() Value {
-	if v.Items != nil && allStringItems(v.Items) {
-		var b strings.Builder
-		for _, item := range v.Items {
-			b.WriteString(item.Str)
+	if v.isList() {
+		items := v.list()
+		if allStringItems(items) {
+			var b strings.Builder
+			for i := range items {
+				b.WriteString(items[i].text())
+			}
+			return StringVal(b.String())
 		}
-		return StringVal(b.String())
 	}
 	return StringVal(v.String())
 }
 
 // allStringItems reports whether every element in items is a TypeString
 // Value. Used by ToStringVal to decide between joining (the rune-array
-// case) and debug-formatting (heterogeneous arrays).
+// case) and debug-formatting (mixed arrays).
 func allStringItems(items []Value) bool {
 	if len(items) == 0 {
 		return false
@@ -564,12 +938,13 @@ func (v Value) ToIntVal() Value {
 	case program.TypeInt:
 		return v
 	case program.TypeFloat:
-		return IntVal(int(v.Num))
+		return IntVal(int(v.num))
 	case program.TypeString:
-		n, err := strconv.ParseInt(v.Str, 10, 64)
+		text := v.text()
+		n, err := strconv.ParseInt(text, 10, 64)
 		if err != nil {
 			// Try parsing as float then truncating
-			f, err2 := strconv.ParseFloat(v.Str, 64)
+			f, err2 := strconv.ParseFloat(text, 64)
 			if err2 != nil {
 				return IntVal(0)
 			}
@@ -577,7 +952,7 @@ func (v Value) ToIntVal() Value {
 		}
 		return IntVal(int(n))
 	case program.TypeBool:
-		if v.Bool {
+		if v.truth() {
 			return IntVal(1)
 		}
 		return IntVal(0)
@@ -592,15 +967,15 @@ func (v Value) ToFloatVal() Value {
 	case program.TypeFloat:
 		return v
 	case program.TypeInt:
-		return FloatVal(v.Num)
+		return FloatVal(v.num)
 	case program.TypeString:
-		f, err := strconv.ParseFloat(v.Str, 64)
+		f, err := strconv.ParseFloat(v.text(), 64)
 		if err != nil {
 			return FloatVal(0)
 		}
 		return FloatVal(f)
 	case program.TypeBool:
-		if v.Bool {
+		if v.truth() {
 			return FloatVal(1)
 		}
 		return FloatVal(0)
@@ -608,3 +983,116 @@ func (v Value) ToFloatVal() Value {
 		return FloatVal(0)
 	}
 }
+
+// --- Value representation: why the layout is a 32-byte tagged union ---
+//
+// Value used to be a struct of parallel payload fields: a string header, a
+// slice header, a map word, a closure word, a float, and three tag bytes.
+// That cost 72 bytes and flattened to 11 leaf fields. The amd64 register ABI
+// gives an argument at most 9 integer registers, so an 11-field Value went
+// through memory on every call, three times per binary operation.
+//
+// The union stores one pointer word plus one length word and reads them
+// through the kind bits of tag. That is 32 bytes and 4 integer-class leaf
+// fields plus one float. A receiver and one Value argument now both pass in
+// registers. Verify that claim with:
+//
+//	go build -gcflags=-S ./client/vm 2>&1 | grep 'TEXT.*Value..Add'
+//
+// A register-passed Add reports 64 bytes of argument area, which is only the
+// spill slots for two 32-byte Values, and its prologue moves AX, BX, SI, R8,
+// X0 and X1 into that area. The 72-byte layout reported 216 bytes, which is
+// three whole Values on the stack, and read its operands from caller slots.
+//
+// MEASURED RESULT over the whole client/vm benchmark set, 12 interleaved A/B
+// rounds on one loaded machine:
+//
+//	sec/op     geomean -12.2%
+//	B/op       geomean -16.8%
+//	allocs/op  geomean unchanged
+//
+// The biggest wins land where a Value crosses a call boundary:
+// OpHostCallTwoArgs -29%, MapCompositeThenLookup100 -28%, OpHostCallDrawShape
+// -26%, IndirectCallTwoArgs -24%, InvokeClosureCapturedWrite -24%, FieldSet
+// -23%, IndexSetSlice -18%.
+//
+// One case got slower. A dedicated 15-round run put BenchmarkValueIntToString
+// at 1.90 ns before and 2.09 ns after, about +0.19 ns. A register-passed callee
+// spends its prologue writing five arguments into the frame, and String() on an
+// int returns almost at once, so it pays the prologue and collects none of the
+// benefit. The 72-byte layout had its arguments in memory already and skipped
+// that step. Every benchmark that lets the Value travel further wins far more
+// than 0.19 ns back, so the trade stands.
+//
+// MIGRATION HISTORY. Every route to this layout needed the same first step:
+// Str, Num, Bool, Items and Fields had to stop being struct fields, because a
+// union cannot expose five overlapping fields.
+//
+//   1. DONE. Reader methods sit beside the payload: Text(), Number(),
+//      Truth(), List(), Map(), plus IsList() and IsMap().
+//   2. DONE. Every reader inside client/bridge, client/wasm and ir uses the
+//      methods.
+//   3. DONE. SetField and SetIndex cover the in-place mutation sites.
+//      OpFieldSet writes through SetField. Host receivers that fill a
+//      caller-supplied props struct use it too.
+//   4. DONE. The five payload fields are unexported. Six files outside
+//      client/vm named them and now do not:
+//        engine/surface/context_host.go       used ArrayVal and SetField
+//        engine/surface/vm_host.go            used Number() and Text()
+//        engine/surface/context_host_test.go
+//        engine/surface/vm_host_test.go
+//        client/bridge/bridge_test.go         missed by the first inventory
+//        test/store_test.go
+//   5. DONE. The union replaced the parallel fields. Control moved from an
+//      exported field to Control() and WithControl(), because packing it into
+//      tag is what holds the leaf-field count at 4.
+//
+// RULES A NEW FIELD MUST FOLLOW.
+//
+//   - Do not add an integer-class field. Four is the budget. A fifth pushes
+//     the second Value argument back onto the stack and undoes the work.
+//     Pack new tag-like state into the spare bits 6 and 7 of tag.
+//   - A float field is cheap: float arguments use a separate register file
+//     with 15 slots.
+//   - Keep the noCompare marker. A comparable Value makes signal.New install a
+//     pointer-based change test that misses in-place mutation, and makes it box
+//     both operands on every Set.
+//   - value_layout_test.go pins the size, the register-passing property, the
+//     tag packing, and the non-comparability. Keep all four pinned.
+//
+// RULE FOR READING A PAYLOAD INSIDE THIS PACKAGE.
+//
+// Call the unexported pointer-receiver form: text(), list(), dict(), truth(),
+// isList(), isMap(), control(). Read num directly, it is still a field.
+//
+// Do NOT call the exported value-receiver seams on a hot path in this package.
+// The inliner gives each nested value-receiver call its own copy of the
+// receiver, and it cannot fold those copies away once the Value lives in a
+// stack slot. stringAtDepth chained IsList() over kind(), which produced three
+// 32-byte MOVUPS copies per call and made BenchmarkValueIntToString 5x slower
+// than the 72-byte layout it replaced. Switching that one function to pointer
+// receivers took it from 9.3 ns back to 2.0 ns.
+//
+// THE IN-PLACE MUTATION CONTRACT, WHICH THE UNION KEEPS UNCHANGED.
+//
+// OpFieldSet and OpIndexSet mutate the array and object payloads IN PLACE, and
+// island/program/program.go records that as a deliberate decision: composite
+// parameters pass by reference because Go maps and slices are reference types.
+// The union satisfies this by storing the map header word, or the array's data
+// pointer, and writing through it. Two Values built from the same map or the
+// same array still share one object, so a write through either is visible to
+// both. Copy-on-write does not satisfy the contract and would break it.
+//
+// One narrow difference. List() rebuilds the slice header with capacity equal
+// to length, because the union does not store a capacity. Nothing in the VM
+// appended to a shared array in place, so no behaviour changed; AppendVal
+// already copied. An append to a List() result now always allocates a fresh
+// array, which is the safer of the two outcomes.
+//
+// A second narrow difference. ArrayVal(nil) and ObjectVal(nil) produce a Value
+// that is not a list and not a map, exactly as a nil Items or Fields field read
+// before. An empty but non-nil slice still reports IsList() == true, and its
+// List() still comes back non-nil, because unsafe.SliceData hands back the
+// original data pointer. Treat that pointer as unspecified all the same: ask
+// IsList() whether a payload exists, and ask len() how long it is. Never test
+// List() or Map() against nil.

--- a/client/vm/value_layout_test.go
+++ b/client/vm/value_layout_test.go
@@ -1,0 +1,215 @@
+package vm
+
+import (
+	"reflect"
+	"testing"
+	"unsafe"
+)
+
+// TestValueStaysCompact pins the size of Value.
+//
+// Every VM method takes and returns a Value by value, so one binary operation
+// copies the struct three times. A field added in the wrong place silently
+// widens every copy on the interactive hot path.
+func TestValueStaysCompact(t *testing.T) {
+	const want = 32
+	if got := unsafe.Sizeof(Value{}); got != want {
+		t.Errorf("unsafe.Sizeof(Value{}) = %d, want %d; store new payload state "+
+			"in the spare bits of tag, not in a new field", got, want)
+	}
+}
+
+// TestValuePassesInRegisters pins the leaf-field budget that keeps a Value in
+// CPU registers.
+//
+// The amd64 register ABI gives the whole call at most 9 integer registers and
+// 15 float registers. It assigns one register per leaf field. A binary method
+// such as Add passes a receiver and one argument, so each Value may spend at
+// most 4 integer-class leaf fields. A fifth pushes the argument back onto the
+// stack, which is exactly the cost the tagged union removed.
+//
+// Verify the assembly directly with:
+//
+//	go build -gcflags=-S ./client/vm 2>&1 | grep 'TEXT.*Value..Add'
+func TestValuePassesInRegisters(t *testing.T) {
+	const maxIntFields = 4
+	const maxFloatFields = 7
+
+	ints, floats := countLeafFields(reflect.TypeOf(Value{}))
+	if ints > maxIntFields {
+		t.Errorf("Value has %d integer-class leaf fields, want at most %d; "+
+			"a fifth spills the second Value argument to the stack",
+			ints, maxIntFields)
+	}
+	if floats > maxFloatFields {
+		t.Errorf("Value has %d float leaf fields, want at most %d", floats, maxFloatFields)
+	}
+}
+
+// countLeafFields flattens t the way the register ABI does and returns the
+// number of integer-class leaf fields and the number of float leaf fields.
+// An array of more than one element disqualifies register passing outright,
+// so it reports a count over any budget.
+func countLeafFields(t reflect.Type) (ints, floats int) {
+	switch t.Kind() {
+	case reflect.Float32, reflect.Float64:
+		return 0, 1
+	case reflect.Complex64, reflect.Complex128:
+		return 0, 2
+	case reflect.String, reflect.Interface:
+		return 2, 0
+	case reflect.Slice:
+		return 3, 0
+	case reflect.Array:
+		if t.Len() > 1 {
+			// The ABI never puts a multi-element array in registers.
+			return 99, 0
+		}
+		if t.Len() == 0 {
+			return 0, 0
+		}
+		return countLeafFields(t.Elem())
+	case reflect.Struct:
+		for i := 0; i < t.NumField(); i++ {
+			fi, ff := countLeafFields(t.Field(i).Type)
+			ints += fi
+			floats += ff
+		}
+		return ints, floats
+	default:
+		return 1, 0
+	}
+}
+
+// TestValueStaysIncomparable pins that Go refuses to compare two Values with ==.
+//
+// signal.New installs a == based change test for every comparable type. On a
+// union, == compares the payload pointer, and OpIndexSet mutates the array
+// behind that pointer in place. A comparable Value therefore makes a signal
+// report "unchanged" for contents that just changed, and the signal never
+// notifies. The pre-union layout held a map field, so it was never comparable.
+// Keep it that way. Use Eq, which walks the payload.
+func TestValueStaysIncomparable(t *testing.T) {
+	if reflect.TypeOf(Value{}).Comparable() {
+		t.Error("Value is comparable; signal.New will install a pointer-based " +
+			"change test that misses in-place mutation. Keep the noCompare field.")
+	}
+}
+
+// TestMapFitsOnePointerWord pins the assumption Map() and ObjectVal depend on.
+//
+// The union stores the object payload by copying the map header into the
+// pointer word and reading it back. That only works while a map value is
+// exactly one pointer wide. Both the gc toolchain and TinyGo represent a map
+// as one pointer today. A toolchain that changes it must fail here, loudly,
+// instead of corrupting every object Value.
+func TestMapFitsOnePointerWord(t *testing.T) {
+	var m map[string]Value
+	if got, want := unsafe.Sizeof(m), unsafe.Sizeof(unsafe.Pointer(nil)); got != want {
+		t.Fatalf("unsafe.Sizeof(map[string]Value) = %d, want %d; "+
+			"Value.Map() and ObjectVal must stop reinterpreting the map header", got, want)
+	}
+}
+
+// TestObjectValRoundTripsTheSameMap pins that the pointer-word round trip
+// hands back the identical map, not a copy. The whole in-place mutation
+// contract rests on it.
+func TestObjectValRoundTripsTheSameMap(t *testing.T) {
+	original := map[string]Value{"a": IntVal(1)}
+	got := ObjectVal(original).Map()
+
+	got["b"] = IntVal(2)
+	if _, ok := original["b"]; !ok {
+		t.Fatal("write through Map() did not reach the original map")
+	}
+	original["c"] = IntVal(3)
+	if _, ok := got["c"]; !ok {
+		t.Fatal("write through the original map did not reach Map()")
+	}
+	if len(got) != len(original) {
+		t.Fatalf("len(Map()) = %d, len(original) = %d", len(got), len(original))
+	}
+}
+
+// TestArrayValRoundTripsTheSameArray pins the array half of the same
+// contract: List() must alias the caller's backing array.
+func TestArrayValRoundTripsTheSameArray(t *testing.T) {
+	original := []Value{IntVal(1), IntVal(2), IntVal(3)}
+	v := ArrayVal(original)
+
+	if !v.SetIndex(1, IntVal(9)) {
+		t.Fatal("SetIndex reported no write")
+	}
+	if original[1].Number() != 9 {
+		t.Fatalf("original[1] = %v, want 9; SetIndex did not write in place", original[1].Number())
+	}
+	got := v.List()
+	if len(got) != len(original) {
+		t.Fatalf("len(List()) = %d, want %d", len(got), len(original))
+	}
+	if &got[0] != &original[0] {
+		t.Fatal("List() returned a copy, not an alias")
+	}
+}
+
+// TestValueTagBitsDoNotOverlap pins the packing inside the tag byte.
+//
+// tag carries the payload kind, the boolean payload, and the control signal.
+// Three separate bytes would cost three registers, which breaks the budget
+// TestValuePassesInRegisters guards. Overlapping masks would corrupt one
+// field when another is written, so pin them.
+func TestValueTagBitsDoNotOverlap(t *testing.T) {
+	controlBits := tagControlMask
+	if tagKindMask&tagTruthBit != 0 {
+		t.Errorf("tagKindMask %#x overlaps tagTruthBit %#x", tagKindMask, tagTruthBit)
+	}
+	if tagKindMask&controlBits != 0 {
+		t.Errorf("tagKindMask %#x overlaps tagControlMask %#x", tagKindMask, controlBits)
+	}
+	if tagTruthBit&controlBits != 0 {
+		t.Errorf("tagTruthBit %#x overlaps tagControlMask %#x", tagTruthBit, controlBits)
+	}
+	if uint8(kindClosure) > tagKindMask {
+		t.Errorf("kindClosure %d does not fit in tagKindMask %#x", kindClosure, tagKindMask)
+	}
+	if uint8(ControlContinue)<<tagControlShift&^tagControlMask != 0 {
+		t.Errorf("ControlContinue %d does not fit in tagControlMask %#x",
+			ControlContinue, tagControlMask)
+	}
+}
+
+// TestValueTagRoundTrips pins that each packed field survives a write to the
+// others. A shared byte only works if every setter masks its own bits.
+func TestValueTagRoundTrips(t *testing.T) {
+	kinds := []Value{
+		ZeroValue(0),
+		StringVal("payload"),
+		ArrayVal([]Value{IntVal(1)}),
+		ObjectVal(map[string]Value{"k": IntVal(1)}),
+		ClosureVal("fn", []string{"a"}, nil),
+	}
+	controls := []ControlSignal{ControlNone, ControlReturn, ControlBreak, ControlContinue}
+
+	for _, base := range kinds {
+		for _, truth := range []bool{false, true} {
+			v := base
+			if truth {
+				v.tag |= tagTruthBit
+			}
+			for _, ctrl := range controls {
+				got := v.WithControl(ctrl)
+				if got.Control() != ctrl {
+					t.Errorf("Control() = %d, want %d", got.Control(), ctrl)
+				}
+				if got.Truth() != truth {
+					t.Errorf("WithControl(%d) changed Truth() to %v, want %v",
+						ctrl, got.Truth(), truth)
+				}
+				if got.kind() != base.kind() {
+					t.Errorf("WithControl(%d) changed kind() to %d, want %d",
+						ctrl, got.kind(), base.kind())
+				}
+			}
+		}
+	}
+}

--- a/client/vm/value_test.go
+++ b/client/vm/value_test.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"math"
+	"strings"
 	"testing"
 
 	"m31labs.dev/gosx/island/program"
@@ -12,8 +13,8 @@ func TestStringVal(t *testing.T) {
 	if v.Type != program.TypeString {
 		t.Fatalf("expected TypeString, got %d", v.Type)
 	}
-	if v.Str != "hello" {
-		t.Fatalf("expected 'hello', got %q", v.Str)
+	if v.Text() != "hello" {
+		t.Fatalf("expected 'hello', got %q", v.Text())
 	}
 }
 
@@ -22,8 +23,8 @@ func TestIntVal(t *testing.T) {
 	if v.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", v.Type)
 	}
-	if v.Num != 42 {
-		t.Fatalf("expected 42, got %f", v.Num)
+	if v.num != 42 {
+		t.Fatalf("expected 42, got %f", v.num)
 	}
 }
 
@@ -32,8 +33,8 @@ func TestFloatVal(t *testing.T) {
 	if v.Type != program.TypeFloat {
 		t.Fatalf("expected TypeFloat, got %d", v.Type)
 	}
-	if v.Num != 3.14 {
-		t.Fatalf("expected 3.14, got %f", v.Num)
+	if v.num != 3.14 {
+		t.Fatalf("expected 3.14, got %f", v.num)
 	}
 }
 
@@ -42,12 +43,12 @@ func TestBoolVal(t *testing.T) {
 	if v.Type != program.TypeBool {
 		t.Fatalf("expected TypeBool, got %d", v.Type)
 	}
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("expected true")
 	}
 
 	v2 := BoolVal(false)
-	if v2.Bool {
+	if v2.Truth() {
 		t.Fatal("expected false")
 	}
 }
@@ -70,14 +71,14 @@ func TestZeroValue(t *testing.T) {
 		if v.Type != tt.typ {
 			t.Errorf("ZeroValue(%d): type = %d, want %d", tt.typ, v.Type, tt.typ)
 		}
-		if v.Str != tt.wantStr {
-			t.Errorf("ZeroValue(%d): Str = %q, want %q", tt.typ, v.Str, tt.wantStr)
+		if v.Text() != tt.wantStr {
+			t.Errorf("ZeroValue(%d): Str = %q, want %q", tt.typ, v.Text(), tt.wantStr)
 		}
-		if v.Num != tt.wantNum {
-			t.Errorf("ZeroValue(%d): Num = %f, want %f", tt.typ, v.Num, tt.wantNum)
+		if v.num != tt.wantNum {
+			t.Errorf("ZeroValue(%d): Num = %f, want %f", tt.typ, v.num, tt.wantNum)
 		}
-		if v.Bool != tt.wantBol {
-			t.Errorf("ZeroValue(%d): Bool = %v, want %v", tt.typ, v.Bool, tt.wantBol)
+		if v.Truth() != tt.wantBol {
+			t.Errorf("ZeroValue(%d): Bool = %v, want %v", tt.typ, v.Truth(), tt.wantBol)
 		}
 	}
 }
@@ -91,8 +92,8 @@ func TestAddInt(t *testing.T) {
 	if r.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
 	}
-	if r.Num != 13 {
-		t.Fatalf("expected 13, got %f", r.Num)
+	if r.num != 13 {
+		t.Fatalf("expected 13, got %f", r.num)
 	}
 }
 
@@ -103,8 +104,8 @@ func TestAddFloat(t *testing.T) {
 	if r.Type != program.TypeFloat {
 		t.Fatalf("expected TypeFloat, got %d", r.Type)
 	}
-	if r.Num != 4.0 {
-		t.Fatalf("expected 4.0, got %f", r.Num)
+	if r.num != 4.0 {
+		t.Fatalf("expected 4.0, got %f", r.num)
 	}
 }
 
@@ -115,8 +116,8 @@ func TestAddIntFloat(t *testing.T) {
 	if r.Type != program.TypeFloat {
 		t.Fatalf("expected TypeFloat for mixed add, got %d", r.Type)
 	}
-	if r.Num != 3.5 {
-		t.Fatalf("expected 3.5, got %f", r.Num)
+	if r.num != 3.5 {
+		t.Fatalf("expected 3.5, got %f", r.num)
 	}
 }
 
@@ -127,8 +128,8 @@ func TestSubInt(t *testing.T) {
 	if r.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
 	}
-	if r.Num != 7 {
-		t.Fatalf("expected 7, got %f", r.Num)
+	if r.num != 7 {
+		t.Fatalf("expected 7, got %f", r.num)
 	}
 }
 
@@ -136,8 +137,8 @@ func TestSubFloat(t *testing.T) {
 	a := FloatVal(5.5)
 	b := FloatVal(2.0)
 	r := a.Sub(b)
-	if r.Num != 3.5 {
-		t.Fatalf("expected 3.5, got %f", r.Num)
+	if r.num != 3.5 {
+		t.Fatalf("expected 3.5, got %f", r.num)
 	}
 }
 
@@ -148,8 +149,8 @@ func TestMulInt(t *testing.T) {
 	if r.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
 	}
-	if r.Num != 20 {
-		t.Fatalf("expected 20, got %f", r.Num)
+	if r.num != 20 {
+		t.Fatalf("expected 20, got %f", r.num)
 	}
 }
 
@@ -157,8 +158,8 @@ func TestMulFloat(t *testing.T) {
 	a := FloatVal(2.5)
 	b := FloatVal(4.0)
 	r := a.Mul(b)
-	if r.Num != 10.0 {
-		t.Fatalf("expected 10.0, got %f", r.Num)
+	if r.num != 10.0 {
+		t.Fatalf("expected 10.0, got %f", r.num)
 	}
 }
 
@@ -170,8 +171,8 @@ func TestDivInt(t *testing.T) {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
 	}
 	// integer division: 10 / 3 = 3
-	if r.Num != 3 {
-		t.Fatalf("expected 3 (integer division), got %f", r.Num)
+	if r.num != 3 {
+		t.Fatalf("expected 3 (integer division), got %f", r.num)
 	}
 }
 
@@ -183,8 +184,8 @@ func TestDivFloat(t *testing.T) {
 		t.Fatalf("expected TypeFloat, got %d", r.Type)
 	}
 	expected := 10.0 / 3.0
-	if math.Abs(r.Num-expected) > 1e-12 {
-		t.Fatalf("expected %f, got %f", expected, r.Num)
+	if math.Abs(r.num-expected) > 1e-12 {
+		t.Fatalf("expected %f, got %f", expected, r.num)
 	}
 }
 
@@ -192,8 +193,8 @@ func TestDivByZeroInt(t *testing.T) {
 	a := IntVal(10)
 	b := IntVal(0)
 	r := a.Div(b)
-	if r.Num != 0 {
-		t.Fatalf("expected 0 for div by zero, got %f", r.Num)
+	if r.num != 0 {
+		t.Fatalf("expected 0 for div by zero, got %f", r.num)
 	}
 }
 
@@ -201,8 +202,8 @@ func TestDivByZeroFloat(t *testing.T) {
 	a := FloatVal(10.0)
 	b := FloatVal(0.0)
 	r := a.Div(b)
-	if r.Num != 0 {
-		t.Fatalf("expected 0 for div by zero, got %f", r.Num)
+	if r.num != 0 {
+		t.Fatalf("expected 0 for div by zero, got %f", r.num)
 	}
 }
 
@@ -213,8 +214,8 @@ func TestModInt(t *testing.T) {
 	if r.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
 	}
-	if r.Num != 1 {
-		t.Fatalf("expected 1, got %f", r.Num)
+	if r.num != 1 {
+		t.Fatalf("expected 1, got %f", r.num)
 	}
 }
 
@@ -223,16 +224,16 @@ func TestModFloat(t *testing.T) {
 	b := FloatVal(3.0)
 	r := a.Mod(b)
 	expected := math.Mod(10.5, 3.0)
-	if math.Abs(r.Num-expected) > 1e-12 {
-		t.Fatalf("expected %f, got %f", expected, r.Num)
+	if math.Abs(r.num-expected) > 1e-12 {
+		t.Fatalf("expected %f, got %f", expected, r.num)
 	}
 }
 
 func TestNeg(t *testing.T) {
 	a := IntVal(5)
 	r := a.Neg()
-	if r.Num != -5 {
-		t.Fatalf("expected -5, got %f", r.Num)
+	if r.num != -5 {
+		t.Fatalf("expected -5, got %f", r.num)
 	}
 	if r.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", r.Type)
@@ -240,8 +241,8 @@ func TestNeg(t *testing.T) {
 
 	b := FloatVal(3.14)
 	r2 := b.Neg()
-	if r2.Num != -3.14 {
-		t.Fatalf("expected -3.14, got %f", r2.Num)
+	if r2.num != -3.14 {
+		t.Fatalf("expected -3.14, got %f", r2.num)
 	}
 }
 
@@ -253,86 +254,86 @@ func TestIntSemantics(t *testing.T) {
 	b := IntVal(2)
 
 	div := a.Div(b)
-	if div.Num != 3 {
-		t.Fatalf("7/2 should be 3 (int), got %f", div.Num)
+	if div.num != 3 {
+		t.Fatalf("7/2 should be 3 (int), got %f", div.num)
 	}
 
 	mod := a.Mod(b)
-	if mod.Num != 1 {
-		t.Fatalf("7%%2 should be 1, got %f", mod.Num)
+	if mod.num != 1 {
+		t.Fatalf("7%%2 should be 1, got %f", mod.num)
 	}
 }
 
 // --- Comparisons ---
 
 func TestEq(t *testing.T) {
-	if !IntVal(5).Eq(IntVal(5)).Bool {
+	if !IntVal(5).Eq(IntVal(5)).Truth() {
 		t.Fatal("5 == 5 should be true")
 	}
-	if IntVal(5).Eq(IntVal(6)).Bool {
+	if IntVal(5).Eq(IntVal(6)).Truth() {
 		t.Fatal("5 == 6 should be false")
 	}
-	if !StringVal("hi").Eq(StringVal("hi")).Bool {
+	if !StringVal("hi").Eq(StringVal("hi")).Truth() {
 		t.Fatal(`"hi" == "hi" should be true`)
 	}
-	if StringVal("hi").Eq(StringVal("bye")).Bool {
+	if StringVal("hi").Eq(StringVal("bye")).Truth() {
 		t.Fatal(`"hi" == "bye" should be false`)
 	}
-	if !BoolVal(true).Eq(BoolVal(true)).Bool {
+	if !BoolVal(true).Eq(BoolVal(true)).Truth() {
 		t.Fatal("true == true should be true")
 	}
 }
 
 func TestNeq(t *testing.T) {
-	if IntVal(5).Neq(IntVal(5)).Bool {
+	if IntVal(5).Neq(IntVal(5)).Truth() {
 		t.Fatal("5 != 5 should be false")
 	}
-	if !IntVal(5).Neq(IntVal(6)).Bool {
+	if !IntVal(5).Neq(IntVal(6)).Truth() {
 		t.Fatal("5 != 6 should be true")
 	}
 }
 
 func TestLt(t *testing.T) {
-	if !IntVal(3).Lt(IntVal(5)).Bool {
+	if !IntVal(3).Lt(IntVal(5)).Truth() {
 		t.Fatal("3 < 5 should be true")
 	}
-	if IntVal(5).Lt(IntVal(3)).Bool {
+	if IntVal(5).Lt(IntVal(3)).Truth() {
 		t.Fatal("5 < 3 should be false")
 	}
-	if IntVal(5).Lt(IntVal(5)).Bool {
+	if IntVal(5).Lt(IntVal(5)).Truth() {
 		t.Fatal("5 < 5 should be false")
 	}
 }
 
 func TestGt(t *testing.T) {
-	if !IntVal(5).Gt(IntVal(3)).Bool {
+	if !IntVal(5).Gt(IntVal(3)).Truth() {
 		t.Fatal("5 > 3 should be true")
 	}
-	if IntVal(3).Gt(IntVal(5)).Bool {
+	if IntVal(3).Gt(IntVal(5)).Truth() {
 		t.Fatal("3 > 5 should be false")
 	}
 }
 
 func TestLte(t *testing.T) {
-	if !IntVal(3).Lte(IntVal(5)).Bool {
+	if !IntVal(3).Lte(IntVal(5)).Truth() {
 		t.Fatal("3 <= 5 should be true")
 	}
-	if !IntVal(5).Lte(IntVal(5)).Bool {
+	if !IntVal(5).Lte(IntVal(5)).Truth() {
 		t.Fatal("5 <= 5 should be true")
 	}
-	if IntVal(6).Lte(IntVal(5)).Bool {
+	if IntVal(6).Lte(IntVal(5)).Truth() {
 		t.Fatal("6 <= 5 should be false")
 	}
 }
 
 func TestGte(t *testing.T) {
-	if !IntVal(5).Gte(IntVal(3)).Bool {
+	if !IntVal(5).Gte(IntVal(3)).Truth() {
 		t.Fatal("5 >= 3 should be true")
 	}
-	if !IntVal(5).Gte(IntVal(5)).Bool {
+	if !IntVal(5).Gte(IntVal(5)).Truth() {
 		t.Fatal("5 >= 5 should be true")
 	}
-	if IntVal(3).Gte(IntVal(5)).Bool {
+	if IntVal(3).Gte(IntVal(5)).Truth() {
 		t.Fatal("3 >= 5 should be false")
 	}
 }
@@ -340,34 +341,34 @@ func TestGte(t *testing.T) {
 // --- Boolean ops ---
 
 func TestAnd(t *testing.T) {
-	if !BoolVal(true).And(BoolVal(true)).Bool {
+	if !BoolVal(true).And(BoolVal(true)).Truth() {
 		t.Fatal("true && true should be true")
 	}
-	if BoolVal(true).And(BoolVal(false)).Bool {
+	if BoolVal(true).And(BoolVal(false)).Truth() {
 		t.Fatal("true && false should be false")
 	}
-	if BoolVal(false).And(BoolVal(true)).Bool {
+	if BoolVal(false).And(BoolVal(true)).Truth() {
 		t.Fatal("false && true should be false")
 	}
 }
 
 func TestOr(t *testing.T) {
-	if !BoolVal(true).Or(BoolVal(false)).Bool {
+	if !BoolVal(true).Or(BoolVal(false)).Truth() {
 		t.Fatal("true || false should be true")
 	}
-	if !BoolVal(false).Or(BoolVal(true)).Bool {
+	if !BoolVal(false).Or(BoolVal(true)).Truth() {
 		t.Fatal("false || true should be true")
 	}
-	if BoolVal(false).Or(BoolVal(false)).Bool {
+	if BoolVal(false).Or(BoolVal(false)).Truth() {
 		t.Fatal("false || false should be false")
 	}
 }
 
 func TestNot(t *testing.T) {
-	if BoolVal(true).Not().Bool {
+	if BoolVal(true).Not().Truth() {
 		t.Fatal("!true should be false")
 	}
-	if !BoolVal(false).Not().Bool {
+	if !BoolVal(false).Not().Truth() {
 		t.Fatal("!false should be true")
 	}
 }
@@ -378,8 +379,8 @@ func TestConcat(t *testing.T) {
 	a := StringVal("hello")
 	b := StringVal(" world")
 	r := a.Concat(b)
-	if r.Str != "hello world" {
-		t.Fatalf("expected 'hello world', got %q", r.Str)
+	if r.Text() != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", r.Text())
 	}
 	if r.Type != program.TypeString {
 		t.Fatalf("expected TypeString, got %d", r.Type)
@@ -426,8 +427,8 @@ func TestArrayValCreation(t *testing.T) {
 	if v.Type != program.TypeAny {
 		t.Fatalf("expected TypeAny, got %d", v.Type)
 	}
-	if len(v.Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(v.Items))
+	if len(v.List()) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(v.List()))
 	}
 }
 
@@ -447,60 +448,60 @@ func TestArrayLen(t *testing.T) {
 func TestAppendVal(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2)})
 	v2 := v.AppendVal(IntVal(3))
-	if len(v2.Items) != 3 {
-		t.Fatalf("expected 3 items after append, got %d", len(v2.Items))
+	if len(v2.List()) != 3 {
+		t.Fatalf("expected 3 items after append, got %d", len(v2.List()))
 	}
-	if v2.Items[2].Num != 3 {
-		t.Fatalf("expected last item=3, got %f", v2.Items[2].Num)
+	if v2.List()[2].num != 3 {
+		t.Fatalf("expected last item=3, got %f", v2.List()[2].num)
 	}
 	// Original should be unchanged (immutability)
-	if len(v.Items) != 2 {
-		t.Fatalf("original should still have 2 items, got %d", len(v.Items))
+	if len(v.List()) != 2 {
+		t.Fatalf("original should still have 2 items, got %d", len(v.List()))
 	}
 }
 
 func TestFilterFunc(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3), IntVal(4)})
 	even := v.FilterFunc(func(val Value) bool {
-		return int(val.Num)%2 == 0
+		return int(val.num)%2 == 0
 	})
-	if len(even.Items) != 2 {
-		t.Fatalf("expected 2 even items, got %d", len(even.Items))
+	if len(even.List()) != 2 {
+		t.Fatalf("expected 2 even items, got %d", len(even.List()))
 	}
-	if even.Items[0].Num != 2 || even.Items[1].Num != 4 {
-		t.Fatalf("expected [2, 4], got [%f, %f]", even.Items[0].Num, even.Items[1].Num)
+	if even.List()[0].num != 2 || even.List()[1].num != 4 {
+		t.Fatalf("expected [2, 4], got [%f, %f]", even.List()[0].num, even.List()[1].num)
 	}
 }
 
 func TestMapFunc(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3)})
 	doubled := v.MapFunc(func(val Value, i int) Value {
-		return IntVal(int(val.Num) * 2)
+		return IntVal(int(val.num) * 2)
 	})
-	if len(doubled.Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(doubled.Items))
+	if len(doubled.List()) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(doubled.List()))
 	}
-	if doubled.Items[0].Num != 2 || doubled.Items[1].Num != 4 || doubled.Items[2].Num != 6 {
+	if doubled.List()[0].num != 2 || doubled.List()[1].num != 4 || doubled.List()[2].num != 6 {
 		t.Fatalf("expected [2, 4, 6]")
 	}
 }
 
 func TestContainsValArray(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3)})
-	if !v.ContainsVal(IntVal(2)).Bool {
+	if !v.ContainsVal(IntVal(2)).Truth() {
 		t.Fatal("array should contain 2")
 	}
-	if v.ContainsVal(IntVal(5)).Bool {
+	if v.ContainsVal(IntVal(5)).Truth() {
 		t.Fatal("array should not contain 5")
 	}
 }
 
 func TestContainsValString(t *testing.T) {
 	v := StringVal("hello world")
-	if !v.ContainsVal(StringVal("world")).Bool {
+	if !v.ContainsVal(StringVal("world")).Truth() {
 		t.Fatal("string should contain 'world'")
 	}
-	if v.ContainsVal(StringVal("xyz")).Bool {
+	if v.ContainsVal(StringVal("xyz")).Truth() {
 		t.Fatal("string should not contain 'xyz'")
 	}
 }
@@ -520,24 +521,68 @@ func TestArrayEq(t *testing.T) {
 	c := ArrayVal([]Value{IntVal(1), IntVal(3)})
 	d := ArrayVal([]Value{IntVal(1)})
 
-	if !a.Eq(b).Bool {
+	if !a.Eq(b).Truth() {
 		t.Fatal("[1,2] == [1,2] should be true")
 	}
-	if a.Eq(c).Bool {
+	if a.Eq(c).Truth() {
 		t.Fatal("[1,2] == [1,3] should be false")
 	}
-	if a.Eq(d).Bool {
+	if a.Eq(d).Truth() {
 		t.Fatal("[1,2] == [1] should be false (different length)")
+	}
+}
+
+// TestValueStringSelfReferentialArrayDoesNotOverflow pins the
+// unrecoverable-crash reproduction from OpIndexSet's in-place
+// mutation. `arr[0] = arr` makes Items[0] alias the very array it
+// lives in. Value.Items is a shared slice header, so the write is
+// visible through every alias (see lhs_set.go's file header).
+//
+// The pre-fix String() recursed over Items with no depth guard and
+// no visited set. A self-referential Value recurses forever, so the
+// test hung until the goroutine stack hit its limit. The process
+// then died with "fatal error: stack overflow", which recover()
+// cannot catch. String() must now degrade to the cycle sentinel
+// instead.
+func TestValueStringSelfReferentialArrayDoesNotOverflow(t *testing.T) {
+	arr := ArrayVal([]Value{{}})
+	arr.List()[0] = arr // build the cycle exactly as OpIndexSet would
+
+	got := arr.String()
+	if got == "" {
+		t.Fatal("String() on a self-referential array returned empty; want a bounded, non-empty result")
+	}
+	if !strings.Contains(got, cycleSentinel) {
+		t.Fatalf("String() on a self-referential array = %q, want it to contain the cycle sentinel %q", got, cycleSentinel)
+	}
+}
+
+// TestValueEqSelfReferentialArrayDoesNotOverflow mirrors the String()
+// regression above for Eq(), which recurses over Items the same way.
+func TestValueEqSelfReferentialArrayDoesNotOverflow(t *testing.T) {
+	arr := ArrayVal([]Value{{}})
+	arr.List()[0] = arr
+
+	other := ArrayVal([]Value{{}})
+	other.List()[0] = other
+
+	// The assertion here is simply that Eq returns without
+	// crashing. Depth-capped comparison on a genuine cycle is
+	// inherently inconclusive. So BoolVal(false) is the safe answer
+	// once the depth guard fires.
+	got := arr.Eq(other)
+	if got.Type != program.TypeBool {
+		t.Fatalf("Eq on self-referential arrays = %+v, want a BoolVal", got)
 	}
 }
 
 func TestSliceVal(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2), IntVal(3), IntVal(4)})
 	s := v.SliceVal(1, 3)
-	if len(s.Items) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(s.Items))
+	if len(s.List()) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(s.List()))
 	}
-	if s.Items[0].Num != 2 || s.Items[1].Num != 3 {
+	if s.List()[0].num != 2 || s.List()[1].num != 3 {
 		t.Fatalf("expected [2, 3]")
 	}
 }
@@ -545,16 +590,59 @@ func TestSliceVal(t *testing.T) {
 func TestSliceValBoundsClamp(t *testing.T) {
 	v := ArrayVal([]Value{IntVal(1), IntVal(2)})
 	s := v.SliceVal(-1, 100)
-	if len(s.Items) != 2 {
-		t.Fatalf("expected clamped to 2 items, got %d", len(s.Items))
+	if len(s.List()) != 2 {
+		t.Fatalf("expected clamped to 2 items, got %d", len(s.List()))
+	}
+}
+
+// TestSliceValNegativeEndDoesNotPanic pins the exact crash
+// reproduction for `items[0:len(items)-1]` on an empty array. end
+// (len(items)-1) evaluates to -1. The pre-fix SliceVal only clamped
+// end on its high side (end > n), never on its low side.
+//
+// A negative end reached the start-over-end swap as the smaller
+// value. It then reached v.Items[start:end] as a negative index and
+// panicked with "slice bounds out of range [:-1]". Before the fix
+// this test panicked. It now must return an empty array with no
+// panic.
+func TestSliceValNegativeEndDoesNotPanic(t *testing.T) {
+	v := ArrayVal(nil)
+	got := v.SliceVal(0, len(v.List())-1)
+	if len(got.List()) != 0 {
+		t.Fatalf("SliceVal(0, -1) on empty array = %+v, want 0 items", got)
+	}
+}
+
+// TestSliceValInfEndDoesNotPanic pins the float-literal
+// reproduction. A source expression like `9e999` parses to +Inf,
+// and int(+Inf) is math.MinInt64 on amd64. Passed straight through
+// as `end`, the old SliceVal panicked with "slice bounds out of
+// range [:-9223372036854775808]".
+//
+// The fixed SliceVal clamps end into [0, n] regardless of how it
+// got there. The degenerate cast lands on a deeply negative int
+// here, so the safe, non-panicking answer is an empty slice, not
+// the full array.
+//
+// vm.go's safeBoundInt intercepts the float itself before this
+// conversion happens. So a real OpSlice dispatch sees +Inf clamp
+// toward the array's length instead — see
+// TestVMOpSliceFloatOverflowEndDoesNotPanic in safety_test.go. This
+// test pins SliceVal's own defense-in-depth clamp in isolation.
+func TestSliceValInfEndDoesNotPanic(t *testing.T) {
+	v := ArrayVal([]Value{IntVal(1), IntVal(2)})
+	end := int(math.Inf(1))
+	got := v.SliceVal(0, end)
+	if len(got.List()) != 0 {
+		t.Fatalf("SliceVal(0, MinInt64-from-+Inf) = %+v, want an empty (not panicking) result", got)
 	}
 }
 
 func TestJoinVal(t *testing.T) {
 	v := ArrayVal([]Value{StringVal("a"), StringVal("b"), StringVal("c")})
 	joined := v.JoinVal(", ")
-	if joined.Str != "a, b, c" {
-		t.Fatalf("expected 'a, b, c', got %q", joined.Str)
+	if joined.Text() != "a, b, c" {
+		t.Fatalf("expected 'a, b, c', got %q", joined.Text())
 	}
 }
 
@@ -562,32 +650,32 @@ func TestJoinVal(t *testing.T) {
 
 func TestToUpper(t *testing.T) {
 	v := StringVal("hello")
-	if v.ToUpper().Str != "HELLO" {
-		t.Fatalf("expected 'HELLO', got %q", v.ToUpper().Str)
+	if v.ToUpper().Text() != "HELLO" {
+		t.Fatalf("expected 'HELLO', got %q", v.ToUpper().Text())
 	}
 }
 
 func TestToLower(t *testing.T) {
 	v := StringVal("HELLO")
-	if v.ToLower().Str != "hello" {
-		t.Fatalf("expected 'hello', got %q", v.ToLower().Str)
+	if v.ToLower().Text() != "hello" {
+		t.Fatalf("expected 'hello', got %q", v.ToLower().Text())
 	}
 }
 
 func TestTrimVal(t *testing.T) {
 	v := StringVal("  hello  ")
-	if v.TrimVal().Str != "hello" {
-		t.Fatalf("expected 'hello', got %q", v.TrimVal().Str)
+	if v.TrimVal().Text() != "hello" {
+		t.Fatalf("expected 'hello', got %q", v.TrimVal().Text())
 	}
 }
 
 func TestSplitVal(t *testing.T) {
 	v := StringVal("a,b,c")
 	result := v.SplitVal(",")
-	if len(result.Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(result.Items))
+	if len(result.List()) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(result.List()))
 	}
-	if result.Items[0].Str != "a" || result.Items[1].Str != "b" || result.Items[2].Str != "c" {
+	if result.List()[0].Text() != "a" || result.List()[1].Text() != "b" || result.List()[2].Text() != "c" {
 		t.Fatal("split items don't match")
 	}
 }
@@ -595,43 +683,67 @@ func TestSplitVal(t *testing.T) {
 func TestReplaceVal(t *testing.T) {
 	v := StringVal("hello world world")
 	r := v.ReplaceVal("world", "go")
-	if r.Str != "hello go go" {
-		t.Fatalf("expected 'hello go go', got %q", r.Str)
+	if r.Text() != "hello go go" {
+		t.Fatalf("expected 'hello go go', got %q", r.Text())
 	}
 }
 
 func TestSubstringVal(t *testing.T) {
 	v := StringVal("hello world")
 	s := v.SubstringVal(0, 5)
-	if s.Str != "hello" {
-		t.Fatalf("expected 'hello', got %q", s.Str)
+	if s.Text() != "hello" {
+		t.Fatalf("expected 'hello', got %q", s.Text())
 	}
 }
 
 func TestSubstringValBoundsClamp(t *testing.T) {
 	v := StringVal("hi")
 	s := v.SubstringVal(-1, 100)
-	if s.Str != "hi" {
-		t.Fatalf("expected clamped to 'hi', got %q", s.Str)
+	if s.Text() != "hi" {
+		t.Fatalf("expected clamped to 'hi', got %q", s.Text())
+	}
+}
+
+// TestSubstringValNegativeEndDoesNotPanic pins the exact crash
+// reproduction for `name[0:len(name)-1]` on an empty string. end
+// evaluates to -1. The pre-fix SubstringVal panicked the same way
+// SliceVal did ("slice bounds out of range [:-1]").
+func TestSubstringValNegativeEndDoesNotPanic(t *testing.T) {
+	v := StringVal("")
+	got := v.SubstringVal(0, len(v.Text())-1)
+	if got.Text() != "" {
+		t.Fatalf("SubstringVal(0, -1) on empty string = %q, want \"\"", got.Text())
+	}
+}
+
+// TestSubstringValInfEndDoesNotPanic mirrors
+// TestSliceValInfEndDoesNotPanic for the string path: the degenerate
+// MinInt64 cast clamps to an empty result rather than panicking.
+func TestSubstringValInfEndDoesNotPanic(t *testing.T) {
+	v := StringVal("hello")
+	end := int(math.Inf(1))
+	got := v.SubstringVal(0, end)
+	if got.Text() != "" {
+		t.Fatalf("SubstringVal(0, MinInt64-from-+Inf) = %q, want an empty (not panicking) result", got.Text())
 	}
 }
 
 func TestStartsWithVal(t *testing.T) {
 	v := StringVal("hello world")
-	if !v.StartsWithVal(StringVal("hello")).Bool {
+	if !v.StartsWithVal(StringVal("hello")).Truth() {
 		t.Fatal("should start with 'hello'")
 	}
-	if v.StartsWithVal(StringVal("world")).Bool {
+	if v.StartsWithVal(StringVal("world")).Truth() {
 		t.Fatal("should not start with 'world'")
 	}
 }
 
 func TestEndsWithVal(t *testing.T) {
 	v := StringVal("hello world")
-	if !v.EndsWithVal(StringVal("world")).Bool {
+	if !v.EndsWithVal(StringVal("world")).Truth() {
 		t.Fatal("should end with 'world'")
 	}
-	if v.EndsWithVal(StringVal("hello")).Bool {
+	if v.EndsWithVal(StringVal("hello")).Truth() {
 		t.Fatal("should not end with 'hello'")
 	}
 }
@@ -639,16 +751,16 @@ func TestEndsWithVal(t *testing.T) {
 // --- Type conversions ---
 
 func TestToStringVal(t *testing.T) {
-	if IntVal(42).ToStringVal().Str != "42" {
+	if IntVal(42).ToStringVal().Text() != "42" {
 		t.Fatal("int 42 should convert to string '42'")
 	}
-	if FloatVal(3.14).ToStringVal().Str != "3.14" {
+	if FloatVal(3.14).ToStringVal().Text() != "3.14" {
 		t.Fatal("float 3.14 should convert to string '3.14'")
 	}
-	if BoolVal(true).ToStringVal().Str != "true" {
+	if BoolVal(true).ToStringVal().Text() != "true" {
 		t.Fatal("bool true should convert to string 'true'")
 	}
-	if StringVal("hi").ToStringVal().Str != "hi" {
+	if StringVal("hi").ToStringVal().Text() != "hi" {
 		t.Fatal("string should stay the same")
 	}
 }
@@ -656,47 +768,47 @@ func TestToStringVal(t *testing.T) {
 func TestToIntVal(t *testing.T) {
 	// From string
 	v := StringVal("42").ToIntVal()
-	if v.Type != program.TypeInt || v.Num != 42 {
-		t.Fatalf("expected IntVal(42), got type=%d num=%f", v.Type, v.Num)
+	if v.Type != program.TypeInt || v.num != 42 {
+		t.Fatalf("expected IntVal(42), got type=%d num=%f", v.Type, v.num)
 	}
 
 	// From float (truncates)
 	v = FloatVal(3.9).ToIntVal()
-	if v.Type != program.TypeInt || v.Num != 3 {
-		t.Fatalf("expected IntVal(3), got type=%d num=%f", v.Type, v.Num)
+	if v.Type != program.TypeInt || v.num != 3 {
+		t.Fatalf("expected IntVal(3), got type=%d num=%f", v.Type, v.num)
 	}
 
 	// From bool
-	if BoolVal(true).ToIntVal().Num != 1 {
+	if BoolVal(true).ToIntVal().num != 1 {
 		t.Fatal("true should convert to 1")
 	}
-	if BoolVal(false).ToIntVal().Num != 0 {
+	if BoolVal(false).ToIntVal().num != 0 {
 		t.Fatal("false should convert to 0")
 	}
 
 	// Invalid string
 	v = StringVal("abc").ToIntVal()
-	if v.Num != 0 {
-		t.Fatalf("invalid string should give 0, got %f", v.Num)
+	if v.num != 0 {
+		t.Fatalf("invalid string should give 0, got %f", v.num)
 	}
 }
 
 func TestToFloatVal(t *testing.T) {
 	// From string
 	v := StringVal("3.14").ToFloatVal()
-	if v.Type != program.TypeFloat || v.Num != 3.14 {
-		t.Fatalf("expected FloatVal(3.14), got type=%d num=%f", v.Type, v.Num)
+	if v.Type != program.TypeFloat || v.num != 3.14 {
+		t.Fatalf("expected FloatVal(3.14), got type=%d num=%f", v.Type, v.num)
 	}
 
 	// From int (promotes)
 	v = IntVal(5).ToFloatVal()
-	if v.Type != program.TypeFloat || v.Num != 5 {
-		t.Fatalf("expected FloatVal(5), got type=%d num=%f", v.Type, v.Num)
+	if v.Type != program.TypeFloat || v.num != 5 {
+		t.Fatalf("expected FloatVal(5), got type=%d num=%f", v.Type, v.num)
 	}
 
 	// Invalid string
 	v = StringVal("abc").ToFloatVal()
-	if v.Num != 0 {
-		t.Fatalf("invalid string should give 0, got %f", v.Num)
+	if v.num != 0 {
+		t.Fatalf("invalid string should give 0, got %f", v.num)
 	}
 }

--- a/client/vm/vm.go
+++ b/client/vm/vm.go
@@ -2,6 +2,7 @@ package vm
 
 import (
 	"fmt"
+	"math"
 	"sort"
 	"strconv"
 	"sync"
@@ -16,15 +17,25 @@ type VM struct {
 	props          map[string]Value
 	signals        map[string]*signal.Signal[Value]
 	exprs          []program.Expr
+	lits           []litSlot                   // numeric literals decoded once, indexed by ExprID
 	eventData      map[string]string           // current event data (set during handler dispatch)
 	frame          *frame                      // locals table for the current handler evaluation (X.A)
-	forCap         int                         // per-loop iteration cap (X.C); 0 → default
+	forCap         int                         // per-loop AND per-dispatch total iteration cap (X.C, loops.go); 0 → default
 	funcs          map[string]*program.FuncDef // user-function registry (Y.D)
 	callDepth      int                         // current OpIndirectCall recursion depth (Y.D)
+	evalDepth      int                         // current Eval recursion depth, guards the general (non-call) recursion path
+	loopSteps      int                         // total OpFor / OpForRange iterations charged in the current top-level dispatch
+	loopBudgetHit  bool                        // sticky once loopSteps exceeds its budget, so every nested loop level stops
 	hosts          map[string]HostReceiver     // per-VM host-receiver bindings for OpHostCall (Y.E)
 	hostsMu        sync.RWMutex                // guards hosts: BindHost may run on a teardown goroutine concurrently with LookupHost / dispatch
 	diagnostics    []Diagnostic
 	diagnosticSink DiagnosticSink
+
+	// reuse carries the subtree-reuse context for the current EvalTree
+	// call. The Island sets it before the walk and clears it after, so a
+	// direct EvalTree caller sees the original full-evaluation behaviour.
+	// nil means "evaluate every node". See reuse.go.
+	reuse *treeReuse
 }
 
 type iterationContext struct {
@@ -68,6 +79,7 @@ func NewVM(prog *program.Program, props map[string]Value) *VM {
 		return vm
 	}
 	vm.exprs = prog.Exprs
+	vm.lits = buildLiteralTable(prog.Exprs)
 	// Slice Y.D: build a fast funcDef lookup so OpIndirectCall is one
 	// map probe. Programs without user functions (Funcs nil/empty)
 	// pay nothing — the map stays nil and the dispatcher records the
@@ -127,6 +139,7 @@ func (vm *VM) SwapProgram(p *program.Program) {
 	// its funcs releases the old map).
 	vm.program = p
 	vm.exprs = p.Exprs
+	vm.lits = buildLiteralTable(p.Exprs)
 	vm.funcs = nil
 	if len(p.Funcs) > 0 {
 		vm.funcs = make(map[string]*program.FuncDef, len(p.Funcs))
@@ -179,6 +192,18 @@ func (vm *VM) DeleteProp(name string) {
 	delete(vm.props, name)
 }
 
+// maxEvalDepth bounds Eval's own recursion. Program.MaxCallDepth
+// (Y.D) only guards OpIndirectCall and closure dispatch. A
+// self-referential or pathologically deep expression graph instead
+// reaches Eval through ordinary operand recursion, with no call
+// boundary at all. Examples include evalBinary, OpCond, and OpSeq.
+// This path needs its own, independent cap.
+//
+// The cap is generous relative to the deepest legitimate
+// call/expression nesting seen in the test suite. It still sits far
+// below the depth that would exhaust the goroutine stack.
+const maxEvalDepth = 10000
+
 // Eval evaluates an expression by ID and returns its value. The VM keeps its
 // panic-free contract: malformed programs produce zero values and structured
 // diagnostics instead of panics.
@@ -192,67 +217,167 @@ func (vm *VM) Eval(id program.ExprID) Value {
 		})
 		return ZeroValue(program.TypeAny)
 	}
-	return vm.evalExpr(vm.exprs[id])
+	// evalDepth == 0 marks the start of a fresh top-level dispatch: a
+	// call from EvalWithFrame, EvalTree, or a direct Eval by a host.
+	// Reset the loop step budget here. This bounds the total OpFor /
+	// OpForRange work for THIS dispatch, not for every dispatch the
+	// VM ever runs.
+	if vm.evalDepth == 0 {
+		vm.loopSteps = 0
+		vm.loopBudgetHit = false
+	}
+	if vm.evalDepth >= maxEvalDepth {
+		vm.recordExprDiagnostic(
+			"eval_depth_exceeded",
+			fmt.Sprintf("Eval recursion exceeded depth cap %d; aborting to avoid a stack overflow", maxEvalDepth),
+			vm.exprs[id].Op,
+			vm.exprs[id].Value,
+		)
+		return ZeroValue(program.TypeAny)
+	}
+	// Numeric literals answer straight from the table built at program load.
+	// A loop body re-evaluates the same literal once per iteration, so this
+	// removes up to one strconv parse per iteration. Literals recurse into
+	// nothing, so they need no depth charge.
+	if int(id) < len(vm.lits) {
+		if slot := vm.lits[id]; slot.kind != litNone {
+			return vm.decodedLiteral(id, slot)
+		}
+	}
+	vm.evalDepth++
+	v := vm.evalExpr(&vm.exprs[id])
+	vm.evalDepth--
+	return v
 }
 
-func (vm *VM) evalExpr(e program.Expr) Value {
-	if value, ok := vm.evalLiteralExpr(e); ok {
-		return value
+// evalExpr routes one expression to its handler.
+//
+// Dispatch is a single switch on the opcode. It replaced a chain of nineteen
+// "try this opcode family, else try the next" calls, which charged a late
+// opcode up to eighteen extra calls and switches before it reached its own
+// handler. The Expr arrives by pointer: the struct is 56 bytes, and the old
+// chain copied it once per stage.
+func (vm *VM) evalExpr(e *program.Expr) Value {
+	switch e.Op {
+	// --- literals ---
+	case program.OpLitString:
+		return StringVal(e.Value)
+	case program.OpLitInt:
+		return vm.parseIntLiteral(e)
+	case program.OpLitFloat:
+		return vm.parseFloatLiteral(e)
+	case program.OpLitBool:
+		return BoolVal(e.Value == "true")
+
+	// --- props, signals, event data ---
+	case program.OpPropGet:
+		return vm.propValue(e.Value, e.Type)
+	case program.OpSignalGet:
+		return vm.signalValue(e.Value, e.Type)
+	case program.OpSignalSet, program.OpSignalUpdate:
+		return vm.updateSignal(e)
+	case program.OpEventGet:
+		return vm.eventValue(e.Value)
+
+	// --- two-operand arithmetic, comparison, boolean and string joins ---
+	case program.OpAdd, program.OpSub, program.OpMul, program.OpDiv,
+		program.OpMod, program.OpEq, program.OpNeq, program.OpLt,
+		program.OpGt, program.OpLte, program.OpGte, program.OpAnd,
+		program.OpOr, program.OpConcat:
+		return vm.evalBinaryOp(e)
+
+	// --- one-operand negation, conversion and string case/trim ---
+	case program.OpNeg, program.OpNot, program.OpToUpper, program.OpToLower,
+		program.OpTrim, program.OpToString, program.OpToInt, program.OpToFloat:
+		return vm.evalUnaryOp(e)
+
+	// --- formatting and control flow ---
+	case program.OpFormat:
+		return vm.formatValue(e)
+	case program.OpCond:
+		return vm.conditionalValue(e)
+	case program.OpCall:
+		return vm.callValue(e)
+
+	// --- collections ---
+	case program.OpIndex:
+		return vm.indexValue(e)
+	case program.OpLen:
+		return vm.lenValue(e)
+	case program.OpRange:
+		return ZeroValue(program.TypeAny)
+	case program.OpMap:
+		return vm.mapValue(e)
+	case program.OpFilter:
+		return vm.filterValue(e)
+	case program.OpFind:
+		return vm.findValue(e)
+	case program.OpSlice:
+		return vm.sliceValue(e)
+	case program.OpAppend:
+		return vm.appendValue(e)
+	case program.OpContains:
+		return vm.containsValue(e)
+
+	// --- string methods with extra operands ---
+	case program.OpSplit:
+		return vm.splitValue(e)
+	case program.OpJoin:
+		return vm.joinValue(e)
+	case program.OpReplace:
+		return vm.replaceValue(e)
+	case program.OpSubstring:
+		return vm.substringValue(e)
+	case program.OpStartsWith:
+		return vm.startsWithValue(e)
+	case program.OpEndsWith:
+		return vm.endsWithValue(e)
+	case program.OpToRunes:
+		return vm.toRunesValue(e)
+
+	// --- statement sequencing and locals (Slice X.A) ---
+	case program.OpSeq:
+		return vm.seqValue(e)
+	case program.OpAssign:
+		return vm.assignValue(e)
+	case program.OpLocalDecl:
+		return vm.localDeclValue(e)
+	case program.OpLocalGet:
+		return vm.localGetValue(e)
+	case program.OpLocalSet:
+		return vm.localSetValue(e)
+
+	// --- imperative iteration and control exits (Slice X.C) ---
+	case program.OpFor:
+		return vm.forValue(e)
+	case program.OpForRange:
+		return vm.forRangeValue(e)
+	case program.OpReturn:
+		return vm.returnValue(e)
+	case program.OpBreak:
+		return Value{}.WithControl(ControlBreak)
+	case program.OpContinue:
+		return Value{}.WithControl(ControlContinue)
+
+	// --- composites, lookups, in-place writes, calls (Slices Y.A–Y.G) ---
+	case program.OpComposite:
+		return vm.compositeValue(e)
+	case program.OpMapLookup:
+		return vm.mapLookupValue(e)
+	case program.OpFieldSet:
+		return vm.fieldSetValue(e)
+	case program.OpIndexSet:
+		return vm.indexSetValue(e)
+	case program.OpIndirectCall:
+		return vm.indirectCallValue(e)
+	case program.OpMake:
+		return vm.makeValue(e)
+	case program.OpHostCall:
+		return vm.hostCallValue(e)
+	case program.OpClosure:
+		return vm.closureValue(e)
 	}
-	if value, ok := vm.evalAccessExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalArithmeticExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalComparisonExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalBooleanExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalStringExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalControlExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalCollectionExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalIterationExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalStringMethodExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalConversionExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalSequencingExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalCompositeExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalMapLookupExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalLHSSetExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalIndirectCallExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalMakeExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalHostCallExpr(e); ok {
-		return value
-	}
-	if value, ok := vm.evalClosureExpr(e); ok {
-		return value
-	}
+
 	vm.recordExprDiagnostic(
 		"unknown_opcode",
 		fmt.Sprintf("unknown island VM opcode %d", e.Op),
@@ -278,10 +403,7 @@ func (vm *VM) evalExpr(e program.Expr) Value {
 //
 // Unknown kind tags record an "invalid_composite" diagnostic and fall
 // back to the zero Any value so the VM's panic-free contract holds.
-func (vm *VM) evalCompositeExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpComposite {
-		return Value{}, false
-	}
+func (vm *VM) compositeValue(e *program.Expr) Value {
 	if len(e.Operands)%2 != 0 {
 		vm.recordExprDiagnostic(
 			"invalid_composite",
@@ -289,15 +411,15 @@ func (vm *VM) evalCompositeExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 	switch {
 	case e.Value == "slice":
-		return vm.compositeSlice(e), true
+		return vm.compositeSlice(e)
 	case e.Value == "map":
-		return vm.compositeMap(e), true
+		return vm.compositeMap(e)
 	case len(e.Value) >= 7 && e.Value[:7] == "struct:":
-		return vm.compositeStruct(e), true
+		return vm.compositeStruct(e)
 	default:
 		vm.recordExprDiagnostic(
 			"invalid_composite",
@@ -305,7 +427,7 @@ func (vm *VM) evalCompositeExpr(e program.Expr) (Value, bool) {
 			e.Op,
 			e.Value,
 		)
-		return ZeroValue(program.TypeAny), true
+		return ZeroValue(program.TypeAny)
 	}
 }
 
@@ -313,7 +435,7 @@ func (vm *VM) evalCompositeExpr(e program.Expr) (Value, bool) {
 // (keyExpr, valueExpr) operand pairs. Keys must evaluate to strings —
 // the lowerer always emits OpLitString for them, so this is a near-
 // noop string read at runtime.
-func (vm *VM) compositeStruct(e program.Expr) Value {
+func (vm *VM) compositeStruct(e *program.Expr) Value {
 	fields := make(map[string]Value, len(e.Operands)/2)
 	for i := 0; i < len(e.Operands); i += 2 {
 		key := vm.Eval(e.Operands[i]).String()
@@ -326,7 +448,7 @@ func (vm *VM) compositeStruct(e program.Expr) Value {
 // each (indexExpr, valueExpr) operand pair. The index operand is
 // evaluated for side effects but its result is discarded — items
 // land in the slice in pair order.
-func (vm *VM) compositeSlice(e program.Expr) Value {
+func (vm *VM) compositeSlice(e *program.Expr) Value {
 	items := make([]Value, 0, len(e.Operands)/2)
 	for i := 0; i < len(e.Operands); i += 2 {
 		// Evaluate the index expr for any side effects (typically a literal).
@@ -339,7 +461,7 @@ func (vm *VM) compositeSlice(e program.Expr) Value {
 // compositeMap materializes a map Value whose Fields keys are each
 // pair's evaluated key (stringified through Value.String). Duplicate
 // keys are last-wins, matching Go's map literal evaluation order.
-func (vm *VM) compositeMap(e program.Expr) Value {
+func (vm *VM) compositeMap(e *program.Expr) Value {
 	fields := make(map[string]Value, len(e.Operands)/2)
 	for i := 0; i < len(e.Operands); i += 2 {
 		key := vm.Eval(e.Operands[i]).String()
@@ -348,7 +470,7 @@ func (vm *VM) compositeMap(e program.Expr) Value {
 	return ObjectVal(fields)
 }
 
-// evalMapLookupExpr dispatches the Slice Y.B two-value map lookup
+// mapLookupValue evaluates the Slice Y.B two-value map lookup
 // opcode. OpMapLookup mirrors Go's comma-ok form (`v, ok := m[k]`) by
 // returning an ObjectVal with "value" and "ok" fields so the lowerer
 // can extract each binding via two OpIndex reads against the result.
@@ -362,19 +484,16 @@ func (vm *VM) compositeMap(e program.Expr) Value {
 //   - key present  → {"value": <stored>, "ok": true}
 //   - key absent   → {"value": <zero Any>, "ok": false}
 //   - non-map LHS  → {"value": <zero Any>, "ok": false} + diagnostic
-func (vm *VM) evalMapLookupExpr(e program.Expr) (Value, bool) {
-	if e.Op != program.OpMapLookup {
-		return Value{}, false
-	}
+func (vm *VM) mapLookupValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ObjectVal(map[string]Value{
 			"value": ZeroValue(program.TypeAny),
 			"ok":    BoolVal(false),
-		}), true
+		})
 	}
 	coll := vm.Eval(e.Operands[0])
 	key := vm.Eval(e.Operands[1]).String()
-	if coll.Fields == nil {
+	if !coll.isMap() {
 		// Non-map collection — diagnose and yield the zero/false pair so
 		// downstream OpIndex reads still resolve to safe defaults.
 		vm.recordExprDiagnostic(
@@ -386,61 +505,29 @@ func (vm *VM) evalMapLookupExpr(e program.Expr) (Value, bool) {
 		return ObjectVal(map[string]Value{
 			"value": ZeroValue(program.TypeAny),
 			"ok":    BoolVal(false),
-		}), true
+		})
 	}
-	if got, ok := coll.Fields[key]; ok {
+	if got, ok := coll.dict()[key]; ok {
 		return ObjectVal(map[string]Value{
 			"value": got,
 			"ok":    BoolVal(true),
-		}), true
+		})
 	}
 	return ObjectVal(map[string]Value{
 		"value": ZeroValue(program.TypeAny),
 		"ok":    BoolVal(false),
-	}), true
-}
-
-// evalSequencingExpr dispatches the Slice X.A statement-sequencing opcodes:
-// OpSeq, OpAssign, OpLocalDecl, OpLocalGet, OpLocalSet, plus the Slice X.C
-// imperative iteration opcodes OpFor and OpForRange. These let a Program
-// carry multi-statement handler bodies as a single Expr tree.
-func (vm *VM) evalSequencingExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpSeq:
-		return vm.seqValue(e), true
-	case program.OpAssign:
-		return vm.assignValue(e), true
-	case program.OpLocalDecl:
-		return vm.localDeclValue(e), true
-	case program.OpLocalGet:
-		return vm.localGetValue(e), true
-	case program.OpLocalSet:
-		return vm.localSetValue(e), true
-	case program.OpFor:
-		return vm.forValue(e), true
-	case program.OpForRange:
-		return vm.forRangeValue(e), true
-	case program.OpReturn:
-		return vm.returnValue(e), true
-	case program.OpBreak:
-		return Value{Control: ControlBreak}, true
-	case program.OpContinue:
-		return Value{Control: ControlContinue}, true
-	default:
-		return Value{}, false
-	}
+	})
 }
 
 // returnValue evaluates Operands[0] (or yields zero when absent) and
 // marks the result with ControlReturn so OpSeq and EvalWithFrame can
 // unwind to the handler boundary.
-func (vm *VM) returnValue(e program.Expr) Value {
+func (vm *VM) returnValue(e *program.Expr) Value {
 	var payload Value
 	if len(e.Operands) > 0 {
 		payload = vm.Eval(e.Operands[0])
 	}
-	payload.Control = ControlReturn
-	return payload
+	return payload.WithControl(ControlReturn)
 }
 
 // seqValue evaluates each operand in order and returns the last one's
@@ -451,14 +538,14 @@ func (vm *VM) returnValue(e program.Expr) Value {
 // If any operand returns a Control signal (return / break / continue
 // from X.C), evaluation stops and the signal propagates up; the
 // enclosing loop or EvalWithFrame is responsible for catching it.
-func (vm *VM) seqValue(e program.Expr) Value {
+func (vm *VM) seqValue(e *program.Expr) Value {
 	if len(e.Operands) == 0 {
 		return ZeroValue(program.TypeAny)
 	}
 	var last Value
 	for _, op := range e.Operands {
 		last = vm.Eval(op)
-		if last.Control != ControlNone {
+		if last.Control() != ControlNone {
 			return last
 		}
 	}
@@ -474,7 +561,7 @@ func (vm *VM) seqValue(e program.Expr) Value {
 //  4. with no frame and no signal — diagnostic and zero return.
 //
 // Returns the assigned value so OpSeq sequences can chain assignments.
-func (vm *VM) assignValue(e program.Expr) Value {
+func (vm *VM) assignValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 1) {
 		return ZeroValue(program.TypeAny)
 	}
@@ -499,7 +586,7 @@ func (vm *VM) assignValue(e program.Expr) Value {
 // localDeclValue reserves a slot in the current frame. Re-declarations
 // are no-ops so the lowerer can emit OpLocalDecl idempotently. Returns
 // the zero Value of TypeAny.
-func (vm *VM) localDeclValue(e program.Expr) Value {
+func (vm *VM) localDeclValue(e *program.Expr) Value {
 	if vm.frame == nil {
 		vm.recordExprDiagnostic(
 			"missing_frame",
@@ -523,7 +610,7 @@ func (vm *VM) localDeclValue(e program.Expr) Value {
 //
 // Only when none of the tiers contain the name does the VM record a
 // missing_local diagnostic and return the zero value.
-func (vm *VM) localGetValue(e program.Expr) Value {
+func (vm *VM) localGetValue(e *program.Expr) Value {
 	if v, ok := vm.frame.get(e.Value); ok {
 		return v
 	}
@@ -545,7 +632,7 @@ func (vm *VM) localGetValue(e program.Expr) Value {
 // localSetValue writes Operands[0] to the local named in Value. Unlike
 // OpAssign, OpLocalSet never falls through to signals; the lowerer
 // emits it only when the target is known to be a local.
-func (vm *VM) localSetValue(e program.Expr) Value {
+func (vm *VM) localSetValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 1) {
 		return ZeroValue(program.TypeAny)
 	}
@@ -578,222 +665,231 @@ func (vm *VM) EvalWithFrame(id program.ExprID) Value {
 	vm.frame = newFrame()
 	defer func() { vm.frame = prev }()
 	v := vm.Eval(id)
-	if v.Control == ControlReturn {
-		v.Control = ControlNone
+	if v.Control() == ControlReturn {
+		return v.WithControl(ControlNone)
 	}
 	return v
 }
 
-func (vm *VM) evalLiteralExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpLitString:
-		return StringVal(e.Value), true
-	case program.OpLitInt:
-		n, err := strconv.ParseInt(e.Value, 10, 64)
-		if err != nil {
-			vm.recordExprDiagnostic("invalid_int_literal", fmt.Sprintf("invalid integer literal %q: %v", e.Value, err), e.Op, e.Value)
-			return ZeroValue(program.TypeInt), true
-		}
-		return IntVal(int(n)), true
-	case program.OpLitFloat:
-		f, err := strconv.ParseFloat(e.Value, 64)
-		if err != nil {
-			vm.recordExprDiagnostic("invalid_float_literal", fmt.Sprintf("invalid float literal %q: %v", e.Value, err), e.Op, e.Value)
-			return ZeroValue(program.TypeFloat), true
-		}
-		return FloatVal(f), true
-	case program.OpLitBool:
-		return BoolVal(e.Value == "true"), true
-	default:
-		return Value{}, false
-	}
+// litKind tags a slot in the pre-decoded numeric literal table.
+type litKind uint8
+
+const (
+	litNone  litKind = iota // the expression is not a numeric literal
+	litInt                  // OpLitInt whose text parsed
+	litFloat                // OpLitFloat whose text parsed
+	litBad                  // numeric literal whose text does not parse
+)
+
+// litSlot caches the decoded form of one OpLitInt or OpLitFloat expression.
+type litSlot struct {
+	num  float64
+	kind litKind
 }
 
-func (vm *VM) evalAccessExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpPropGet:
-		return vm.propValue(e.Value, e.Type), true
-	case program.OpSignalGet:
-		return vm.signalValue(e.Value, e.Type), true
-	case program.OpSignalSet, program.OpSignalUpdate:
-		return vm.updateSignal(e), true
-	case program.OpEventGet:
-		return vm.eventValue(e.Value), true
-	default:
-		return Value{}, false
+// buildLiteralTable decodes every numeric literal in the expression table once,
+// at program load.
+//
+// A tree-walking VM re-evaluates the same literal expression on every visit, so
+// a loop bounded at 1<<20 paid up to a million strconv calls for one literal.
+// The table is indexed by ExprID and stops after the last numeric literal, so a
+// program with none allocates nothing.
+func buildLiteralTable(exprs []program.Expr) []litSlot {
+	last := -1
+	for i := range exprs {
+		switch exprs[i].Op {
+		case program.OpLitInt, program.OpLitFloat:
+			last = i
+		}
 	}
+	if last < 0 {
+		return nil
+	}
+	table := make([]litSlot, last+1)
+	for i := 0; i <= last; i++ {
+		switch exprs[i].Op {
+		case program.OpLitInt:
+			n, err := strconv.ParseInt(exprs[i].Value, 10, 64)
+			if err != nil {
+				table[i] = litSlot{kind: litBad}
+				continue
+			}
+			// Match IntVal(int(n)) exactly, including its narrowing.
+			table[i] = litSlot{num: float64(int(n)), kind: litInt}
+		case program.OpLitFloat:
+			f, err := strconv.ParseFloat(exprs[i].Value, 64)
+			if err != nil {
+				table[i] = litSlot{kind: litBad}
+				continue
+			}
+			table[i] = litSlot{num: f, kind: litFloat}
+		}
+	}
+	return table
 }
 
-func (vm *VM) evalArithmeticExpr(e program.Expr) (Value, bool) {
+// decodedLiteral turns a pre-decoded slot into a Value. A slot that failed to
+// parse falls back to the parsing path, which records the diagnostic naming the
+// offending text.
+func (vm *VM) decodedLiteral(id program.ExprID, slot litSlot) Value {
+	switch slot.kind {
+	case litInt:
+		return Value{Type: program.TypeInt, num: slot.num}
+	case litFloat:
+		return Value{Type: program.TypeFloat, num: slot.num}
+	}
+	e := &vm.exprs[id]
+	if e.Op == program.OpLitFloat {
+		return vm.parseFloatLiteral(e)
+	}
+	return vm.parseIntLiteral(e)
+}
+
+// parseIntLiteral decodes an OpLitInt from its text. Eval normally answers from
+// the pre-decoded table; this path serves synthetic expressions that carry no
+// ExprID and literals whose text is invalid.
+func (vm *VM) parseIntLiteral(e *program.Expr) Value {
+	n, err := strconv.ParseInt(e.Value, 10, 64)
+	if err != nil {
+		vm.recordExprDiagnostic("invalid_int_literal", fmt.Sprintf("invalid integer literal %q: %v", e.Value, err), e.Op, e.Value)
+		return ZeroValue(program.TypeInt)
+	}
+	return IntVal(int(n))
+}
+
+// parseFloatLiteral decodes an OpLitFloat from its text. See parseIntLiteral.
+func (vm *VM) parseFloatLiteral(e *program.Expr) Value {
+	f, err := strconv.ParseFloat(e.Value, 64)
+	if err != nil {
+		vm.recordExprDiagnostic("invalid_float_literal", fmt.Sprintf("invalid float literal %q: %v", e.Value, err), e.Op, e.Value)
+		return ZeroValue(program.TypeFloat)
+	}
+	return FloatVal(f)
+}
+
+// evalBinaryOp evaluates both operands once, then applies the opcode.
+//
+// The previous shape passed a method value (Value.Add and friends) into a
+// generic helper, which forced an indirect call and an extra Value copy on
+// every arithmetic step.
+func (vm *VM) evalBinaryOp(e *program.Expr) Value {
+	if !vm.requireOperands(e, 2) {
+		return ZeroValue(program.TypeAny)
+	}
+	left := vm.Eval(e.Operands[0])
+	right := vm.Eval(e.Operands[1])
 	switch e.Op {
 	case program.OpAdd:
-		return vm.evalBinary(e, Value.Add), true
+		return left.Add(right)
 	case program.OpSub:
-		return vm.evalBinary(e, Value.Sub), true
+		return left.Sub(right)
 	case program.OpMul:
-		return vm.evalBinary(e, Value.Mul), true
+		return left.Mul(right)
 	case program.OpDiv:
-		return vm.evalBinary(e, Value.Div), true
+		return left.Div(right)
 	case program.OpMod:
-		return vm.evalBinary(e, Value.Mod), true
-	case program.OpNeg:
-		return vm.evalUnary(e, Value.Neg, program.TypeInt), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalComparisonExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
+		return left.Mod(right)
 	case program.OpEq:
-		return vm.evalBinary(e, Value.Eq), true
+		return left.Eq(right)
 	case program.OpNeq:
-		return vm.evalBinary(e, Value.Neq), true
+		return left.Neq(right)
 	case program.OpLt:
-		return vm.evalBinary(e, Value.Lt), true
+		return left.Lt(right)
 	case program.OpGt:
-		return vm.evalBinary(e, Value.Gt), true
+		return left.Gt(right)
 	case program.OpLte:
-		return vm.evalBinary(e, Value.Lte), true
+		return left.Lte(right)
 	case program.OpGte:
-		return vm.evalBinary(e, Value.Gte), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalBooleanExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
+		return left.Gte(right)
 	case program.OpAnd:
-		return vm.evalBinary(e, Value.And), true
+		return left.And(right)
 	case program.OpOr:
-		return vm.evalBinary(e, Value.Or), true
+		return left.Or(right)
+	default: // program.OpConcat
+		return left.Concat(right)
+	}
+}
+
+// evalUnaryOp evaluates the single operand once, then applies the opcode. A
+// missing operand yields the zero value the opcode's result type expects.
+func (vm *VM) evalUnaryOp(e *program.Expr) Value {
+	if !vm.requireOperands(e, 1) {
+		return unaryFallback(e.Op)
+	}
+	operand := vm.Eval(e.Operands[0])
+	switch e.Op {
+	case program.OpNeg:
+		return operand.Neg()
 	case program.OpNot:
-		return vm.evalUnary(e, Value.Not, program.TypeBool), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalStringExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpConcat:
-		return vm.evalBinary(e, Value.Concat), true
-	case program.OpFormat:
-		return vm.formatValue(e), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalControlExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpCond:
-		return vm.conditionalValue(e), true
-	case program.OpCall:
-		// Slice X.B: OpCall first tries the stdlib intrinsic registry
-		// (math.Sin, strings.Split, ...). Unknown callee names fall back
-		// to the existing zero-Value behavior so legacy programs that
-		// never registered an intrinsic keep evaluating identically.
-		//
-		// sort.Slice is dispatched via a dedicated path because its
-		// comparator operand is a body expression that must be
-		// re-evaluated for each comparison, not pre-evaluated once.
-		if e.Value == "sort.Slice" {
-			return vm.sortSliceValue(e), true
-		}
-		if v, ok := vm.callIntrinsic(e); ok {
-			return v, true
-		}
-		return ZeroValue(program.TypeAny), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalCollectionExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpIndex:
-		return vm.indexValue(e), true
-	case program.OpLen:
-		return vm.lenValue(e), true
-	case program.OpRange:
-		return ZeroValue(program.TypeAny), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalIterationExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpMap:
-		return vm.mapValue(e), true
-	case program.OpFilter:
-		return vm.filterValue(e), true
-	case program.OpFind:
-		return vm.findValue(e), true
-	case program.OpSlice:
-		return vm.sliceValue(e), true
-	case program.OpAppend:
-		return vm.appendValue(e), true
-	case program.OpContains:
-		return vm.containsValue(e), true
-	default:
-		return Value{}, false
-	}
-}
-
-func (vm *VM) evalStringMethodExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
+		return operand.Not()
 	case program.OpToUpper:
-		return vm.stringUnary(e, Value.ToUpper, StringVal("")), true
+		return operand.ToUpper()
 	case program.OpToLower:
-		return vm.stringUnary(e, Value.ToLower, StringVal("")), true
+		return operand.ToLower()
 	case program.OpTrim:
-		return vm.stringUnary(e, Value.TrimVal, StringVal("")), true
-	case program.OpSplit:
-		return vm.splitValue(e), true
-	case program.OpJoin:
-		return vm.joinValue(e), true
-	case program.OpReplace:
-		return vm.replaceValue(e), true
-	case program.OpSubstring:
-		return vm.substringValue(e), true
-	case program.OpStartsWith:
-		return vm.startsWithValue(e), true
-	case program.OpEndsWith:
-		return vm.endsWithValue(e), true
-	default:
-		return Value{}, false
+		return operand.TrimVal()
+	case program.OpToString:
+		return operand.ToStringVal()
+	case program.OpToInt:
+		return operand.ToIntVal()
+	default: // program.OpToFloat
+		return operand.ToFloatVal()
 	}
 }
 
-func (vm *VM) evalConversionExpr(e program.Expr) (Value, bool) {
-	switch e.Op {
-	case program.OpToString:
-		return vm.stringUnary(e, Value.ToStringVal, StringVal("")), true
+// unaryFallback returns the value a one-operand opcode yields when its operand
+// is missing.
+func unaryFallback(op program.OpCode) Value {
+	switch op {
+	case program.OpNeg:
+		return ZeroValue(program.TypeInt)
+	case program.OpNot:
+		return ZeroValue(program.TypeBool)
 	case program.OpToInt:
-		return vm.intUnary(e, Value.ToIntVal), true
+		return IntVal(0)
 	case program.OpToFloat:
-		return vm.floatUnary(e, Value.ToFloatVal), true
-	case program.OpToRunes:
-		// Slice Y.E.3: `[]rune(s)` / `[]byte(s)` — convert a string
-		// into an ArrayVal whose Items are one-rune StringVals. Reading
-		// len() returns the rune count; slicing returns a rune
-		// subsequence; OpToString concatenates back to a string via
-		// the ToStringVal join path.
-		if !vm.requireOperands(e, 1) {
-			return ArrayVal(nil), true
-		}
-		src := vm.Eval(e.Operands[0]).Str
-		items := make([]Value, 0, len(src))
-		for _, r := range src {
-			items = append(items, StringVal(string(r)))
-		}
-		return ArrayVal(items), true
-	default:
-		return Value{}, false
+		return FloatVal(0)
+	default: // OpToUpper, OpToLower, OpTrim, OpToString
+		return StringVal("")
 	}
+}
+
+// callValue evaluates OpCall.
+//
+// Slice X.B: OpCall first tries the stdlib intrinsic registry (math.Sin,
+// strings.Split, ...). Unknown callee names fall back to the zero Value so
+// legacy programs that never registered an intrinsic keep evaluating
+// identically.
+//
+// sort.Slice takes a dedicated path because its comparator operand is a body
+// expression that must be re-evaluated for each comparison, not pre-evaluated
+// once.
+func (vm *VM) callValue(e *program.Expr) Value {
+	if e.Value == "sort.Slice" {
+		return vm.sortSliceValue(e)
+	}
+	if v, ok := vm.callIntrinsic(e); ok {
+		return v
+	}
+	return ZeroValue(program.TypeAny)
+}
+
+// toRunesValue evaluates OpToRunes.
+//
+// Slice Y.E.3: `[]rune(s)` / `[]byte(s)` — convert a string into an ArrayVal
+// whose Items are one-rune StringVals. Reading len() returns the rune count;
+// slicing returns a rune subsequence; OpToString concatenates back to a string
+// via the ToStringVal join path.
+func (vm *VM) toRunesValue(e *program.Expr) Value {
+	if !vm.requireOperands(e, 1) {
+		return ArrayVal(nil)
+	}
+	src := vm.Eval(e.Operands[0]).Text()
+	items := make([]Value, 0, len(src))
+	for _, r := range src {
+		items = append(items, StringVal(string(r)))
+	}
+	return ArrayVal(items)
 }
 
 func (vm *VM) propValue(name string, typ program.ExprType) Value {
@@ -810,7 +906,7 @@ func (vm *VM) signalValue(name string, typ program.ExprType) Value {
 	return ZeroValue(typ)
 }
 
-func (vm *VM) updateSignal(e program.Expr) Value {
+func (vm *VM) updateSignal(e *program.Expr) Value {
 	if !vm.requireOperands(e, 1) {
 		return ZeroValue(program.TypeAny)
 	}
@@ -831,35 +927,7 @@ func (vm *VM) eventValue(name string) Value {
 	return StringVal("")
 }
 
-func (vm *VM) evalUnary(e program.Expr, fn func(Value) Value, fallback program.ExprType) Value {
-	if vm.requireOperands(e, 1) {
-		return fn(vm.Eval(e.Operands[0]))
-	}
-	return ZeroValue(fallback)
-}
-
-func (vm *VM) stringUnary(e program.Expr, fn func(Value) Value, fallback Value) Value {
-	if vm.requireOperands(e, 1) {
-		return fn(vm.Eval(e.Operands[0]))
-	}
-	return fallback
-}
-
-func (vm *VM) intUnary(e program.Expr, fn func(Value) Value) Value {
-	if vm.requireOperands(e, 1) {
-		return fn(vm.Eval(e.Operands[0]))
-	}
-	return IntVal(0)
-}
-
-func (vm *VM) floatUnary(e program.Expr, fn func(Value) Value) Value {
-	if vm.requireOperands(e, 1) {
-		return fn(vm.Eval(e.Operands[0]))
-	}
-	return FloatVal(0)
-}
-
-func (vm *VM) formatValue(e program.Expr) Value {
+func (vm *VM) formatValue(e *program.Expr) Value {
 	result := e.Value
 	for _, op := range e.Operands {
 		result += vm.Eval(op).String()
@@ -867,62 +935,88 @@ func (vm *VM) formatValue(e program.Expr) Value {
 	return StringVal(result)
 }
 
-func (vm *VM) conditionalValue(e program.Expr) Value {
+func (vm *VM) conditionalValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 3) {
 		return ZeroValue(program.TypeAny)
 	}
-	if vm.Eval(e.Operands[0]).Bool {
+	if vm.Eval(e.Operands[0]).Truth() {
 		return vm.Eval(e.Operands[1])
 	}
 	return vm.Eval(e.Operands[2])
 }
 
-func (vm *VM) indexValue(e program.Expr) Value {
+func (vm *VM) indexValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 2) {
 		return vm.Eval(e.Operands[0]).IndexVal(vm.Eval(e.Operands[1]))
 	}
 	return ZeroValue(program.TypeAny)
 }
 
-func (vm *VM) lenValue(e program.Expr) Value {
+func (vm *VM) lenValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 1) {
 		return IntVal(vm.Eval(e.Operands[0]).Len())
 	}
 	return IntVal(0)
 }
 
-func (vm *VM) mapValue(e program.Expr) Value {
+func (vm *VM) mapValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ArrayVal(nil)
 	}
 	coll := vm.Eval(e.Operands[0])
-	return ArrayVal(vm.mapItems(coll.Items, e.Operands[1]))
+	return ArrayVal(vm.mapItems(coll.list(), e.Operands[1]))
 }
 
-func (vm *VM) filterValue(e program.Expr) Value {
+func (vm *VM) filterValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ArrayVal(nil)
 	}
 	coll := vm.Eval(e.Operands[0])
-	return ArrayVal(vm.filterItems(coll.Items, e.Operands[1]))
+	return ArrayVal(vm.filterItems(coll.list(), e.Operands[1]))
 }
 
-func (vm *VM) findValue(e program.Expr) Value {
+func (vm *VM) findValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 2) {
 		return ZeroValue(program.TypeAny)
 	}
 	coll := vm.Eval(e.Operands[0])
-	if found, ok := vm.findItem(coll.Items, e.Operands[1]); ok {
+	if found, ok := vm.findItem(coll.list(), e.Operands[1]); ok {
 		return found
 	}
 	return ZeroValue(program.TypeAny)
 }
 
-func (vm *VM) sliceValue(e program.Expr) Value {
+// safeBoundInt converts a slice/substring bound's float64 field to
+// an int. It never lets NaN or +/-Inf produce a huge or negative
+// int.
+//
+// Go's float-to-int conversion is implementation-defined once the
+// value is outside the target range. In practice, NaN and Inf both
+// land on math.MinInt64 on amd64. So a literal like 9e999 (which
+// parses as +Inf) would otherwise reach SliceVal / SubstringVal as
+// MinInt64.
+//
+// SliceVal and SubstringVal both clamp into [0, n] on their own now.
+// Clamping the cast here too keeps any future caller of this
+// conversion safe by construction, not just by convention.
+func safeBoundInt(f float64) int {
+	if math.IsNaN(f) {
+		return 0
+	}
+	if f > math.MaxInt32 {
+		return math.MaxInt32
+	}
+	if f < math.MinInt32 {
+		return math.MinInt32
+	}
+	return int(f)
+}
+
+func (vm *VM) sliceValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 3) {
 		coll := vm.Eval(e.Operands[0])
-		start := int(vm.Eval(e.Operands[1]).Num)
-		end := int(vm.Eval(e.Operands[2]).Num)
+		start := safeBoundInt(vm.Eval(e.Operands[1]).num)
+		end := safeBoundInt(vm.Eval(e.Operands[2]).num)
 		// Slice Y.E.3: OpSlice now dispatches on the runtime collection
 		// kind so the lowerer's *ast.SliceExpr handler can emit a single
 		// opcode without knowing whether the source operand is a slice
@@ -930,7 +1024,7 @@ func (vm *VM) sliceValue(e program.Expr) Value {
 		// rune-array operands (produced by Y.E's `[]rune(s)` cast)
 		// route through the existing SliceVal path because they carry
 		// Items, not Str.
-		if coll.Items == nil && coll.Str != "" {
+		if !coll.isList() && coll.text() != "" {
 			return coll.SubstringVal(start, end)
 		}
 		return coll.SliceVal(start, end)
@@ -938,35 +1032,35 @@ func (vm *VM) sliceValue(e program.Expr) Value {
 	return ArrayVal(nil)
 }
 
-func (vm *VM) appendValue(e program.Expr) Value {
+func (vm *VM) appendValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 2) {
 		return vm.Eval(e.Operands[0]).AppendVal(vm.Eval(e.Operands[1]))
 	}
 	return ArrayVal(nil)
 }
 
-func (vm *VM) containsValue(e program.Expr) Value {
+func (vm *VM) containsValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 2) {
 		return vm.Eval(e.Operands[0]).ContainsVal(vm.Eval(e.Operands[1]))
 	}
 	return BoolVal(false)
 }
 
-func (vm *VM) splitValue(e program.Expr) Value {
+func (vm *VM) splitValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 1) {
 		return ArrayVal(nil)
 	}
 	return vm.Eval(e.Operands[0]).SplitVal(vm.separatorValue(e))
 }
 
-func (vm *VM) joinValue(e program.Expr) Value {
+func (vm *VM) joinValue(e *program.Expr) Value {
 	if !vm.requireOperands(e, 1) {
 		return StringVal("")
 	}
 	return vm.Eval(e.Operands[0]).JoinVal(vm.separatorValue(e))
 }
 
-func (vm *VM) separatorValue(e program.Expr) string {
+func (vm *VM) separatorValue(e *program.Expr) string {
 	sep := e.Value
 	if len(e.Operands) >= 2 {
 		sep = vm.Eval(e.Operands[1]).String()
@@ -974,28 +1068,31 @@ func (vm *VM) separatorValue(e program.Expr) string {
 	return sep
 }
 
-func (vm *VM) replaceValue(e program.Expr) Value {
+func (vm *VM) replaceValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 3) {
-		return vm.Eval(e.Operands[0]).ReplaceVal(vm.Eval(e.Operands[1]).Str, vm.Eval(e.Operands[2]).Str)
+		return vm.Eval(e.Operands[0]).ReplaceVal(vm.Eval(e.Operands[1]).Text(), vm.Eval(e.Operands[2]).Text())
 	}
 	return StringVal("")
 }
 
-func (vm *VM) substringValue(e program.Expr) Value {
+func (vm *VM) substringValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 3) {
-		return vm.Eval(e.Operands[0]).SubstringVal(int(vm.Eval(e.Operands[1]).Num), int(vm.Eval(e.Operands[2]).Num))
+		coll := vm.Eval(e.Operands[0])
+		start := safeBoundInt(vm.Eval(e.Operands[1]).num)
+		end := safeBoundInt(vm.Eval(e.Operands[2]).num)
+		return coll.SubstringVal(start, end)
 	}
 	return StringVal("")
 }
 
-func (vm *VM) startsWithValue(e program.Expr) Value {
+func (vm *VM) startsWithValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 2) {
 		return vm.Eval(e.Operands[0]).StartsWithVal(vm.Eval(e.Operands[1]))
 	}
 	return BoolVal(false)
 }
 
-func (vm *VM) endsWithValue(e program.Expr) Value {
+func (vm *VM) endsWithValue(e *program.Expr) Value {
 	if vm.requireOperands(e, 2) {
 		return vm.Eval(e.Operands[0]).EndsWithVal(vm.Eval(e.Operands[1]))
 	}
@@ -1021,7 +1118,7 @@ func (vm *VM) filterItems(items []Value, exprID program.ExprID) []Value {
 	for i, item := range items {
 		vm.props["_item"] = item
 		vm.props["_index"] = IntVal(i)
-		if vm.Eval(exprID).Bool {
+		if vm.Eval(exprID).Truth() {
 			result = append(result, item)
 		}
 	}
@@ -1034,18 +1131,11 @@ func (vm *VM) findItem(items []Value, exprID program.ExprID) (Value, bool) {
 	for i, item := range items {
 		vm.props["_item"] = item
 		vm.props["_index"] = IntVal(i)
-		if vm.Eval(exprID).Bool {
+		if vm.Eval(exprID).Truth() {
 			return item, true
 		}
 	}
 	return Value{}, false
-}
-
-func (vm *VM) evalBinary(e program.Expr, fn func(Value, Value) Value) Value {
-	if vm.requireOperands(e, 2) {
-		return fn(vm.Eval(e.Operands[0]), vm.Eval(e.Operands[1]))
-	}
-	return ZeroValue(program.TypeAny)
 }
 
 // EvalTree walks the island's node tree, evaluating all dynamic expressions,
@@ -1113,6 +1203,9 @@ func (vm *VM) appendNodeRefs(tree *ResolvedTree, out []int, nodeID program.NodeI
 	case program.NodeConditional:
 		return vm.appendConditional(tree, out, int(nodeID), node)
 	default:
+		if idx, ok := vm.reuseResolvedNode(tree, int(nodeID)); ok {
+			return append(out, idx)
+		}
 		idx := vm.appendResolvedNode(tree, int(nodeID), node)
 		return append(out, idx)
 	}
@@ -1135,6 +1228,11 @@ func (vm *VM) appendResolvedNode(tree *ResolvedTree, source int, node program.No
 		vm.resolveElementNode(&tree.Nodes[idx], source, node)
 		tree.Nodes[idx].Children = vm.resolveChildren(tree, node.Children)
 	}
+
+	// The subtree is complete and contiguous now, so record where it
+	// landed. The next walk copies it from here when nothing it reads has
+	// changed. recordReuseSpan ignores nodes the plan cannot reuse.
+	vm.recordReuseSpan(source, idx, len(tree.Nodes))
 
 	return idx
 }
@@ -1302,7 +1400,7 @@ func (vm *VM) resolveElementAttrs(attrs []program.Attr) (resolved, domAttrs []Re
 	for _, event := range events {
 		eventType := eventAttrType(event.Name)
 		domAttrs = append(domAttrs, ResolvedAttr{
-			Name:  "data-gosx-on-" + eventType,
+			Name:  eventMarkerAttr(eventType),
 			Value: event.Handler,
 		})
 		if eventType == "click" {
@@ -1324,7 +1422,7 @@ func (vm *VM) autoKey(source int, tag string) (string, bool) {
 	if !hasIndex {
 		return "", false
 	}
-	return fmt.Sprintf("_auto_%d_%s_%d", int(idxVal.Num), tag, source), true
+	return fmt.Sprintf("_auto_%d_%s_%d", int(idxVal.num), tag, source), true
 }
 
 type eachEntry struct {
@@ -1362,30 +1460,31 @@ func (vm *VM) appendConditional(tree *ResolvedTree, out []int, source int, node 
 }
 
 func valueTruthy(value Value) bool {
-	if value.Items != nil {
-		return len(value.Items) > 0
+	if value.isList() {
+		return len(value.list()) > 0
 	}
-	if value.Fields != nil {
-		return len(value.Fields) > 0
+	if value.isMap() {
+		return len(value.dict()) > 0
 	}
 	switch value.Type {
 	case program.TypeBool:
-		return value.Bool
+		return value.truth()
 	case program.TypeString:
-		return value.Str != "" && value.Str != "0" && value.Str != "false"
+		text := value.text()
+		return text != "" && text != "0" && text != "false"
 	case program.TypeInt, program.TypeFloat:
-		return value.Num != 0
+		return value.num != 0
 	default:
-		return value.Bool || value.Num != 0 || value.Str != ""
+		return value.truth() || value.num != 0 || value.text() != ""
 	}
 }
 
 func valueEachEntries(value Value) []eachEntry {
-	if value.Items != nil {
-		return arrayEachEntries(value.Items)
+	if value.isList() {
+		return arrayEachEntries(value.list())
 	}
-	if value.Fields != nil {
-		return objectEachEntries(value.Fields)
+	if value.isMap() {
+		return objectEachEntries(value.dict())
 	}
 	return nil
 }
@@ -1499,15 +1598,26 @@ func (vm *VM) resolveFallbackText(tree *ResolvedTree, source int, fallbackID pro
 	return []int{idx}
 }
 
+// captureProps records the state of every scoped name before a forEach binds
+// it, so restoreProps can put the scope back exactly as it was.
+//
+// present records a name even when the name is ABSENT. That matters: a
+// forEach binds `_item`, `_index`, `_key` and the `as`/`index` names, and
+// most of those do not exist before the loop starts. Recording only the
+// names that existed left the rest in vm.props after the loop returned, so
+// the last iteration's index stayed visible to every later node. autoKey
+// reads `_index`, so a plain element after a list picked up a key built from
+// a loop it never belonged to.
 func (vm *VM) captureProps(names []string) iterationContext {
 	ctx := iterationContext{
 		values:  make(map[string]Value, len(names)),
 		present: make(map[string]bool, len(names)),
 	}
 	for _, name := range names {
-		if value, ok := vm.props[name]; ok {
+		value, ok := vm.props[name]
+		ctx.present[name] = ok
+		if ok {
 			ctx.values[name] = value
-			ctx.present[name] = true
 		}
 	}
 	return ctx
@@ -1530,10 +1640,6 @@ func forEachStaticAttr(attrs []program.Attr, name string) string {
 		}
 	}
 	return ""
-}
-
-func forEachFallbackExpr(attrs []program.Attr) (program.ExprID, bool) {
-	return fallbackExpr(attrs)
 }
 
 func fallbackExpr(attrs []program.Attr) (program.ExprID, bool) {

--- a/client/vm/vm_test.go
+++ b/client/vm/vm_test.go
@@ -86,8 +86,8 @@ func TestVMLitInt(t *testing.T) {
 	if v.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", v.Type)
 	}
-	if v.Num != 42 {
-		t.Fatalf("expected 42, got %f", v.Num)
+	if v.num != 42 {
+		t.Fatalf("expected 42, got %f", v.num)
 	}
 }
 
@@ -100,8 +100,8 @@ func TestVMLitString(t *testing.T) {
 	if v.Type != program.TypeString {
 		t.Fatalf("expected TypeString, got %d", v.Type)
 	}
-	if v.Str != "hello" {
-		t.Fatalf("expected 'hello', got %q", v.Str)
+	if v.Text() != "hello" {
+		t.Fatalf("expected 'hello', got %q", v.Text())
 	}
 }
 
@@ -114,8 +114,8 @@ func TestVMLitFloat(t *testing.T) {
 	if v.Type != program.TypeFloat {
 		t.Fatalf("expected TypeFloat, got %d", v.Type)
 	}
-	if v.Num != 3.14 {
-		t.Fatalf("expected 3.14, got %f", v.Num)
+	if v.num != 3.14 {
+		t.Fatalf("expected 3.14, got %f", v.num)
 	}
 }
 
@@ -127,12 +127,12 @@ func TestVMLitBool(t *testing.T) {
 	vm := NewVM(prog, nil)
 
 	v := vm.Eval(0)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("expected true")
 	}
 
 	v2 := vm.Eval(1)
-	if v2.Bool {
+	if v2.Truth() {
 		t.Fatal("expected false")
 	}
 }
@@ -147,8 +147,8 @@ func TestVMAdd(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Num != 13 {
-		t.Fatalf("expected 13, got %f", v.Num)
+	if v.num != 13 {
+		t.Fatalf("expected 13, got %f", v.num)
 	}
 }
 
@@ -163,8 +163,8 @@ func TestVMAddConcatsStrings(t *testing.T) {
 	if v.Type != program.TypeString {
 		t.Fatalf("expected TypeString, got %d", v.Type)
 	}
-	if v.Str != "badge tone-success" {
-		t.Fatalf("expected concatenated string, got %q", v.Str)
+	if v.Text() != "badge tone-success" {
+		t.Fatalf("expected concatenated string, got %q", v.Text())
 	}
 }
 
@@ -176,8 +176,8 @@ func TestVMSub(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Num != 7 {
-		t.Fatalf("expected 7, got %f", v.Num)
+	if v.num != 7 {
+		t.Fatalf("expected 7, got %f", v.num)
 	}
 }
 
@@ -189,8 +189,8 @@ func TestVMMul(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Num != 20 {
-		t.Fatalf("expected 20, got %f", v.Num)
+	if v.num != 20 {
+		t.Fatalf("expected 20, got %f", v.num)
 	}
 }
 
@@ -202,8 +202,8 @@ func TestVMDiv(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Num != 3 {
-		t.Fatalf("expected 3 (integer division), got %f", v.Num)
+	if v.num != 3 {
+		t.Fatalf("expected 3 (integer division), got %f", v.num)
 	}
 }
 
@@ -215,8 +215,8 @@ func TestVMMod(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Num != 1 {
-		t.Fatalf("expected 1, got %f", v.Num)
+	if v.num != 1 {
+		t.Fatalf("expected 1, got %f", v.num)
 	}
 }
 
@@ -227,8 +227,8 @@ func TestVMNeg(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(1)
-	if v.Num != -5 {
-		t.Fatalf("expected -5, got %f", v.Num)
+	if v.num != -5 {
+		t.Fatalf("expected -5, got %f", v.num)
 	}
 }
 
@@ -242,7 +242,7 @@ func TestVMEq(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("5 == 5 should be true")
 	}
 }
@@ -255,7 +255,7 @@ func TestVMNeq(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("5 != 6 should be true")
 	}
 }
@@ -268,7 +268,7 @@ func TestVMLt(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("3 < 5 should be true")
 	}
 }
@@ -281,7 +281,7 @@ func TestVMGt(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("5 > 3 should be true")
 	}
 }
@@ -294,7 +294,7 @@ func TestVMLte(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("5 <= 5 should be true")
 	}
 }
@@ -307,7 +307,7 @@ func TestVMGte(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("5 >= 3 should be true")
 	}
 }
@@ -357,7 +357,7 @@ func TestVMAnd(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Bool {
+	if v.Truth() {
 		t.Fatal("true && false should be false")
 	}
 }
@@ -370,7 +370,7 @@ func TestVMOr(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("true || false should be true")
 	}
 }
@@ -382,7 +382,7 @@ func TestVMNot(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(1)
-	if v.Bool {
+	if v.Truth() {
 		t.Fatal("!true should be false")
 	}
 }
@@ -398,8 +398,8 @@ func TestVMPropGet(t *testing.T) {
 	}
 	vm := NewVM(prog, props)
 	v := vm.Eval(0)
-	if v.Str != "Hello World" {
-		t.Fatalf("expected 'Hello World', got %q", v.Str)
+	if v.Text() != "Hello World" {
+		t.Fatalf("expected 'Hello World', got %q", v.Text())
 	}
 }
 
@@ -412,8 +412,8 @@ func TestVMPropGetMissing(t *testing.T) {
 	if v.Type != program.TypeString {
 		t.Fatalf("expected TypeString zero value, got type %d", v.Type)
 	}
-	if v.Str != "" {
-		t.Fatalf("expected empty string, got %q", v.Str)
+	if v.Text() != "" {
+		t.Fatalf("expected empty string, got %q", v.Text())
 	}
 }
 
@@ -428,8 +428,8 @@ func TestVMSignalGet(t *testing.T) {
 	vm.SetSignal("count", sig)
 
 	v := vm.Eval(0)
-	if v.Num != 5 {
-		t.Fatalf("expected 5, got %f", v.Num)
+	if v.num != 5 {
+		t.Fatalf("expected 5, got %f", v.num)
 	}
 }
 
@@ -444,8 +444,8 @@ func TestVMSignalSet(t *testing.T) {
 
 	vm.Eval(1) // execute the set
 	v := sig.Get()
-	if v.Num != 42 {
-		t.Fatalf("expected signal to be 42, got %f", v.Num)
+	if v.num != 42 {
+		t.Fatalf("expected signal to be 42, got %f", v.num)
 	}
 }
 
@@ -460,8 +460,8 @@ func TestVMCondTrue(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(3)
-	if v.Str != "yes" {
-		t.Fatalf("expected 'yes', got %q", v.Str)
+	if v.Text() != "yes" {
+		t.Fatalf("expected 'yes', got %q", v.Text())
 	}
 }
 
@@ -474,8 +474,8 @@ func TestVMCondFalse(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(3)
-	if v.Str != "no" {
-		t.Fatalf("expected 'no', got %q", v.Str)
+	if v.Text() != "no" {
+		t.Fatalf("expected 'no', got %q", v.Text())
 	}
 }
 
@@ -489,8 +489,8 @@ func TestVMConcat(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if v.Str != "hello world" {
-		t.Fatalf("expected 'hello world', got %q", v.Str)
+	if v.Text() != "hello world" {
+		t.Fatalf("expected 'hello world', got %q", v.Text())
 	}
 }
 
@@ -506,24 +506,24 @@ func TestVMCounterProgram(t *testing.T) {
 
 	// Evaluate expr[0] (SignalGet "count") — should return 5.
 	v := vm.Eval(0)
-	if v.Num != 5 {
-		t.Fatalf("expected count=5, got %f", v.Num)
+	if v.num != 5 {
+		t.Fatalf("expected count=5, got %f", v.num)
 	}
 
 	// Dispatch decrement: evaluate expr[2] (SignalSet "count" <- expr[4])
 	// expr[4] = Sub(expr[6], expr[7]) = Sub(SignalGet("count"), LitInt("1")) = 5 - 1 = 4
 	vm.Eval(2)
 	v = countSig.Get()
-	if v.Num != 4 {
-		t.Fatalf("expected count=4 after decrement, got %f", v.Num)
+	if v.num != 4 {
+		t.Fatalf("expected count=4 after decrement, got %f", v.num)
 	}
 
 	// Dispatch increment: evaluate expr[3] (SignalSet "count" <- expr[5])
 	// expr[5] = Add(expr[8], expr[9]) = Add(SignalGet("count"), LitInt("1")) = 4 + 1 = 5
 	vm.Eval(3)
 	v = countSig.Get()
-	if v.Num != 5 {
-		t.Fatalf("expected count=5 after increment, got %f", v.Num)
+	if v.num != 5 {
+		t.Fatalf("expected count=5 after increment, got %f", v.num)
 	}
 }
 
@@ -608,8 +608,8 @@ func TestVMMissingSignalReturnsZero(t *testing.T) {
 	if v.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt zero value, got type %d", v.Type)
 	}
-	if v.Num != 0 {
-		t.Fatalf("expected 0, got %f", v.Num)
+	if v.num != 0 {
+		t.Fatalf("expected 0, got %f", v.num)
 	}
 }
 
@@ -645,7 +645,7 @@ func TestVMNotWithMissingOperand(t *testing.T) {
 	vm := NewVM(prog, nil)
 
 	v := vm.Eval(0)
-	if v.Bool {
+	if v.Truth() {
 		t.Fatal("expected false for Not with no operand")
 	}
 }
@@ -692,11 +692,11 @@ func TestVMOpMap(t *testing.T) {
 	}
 	vm := NewVM(prog, props)
 	v := vm.Eval(4)
-	if len(v.Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(v.Items))
+	if len(v.List()) != 3 {
+		t.Fatalf("expected 3 items, got %d", len(v.List()))
 	}
-	if v.Items[0].Num != 2 || v.Items[1].Num != 4 || v.Items[2].Num != 6 {
-		t.Fatalf("expected [2, 4, 6], got [%f, %f, %f]", v.Items[0].Num, v.Items[1].Num, v.Items[2].Num)
+	if v.List()[0].num != 2 || v.List()[1].num != 4 || v.List()[2].num != 6 {
+		t.Fatalf("expected [2, 4, 6], got [%f, %f, %f]", v.List()[0].num, v.List()[1].num, v.List()[2].num)
 	}
 }
 
@@ -718,11 +718,11 @@ func TestVMOpFilter(t *testing.T) {
 	}
 	vm := NewVM(prog, props)
 	v := vm.Eval(6)
-	if len(v.Items) != 2 {
-		t.Fatalf("expected 2 items, got %d", len(v.Items))
+	if len(v.List()) != 2 {
+		t.Fatalf("expected 2 items, got %d", len(v.List()))
 	}
-	if v.Items[0].Num != 2 || v.Items[1].Num != 4 {
-		t.Fatalf("expected [2, 4], got [%f, %f]", v.Items[0].Num, v.Items[1].Num)
+	if v.List()[0].num != 2 || v.List()[1].num != 4 {
+		t.Fatalf("expected [2, 4], got [%f, %f]", v.List()[0].num, v.List()[1].num)
 	}
 }
 
@@ -736,7 +736,7 @@ func TestVMOpContainsString(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(2)
-	if !v.Bool {
+	if !v.Truth() {
 		t.Fatal("expected 'hello world' to contain 'world'")
 	}
 }
@@ -750,8 +750,8 @@ func TestVMOpToUpper(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 	v := vm.Eval(1)
-	if v.Str != "HELLO" {
-		t.Fatalf("expected 'HELLO', got %q", v.Str)
+	if v.Text() != "HELLO" {
+		t.Fatalf("expected 'HELLO', got %q", v.Text())
 	}
 }
 
@@ -766,8 +766,8 @@ func TestVMOpIndexObjectField(t *testing.T) {
 	})
 
 	v := vm.Eval(2)
-	if v.Str != "Ada" {
-		t.Fatalf("expected Ada, got %q", v.Str)
+	if v.Text() != "Ada" {
+		t.Fatalf("expected Ada, got %q", v.Text())
 	}
 }
 
@@ -782,8 +782,8 @@ func TestVMOpIndexArray(t *testing.T) {
 	})
 
 	v := vm.Eval(2)
-	if v.Str != "b" {
-		t.Fatalf("expected b, got %q", v.Str)
+	if v.Text() != "b" {
+		t.Fatalf("expected b, got %q", v.Text())
 	}
 }
 
@@ -799,14 +799,14 @@ func TestVMOpSplitJoinRoundTrip(t *testing.T) {
 
 	// Check split
 	split := vm.Eval(1)
-	if len(split.Items) != 3 {
-		t.Fatalf("expected 3 items from split, got %d", len(split.Items))
+	if len(split.List()) != 3 {
+		t.Fatalf("expected 3 items from split, got %d", len(split.List()))
 	}
 
 	// Check round-trip
 	joined := vm.Eval(2)
-	if joined.Str != "a,b,c" {
-		t.Fatalf("expected 'a,b,c' after round-trip, got %q", joined.Str)
+	if joined.Text() != "a,b,c" {
+		t.Fatalf("expected 'a,b,c' after round-trip, got %q", joined.Text())
 	}
 }
 
@@ -820,11 +820,11 @@ func TestVMOpSplitJoinDynamicSeparator(t *testing.T) {
 	})
 	vm := NewVM(prog, nil)
 
-	if split := vm.Eval(2); len(split.Items) != 3 {
-		t.Fatalf("expected 3 items from split, got %d", len(split.Items))
+	if split := vm.Eval(2); len(split.List()) != 3 {
+		t.Fatalf("expected 3 items from split, got %d", len(split.List()))
 	}
-	if joined := vm.Eval(4); joined.Str != "a::b::c" {
-		t.Fatalf("expected a::b::c, got %q", joined.Str)
+	if joined := vm.Eval(4); joined.Text() != "a::b::c" {
+		t.Fatalf("expected a::b::c, got %q", joined.Text())
 	}
 }
 
@@ -840,8 +840,8 @@ func TestVMOpToStringInt(t *testing.T) {
 	if v.Type != program.TypeString {
 		t.Fatalf("expected TypeString, got %d", v.Type)
 	}
-	if v.Str != "42" {
-		t.Fatalf("expected '42', got %q", v.Str)
+	if v.Text() != "42" {
+		t.Fatalf("expected '42', got %q", v.Text())
 	}
 }
 
@@ -877,7 +877,7 @@ func TestValueEachEntriesObjectOrderIsStable(t *testing.T) {
 	if len(entries) != 3 {
 		t.Fatalf("expected 3 entries, got %d", len(entries))
 	}
-	if entries[0].Key.Str != "alpha" || entries[1].Key.Str != "mu" || entries[2].Key.Str != "zeta" {
+	if entries[0].Key.Text() != "alpha" || entries[1].Key.Text() != "mu" || entries[2].Key.Text() != "zeta" {
 		t.Fatalf("expected sorted object keys, got %+v", entries)
 	}
 }
@@ -955,22 +955,22 @@ func TestResolveForEachRestoresScopedProps(t *testing.T) {
 	if tree.Nodes[out[0]].Text != "a" || tree.Nodes[out[1]].Text != "b" {
 		t.Fatalf("expected resolved for-each children to be [a b], got %q and %q", tree.Nodes[out[0]].Text, tree.Nodes[out[1]].Text)
 	}
-	if vm.props["_item"].Str != "outer-item" {
-		t.Fatalf("expected _item restored, got %q", vm.props["_item"].Str)
+	if vm.props["_item"].Text() != "outer-item" {
+		t.Fatalf("expected _item restored, got %q", vm.props["_item"].Text())
 	}
-	if vm.props["_index"].Num != 99 {
-		t.Fatalf("expected _index restored, got %f", vm.props["_index"].Num)
+	if vm.props["_index"].num != 99 {
+		t.Fatalf("expected _index restored, got %f", vm.props["_index"].num)
 	}
-	if vm.props["_key"].Str != "outer-key" {
-		t.Fatalf("expected _key restored, got %q", vm.props["_key"].Str)
+	if vm.props["_key"].Text() != "outer-key" {
+		t.Fatalf("expected _key restored, got %q", vm.props["_key"].Text())
 	}
-	if vm.props["row"].Str != "outer-row" {
-		t.Fatalf("expected row restored, got %q", vm.props["row"].Str)
+	if vm.props["row"].Text() != "outer-row" {
+		t.Fatalf("expected row restored, got %q", vm.props["row"].Text())
 	}
-	if vm.props["rowKey"].Str != "outer-row-key" {
-		t.Fatalf("expected rowKey restored, got %q", vm.props["rowKey"].Str)
+	if vm.props["rowKey"].Text() != "outer-row-key" {
+		t.Fatalf("expected rowKey restored, got %q", vm.props["rowKey"].Text())
 	}
-	if vm.props["rowIndex"].Num != 42 {
-		t.Fatalf("expected rowIndex restored, got %f", vm.props["rowIndex"].Num)
+	if vm.props["rowIndex"].num != 42 {
+		t.Fatalf("expected rowIndex restored, got %f", vm.props["rowIndex"].num)
 	}
 }

--- a/client/wasm/main_test.go
+++ b/client/wasm/main_test.go
@@ -179,8 +179,8 @@ func TestRuntimeSetSharedSignalExport(t *testing.T) {
 	if !ok {
 		t.Fatal("expected shared signal to be set")
 	}
-	if val.Fields["count"].Num != 3 {
-		t.Fatalf("expected count 3, got %v", val.Fields["count"].Num)
+	if val.Map()["count"].Number() != 3 {
+		t.Fatalf("expected count 3, got %v", val.Map()["count"].Number())
 	}
 }
 
@@ -520,10 +520,10 @@ func TestRuntimeSetInputBatchExport(t *testing.T) {
 	if !ok {
 		t.Fatal("expected pointer signal to be set")
 	}
-	if got := pointer.Fields["x"].Num; got != 18 {
+	if got := pointer.Map()["x"].Number(); got != 18 {
 		t.Fatalf("expected x 18, got %v", got)
 	}
-	if got := pointer.Fields["y"].Num; got != -4.5 {
+	if got := pointer.Map()["y"].Number(); got != -4.5 {
 		t.Fatalf("expected y -4.5, got %v", got)
 	}
 
@@ -531,8 +531,8 @@ func TestRuntimeSetInputBatchExport(t *testing.T) {
 	if !ok {
 		t.Fatal("expected key signal to be set")
 	}
-	if !keyboard.Fields["space"].Bool {
-		t.Fatalf("expected space=true, got %#v", keyboard.Fields["space"])
+	if !keyboard.Map()["space"].Truth() {
+		t.Fatalf("expected space=true, got %#v", keyboard.Map()["space"])
 	}
 }
 
@@ -1061,8 +1061,8 @@ func TestRuntimeReloadProgramExport(t *testing.T) {
 	}
 	// State preserved (2), new +10 handler active: 2 -> 12.
 	js.Global().Get("__gosx_action").Invoke("rc-0", "increment", `{}`)
-	if got, _ := b.GetStore().Get("$count"); got.Num != 12 {
-		t.Fatalf("$count after json reload+bump = %v, want 12", got.Num)
+	if got, _ := b.GetStore().Get("$count"); got.Number() != 12 {
+		t.Fatalf("$count after json reload+bump = %v, want 12", got.Number())
 	}
 
 	// Reload again via a Uint8Array binary payload (+5 this time): 12 -> 17.
@@ -1074,8 +1074,8 @@ func TestRuntimeReloadProgramExport(t *testing.T) {
 		t.Fatalf("reload (bin) returned %q, want null", ret.String())
 	}
 	js.Global().Get("__gosx_action").Invoke("rc-0", "increment", `{}`)
-	if got, _ := b.GetStore().Get("$count"); got.Num != 17 {
-		t.Fatalf("$count after binary reload+bump = %v, want 17", got.Num)
+	if got, _ := b.GetStore().Get("$count"); got.Number() != 17 {
+		t.Fatalf("$count after binary reload+bump = %v, want 17", got.Number())
 	}
 
 	// Unknown island id surfaces a string error.

--- a/engine/surface/context_host.go
+++ b/engine/surface/context_host.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 
 	"m31labs.dev/gosx/client/vm"
-	"m31labs.dev/gosx/island/program"
 )
 
 // ContextHostReceiver bridges per-mount surface context state (props,
@@ -104,7 +103,7 @@ func (r *ContextHostReceiver) propsInto(args []vm.Value) (vm.Value, error) {
 		return vm.ZeroValue(0), fmt.Errorf("PropsInto expects 1 arg, got %d", len(args))
 	}
 	target := args[0]
-	if target.Fields == nil {
+	if !target.IsMap() {
 		return vm.ZeroValue(0), fmt.Errorf("PropsInto target has nil Fields (declare props as a struct type so the lowerer's eager zero-init runs)")
 	}
 	if len(r.propsJSON) == 0 {
@@ -118,9 +117,9 @@ func (r *ContextHostReceiver) propsInto(args []vm.Value) (vm.Value, error) {
 
 	for key, val := range raw {
 		v := jsonToVMValue(val)
-		target.Fields[key] = v
+		target.SetField(key, v)
 		if pascal := pascalCase(key); pascal != key {
-			target.Fields[pascal] = v
+			target.SetField(pascal, v)
 		}
 	}
 	return vm.ZeroValue(0), nil
@@ -164,7 +163,7 @@ func jsonToVMValue(v any) vm.Value {
 		for i, e := range x {
 			items[i] = jsonToVMValue(e)
 		}
-		return vm.Value{Type: program.TypeAny, Items: items}
+		return vm.ArrayVal(items)
 	case map[string]any:
 		fields := make(map[string]vm.Value, len(x)*2)
 		for k, val := range x {

--- a/engine/surface/context_host_test.go
+++ b/engine/surface/context_host_test.go
@@ -19,16 +19,16 @@ func TestContextHostReceiver_PropsIntoPopulatesFields(t *testing.T) {
 	if err != nil {
 		t.Fatalf("PropsInto: %v", err)
 	}
-	if out.Str != "" || out.Num != 0 {
+	if out.Text() != "" || out.Number() != 0 {
 		t.Fatalf("PropsInto should return zero Value, got %+v", out)
 	}
-	if got := target.Fields["Name"].Str; got != "hello" {
+	if got := target.Map()["Name"].Text(); got != "hello" {
 		t.Fatalf("Name = %q, want %q", got, "hello")
 	}
-	if got := target.Fields["Count"].Num; got != 42 {
+	if got := target.Map()["Count"].Number(); got != 42 {
 		t.Fatalf("Count = %v, want 42", got)
 	}
-	if got := target.Fields["Active"].Bool; got != true {
+	if got := target.Map()["Active"].Truth(); got != true {
 		t.Fatalf("Active = %v, want true", got)
 	}
 }
@@ -42,23 +42,23 @@ func TestContextHostReceiver_PropsIntoHandlesNestedArrays(t *testing.T) {
 		t.Fatalf("PropsInto: %v", err)
 	}
 
-	nodes := target.Fields["Nodes"]
-	if len(nodes.Items) != 2 {
-		t.Fatalf("Nodes length = %d, want 2", len(nodes.Items))
+	nodes := target.Map()["Nodes"]
+	if len(nodes.List()) != 2 {
+		t.Fatalf("Nodes length = %d, want 2", len(nodes.List()))
 	}
-	if got := nodes.Items[0].Fields["ID"].Str; got != "a" {
+	if got := nodes.List()[0].Map()["ID"].Text(); got != "a" {
 		t.Fatalf("Nodes[0].ID = %q, want %q", got, "a")
 	}
-	if got := nodes.Items[1].Fields["ID"].Str; got != "b" {
+	if got := nodes.List()[1].Map()["ID"].Text(); got != "b" {
 		t.Fatalf("Nodes[1].ID = %q, want %q", got, "b")
 	}
 
-	tags := target.Fields["Tags"]
-	if len(tags.Items) != 3 {
-		t.Fatalf("Tags length = %d, want 3", len(tags.Items))
+	tags := target.Map()["Tags"]
+	if len(tags.List()) != 3 {
+		t.Fatalf("Tags length = %d, want 3", len(tags.List()))
 	}
-	if tags.Items[2].Str != "z" {
-		t.Fatalf("Tags[2] = %q, want %q", tags.Items[2].Str, "z")
+	if tags.List()[2].Text() != "z" {
+		t.Fatalf("Tags[2] = %q, want %q", tags.List()[2].Text(), "z")
 	}
 }
 
@@ -69,8 +69,8 @@ func TestContextHostReceiver_PropsIntoEmptyJSONIsNoOp(t *testing.T) {
 	if _, err := recv.Call("PropsInto", []vm.Value{target}); err != nil {
 		t.Fatalf("empty propsJSON should be no-op success, got: %v", err)
 	}
-	if len(target.Fields) != 0 {
-		t.Fatalf("target Fields should stay empty, got %d entries", len(target.Fields))
+	if len(target.Map()) != 0 {
+		t.Fatalf("target Fields should stay empty, got %d entries", len(target.Map()))
 	}
 }
 
@@ -143,7 +143,7 @@ func TestContextHostReceiver_MutationPropagatesByReference(t *testing.T) {
 
 	// The mutation went through the shared Fields map, so the original
 	// sees it too.
-	if got := original.Fields["NodeCount"].Num; got != 7 {
+	if got := original.Map()["NodeCount"].Number(); got != 7 {
 		t.Fatalf("by-reference propagation failed: original NodeCount = %v, want 7", got)
 	}
 }

--- a/engine/surface/vm_host.go
+++ b/engine/surface/vm_host.go
@@ -320,19 +320,20 @@ func (r *CanvasHostReceiver) dispatchCanvasMethod(method string, args []vm.Value
 	return vm.ZeroValue(0), nil
 }
 
-// arg returns args[i].Num or 0 if i is out of range. Centralizes the
-// bounds-tolerance contract so each dispatch case stays one line.
+// arg returns the number payload of args[i], or 0 if i is out of range.
+// Centralizes the bounds-tolerance contract so each dispatch case stays
+// one line.
 func arg(args []vm.Value, i int) float64 {
 	if i < 0 || i >= len(args) {
 		return 0
 	}
-	return args[i].Num
+	return args[i].Number()
 }
 
-// argStr returns args[i].Str or "" if i is out of range.
+// argStr returns the text payload of args[i], or "" if i is out of range.
 func argStr(args []vm.Value, i int) string {
 	if i < 0 || i >= len(args) {
 		return ""
 	}
-	return args[i].Str
+	return args[i].Text()
 }

--- a/engine/surface/vm_host_test.go
+++ b/engine/surface/vm_host_test.go
@@ -58,7 +58,7 @@ type tickRecorder struct {
 
 func (r *tickRecorder) Call(method string, args []vm.Value) (vm.Value, error) {
 	if method == "Tick" && len(args) == 1 {
-		*r.ticks = append(*r.ticks, args[0].Num)
+		*r.ticks = append(*r.ticks, args[0].Number())
 	}
 	return vm.ZeroValue(program.TypeAny), nil
 }
@@ -171,9 +171,9 @@ func (r *abRecorder) Call(method string, args []vm.Value) (vm.Value, error) {
 	}
 	switch method {
 	case "TickA":
-		*r.a = append(*r.a, args[0].Num)
+		*r.a = append(*r.a, args[0].Number())
 	case "TickB":
-		*r.b = append(*r.b, args[0].Num)
+		*r.b = append(*r.b, args[0].Number())
 	}
 	return vm.ZeroValue(program.TypeAny), nil
 }
@@ -352,15 +352,15 @@ func TestCanvasHostReceiver_DispatchesCanvasMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Width: %v", err)
 	}
-	if int(got.Num) != 1024 {
-		t.Errorf("Width = %v, want 1024", got.Num)
+	if int(got.Number()) != 1024 {
+		t.Errorf("Width = %v, want 1024", got.Number())
 	}
 
 	got, err = recv.Call("Height", nil)
 	if err != nil {
 		t.Fatalf("Height: %v", err)
 	}
-	if int(got.Num) != 768 {
-		t.Errorf("Height = %v, want 768", got.Num)
+	if int(got.Number()) != 768 {
+		t.Errorf("Height = %v, want 768", got.Number())
 	}
 }

--- a/ir/closure_eval_test.go
+++ b/ir/closure_eval_test.go
@@ -31,14 +31,15 @@ func TestClosureRoundTripFilterByField(t *testing.T) {
 	if got.Type != program.TypeAny {
 		// ArrayVal carries TypeAny; the underlying Items slice is what matters.
 	}
-	if len(got.Items) != 2 {
-		t.Fatalf("expected 2 active items, got %d (%+v)", len(got.Items), got.Items)
+	gotItems := got.List()
+	if len(gotItems) != 2 {
+		t.Fatalf("expected 2 active items, got %d (%+v)", len(gotItems), gotItems)
 	}
-	if got.Items[0].IndexVal(vm.StringVal("name")).Str != "alpha" {
-		t.Fatalf("first kept item should be alpha, got %+v", got.Items[0])
+	if gotItems[0].IndexVal(vm.StringVal("name")).Text() != "alpha" {
+		t.Fatalf("first kept item should be alpha, got %+v", gotItems[0])
 	}
-	if got.Items[1].IndexVal(vm.StringVal("name")).Str != "gamma" {
-		t.Fatalf("second kept item should be gamma, got %+v", got.Items[1])
+	if gotItems[1].IndexVal(vm.StringVal("name")).Text() != "gamma" {
+		t.Fatalf("second kept item should be gamma, got %+v", gotItems[1])
 	}
 }
 
@@ -56,11 +57,12 @@ func TestClosureRoundTripMapProject(t *testing.T) {
 
 	machine := vm.NewVM(&program.Program{Name: "round-trip", Exprs: exprs}, map[string]vm.Value{"items": items})
 	got := machine.Eval(rootID)
-	if len(got.Items) != 2 {
-		t.Fatalf("expected 2 projected items, got %d", len(got.Items))
+	gotItems := got.List()
+	if len(gotItems) != 2 {
+		t.Fatalf("expected 2 projected items, got %d", len(gotItems))
 	}
-	if got.Items[0].Str != "one" || got.Items[1].Str != "two" {
-		t.Fatalf("expected [one, two], got %+v", got.Items)
+	if gotItems[0].Text() != "one" || gotItems[1].Text() != "two" {
+		t.Fatalf("expected [one, two], got %+v", gotItems)
 	}
 }
 
@@ -79,11 +81,12 @@ func TestClosureRoundTripChainedFilterMap(t *testing.T) {
 
 	machine := vm.NewVM(&program.Program{Name: "round-trip", Exprs: exprs}, map[string]vm.Value{"items": items})
 	got := machine.Eval(rootID)
-	if len(got.Items) != 2 {
-		t.Fatalf("expected 2 names, got %d (%+v)", len(got.Items), got.Items)
+	gotItems := got.List()
+	if len(gotItems) != 2 {
+		t.Fatalf("expected 2 names, got %d (%+v)", len(gotItems), gotItems)
 	}
-	if got.Items[0].Str != "alpha" || got.Items[1].Str != "gamma" {
-		t.Fatalf("expected [alpha, gamma], got %+v", got.Items)
+	if gotItems[0].Text() != "alpha" || gotItems[1].Text() != "gamma" {
+		t.Fatalf("expected [alpha, gamma], got %+v", gotItems)
 	}
 }
 
@@ -102,7 +105,7 @@ func TestClosureRoundTripFindByID(t *testing.T) {
 
 	machine := vm.NewVM(&program.Program{Name: "round-trip", Exprs: exprs}, map[string]vm.Value{"items": items})
 	got := machine.Eval(rootID)
-	if got.IndexVal(vm.StringVal("name")).Str != "beta" {
+	if got.IndexVal(vm.StringVal("name")).Text() != "beta" {
 		t.Fatalf("expected beta, got %+v", got)
 	}
 }

--- a/ir/golower/composite_lit_test.go
+++ b/ir/golower/composite_lit_test.go
@@ -43,13 +43,13 @@ func F(x float64, y float64) float64 {
 		"y": vm.FloatVal(1.25),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 4.75 {
-		t.Errorf("F(3.5, 1.25) = %f, want 4.75", got.Num)
+	if got.Number() != 4.75 {
+		t.Errorf("F(3.5, 1.25) = %f, want 4.75", got.Number())
 	}
 }
 
 // TestLowerNamedStructLiteral verifies `Node{ID: id, Pos: pos}` lowers
-// such that the resulting Value.Fields map is keyed by the explicit
+// such that the resulting Value.Map() map is keyed by the explicit
 // field names.
 func TestLowerNamedStructLiteral(t *testing.T) {
 	src := []byte(`package handlers
@@ -73,8 +73,8 @@ func F(id string, pos float64) string {
 		"pos": vm.FloatVal(2.5),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "n42" {
-		t.Errorf("F() = %q, want %q", got.Str, "n42")
+	if got.Text() != "n42" {
+		t.Errorf("F() = %q, want %q", got.Text(), "n42")
 	}
 }
 
@@ -96,8 +96,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 0 {
-		t.Errorf("F() = %f, want 0", got.Num)
+	if got.Number() != 0 {
+		t.Errorf("F() = %f, want 0", got.Number())
 	}
 }
 
@@ -119,8 +119,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("len([]Node{a,b,c}) = %d, want 3", int(got.Num))
+	if int(got.Number()) != 3 {
+		t.Errorf("len([]Node{a,b,c}) = %d, want 3", int(got.Number()))
 	}
 }
 
@@ -141,8 +141,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 4.0 {
-		t.Errorf("F() = %f, want 4.0", got.Num)
+	if got.Number() != 4.0 {
+		t.Errorf("F() = %f, want 4.0", got.Number())
 	}
 }
 
@@ -172,8 +172,8 @@ func F() string {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "second" {
-		t.Errorf("F() = %q, want %q", got.Str, "second")
+	if got.Text() != "second" {
+		t.Errorf("F() = %q, want %q", got.Text(), "second")
 	}
 }
 
@@ -198,8 +198,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 4.0 {
-		t.Errorf("F() = %f, want 4.0", got.Num)
+	if got.Number() != 4.0 {
+		t.Errorf("F() = %f, want 4.0", got.Number())
 	}
 }
 
@@ -222,8 +222,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 0 {
-		t.Errorf("F() = %d, want 0", int(got.Num))
+	if int(got.Number()) != 0 {
+		t.Errorf("F() = %d, want 0", int(got.Number()))
 	}
 }
 
@@ -250,7 +250,7 @@ func Count() int { return len(positions) }`)
 	// Initialize the signal from its Init expr — mirrors how the
 	// runtime sets up signals before invoking handlers.
 	initVal := machine.Eval(prog.Signals[0].Init)
-	if initVal.Fields == nil {
+	if initVal.Map() == nil {
 		t.Errorf("positions init = %+v, want empty Fields map", initVal)
 	}
 }

--- a/ir/golower/funclit_edge_test.go
+++ b/ir/golower/funclit_edge_test.go
@@ -37,8 +37,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 10 {
-		t.Errorf("F() = %v, want 10", got.Num)
+	if int(got.Number()) != 10 {
+		t.Errorf("F() = %v, want 10", got.Number())
 	}
 }
 
@@ -66,8 +66,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 30 {
-		t.Errorf("F() = %v, want 30 (nested closures lost a capture)", got.Num)
+	if int(got.Number()) != 30 {
+		t.Errorf("F() = %v, want 30 (nested closures lost a capture)", got.Number())
 	}
 }
 
@@ -103,8 +103,8 @@ func F() int {
 	// Now invoke F() and observe that the closure sees the signal.
 	fH := findHandler(t, prog.Handlers, "F")
 	got := machine.EvalWithFrame(fH.Body[0])
-	if int(got.Num) != 99 {
-		t.Errorf("F() = %v, want 99 (closure should see package-var signal value)", got.Num)
+	if int(got.Number()) != 99 {
+		t.Errorf("F() = %v, want 99 (closure should see package-var signal value)", got.Number())
 	}
 }
 
@@ -131,8 +131,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 15 {
-		t.Errorf("F() = %v, want 15 (cross-invocation capture share broken)", got.Num)
+	if int(got.Number()) != 15 {
+		t.Errorf("F() = %v, want 15 (cross-invocation capture share broken)", got.Number())
 	}
 }
 
@@ -176,7 +176,7 @@ func F() bool {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if !got.Bool {
+	if !got.Truth() {
 		t.Errorf("F() = false, want true (closure should return literal true)")
 	}
 }

--- a/ir/golower/funclit_test.go
+++ b/ir/golower/funclit_test.go
@@ -60,8 +60,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 10 {
-		t.Errorf("F() = %v, want 10", got.Num)
+	if int(got.Number()) != 10 {
+		t.Errorf("F() = %v, want 10", got.Number())
 	}
 }
 
@@ -86,8 +86,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 20 {
-		t.Errorf("F() = %v, want 20 (capture-by-reference)", got.Num)
+	if int(got.Number()) != 20 {
+		t.Errorf("F() = %v, want 20 (capture-by-reference)", got.Number())
 	}
 }
 
@@ -111,8 +111,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 12 {
-		t.Errorf("F() = %v, want 12", got.Num)
+	if int(got.Number()) != 12 {
+		t.Errorf("F() = %v, want 12", got.Number())
 	}
 }
 
@@ -150,7 +150,7 @@ func Mount(c *surface.Canvas) {
 	}
 	cv := rec.Calls[0].Args[0]
 	if !vm.IsClosure(cv) {
-		t.Errorf("StartLoop arg should be a ClosureVal; got Value{Type=%v Str=%q}", cv.Type, cv.Str)
+		t.Errorf("StartLoop arg should be a ClosureVal; got Value{Type=%v Str=%q}", cv.Type, cv.Text())
 	}
 }
 
@@ -177,8 +177,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %v, want 7", got.Num)
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %v, want 7", got.Number())
 	}
 }
 
@@ -206,8 +206,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("F() = %v, want 3 (closure-mutates-captured-local)", got.Num)
+	if int(got.Number()) != 3 {
+		t.Errorf("F() = %v, want 3 (closure-mutates-captured-local)", got.Number())
 	}
 }
 

--- a/ir/golower/golower_test.go
+++ b/ir/golower/golower_test.go
@@ -27,7 +27,7 @@ func F() int { return 42 }`)
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if got.Type != program.TypeInt || int(got.Num) != 42 {
+	if got.Type != program.TypeInt || int(got.Number()) != 42 {
 		t.Errorf("F() = %+v, want IntVal(42)", got)
 	}
 }
@@ -43,8 +43,8 @@ func F() int { return 2 * 3 + 1 }`)
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %f, want 7", got.Num)
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %f, want 7", got.Number())
 	}
 }
 
@@ -63,8 +63,8 @@ func F() int {
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 15 {
-		t.Errorf("F() = %f, want 15", got.Num)
+	if int(got.Number()) != 15 {
+		t.Errorf("F() = %f, want 15", got.Number())
 	}
 }
 
@@ -85,8 +85,8 @@ func F() int {
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 1 {
-		t.Errorf("F() = %f, want 1", got.Num)
+	if int(got.Number()) != 1 {
+		t.Errorf("F() = %f, want 1", got.Number())
 	}
 }
 
@@ -107,8 +107,8 @@ func Sum() int {
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 10 { // 0+1+2+3+4
-		t.Errorf("Sum() = %f, want 10", got.Num)
+	if int(got.Number()) != 10 { // 0+1+2+3+4
+		t.Errorf("Sum() = %f, want 10", got.Number())
 	}
 }
 
@@ -129,8 +129,8 @@ func Count() int {
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("Count() = %f, want 3", got.Num)
+	if int(got.Number()) != 3 {
+		t.Errorf("Count() = %f, want 3", got.Number())
 	}
 }
 
@@ -148,8 +148,8 @@ func F() float64 { return math.Sqrt(16) }`)
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if got.Num != 4 {
-		t.Errorf("F() = %f, want 4", got.Num)
+	if got.Number() != 4 {
+		t.Errorf("F() = %f, want 4", got.Number())
 	}
 }
 
@@ -166,8 +166,8 @@ func F() float64 { return math.Pi }`)
 	}
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if got.Num < 3.14 || got.Num > 3.15 {
-		t.Errorf("math.Pi = %f, want ~3.14159", got.Num)
+	if got.Number() < 3.14 || got.Number() > 3.15 {
+		t.Errorf("math.Pi = %f, want ~3.14159", got.Number())
 	}
 }
 
@@ -224,7 +224,7 @@ func F() int {
 		"items": vm.ArrayVal([]vm.Value{vm.IntVal(10), vm.IntVal(20), vm.IntVal(30)}),
 	})
 	got := machine.EvalWithFrame(prog.Handlers[0].Body[0])
-	if int(got.Num) != 60 {
-		t.Errorf("F() = %f, want 60", got.Num)
+	if int(got.Number()) != 60 {
+		t.Errorf("F() = %f, want 60", got.Number())
 	}
 }

--- a/ir/golower/graph_surface_test.go
+++ b/ir/golower/graph_surface_test.go
@@ -70,8 +70,8 @@ func TestGraphSurfaceTier1IsGraftKind(t *testing.T) {
 	for _, tc := range cases {
 		machine := vm.NewVM(prog, map[string]vm.Value{"kind": vm.StringVal(tc.kind)})
 		got := machine.EvalWithFrame(handler.Body[0])
-		if got.Bool != tc.want {
-			t.Errorf("IsGraftKind(%q) = %v, want %v", tc.kind, got.Bool, tc.want)
+		if got.Truth() != tc.want {
+			t.Errorf("IsGraftKind(%q) = %v, want %v", tc.kind, got.Truth(), tc.want)
 		}
 	}
 }
@@ -87,8 +87,8 @@ func TestGraphSurfaceTier2AccumulateAngle(t *testing.T) {
 		machine := vm.NewVM(prog, map[string]vm.Value{"n": vm.IntVal(n)})
 		got := machine.EvalWithFrame(handler.Body[0])
 		want := refAccumulateAngle(n)
-		if math.Abs(got.Num-want) > 1e-9 {
-			t.Errorf("AccumulateAngle(%d) = %f, want %f", n, got.Num, want)
+		if math.Abs(got.Number()-want) > 1e-9 {
+			t.Errorf("AccumulateAngle(%d) = %f, want %f", n, got.Number(), want)
 		}
 	}
 }
@@ -163,8 +163,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	want := refStepLayoutKernel()
-	if math.Abs(got.Num-want) > 1e-9 {
-		t.Errorf("F() = %f, want %f", got.Num, want)
+	if math.Abs(got.Number()-want) > 1e-9 {
+		t.Errorf("F() = %f, want %f", got.Number(), want)
 	}
 }
 
@@ -211,8 +211,8 @@ func TestGraphSurfaceTier3ForceFalloff(t *testing.T) {
 		})
 		got := machine.EvalWithFrame(handler.Body[0])
 		want := refForceFalloff(tc.dx, tc.dy)
-		if math.Abs(got.Num-want) > 1e-3 {
-			t.Errorf("ForceFalloff(%f, %f) = %f, want %f", tc.dx, tc.dy, got.Num, want)
+		if math.Abs(got.Number()-want) > 1e-3 {
+			t.Errorf("ForceFalloff(%f, %f) = %f, want %f", tc.dx, tc.dy, got.Number(), want)
 		}
 	}
 }

--- a/ir/golower/host_call_graph_surface_test.go
+++ b/ir/golower/host_call_graph_surface_test.go
@@ -59,14 +59,14 @@ func Draw(c *surface.Canvas, x1 float64, y1 float64, x2 float64, y2 float64, col
 		}
 	}
 	// Spot-check arg propagation.
-	if rec.Calls[1].Args[0].Num != 10 || rec.Calls[1].Args[1].Num != 20 {
+	if rec.Calls[1].Args[0].Number() != 10 || rec.Calls[1].Args[1].Number() != 20 {
 		t.Errorf("MoveTo args = %+v, want [10, 20]", rec.Calls[1].Args)
 	}
-	if rec.Calls[2].Args[0].Num != 30 || rec.Calls[2].Args[1].Num != 40 {
+	if rec.Calls[2].Args[0].Number() != 30 || rec.Calls[2].Args[1].Number() != 40 {
 		t.Errorf("LineTo args = %+v, want [30, 40]", rec.Calls[2].Args)
 	}
-	if rec.Calls[3].Args[0].Str != "rgba(120,100,75,0.25)" {
-		t.Errorf("SetStrokeStyle arg = %q, want \"rgba(120,100,75,0.25)\"", rec.Calls[3].Args[0].Str)
+	if rec.Calls[3].Args[0].Text() != "rgba(120,100,75,0.25)" {
+		t.Errorf("SetStrokeStyle arg = %q, want \"rgba(120,100,75,0.25)\"", rec.Calls[3].Args[0].Text())
 	}
 }
 
@@ -98,8 +98,8 @@ func Step(c *surface.Canvas, n int) int {
 	})
 	machine.BindHost("c", rec)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 2 {
-		t.Errorf("Step returned %d, want 2 (len of fx after two writes)", int(got.Num))
+	if int(got.Number()) != 2 {
+		t.Errorf("Step returned %d, want 2 (len of fx after two writes)", int(got.Number()))
 	}
 	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
 		t.Errorf("expected one SetFillStyle host call; got %+v", rec.Calls)

--- a/ir/golower/host_call_test.go
+++ b/ir/golower/host_call_test.go
@@ -92,11 +92,11 @@ func F(c *surface.Canvas, x float64, y float64) {
 	if len(rec.Calls[0].Args) != 2 {
 		t.Fatalf("call.Args len = %d, want 2", len(rec.Calls[0].Args))
 	}
-	if rec.Calls[0].Args[0].Num != 3.5 {
-		t.Errorf("args[0] = %f, want 3.5", rec.Calls[0].Args[0].Num)
+	if rec.Calls[0].Args[0].Number() != 3.5 {
+		t.Errorf("args[0] = %f, want 3.5", rec.Calls[0].Args[0].Number())
 	}
-	if rec.Calls[0].Args[1].Num != 7.25 {
-		t.Errorf("args[1] = %f, want 7.25", rec.Calls[0].Args[1].Num)
+	if rec.Calls[0].Args[1].Number() != 7.25 {
+		t.Errorf("args[1] = %f, want 7.25", rec.Calls[0].Args[1].Number())
 	}
 }
 
@@ -125,8 +125,8 @@ func F(c *surface.Canvas, color string) {
 	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
 		t.Fatalf("expected one canvas.SetFillStyle call; got %+v", rec.Calls)
 	}
-	if rec.Calls[0].Args[0].Str != "#7b5c3a" {
-		t.Errorf("args[0] = %q, want %q", rec.Calls[0].Args[0].Str, "#7b5c3a")
+	if rec.Calls[0].Args[0].Text() != "#7b5c3a" {
+		t.Errorf("args[0] = %q, want %q", rec.Calls[0].Args[0].Text(), "#7b5c3a")
 	}
 }
 
@@ -161,8 +161,8 @@ func F(ctx *surface.Context, slot int) {
 	if len(rec.Calls) != 1 || rec.Calls[0].Method != "RegisterSlot" {
 		t.Fatalf("expected one ctx.RegisterSlot call; got %+v", rec.Calls)
 	}
-	if int(rec.Calls[0].Args[0].Num) != 42 {
-		t.Errorf("args[0] = %d, want 42", int(rec.Calls[0].Args[0].Num))
+	if int(rec.Calls[0].Args[0].Number()) != 42 {
+		t.Errorf("args[0] = %d, want 42", int(rec.Calls[0].Args[0].Number()))
 	}
 }
 
@@ -198,14 +198,14 @@ func F(c *surface.Canvas, label string, x float64, y float64) {
 	if len(rec.Calls[0].Args) != 3 {
 		t.Fatalf("call.Args len = %d, want 3", len(rec.Calls[0].Args))
 	}
-	if rec.Calls[0].Args[0].Str != "hello" {
-		t.Errorf("args[0] = %q, want \"hello\"", rec.Calls[0].Args[0].Str)
+	if rec.Calls[0].Args[0].Text() != "hello" {
+		t.Errorf("args[0] = %q, want \"hello\"", rec.Calls[0].Args[0].Text())
 	}
-	if rec.Calls[0].Args[1].Num != 10 {
-		t.Errorf("args[1] = %f, want 10", rec.Calls[0].Args[1].Num)
+	if rec.Calls[0].Args[1].Number() != 10 {
+		t.Errorf("args[1] = %f, want 10", rec.Calls[0].Args[1].Number())
 	}
-	if rec.Calls[0].Args[2].Num != 32 {
-		t.Errorf("args[2] = %f, want 32 (y + 12)", rec.Calls[0].Args[2].Num)
+	if rec.Calls[0].Args[2].Number() != 32 {
+		t.Errorf("args[2] = %f, want 32 (y + 12)", rec.Calls[0].Args[2].Number())
 	}
 }
 
@@ -231,7 +231,7 @@ func F(x float64) float64 {
 		"x": vm.FloatVal(0),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 0 {
-		t.Errorf("sin(0) = %f, want 0", got.Num)
+	if got.Number() != 0 {
+		t.Errorf("sin(0) = %f, want 0", got.Number())
 	}
 }

--- a/ir/golower/lhs_edge_cases_test.go
+++ b/ir/golower/lhs_edge_cases_test.go
@@ -49,8 +49,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 99.0 {
-		t.Errorf("F() = %f, want 99.0", got.Num)
+	if got.Number() != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Number())
 	}
 }
 
@@ -75,8 +75,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 7.5 {
-		t.Errorf("F() = %f, want 7.5", got.Num)
+	if got.Number() != 7.5 {
+		t.Errorf("F() = %f, want 7.5", got.Number())
 	}
 }
 
@@ -85,7 +85,7 @@ func F() float64 {
 // Slice Y.E.3 update: pre-Y.E this test relied on `p := &x` being
 // rejected at the `&` operator. Y.E now lowers `&x` cleanly (treats
 // it as a pass-through for the underlying Value because composite
-// values are reference-shared via Value.Fields/Items per Y.C/Y.D).
+// values are reference-shared via Value.Map()/Items per Y.C/Y.D).
 // The test now reaches the `*p` LHS rejection, which surfaces as
 // "left-hand side must be a simple identifier" — the dispatcher in
 // lowerAssignStmt's bare-ident branch is the gatekeeper.
@@ -169,8 +169,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 2 + 3 + 4 + 5 + 5 = 19.
-	if got.Num != 19.0 {
-		t.Errorf("F() = %f, want 19.0", got.Num)
+	if got.Number() != 19.0 {
+		t.Errorf("F() = %f, want 19.0", got.Number())
 	}
 }
 
@@ -193,8 +193,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 42.0 {
-		t.Errorf("F() = %f, want 42.0", got.Num)
+	if got.Number() != 42.0 {
+		t.Errorf("F() = %f, want 42.0", got.Number())
 	}
 }
 
@@ -230,8 +230,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 42.0 {
-		t.Errorf("F() = %f, want 42.0", got.Num)
+	if got.Number() != 42.0 {
+		t.Errorf("F() = %f, want 42.0", got.Number())
 	}
 }
 
@@ -256,7 +256,7 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 99.0 {
-		t.Errorf("F() = %f, want 99.0", got.Num)
+	if got.Number() != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Number())
 	}
 }

--- a/ir/golower/lhs_graph_surface_test.go
+++ b/ir/golower/lhs_graph_surface_test.go
@@ -52,8 +52,8 @@ func F() float64 {
 	// gTx.Y = 150 - 1.5 * (150 - 50) = 150 - 150 = 0.
 	// gTx.Scale = 2 * 1.5 = 3.
 	// sum = 50 + 0 + 3 = 53.
-	if got.Num != 53.0 {
-		t.Errorf("F() = %f, want 53.0", got.Num)
+	if got.Number() != 53.0 {
+		t.Errorf("F() = %f, want 53.0", got.Number())
 	}
 }
 
@@ -94,8 +94,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// (1 + 3) * 2 = 8.
-	if got.Num != 8.0 {
-		t.Errorf("F() = %f, want 8.0", got.Num)
+	if got.Number() != 8.0 {
+		t.Errorf("F() = %f, want 8.0", got.Number())
 	}
 }
 
@@ -126,8 +126,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 0 + 10 + 20 = 30.
-	if got.Num != 30.0 {
-		t.Errorf("F() = %f, want 30.0", got.Num)
+	if got.Number() != 30.0 {
+		t.Errorf("F() = %f, want 30.0", got.Number())
 	}
 }
 
@@ -141,7 +141,7 @@ func F() float64 {
 // target sub-expression is OpSignalGet → ObjectVal whose Fields map
 // the OpFieldSet mutates in place. Critically, the test confirms the
 // mutation is visible through subsequent OpSignalGet reads: because
-// Value.Fields is a map (reference type), every signal-get returns a
+// Value.Map() is a map (reference type), every signal-get returns a
 // Value sharing the same underlying Fields map, so the OpFieldSet
 // write propagates without a signal.Set() roundtrip.
 func TestLowerGraphSurfacePackageVarStructField(t *testing.T) {
@@ -174,8 +174,8 @@ func F() float64 {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 10 + 20 + 2.5 = 32.5.
-	if got.Num != 32.5 {
-		t.Errorf("F() = %f, want 32.5", got.Num)
+	if got.Number() != 32.5 {
+		t.Errorf("F() = %f, want 32.5", got.Number())
 	}
 }
 
@@ -207,8 +207,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 42 + 1 = 43.
-	if got.Num != 43.0 {
-		t.Errorf("F() = %f, want 43.0", got.Num)
+	if got.Number() != 43.0 {
+		t.Errorf("F() = %f, want 43.0", got.Number())
 	}
 }
 
@@ -245,8 +245,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 42 {
-		t.Errorf("F() = %d, want 42", int(got.Num))
+	if int(got.Number()) != 42 {
+		t.Errorf("F() = %d, want 42", int(got.Number()))
 	}
 }
 
@@ -274,7 +274,7 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 99.0 {
-		t.Errorf("F() = %f, want 99.0", got.Num)
+	if got.Number() != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Number())
 	}
 }

--- a/ir/golower/lhs_selectors_test.go
+++ b/ir/golower/lhs_selectors_test.go
@@ -54,8 +54,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 12.5 {
-		t.Errorf("F() = %f, want 12.5", got.Num)
+	if got.Number() != 12.5 {
+		t.Errorf("F() = %f, want 12.5", got.Number())
 	}
 }
 
@@ -85,8 +85,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// (10 + 5.5) * 2 = 31.
-	if got.Num != 31.0 {
-		t.Errorf("F() = %f, want 31.0", got.Num)
+	if got.Number() != 31.0 {
+		t.Errorf("F() = %f, want 31.0", got.Number())
 	}
 }
 
@@ -109,8 +109,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 9.5 {
-		t.Errorf("F() = %f, want 9.5", got.Num)
+	if got.Number() != 9.5 {
+		t.Errorf("F() = %f, want 9.5", got.Number())
 	}
 }
 
@@ -134,8 +134,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// (1+4.5) + (3-1.5) = 5.5 + 1.5 = 7.
-	if got.Num != 7.0 {
-		t.Errorf("F() = %f, want 7.0", got.Num)
+	if got.Number() != 7.0 {
+		t.Errorf("F() = %f, want 7.0", got.Number())
 	}
 }
 
@@ -158,8 +158,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 18.5 {
-		t.Errorf("F() = %f, want 18.5", got.Num)
+	if got.Number() != 18.5 {
+		t.Errorf("F() = %f, want 18.5", got.Number())
 	}
 }
 
@@ -181,8 +181,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 12.5 {
-		t.Errorf("F() = %f, want 12.5", got.Num)
+	if got.Number() != 12.5 {
+		t.Errorf("F() = %f, want 12.5", got.Number())
 	}
 }
 
@@ -216,7 +216,7 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 99.0 {
-		t.Errorf("F() = %f, want 99.0", got.Num)
+	if got.Number() != 99.0 {
+		t.Errorf("F() = %f, want 99.0", got.Number())
 	}
 }

--- a/ir/golower/lhs_signal_test.go
+++ b/ir/golower/lhs_signal_test.go
@@ -8,7 +8,7 @@
 // reads see the new value.
 //
 // **Critical implementation note.** The mutation works because
-// Value.Fields and Value.Items are reference types (map / slice). When
+// Value.Map() and Value.List() are reference types (map / slice). When
 // OpSignalGet returns Value-by-value, the inner Fields map and Items
 // slice still alias the same storage held by the signal. The mutation
 // does NOT call signal.Set(), so signal subscribers are not notified
@@ -51,8 +51,8 @@ func F() float64 {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 99 + (4 + 5) = 108.
-	if got.Num != 108.0 {
-		t.Errorf("F() = %f, want 108.0", got.Num)
+	if got.Number() != 108.0 {
+		t.Errorf("F() = %f, want 108.0", got.Number())
 	}
 }
 
@@ -85,8 +85,8 @@ func F() float64 {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 42 + 100 = 142.
-	if got.Num != 142.0 {
-		t.Errorf("F() = %f, want 142.0", got.Num)
+	if got.Number() != 142.0 {
+		t.Errorf("F() = %f, want 142.0", got.Number())
 	}
 }
 
@@ -127,8 +127,8 @@ func Read() float64 {
 	}
 	got := machine.EvalWithFrame(readHandler.Body[0])
 	// X = 0 + 1 + 1 + 1 = 3; Scale = 1 * 2 * 2 * 2 = 8; sum = 11.
-	if got.Num != 11.0 {
-		t.Errorf("Read() after 3 steps = %f, want 11.0", got.Num)
+	if got.Number() != 11.0 {
+		t.Errorf("Read() after 3 steps = %f, want 11.0", got.Number())
 	}
 }
 
@@ -167,8 +167,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 15.0 {
-		t.Errorf("F() = %f, want 15.0 (7 + 8)", got.Num)
+	if got.Number() != 15.0 {
+		t.Errorf("F() = %f, want 15.0 (7 + 8)", got.Number())
 	}
 }
 
@@ -195,7 +195,7 @@ func F() float64 {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 0 + 2 + 4 + 6 = 12.
-	if got.Num != 12.0 {
-		t.Errorf("F() = %f, want 12.0", got.Num)
+	if got.Number() != 12.0 {
+		t.Errorf("F() = %f, want 12.0", got.Number())
 	}
 }

--- a/ir/golower/make_test.go
+++ b/ir/golower/make_test.go
@@ -47,8 +47,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 3.5 {
-		t.Errorf("F() = %f, want 3.5", got.Num)
+	if got.Number() != 3.5 {
+		t.Errorf("F() = %f, want 3.5", got.Number())
 	}
 }
 
@@ -74,8 +74,8 @@ func F(n int) int {
 		"n": vm.IntVal(8),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 2 {
-		t.Errorf("F(8) = %d, want 2", int(got.Num))
+	if int(got.Number()) != 2 {
+		t.Errorf("F(8) = %d, want 2", int(got.Number()))
 	}
 }
 
@@ -97,8 +97,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 2 {
-		t.Errorf("F() = %d, want 2", int(got.Num))
+	if int(got.Number()) != 2 {
+		t.Errorf("F() = %d, want 2", int(got.Number()))
 	}
 }
 
@@ -123,8 +123,8 @@ func F(n int) int {
 		"n": vm.IntVal(3),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 36 {
-		t.Errorf("F(3) = %d, want 36 (11 + 22 + 3)", int(got.Num))
+	if int(got.Number()) != 36 {
+		t.Errorf("F(3) = %d, want 36 (11 + 22 + 3)", int(got.Number()))
 	}
 }
 
@@ -147,7 +147,7 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("F() = %d, want 3", int(got.Num))
+	if int(got.Number()) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Number()))
 	}
 }

--- a/ir/golower/multi_assign_test.go
+++ b/ir/golower/multi_assign_test.go
@@ -46,8 +46,8 @@ func F(x float64, y float64) float64 {
 		"y": vm.FloatVal(1.25),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 4.75 {
-		t.Errorf("F(3.5, 1.25) = %f, want 4.75", got.Num)
+	if got.Number() != 4.75 {
+		t.Errorf("F(3.5, 1.25) = %f, want 4.75", got.Number())
 	}
 }
 
@@ -73,8 +73,8 @@ func F(x int, y int) int {
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
 	// After swap a=3, b=10, so a-b = -7.
-	if int(got.Num) != -7 {
-		t.Errorf("F(10, 3) = %d, want -7", int(got.Num))
+	if int(got.Number()) != -7 {
+		t.Errorf("F(10, 3) = %d, want -7", int(got.Number()))
 	}
 }
 
@@ -99,8 +99,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 7.5 {
-		t.Errorf("F() = %f, want 7.5", got.Num)
+	if got.Number() != 7.5 {
+		t.Errorf("F() = %f, want 7.5", got.Number())
 	}
 }
 
@@ -125,8 +125,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != -1 {
-		t.Errorf("F() = %f, want -1", got.Num)
+	if got.Number() != -1 {
+		t.Errorf("F() = %f, want -1", got.Number())
 	}
 }
 
@@ -151,8 +151,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 42 {
-		t.Errorf("F() = %d, want 42", int(got.Num))
+	if int(got.Number()) != 42 {
+		t.Errorf("F() = %d, want 42", int(got.Number()))
 	}
 }
 
@@ -175,8 +175,8 @@ func F(x int, z int) int {
 		"z": vm.IntVal(9),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 9 {
-		t.Errorf("F(1, 9) = %d, want 9", int(got.Num))
+	if int(got.Number()) != 9 {
+		t.Errorf("F(1, 9) = %d, want 9", int(got.Number()))
 	}
 }
 
@@ -202,8 +202,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 7.0 {
-		t.Errorf("F() = %f, want 7.0", got.Num)
+	if got.Number() != 7.0 {
+		t.Errorf("F() = %f, want 7.0", got.Number())
 	}
 }
 
@@ -234,8 +234,8 @@ func F() string {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "beta" {
-		t.Errorf("F() = %q, want %q", got.Str, "beta")
+	if got.Text() != "beta" {
+		t.Errorf("F() = %q, want %q", got.Text(), "beta")
 	}
 }
 
@@ -269,8 +269,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// dx=2, dy=8, dist=10, ux=0.2, uy=0.8, ux+uy = 1.0
-	if got.Num != 1.0 {
-		t.Errorf("F() = %f, want 1.0", got.Num)
+	if got.Number() != 1.0 {
+		t.Errorf("F() = %f, want 1.0", got.Number())
 	}
 }
 
@@ -298,8 +298,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 1.0 {
-		t.Errorf("F() = %f, want 1.0", got.Num)
+	if got.Number() != 1.0 {
+		t.Errorf("F() = %f, want 1.0", got.Number())
 	}
 }
 
@@ -324,7 +324,7 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 1 {
-		t.Errorf("F() = %d, want 1", int(got.Num))
+	if int(got.Number()) != 1 {
+		t.Errorf("F() = %d, want 1", int(got.Number()))
 	}
 }

--- a/ir/golower/nil_fields_test.go
+++ b/ir/golower/nil_fields_test.go
@@ -6,7 +6,7 @@
 // which reads the local's current Value. Pre-Y.G, OpLocalDecl reserves
 // the slot with the bare zero Value{} — Fields map is nil — and the
 // host receives a Value-by-value copy whose Fields map is also nil.
-// Any host-side `target.Fields[key] = ...` write either panics (writing
+// Any host-side `target.Map()[key] = ...` write either panics (writing
 // to a nil map) or, with a workaround that allocates the map, lands in
 // the host's copy and never propagates back to the caller's local.
 //
@@ -60,8 +60,8 @@ func Mount() string {
 	machine.BindHost("host", &propsIntoHost{value: "ALPHA"})
 
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "ALPHA" {
-		t.Errorf("props.Center = %q, want \"ALPHA\"\n(host wrote Center to the Fields map but caller didn't observe the write — `&x` pass-through on a nil-Fields receiver dropped the update)", got.Str)
+	if got.Text() != "ALPHA" {
+		t.Errorf("props.Center = %q, want \"ALPHA\"\n(host wrote Center to the Fields map but caller didn't observe the write — `&x` pass-through on a nil-Fields receiver dropped the update)", got.Text())
 	}
 }
 
@@ -89,8 +89,8 @@ func F() string {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "set" {
-		t.Errorf("F() = %q, want \"set\" (b.Name = \"set\" must land in the local's Fields map even when b was declared via `var b Box`)", got.Str)
+	if got.Text() != "set" {
+		t.Errorf("F() = %q, want \"set\" (b.Name = \"set\" must land in the local's Fields map even when b was declared via `var b Box`)", got.Text())
 	}
 }
 
@@ -112,13 +112,13 @@ func (h *propsIntoHost) Call(method string, args []vm.Value) (vm.Value, error) {
 		return vm.ZeroValue(0), nil
 	}
 	target := args[0]
-	if target.Fields == nil {
+	if target.Map() == nil {
 		// Pre-Y.G this is the failure point — the host has no map
 		// to write into, and even allocating one locally would not
 		// propagate back to the caller's local.
 		return vm.ZeroValue(0), nil
 	}
-	target.Fields["Center"] = vm.StringVal(h.value)
-	target.Fields["Name"] = vm.StringVal(h.value)
+	target.Map()["Center"] = vm.StringVal(h.value)
+	target.Map()["Name"] = vm.StringVal(h.value)
 	return vm.ZeroValue(0), nil
 }

--- a/ir/golower/residuals_test.go
+++ b/ir/golower/residuals_test.go
@@ -65,8 +65,8 @@ func F(t string) string {
 			"t": vm.StringVal(tc.in),
 		})
 		got := machine.EvalWithFrame(handler.Body[0])
-		if got.Str != tc.want {
-			t.Errorf("F(%q) = %q, want %q", tc.in, got.Str, tc.want)
+		if got.Text() != tc.want {
+			t.Errorf("F(%q) = %q, want %q", tc.in, got.Text(), tc.want)
 		}
 	}
 }
@@ -96,8 +96,8 @@ func F(t string) int {
 			"t": vm.StringVal(in),
 		})
 		got := machine.EvalWithFrame(handler.Body[0])
-		if int(got.Num) != want {
-			t.Errorf("F(%q) = %d, want %d", in, int(got.Num), want)
+		if int(got.Number()) != want {
+			t.Errorf("F(%q) = %d, want %d", in, int(got.Number()), want)
 		}
 	}
 }
@@ -121,8 +121,8 @@ func F(s string) string {
 		"s": vm.StringVal("hello"),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "ell" {
-		t.Errorf("F(\"hello\")[1:4] = %q, want \"ell\"", got.Str)
+	if got.Text() != "ell" {
+		t.Errorf("F(\"hello\")[1:4] = %q, want \"ell\"", got.Text())
 	}
 }
 
@@ -146,14 +146,14 @@ func F(s string) int {
 	got := machine.EvalWithFrame(handler.Body[0])
 	// "héllo" is 5 runes; the VM treats len(string) as byte length
 	// historically, but len([]rune(...)) must use rune count.
-	if int(got.Num) != 5 {
-		t.Errorf("len([]rune(\"héllo\")) = %d, want 5", int(got.Num))
+	if int(got.Number()) != 5 {
+		t.Errorf("len([]rune(\"héllo\")) = %d, want 5", int(got.Number()))
 	}
 }
 
 // TestLowerAddressOfDropsThrough verifies that `&x` lowers to the
 // underlying expression (composite reference semantics already
-// propagate through Value.Fields/Items per Y.C/Y.D; the explicit `&`
+// propagate through Value.Map()/Items per Y.C/Y.D; the explicit `&`
 // has no additional opcode-level meaning in the supported subset).
 // Mirrors graph_surface.go's Mount handler: `ctx.PropsInto(&props)`.
 func TestLowerAddressOfDropsThrough(t *testing.T) {
@@ -192,8 +192,8 @@ func F(ctx *surface.Context, x float64) {
 	if len(rec.Calls) != 1 || rec.Calls[0].Method != "Set" {
 		t.Fatalf("expected one Set call; got %+v", rec.Calls)
 	}
-	if rec.Calls[0].Args[0].Num != 7.5 {
-		t.Errorf("&x lowered arg = %f, want 7.5 (underlying value)", rec.Calls[0].Args[0].Num)
+	if rec.Calls[0].Args[0].Number() != 7.5 {
+		t.Errorf("&x lowered arg = %f, want 7.5 (underlying value)", rec.Calls[0].Args[0].Number())
 	}
 }
 
@@ -214,7 +214,7 @@ func F(label string) string {
 		"label": vm.StringVal("héllo world"),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "hél…" {
-		t.Errorf("F(\"héllo world\") = %q, want %q", got.Str, "hél…")
+	if got.Text() != "hél…" {
+		t.Errorf("F(\"héllo world\") = %q, want %q", got.Text(), "hél…")
 	}
 }

--- a/ir/golower/user_fn_calls_test.go
+++ b/ir/golower/user_fn_calls_test.go
@@ -46,8 +46,8 @@ func F() string {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "hi" {
-		t.Errorf("F() = %q, want %q", got.Str, "hi")
+	if got.Text() != "hi" {
+		t.Errorf("F() = %q, want %q", got.Text(), "hi")
 	}
 }
 
@@ -70,8 +70,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 42 {
-		t.Errorf("F() = %d, want 42", int(got.Num))
+	if int(got.Number()) != 42 {
+		t.Errorf("F() = %d, want 42", int(got.Number()))
 	}
 }
 
@@ -95,8 +95,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %d, want 7", int(got.Num))
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %d, want 7", int(got.Number()))
 	}
 }
 
@@ -126,8 +126,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 7.0 {
-		t.Errorf("F() = %f, want 7.0", got.Num)
+	if got.Number() != 7.0 {
+		t.Errorf("F() = %f, want 7.0", got.Number())
 	}
 }
 
@@ -156,8 +156,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 25.0 {
-		t.Errorf("F() = %f, want 25.0", got.Num)
+	if got.Number() != 25.0 {
+		t.Errorf("F() = %f, want 25.0", got.Number())
 	}
 }
 
@@ -184,8 +184,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 720 {
-		t.Errorf("F() = %d, want 720", int(got.Num))
+	if int(got.Number()) != 720 {
+		t.Errorf("F() = %d, want 720", int(got.Number()))
 	}
 }
 
@@ -210,8 +210,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 10 {
-		t.Errorf("F() = %d, want 10", int(got.Num))
+	if int(got.Number()) != 10 {
+		t.Errorf("F() = %d, want 10", int(got.Number()))
 	}
 }
 
@@ -242,8 +242,8 @@ func F() int {
 	machine := vm.NewVM(prog, nil)
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("F() = %d, want 3", int(got.Num))
+	if int(got.Number()) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Number()))
 	}
 }
 

--- a/ir/golower/user_fn_composite_param_test.go
+++ b/ir/golower/user_fn_composite_param_test.go
@@ -2,7 +2,7 @@
 // retrospective handoff guarantee.
 //
 // Y.C's retrospective documented: "OpFieldSet on a parameter-typed
-// receiver already propagates because Value.Fields is reference-
+// receiver already propagates because Value.Map() is reference-
 // typed." Y.D inherits this verbatim — composite arguments are passed
 // by Value-by-value copy but their Fields/Items storage is shared, so
 // the callee's mutations land in the caller's storage.
@@ -45,8 +45,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 101.0 {
-		t.Errorf("F() = %f, want 101.0 (struct param mutation must propagate per Y.C retrospective)", got.Num)
+	if got.Number() != 101.0 {
+		t.Errorf("F() = %f, want 101.0 (struct param mutation must propagate per Y.C retrospective)", got.Number())
 	}
 }
 
@@ -72,8 +72,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 43.0 {
-		t.Errorf("F() = %f, want 43.0 (map param mutation must propagate per Y.C retrospective)", got.Num)
+	if got.Number() != 43.0 {
+		t.Errorf("F() = %f, want 43.0 (map param mutation must propagate per Y.C retrospective)", got.Number())
 	}
 }
 
@@ -101,8 +101,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 0.0 {
-		t.Errorf("F() = %f, want 0.0 (slice element mutation through param must propagate)", got.Num)
+	if got.Number() != 0.0 {
+		t.Errorf("F() = %f, want 0.0 (slice element mutation through param must propagate)", got.Number())
 	}
 }
 
@@ -130,7 +130,7 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %d, want 7 (scalar param must NOT mutate caller's value)", int(got.Num))
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %d, want 7 (scalar param must NOT mutate caller's value)", int(got.Number()))
 	}
 }

--- a/ir/golower/user_fn_graph_surface_test.go
+++ b/ir/golower/user_fn_graph_surface_test.go
@@ -79,8 +79,8 @@ func F() float64 {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	want := refGraphSurfaceHelpers()
-	if math.Abs(got.Num-want) > 1e-9 {
-		t.Errorf("F() = %f, want %f", got.Num, want)
+	if math.Abs(got.Number()-want) > 1e-9 {
+		t.Errorf("F() = %f, want %f", got.Number(), want)
 	}
 }
 
@@ -127,8 +127,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 3.0 {
-		t.Errorf("F() = %f, want 3.0 (map mutation through nested call frames)", got.Num)
+	if got.Number() != 3.0 {
+		t.Errorf("F() = %f, want 3.0 (map mutation through nested call frames)", got.Number())
 	}
 }
 
@@ -155,7 +155,7 @@ func helperDefinedLater(n int) int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 42 {
-		t.Errorf("F() = %d, want 42 (forward reference must resolve via registry pre-pass)", int(got.Num))
+	if int(got.Number()) != 42 {
+		t.Errorf("F() = %d, want 42 (forward reference must resolve via registry pre-pass)", int(got.Number()))
 	}
 }

--- a/ir/golower/user_fn_init_positions_test.go
+++ b/ir/golower/user_fn_init_positions_test.go
@@ -56,8 +56,8 @@ func F() float64 {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 1.0 + 2.0 + 3.0 + 4.0 = 10.0
-	if got.Num != 10.0 {
-		t.Errorf("F() = %f, want 10.0 (initPositions cascade must populate gPos through nested user-fn calls)", got.Num)
+	if got.Number() != 10.0 {
+		t.Errorf("F() = %f, want 10.0 (initPositions cascade must populate gPos through nested user-fn calls)", got.Number())
 	}
 }
 
@@ -91,7 +91,7 @@ func F() int {
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 0+1+2+3+4 = 10
-	if int(got.Num) != 10 {
-		t.Errorf("F() = %d, want 10 (recursive seeding over package state must accumulate)", int(got.Num))
+	if int(got.Number()) != 10 {
+		t.Errorf("F() = %d, want 10 (recursive seeding over package state must accumulate)", int(got.Number()))
 	}
 }

--- a/ir/golower/user_fn_multi_return_edge_test.go
+++ b/ir/golower/user_fn_multi_return_edge_test.go
@@ -37,8 +37,8 @@ func F() int {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 10/3 = 3 (int division); 10 - 3 = 7
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %d, want 7", int(got.Num))
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %d, want 7", int(got.Number()))
 	}
 }
 
@@ -62,8 +62,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 3 {
-		t.Errorf("F() = %d, want 3", int(got.Num))
+	if int(got.Number()) != 3 {
+		t.Errorf("F() = %d, want 3", int(got.Number()))
 	}
 }
 
@@ -89,8 +89,8 @@ func F() int {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// 5 + 10 + 15 = 30
-	if int(got.Num) != 30 {
-		t.Errorf("F() = %d, want 30", int(got.Num))
+	if int(got.Number()) != 30 {
+		t.Errorf("F() = %d, want 30", int(got.Number()))
 	}
 }
 
@@ -119,8 +119,8 @@ func F() float64 {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 7.5 {
-		t.Errorf("F() = %f, want 7.5", got.Num)
+	if got.Number() != 7.5 {
+		t.Errorf("F() = %f, want 7.5", got.Number())
 	}
 }
 
@@ -146,7 +146,7 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 10 {
-		t.Errorf("F() = %d, want 10", int(got.Num))
+	if int(got.Number()) != 10 {
+		t.Errorf("F() = %d, want 10", int(got.Number()))
 	}
 }

--- a/ir/golower/user_fn_mutual_recursion_test.go
+++ b/ir/golower/user_fn_mutual_recursion_test.go
@@ -46,8 +46,8 @@ func F() bool {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if !got.Bool {
-		t.Errorf("isEven(10) = %v, want true (mutual recursion must resolve via registry pre-pass)", got.Bool)
+	if !got.Truth() {
+		t.Errorf("isEven(10) = %v, want true (mutual recursion must resolve via registry pre-pass)", got.Truth())
 	}
 }
 
@@ -80,7 +80,7 @@ func F() bool {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Bool {
-		t.Errorf("isEven(7) = %v, want false", got.Bool)
+	if got.Truth() {
+		t.Errorf("isEven(7) = %v, want false", got.Truth())
 	}
 }

--- a/ir/golower/user_fn_scope_test.go
+++ b/ir/golower/user_fn_scope_test.go
@@ -40,8 +40,8 @@ func F() int {
 	machine := vm.NewVM(prog, nil)
 	vm.InitSignals(machine, prog)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 7 {
-		t.Errorf("F() = %d, want 7 (param must shadow signal in callee frame)", int(got.Num))
+	if int(got.Number()) != 7 {
+		t.Errorf("F() = %d, want 7 (param must shadow signal in callee frame)", int(got.Number()))
 	}
 }
 
@@ -68,8 +68,8 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 42 {
-		t.Errorf("F() = %d, want 42 (caller's local must survive the call)", int(got.Num))
+	if int(got.Number()) != 42 {
+		t.Errorf("F() = %d, want 42 (caller's local must survive the call)", int(got.Number()))
 	}
 }
 
@@ -105,8 +105,8 @@ func F() int {
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
 	// a(5) = b(5)+1 = (c(5)+10)+1 = (5+100+10)+1 = 116
-	if int(got.Num) != 116 {
-		t.Errorf("F() = %d, want 116 (3-deep nested call stack must compose)", int(got.Num))
+	if int(got.Number()) != 116 {
+		t.Errorf("F() = %d, want 116 (3-deep nested call stack must compose)", int(got.Number()))
 	}
 }
 
@@ -139,7 +139,7 @@ func F() int {
 	handler := findHandler(t, prog.Handlers, "F")
 	machine := vm.NewVM(prog, nil)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 0 {
-		t.Errorf("F() = %d, want 0 (callee's hiddenVar must not leak into caller frame)", int(got.Num))
+	if int(got.Number()) != 0 {
+		t.Errorf("F() = %d, want 0 (callee's hiddenVar must not leak into caller frame)", int(got.Number()))
 	}
 }

--- a/ir/golower/y_e_compose_test.go
+++ b/ir/golower/y_e_compose_test.go
@@ -58,8 +58,8 @@ func Paint(c *surface.Canvas, kind string) {
 		if rec.Calls[0].Method != "SetFillStyle" {
 			t.Errorf("kind=%q: method = %q, want SetFillStyle", kind, rec.Calls[0].Method)
 		}
-		if rec.Calls[0].Args[0].Str != want {
-			t.Errorf("kind=%q: arg = %q, want %q", kind, rec.Calls[0].Args[0].Str, want)
+		if rec.Calls[0].Args[0].Text() != want {
+			t.Errorf("kind=%q: arg = %q, want %q", kind, rec.Calls[0].Args[0].Text(), want)
 		}
 	}
 }
@@ -97,8 +97,8 @@ func Trunc(label string, n int) string {
 			"n":     vm.IntVal(tc.n),
 		})
 		got := machine.EvalWithFrame(handler.Body[0])
-		if got.Str != tc.want {
-			t.Errorf("Trunc(%q, %d) = %q, want %q", tc.label, tc.n, got.Str, tc.want)
+		if got.Text() != tc.want {
+			t.Errorf("Trunc(%q, %d) = %q, want %q", tc.label, tc.n, got.Text(), tc.want)
 		}
 	}
 }
@@ -128,8 +128,8 @@ func F(n int) float64 {
 		"n": vm.IntVal(4),
 	})
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Num != 3.0 {
-		t.Errorf("F(4) = %f, want 3.0 (1.0 + 2.0)", got.Num)
+	if got.Number() != 3.0 {
+		t.Errorf("F(4) = %f, want 3.0 (1.0 + 2.0)", got.Number())
 	}
 }
 
@@ -185,8 +185,8 @@ func Step(c *surface.Canvas, n int) int {
 	})
 	machine.BindHost("c", rec)
 	got := machine.EvalWithFrame(handler.Body[0])
-	if int(got.Num) != 1 {
-		t.Errorf("Step returned %d, want 1 (one node)", int(got.Num))
+	if int(got.Number()) != 1 {
+		t.Errorf("Step returned %d, want 1 (one node)", int(got.Number()))
 	}
 	if len(rec.Calls) != 1 || rec.Calls[0].Method != "SetFillStyle" {
 		t.Errorf("expected one SetFillStyle host call; got %+v", rec.Calls)

--- a/ir/golower/y_g_mount_end_to_end_test.go
+++ b/ir/golower/y_g_mount_end_to_end_test.go
@@ -74,8 +74,8 @@ func Mount() string {
 
 	handler := findHandler(t, prog.Handlers, "Mount")
 	got := machine.EvalWithFrame(handler.Body[0])
-	if got.Str != "Mount-via-bytecode" {
-		t.Errorf("Mount returned %q, want %q (props decode + propagate)", got.Str, "Mount-via-bytecode")
+	if got.Text() != "Mount-via-bytecode" {
+		t.Errorf("Mount returned %q, want %q (props decode + propagate)", got.Text(), "Mount-via-bytecode")
 	}
 	if !vm.IsClosure(captured.cb) {
 		t.Fatal("c.StartLoop did not receive a ClosureVal")
@@ -107,14 +107,14 @@ func (h *propsIntoHostNamed) Call(method string, args []vm.Value) (vm.Value, err
 		return vm.ZeroValue(0), nil
 	}
 	target := args[0]
-	if target.Fields == nil {
+	if target.Map() == nil {
 		// Y.G's eager struct zero-init means this branch should
 		// not fire; if it does, the test fails the props-propagate
 		// assertion above.
 		return vm.ZeroValue(0), nil
 	}
-	target.Fields["Name"] = vm.StringVal(h.name)
-	target.Fields["Count"] = vm.IntVal(h.count)
+	target.Map()["Name"] = vm.StringVal(h.name)
+	target.Map()["Count"] = vm.IntVal(h.count)
 	return vm.ZeroValue(0), nil
 }
 

--- a/physics/angular_test.go
+++ b/physics/angular_test.go
@@ -1,0 +1,771 @@
+package physics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Angular contact response is easy to get wrong in ways that still look
+// plausible on screen. Every test in this file checks a physical invariant or a
+// closed-form answer, and none of them shares code with the solver.
+
+// systemState is an independent bookkeeping of the conserved quantities of a
+// closed system. It recomputes the inertia tensor from the collider geometry by
+// hand rather than reading the body's cached tensor.
+type systemState struct {
+	Momentum        Vec3
+	AngularMomentum Vec3
+	Kinetic         float64
+}
+
+// measureSystem sums linear momentum, angular momentum about the world origin
+// and kinetic energy over the given bodies.
+//
+// Angular momentum about the origin is r x p for the translation plus I * w for
+// the spin. Kinetic energy is the translational half m v^2 plus the rotational
+// half w . (I w).
+func measureSystem(t *testing.T, bodies []*RigidBody) systemState {
+	t.Helper()
+	var state systemState
+	for _, body := range bodies {
+		inertia := oracleWorldInertia(t, body)
+		state.Momentum = state.Momentum.Add(body.Velocity.Mul(body.Mass))
+		state.AngularMomentum = state.AngularMomentum.
+			Add(body.Position.Cross(body.Velocity.Mul(body.Mass))).
+			Add(inertia.mul(body.AngularVelocity))
+		state.Kinetic += 0.5 * body.Mass * body.Velocity.Len2()
+		state.Kinetic += 0.5 * body.AngularVelocity.Dot(inertia.mul(body.AngularVelocity))
+	}
+	return state
+}
+
+// oracleWorldInertia rebuilds the world inertia tensor of a body from its shape
+// and rotation, using textbook formulas written out here on purpose. It shares
+// no code with inertia.go.
+func oracleWorldInertia(t *testing.T, body *RigidBody) mat3 {
+	t.Helper()
+	colliders := body.Colliders()
+	if len(colliders) != 1 {
+		t.Fatalf("oracle handles one collider per body, body %q has %d", body.ID, len(colliders))
+	}
+	c := colliders[0]
+	var diagonal Vec3
+	switch c.Shape {
+	case ShapeSphere:
+		i := 2.0 / 5.0 * body.Mass * c.Radius * c.Radius
+		diagonal = Vec3{X: i, Y: i, Z: i}
+	case ShapeBox:
+		w, h, d := c.Width, c.Height, c.Depth
+		diagonal = Vec3{
+			X: body.Mass * (h*h + d*d) / 12,
+			Y: body.Mass * (w*w + d*d) / 12,
+			Z: body.Mass * (w*w + h*h) / 12,
+		}
+	default:
+		t.Fatalf("oracle does not model shape %v", c.Shape)
+	}
+	rotation := mat3FromQuat(body.Rotation)
+	return rotateTensor(rotation, mat3Diagonal(diagonal))
+}
+
+func assertVecNear(t *testing.T, label string, got, want Vec3, tolerance float64) {
+	t.Helper()
+	if math.Abs(got.X-want.X) > tolerance ||
+		math.Abs(got.Y-want.Y) > tolerance ||
+		math.Abs(got.Z-want.Z) > tolerance {
+		t.Fatalf("%s = %+v, want %+v within %v", label, got, want, tolerance)
+	}
+}
+
+// --- Conservation ------------------------------------------------------------
+
+// TestContactImpulseConservesMomentumExactly isolates the solver primitive.
+// Two free bodies receive equal and opposite impulses at one shared world
+// point, which is what every contact does. Linear and angular momentum about
+// the world origin must both survive to the last bit of precision.
+//
+// No position correction runs here, so the check needs no tolerance for body
+// movement. It is the strictest angular statement in the file.
+func TestContactImpulseConservesMomentumExactly(t *testing.T) {
+	rng := rand.New(rand.NewSource(31337))
+	for trial := 0; trial < 200; trial++ {
+		a := NewRigidBody(BodyConfig{
+			Mass:            0.5 + rng.Float64()*3,
+			Position:        Vec3{X: rng.Float64()*4 - 2, Y: rng.Float64()*4 - 2, Z: rng.Float64()*4 - 2},
+			Rotation:        randomUnitQuat(rng),
+			Velocity:        Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+			AngularVelocity: Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+		})
+		a.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 0.6, Height: 1.1, Depth: 0.9})
+		b := NewRigidBody(BodyConfig{
+			Mass:            0.5 + rng.Float64()*3,
+			Position:        Vec3{X: rng.Float64()*4 - 2, Y: rng.Float64()*4 - 2, Z: rng.Float64()*4 - 2},
+			Rotation:        randomUnitQuat(rng),
+			Velocity:        Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+			AngularVelocity: Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+		})
+		b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.55})
+
+		bodies := []*RigidBody{a, b}
+		before := measureSystem(t, bodies)
+
+		point := Vec3{X: rng.Float64()*4 - 2, Y: rng.Float64()*4 - 2, Z: rng.Float64()*4 - 2}
+		impulse := Vec3{X: rng.Float64()*6 - 3, Y: rng.Float64()*6 - 3, Z: rng.Float64()*6 - 3}
+		applyImpulseAtOffset(a, impulse.Neg(), point.Sub(a.Position))
+		applyImpulseAtOffset(b, impulse, point.Sub(b.Position))
+
+		after := measureSystem(t, bodies)
+		assertVecNear(t, "linear momentum", after.Momentum, before.Momentum, 1e-12)
+		assertVecNear(t, "angular momentum", after.AngularMomentum, before.AngularMomentum, 1e-11)
+	}
+}
+
+// TestClosedSystemConservesMomentumAndEnergy runs collisions with no gravity, no
+// damping and no friction. Linear momentum, angular momentum and kinetic energy
+// must all survive the collision.
+//
+// Linear momentum is exact. Angular momentum carries a small tolerance because
+// the position pass removes the overlap by moving bodies, and moving a body
+// with velocity v by dx changes r x p by dx x mv. That shift is bounded by the
+// overlap the discrete step allows, and it is unrelated to the impulse itself,
+// which TestContactImpulseConservesMomentumExactly checks with no tolerance.
+func TestClosedSystemConservesMomentumAndEnergy(t *testing.T) {
+	cases := []struct {
+		name    string
+		build   func(*World) []*RigidBody
+		steps   int
+		angular float64
+		energy  float64
+	}{
+		{
+			name: "head on spheres",
+			build: func(w *World) []*RigidBody {
+				a := w.AddBody(BodyConfig{ID: "a", Mass: 1, Position: Vec3{X: -2}, Velocity: Vec3{X: 4}, Restitution: 1})
+				a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+				b := w.AddBody(BodyConfig{ID: "b", Mass: 1, Position: Vec3{X: 2}, Velocity: Vec3{X: -4}, Restitution: 1})
+				b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+				return []*RigidBody{a, b}
+			},
+			steps: 240, angular: 1e-9, energy: 1e-6,
+		},
+		{
+			name: "spinning sphere strikes a resting sphere",
+			build: func(w *World) []*RigidBody {
+				a := w.AddBody(BodyConfig{
+					ID: "a", Mass: 2, Position: Vec3{X: -2, Y: 0.3},
+					Velocity: Vec3{X: 5}, AngularVelocity: Vec3{Z: 3}, Restitution: 1,
+				})
+				a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+				b := w.AddBody(BodyConfig{ID: "b", Mass: 1, Restitution: 1})
+				b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+				return []*RigidBody{a, b}
+			},
+			steps: 240, angular: 0.02, energy: 1e-4,
+		},
+		{
+			name: "box struck off centre by a sphere",
+			build: func(w *World) []*RigidBody {
+				a := w.AddBody(BodyConfig{ID: "a", Mass: 1, Position: Vec3{X: -2, Y: 0.4}, Velocity: Vec3{X: 6}, Restitution: 1})
+				a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.3})
+				b := w.AddBody(BodyConfig{ID: "b", Mass: 3, Restitution: 1})
+				b.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+				return []*RigidBody{a, b}
+			},
+			steps: 240, angular: 0.05, energy: 1e-3,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			world := NewWorld(WorldConfig{
+				Gravity:       Vec3{},
+				FixedTimestep: 1.0 / 240.0,
+				SolverIter:    30,
+				DisableCCD:    true,
+			})
+			bodies := testCase.build(world)
+			before := measureSystem(t, bodies)
+
+			touched := false
+			for i := 0; i < testCase.steps; i++ {
+				world.StepFixed()
+				if len(world.contacts) > 0 {
+					touched = true
+				}
+			}
+			if !touched {
+				t.Fatal("the bodies never touched; the test proves nothing")
+			}
+
+			after := measureSystem(t, bodies)
+			assertVecNear(t, "linear momentum", after.Momentum, before.Momentum, 1e-9)
+			assertVecNear(t, "angular momentum", after.AngularMomentum, before.AngularMomentum, testCase.angular)
+			if math.Abs(after.Kinetic-before.Kinetic) > testCase.energy {
+				t.Fatalf("kinetic energy = %v, want %v within %v", after.Kinetic, before.Kinetic, testCase.energy)
+			}
+		})
+	}
+}
+
+// TestInelasticCollisionNeverGainsEnergy checks the other half of the energy
+// invariant. Restitution below one must lose energy, never gain it, and both
+// momenta must still survive.
+func TestInelasticCollisionNeverGainsEnergy(t *testing.T) {
+	rng := rand.New(rand.NewSource(4242))
+	for trial := 0; trial < 40; trial++ {
+		world := NewWorld(WorldConfig{
+			Gravity: Vec3{}, FixedTimestep: 1.0 / 240.0, SolverIter: 20, DisableCCD: true,
+		})
+		restitution := rng.Float64() * 0.9
+		a := world.AddBody(BodyConfig{
+			Mass:            0.5 + rng.Float64()*2,
+			Position:        Vec3{X: -1.5, Y: (rng.Float64() - 0.5) * 0.6, Z: (rng.Float64() - 0.5) * 0.6},
+			Velocity:        Vec3{X: 2 + rng.Float64()*4},
+			AngularVelocity: Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+			Restitution:     restitution,
+		})
+		a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+		b := world.AddBody(BodyConfig{
+			Mass:        0.5 + rng.Float64()*2,
+			Position:    Vec3{X: 1.5},
+			Velocity:    Vec3{X: -(1 + rng.Float64()*3)},
+			Restitution: restitution,
+		})
+		b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+		bodies := []*RigidBody{a, b}
+		before := measureSystem(t, bodies)
+		for i := 0; i < 300; i++ {
+			world.StepFixed()
+		}
+		after := measureSystem(t, bodies)
+
+		assertVecNear(t, "linear momentum", after.Momentum, before.Momentum, 1e-9)
+		// Angular momentum keeps a relative tolerance for the same reason as
+		// the test above: the position pass moves overlapping bodies, and that
+		// shifts r x p without any impulse.
+		angularTolerance := 0.02*before.AngularMomentum.Len() + 0.01
+		assertVecNear(t, "angular momentum", after.AngularMomentum, before.AngularMomentum, angularTolerance)
+		if after.Kinetic > before.Kinetic+1e-9 {
+			t.Fatalf("trial %d: kinetic energy grew from %v to %v", trial, before.Kinetic, after.Kinetic)
+		}
+	}
+}
+
+// --- Analytic cases ----------------------------------------------------------
+
+// TestEqualSpheresExchangeVelocityHeadOn is the textbook elastic collision of
+// two equal masses: they swap velocities exactly.
+func TestEqualSpheresExchangeVelocityHeadOn(t *testing.T) {
+	world := NewWorld(WorldConfig{
+		Gravity: Vec3{}, FixedTimestep: 1.0 / 240.0, SolverIter: 20, DisableCCD: true,
+	})
+	a := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: -1.5}, Velocity: Vec3{X: 3}, Restitution: 1})
+	a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+	b := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 1.5}, Restitution: 1})
+	b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 400; i++ {
+		world.StepFixed()
+	}
+
+	assertVecNear(t, "struck sphere velocity", b.Velocity, Vec3{X: 3}, 1e-6)
+	assertVecNear(t, "striker velocity", a.Velocity, Vec3{}, 1e-6)
+	if a.AngularVelocity.Len() > 1e-9 || b.AngularVelocity.Len() > 1e-9 {
+		t.Fatalf("a frictionless central hit must not spin either sphere: a=%+v b=%+v",
+			a.AngularVelocity, b.AngularVelocity)
+	}
+}
+
+// TestOffCentreHitMatchesClosedFormImpulse checks the angular half of the
+// contact response against the closed form of a single elastic impulse.
+//
+// A sphere of mass m1 strikes a resting sphere of mass m2. The contact normal
+// runs between the centres, so the impulse magnitude is
+//
+//	j = (1 + e) * v . n / (1/m1 + 1/m2)
+//
+// The struck sphere leaves along n at j/m2, and the striker keeps v - j/m1 * n.
+// A frictionless normal impulse passes through both centres, so neither sphere
+// gains spin however far off centre the approach is.
+func TestOffCentreHitMatchesClosedFormImpulse(t *testing.T) {
+	const offset = 0.4 // vertical miss distance between the two centres
+	const speed = 5.0
+	const massA = 2.0
+	const massB = 1.0
+	const radius = 0.5
+
+	world := NewWorld(WorldConfig{
+		Gravity: Vec3{}, FixedTimestep: 1.0 / 2000.0, SolverIter: 30, DisableCCD: true,
+	})
+	a := world.AddBody(BodyConfig{Mass: massA, Position: Vec3{X: -3, Y: offset}, Velocity: Vec3{X: speed}, Restitution: 1})
+	a.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: radius})
+	b := world.AddBody(BodyConfig{Mass: massB, Restitution: 1})
+	b.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: radius})
+
+	for i := 0; i < 1600; i++ {
+		world.StepFixed()
+	}
+
+	// At the moment of contact the two centres are 2*radius apart, with a
+	// vertical separation of offset. That fixes the contact normal.
+	horizontal := math.Sqrt(4*radius*radius - offset*offset)
+	normal := Vec3{X: horizontal, Y: -offset}.Normalize()
+	approach := Vec3{X: speed}.Dot(normal)
+	impulse := 2 * approach / (1/massA + 1/massB)
+
+	wantB := normal.Mul(impulse / massB)
+	wantA := Vec3{X: speed}.Sub(normal.Mul(impulse / massA))
+
+	// The tolerance covers the overlap that one discrete step allows: the
+	// contact normal is measured when the centres are slightly closer than two
+	// radii, which tilts the normal by about one step of approach.
+	assertVecNear(t, "struck sphere velocity", b.Velocity, wantB, 0.03)
+	assertVecNear(t, "striker velocity", a.Velocity, wantA, 0.03)
+	if b.AngularVelocity.Len() > 1e-9 {
+		t.Fatalf("a frictionless normal impulse cannot spin a sphere, got %+v", b.AngularVelocity)
+	}
+}
+
+// TestRodPivotingAboutOneEndMatchesAngularAcceleration checks the inertia
+// tensor and the torque integrator against the closed form of a rod on a pivot.
+//
+// A uniform rod of length L pinned at one end has inertia m L^2 / 3 about the
+// pivot. Held horizontal, gravity acts at the centre with moment arm L/2, so
+// the angular acceleration at release is
+//
+//	alpha = m g (L/2) / (m L^2 / 3) = 3 g / (2 L)
+func TestRodPivotingAboutOneEndMatchesAngularAcceleration(t *testing.T) {
+	const length = 2.0
+	const mass = 1.0
+	const gravity = -10.0
+
+	world := NewWorld(WorldConfig{
+		Gravity: Vec3{Y: gravity}, FixedTimestep: 1.0 / 2000.0, SolverIter: 40, DisableCCD: true,
+	})
+	pivot := world.AddBody(BodyConfig{Mass: 0, Position: Vec3{}})
+	rod := world.AddBody(BodyConfig{Mass: mass, Position: Vec3{X: length / 2}})
+	// A thin box along X carries the rod inertia m L^2 / 12 about its centre.
+	rod.AddCollider(ColliderConfig{Shape: ShapeBox, Width: length, Height: 1e-3, Depth: 1e-3})
+	world.AddConstraint(&PointConstraint{
+		BodyA:   pivot,
+		BodyB:   rod,
+		AttachA: Vec3{},
+		AttachB: Vec3{X: -length / 2},
+	})
+
+	for i := 0; i < 20; i++ {
+		world.StepFixed()
+	}
+
+	elapsed := 20.0 / 2000.0
+	want := 3 * gravity / (2 * length)
+	got := rod.AngularVelocity.Z / elapsed
+	if math.Abs(got-want) > math.Abs(want)*0.05 {
+		t.Fatalf("angular acceleration = %v, want %v within 5%%", got, want)
+	}
+}
+
+// TestBoxDroppedFlatDoesNotRotate pins the negative case. A box that lands
+// square on a plane must stay square: four balanced contact impulses produce no
+// net torque.
+func TestBoxDroppedFlatDoesNotRotate(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2}, Friction: 0.5})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 300; i++ {
+		world.StepFixed()
+	}
+
+	tilt := math.Hypot(math.Hypot(box.Rotation.X, box.Rotation.Y), box.Rotation.Z)
+	if tilt > 1e-3 {
+		t.Fatalf("a flat landing must not rotate the box, tilt component = %v", tilt)
+	}
+	if box.AngularVelocity.Len() > 1e-3 {
+		t.Fatalf("box should be still, angular velocity = %+v", box.AngularVelocity)
+	}
+	if box.Position.Y < 0.49 || box.Position.Y > 0.51 {
+		t.Fatalf("box should rest near y=0.5, got %v", box.Position.Y)
+	}
+}
+
+// TestBoxDroppedOnCornerRotatesOntoItsFace pins the positive case. A box
+// balanced on one corner must tip over, and it must come to rest flat.
+func TestBoxDroppedOnCornerRotatesOntoItsFace(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 120.0, SolverIter: 12})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	// Tip the box about two axes so no corner, edge or face is level.
+	tilt := QuatFromAxisAngle(Vec3{Z: 1}, 0.6).Mul(QuatFromAxisAngle(Vec3{X: 1}, 0.5))
+	box := world.AddBody(BodyConfig{
+		Mass: 1, Position: Vec3{Y: 1.4}, Rotation: tilt, Friction: 0.6, Restitution: 0,
+	})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	spun := false
+	for i := 0; i < 1200; i++ {
+		world.StepFixed()
+		if box.AngularVelocity.Len() > 0.5 {
+			spun = true
+		}
+	}
+
+	if !spun {
+		t.Fatal("a corner landing must produce angular velocity; the contact carried no torque")
+	}
+	// A cube at rest on a plane has one axis of its rotation matrix aligned
+	// with the world up axis.
+	up := box.Rotation.Rotate(Vec3{Y: 1})
+	best := math.Max(math.Abs(up.X), math.Max(math.Abs(up.Y), math.Abs(up.Z)))
+	if best < 0.995 {
+		t.Fatalf("box did not settle on a face, local up in world = %+v", up)
+	}
+	if box.Position.Y < 0.49 || box.Position.Y > 0.51 {
+		t.Fatalf("box should rest with a face down near y=0.5, got %v", box.Position.Y)
+	}
+	if box.AngularVelocity.Len() > 0.05 {
+		t.Fatalf("box should have stopped rotating, angular velocity = %+v", box.AngularVelocity)
+	}
+}
+
+// TestFrictionAtContactPointSpinsARollingSphere checks that friction acts at
+// the contact point and therefore produces torque. A sphere thrown along a
+// rough floor with no spin must start to roll, and it must roll forward.
+func TestFrictionAtContactPointSpinsARollingSphere(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIter: 12})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	ball := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 0.5}, Velocity: Vec3{X: 4}, Friction: 0.4})
+	ball.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 1200; i++ {
+		world.StepFixed()
+	}
+
+	// Rolling forward along +X about the -Z axis.
+	if ball.AngularVelocity.Z >= -0.1 {
+		t.Fatalf("friction must spin the ball forward, angular velocity = %+v", ball.AngularVelocity)
+	}
+	// Rolling without slipping gives v = omega * r.
+	surface := -ball.AngularVelocity.Z * 0.5
+	if math.Abs(surface-ball.Velocity.X) > 0.05 {
+		t.Fatalf("ball should roll without slipping: v=%v, omega*r=%v", ball.Velocity.X, surface)
+	}
+	if ball.Velocity.X <= 0 {
+		t.Fatalf("ball must keep moving forward, velocity = %+v", ball.Velocity)
+	}
+}
+
+// --- Rest stability ----------------------------------------------------------
+
+// TestThreeBoxStackStaysStackedOverThousandsOfSteps extends the warm-start stack
+// test to rotation. The stack must keep its heights, keep its alignment, and
+// stop moving.
+func TestThreeBoxStackStaysStackedOverThousandsOfSteps(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	boxes := make([]*RigidBody, 3)
+	for i := range boxes {
+		body := world.AddBody(BodyConfig{
+			Mass: 1, Position: Vec3{Y: 0.5 + float64(i)}, Friction: 0.6, Restitution: 0,
+		})
+		body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+		boxes[i] = body
+	}
+
+	for i := 0; i < 5000; i++ {
+		world.StepFixed()
+	}
+
+	for i, box := range boxes {
+		want := 0.5 + float64(i)
+		if math.Abs(box.Position.Y-want) > 0.01 {
+			t.Fatalf("box[%d] sank or rose: y = %v, want %v", i, box.Position.Y, want)
+		}
+		if lateral := math.Hypot(box.Position.X, box.Position.Z); lateral > 0.05 {
+			t.Fatalf("box[%d] slid %v sideways", i, lateral)
+		}
+		tilt := math.Hypot(math.Hypot(box.Rotation.X, box.Rotation.Y), box.Rotation.Z)
+		if tilt > 0.01 {
+			t.Fatalf("box[%d] tilted, rotation vector part = %v", i, tilt)
+		}
+		if box.AngularVelocity.Len() > 0.01 {
+			t.Fatalf("box[%d] still spinning at %+v", i, box.AngularVelocity)
+		}
+		if box.Velocity.Len() > 0.01 {
+			t.Fatalf("box[%d] still moving at %+v", i, box.Velocity)
+		}
+	}
+}
+
+// TestRestingContactsNeverGainEnergy is the strongest rest invariant available
+// without a rest state: the total mechanical energy of a settling stack must
+// never rise. A solver that injects energy through its angular terms fails here
+// long before the stack visibly jitters.
+func TestRestingContactsNeverGainEnergy(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	boxes := make([]*RigidBody, 3)
+	for i := range boxes {
+		body := world.AddBody(BodyConfig{
+			Mass: 1, Position: Vec3{Y: 0.5 + float64(i)}, Friction: 0.6,
+		})
+		body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+		boxes[i] = body
+	}
+
+	energy := func() float64 {
+		total := 0.0
+		for _, body := range boxes {
+			inertia := oracleWorldInertia(t, body)
+			total += 0.5 * body.Mass * body.Velocity.Len2()
+			total += 0.5 * body.AngularVelocity.Dot(inertia.mul(body.AngularVelocity))
+			total += body.Mass * 10 * body.Position.Y
+		}
+		return total
+	}
+
+	// Let the stack settle before measuring, so the initial drop is not counted.
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+	peak := energy()
+	for i := 0; i < 3000; i++ {
+		world.StepFixed()
+		if now := energy(); now > peak+1e-6 {
+			t.Fatalf("step %d: mechanical energy rose from %.9f to %.9f", i, peak, now)
+		}
+	}
+}
+
+// --- Determinism -------------------------------------------------------------
+
+// TestAngularSolverIsDeterministic replays a tumbling scene twice and demands
+// bit-identical results. Replay is one of this engine's promises, and angular
+// state is new surface where a map iteration or a pointer compare could break
+// it.
+func TestAngularSolverIsDeterministic(t *testing.T) {
+	build := func() ([]*RigidBody, *World) {
+		world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+		world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+		rng := rand.New(rand.NewSource(99))
+		bodies := make([]*RigidBody, 0, 12)
+		for i := 0; i < 12; i++ {
+			body := world.AddBody(BodyConfig{
+				Mass: 1 + rng.Float64(),
+				Position: Vec3{
+					X: (rng.Float64() - 0.5) * 3,
+					Y: 1 + float64(i)*0.8,
+					Z: (rng.Float64() - 0.5) * 3,
+				},
+				Rotation:        randomUnitQuat(rng),
+				Velocity:        Vec3{X: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+				AngularVelocity: Vec3{X: rng.Float64() - 0.5, Y: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+				Friction:        0.4,
+				Restitution:     0.2,
+			})
+			switch i % 3 {
+			case 0:
+				body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 0.8, Height: 0.8, Depth: 0.8})
+			case 1:
+				body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.4})
+			default:
+				body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.35, Height: 0.7})
+			}
+			bodies = append(bodies, body)
+		}
+		return bodies, world
+	}
+
+	run := func() []BodyState {
+		bodies, world := build()
+		for i := 0; i < 600; i++ {
+			world.StepFixed()
+		}
+		out := make([]BodyState, len(bodies))
+		for i, body := range bodies {
+			out[i] = BodyState{
+				Position:        body.Position,
+				Rotation:        body.Rotation,
+				Velocity:        body.Velocity,
+				AngularVelocity: body.AngularVelocity,
+			}
+		}
+		return out
+	}
+
+	first := run()
+	second := run()
+	for i := range first {
+		if first[i] != second[i] {
+			t.Fatalf("body %d diverged between runs:\n first: %+v\nsecond: %+v", i, first[i], second[i])
+		}
+	}
+}
+
+// --- Inertia -----------------------------------------------------------------
+
+// TestInertiaTensorMatchesTextbookValues checks the derived tensor against the
+// closed form for every primitive shape.
+func TestInertiaTensorMatchesTextbookValues(t *testing.T) {
+	const mass = 3.0
+	cases := []struct {
+		name   string
+		config ColliderConfig
+		want   Vec3
+		rel    float64
+	}{
+		{
+			name:   "sphere",
+			config: ColliderConfig{Shape: ShapeSphere, Radius: 0.7},
+			want:   Vec3{X: 0.4 * mass * 0.49, Y: 0.4 * mass * 0.49, Z: 0.4 * mass * 0.49},
+			rel:    1e-12,
+		},
+		{
+			name:   "box",
+			config: ColliderConfig{Shape: ShapeBox, Width: 1, Height: 2, Depth: 3},
+			want: Vec3{
+				X: mass * (4 + 9) / 12,
+				Y: mass * (1 + 9) / 12,
+				Z: mass * (1 + 4) / 12,
+			},
+			rel: 1e-12,
+		},
+		{
+			name:   "cylinder",
+			config: ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2},
+			want: Vec3{
+				X: mass * (3*0.25 + 4) / 12,
+				Y: 0.5 * mass * 0.25,
+				Z: mass * (3*0.25 + 4) / 12,
+			},
+			rel: 1e-12,
+		},
+		{
+			name:   "cone",
+			config: ColliderConfig{Shape: ShapeCone, Radius: 0.5, Height: 2},
+			want: Vec3{
+				X: 0.15*mass*0.25 + mass*4/10,
+				Y: 0.3 * mass * 0.25,
+				Z: 0.15*mass*0.25 + mass*4/10,
+			},
+			rel: 1e-12,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			body := NewRigidBody(BodyConfig{Mass: mass})
+			body.AddCollider(testCase.config)
+			got := body.Inertia()
+			for _, pair := range [][3]float64{
+				{got.X, testCase.want.X, 0},
+				{got.Y, testCase.want.Y, 1},
+				{got.Z, testCase.want.Z, 2},
+			} {
+				tolerance := math.Abs(pair[1])*testCase.rel + 1e-12
+				if math.Abs(pair[0]-pair[1]) > tolerance {
+					t.Fatalf("axis %v: inertia %v, want %v", pair[2], pair[0], pair[1])
+				}
+			}
+		})
+	}
+}
+
+// TestCapsuleInertiaSitsBetweenCylinderAndSphere checks the composite capsule
+// formula against bounds that need no algebra: a capsule is heavier to spin than
+// its cylinder and lighter than the cylinder that encloses it.
+func TestCapsuleInertiaSitsBetweenCylinderAndSphere(t *testing.T) {
+	const mass = 2.0
+	const radius = 0.4
+	const height = 1.2
+
+	capsule := NewRigidBody(BodyConfig{Mass: mass})
+	capsule.AddCollider(ColliderConfig{Shape: ShapeCapsule, Radius: radius, Height: height})
+	got := capsule.Inertia()
+
+	innerAxial := 0.5 * mass * radius * radius
+	outerAxial := 0.5 * mass * radius * radius * 1.0001
+	if got.Y < innerAxial*0.5 || got.Y > outerAxial {
+		t.Fatalf("capsule axial inertia %v is outside the cylinder and sphere bounds", got.Y)
+	}
+	shortCylinder := mass * (3*radius*radius + height*height) / 12
+	longCylinder := mass * (3*radius*radius + (height+2*radius)*(height+2*radius)) / 12
+	if got.X < shortCylinder || got.X > longCylinder {
+		t.Fatalf("capsule radial inertia %v is not between %v and %v", got.X, shortCylinder, longCylinder)
+	}
+	if math.Abs(got.X-got.Z) > 1e-12 {
+		t.Fatalf("a capsule is symmetric about its axis, got X=%v Z=%v", got.X, got.Z)
+	}
+}
+
+// TestOffsetColliderShiftsInertiaByParallelAxis checks the parallel axis term.
+// A sphere held away from the body origin must be harder to spin by exactly
+// m * d^2 about the axes perpendicular to the offset.
+func TestOffsetColliderShiftsInertiaByParallelAxis(t *testing.T) {
+	const mass = 1.5
+	const radius = 0.3
+	const offset = 2.0
+
+	centred := NewRigidBody(BodyConfig{Mass: mass})
+	centred.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: radius})
+	shifted := NewRigidBody(BodyConfig{Mass: mass})
+	shifted.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: radius, Offset: Vec3{X: offset}})
+
+	base := centred.Inertia()
+	moved := shifted.Inertia()
+	want := mass * offset * offset
+
+	if math.Abs(moved.X-base.X) > 1e-9 {
+		t.Fatalf("the offset axis must not change: %v vs %v", moved.X, base.X)
+	}
+	if math.Abs((moved.Y-base.Y)-want) > 1e-9 {
+		t.Fatalf("Y inertia grew by %v, want %v", moved.Y-base.Y, want)
+	}
+	if math.Abs((moved.Z-base.Z)-want) > 1e-9 {
+		t.Fatalf("Z inertia grew by %v, want %v", moved.Z-base.Z, want)
+	}
+}
+
+// TestLockRotationRefusesEveryAngularImpulse checks the escape hatch a
+// character controller needs.
+func TestLockRotationRefusesEveryAngularImpulse(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	box := world.AddBody(BodyConfig{
+		Mass: 1, Position: Vec3{Y: 1.4}, Friction: 0.5, LockRotation: true,
+		Rotation: QuatFromAxisAngle(Vec3{Z: 1}, 0.6),
+	})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	start := box.Rotation
+	box.ApplyTorque(Vec3{Z: 50})
+	box.ApplyImpulse(Vec3{Y: 20}, Vec3{X: 3, Y: 1.4})
+	for i := 0; i < 300; i++ {
+		world.StepFixed()
+	}
+
+	if box.AngularVelocity.Len() > 1e-12 {
+		t.Fatalf("a rotation-locked body must never spin, got %+v", box.AngularVelocity)
+	}
+	if box.Rotation != start {
+		t.Fatalf("rotation changed from %+v to %+v", start, box.Rotation)
+	}
+}
+
+// TestInertiaOverrideReplacesTheDerivedTensor checks that a caller can model a
+// mass distribution the shape does not describe.
+func TestInertiaOverrideReplacesTheDerivedTensor(t *testing.T) {
+	body := NewRigidBody(BodyConfig{Mass: 1, Inertia: Vec3{X: 5, Y: 6, Z: 7}})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 1})
+	got := body.Inertia()
+	assertVecNear(t, "override inertia", got, Vec3{X: 5, Y: 6, Z: 7}, 1e-12)
+
+	body.SetInertia(Vec3{})
+	derived := body.Inertia()
+	assertVecNear(t, "derived inertia", derived, Vec3{X: 0.4, Y: 0.4, Z: 0.4}, 1e-12)
+}

--- a/physics/bench_test.go
+++ b/physics/bench_test.go
@@ -1,0 +1,390 @@
+package physics
+
+import (
+	"fmt"
+	"math"
+	"testing"
+)
+
+// Benchmark scene sizes. The 50/400/1600/3200 ladder shows the scaling of the
+// broadphase and of the swept collision pass.
+var benchBodyCounts = []int{50, 400, 1600, 3200}
+
+// benchLateralSpeed keeps every dynamic body in motion. A body that comes to a
+// complete stop skips the swept pass, which would hide the cost under test.
+const benchLateralSpeed = 0.5
+
+// buildSpheresOnPlane returns a world with one ground plane and count dynamic
+// spheres that slide on a grid. Each body keeps a lateral velocity, so the
+// swept pass runs on every body every step.
+func buildSpheresOnPlane(count int, disableCCD bool) *World {
+	world := NewWorld(WorldConfig{
+		Gravity:          Vec3{Y: -9.81},
+		FixedTimestep:    1.0 / 60.0,
+		SolverIterations: 8,
+		BroadPhaseCell:   2,
+		DisableCCD:       disableCCD,
+	})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	side := int(math.Ceil(math.Sqrt(float64(count))))
+	for i := 0; i < count; i++ {
+		x := float64(i%side) * 1.5
+		z := float64(i/side) * 1.5
+		body := world.AddBody(BodyConfig{
+			Mass:     1,
+			Position: Vec3{X: x, Y: 0.5, Z: z},
+			Velocity: Vec3{X: benchLateralSpeed},
+		})
+		body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+	}
+	return world
+}
+
+// buildSpheresOnStaticFloor returns a world whose ground is a grid of static
+// box colliders instead of one plane. This is the shape of scene geometry that
+// makes a full static scan expensive.
+func buildSpheresOnStaticFloor(count int, disableCCD bool) *World {
+	world := NewWorld(WorldConfig{
+		Gravity:          Vec3{Y: -9.81},
+		FixedTimestep:    1.0 / 60.0,
+		SolverIterations: 8,
+		BroadPhaseCell:   2,
+		DisableCCD:       disableCCD,
+	})
+
+	side := int(math.Ceil(math.Sqrt(float64(count))))
+	for x := 0; x < side; x++ {
+		for z := 0; z < side; z++ {
+			world.AddCollider(ColliderConfig{
+				Shape:  ShapeBox,
+				Offset: Vec3{X: float64(x) * 1.5, Y: -0.5, Z: float64(z) * 1.5},
+				Width:  1.5, Height: 1, Depth: 1.5,
+			})
+		}
+	}
+	for i := 0; i < count; i++ {
+		x := float64(i%side) * 1.5
+		z := float64(i/side) * 1.5
+		body := world.AddBody(BodyConfig{
+			Mass:     1,
+			Position: Vec3{X: x, Y: 0.6, Z: z},
+			Velocity: Vec3{X: benchLateralSpeed},
+		})
+		body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+	}
+	return world
+}
+
+func benchmarkStepFixed(b *testing.B, build func(int, bool) *World, count int, disableCCD bool) {
+	world := build(count, disableCCD)
+	// Warm the contact cache and settle the stack before measuring.
+	for i := 0; i < 30; i++ {
+		world.StepFixed()
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		world.StepFixed()
+	}
+}
+
+func BenchmarkStepFixedSpheresOnPlaneCCDOn(b *testing.B) {
+	for _, count := range benchBodyCounts {
+		b.Run(fmt.Sprintf("n=%d", count), func(b *testing.B) {
+			benchmarkStepFixed(b, buildSpheresOnPlane, count, false)
+		})
+	}
+}
+
+func BenchmarkStepFixedSpheresOnPlaneCCDOff(b *testing.B) {
+	for _, count := range benchBodyCounts {
+		b.Run(fmt.Sprintf("n=%d", count), func(b *testing.B) {
+			benchmarkStepFixed(b, buildSpheresOnPlane, count, true)
+		})
+	}
+}
+
+func BenchmarkStepFixedStaticFloorCCDOn(b *testing.B) {
+	for _, count := range benchBodyCounts {
+		b.Run(fmt.Sprintf("n=%d", count), func(b *testing.B) {
+			benchmarkStepFixed(b, buildSpheresOnStaticFloor, count, false)
+		})
+	}
+}
+
+func BenchmarkStepFixedStaticFloorCCDOff(b *testing.B) {
+	for _, count := range benchBodyCounts {
+		b.Run(fmt.Sprintf("n=%d", count), func(b *testing.B) {
+			benchmarkStepFixed(b, buildSpheresOnStaticFloor, count, true)
+		})
+	}
+}
+
+func BenchmarkCandidatePairs(b *testing.B) {
+	for _, count := range benchBodyCounts {
+		b.Run(fmt.Sprintf("n=%d", count), func(b *testing.B) {
+			world := buildSpheresOnPlane(count, true)
+			for i := 0; i < 30; i++ {
+				world.StepFixed()
+			}
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_ = world.broadphase.CandidatePairs(world.colliders)
+			}
+		})
+	}
+}
+
+// benchmarkCollide measures one narrowphase pair in isolation. The colliders
+// must overlap so the full contact-generation path runs.
+func benchmarkCollide(b *testing.B, a, other *Collider) {
+	if _, ok := Collide(a, other); !ok {
+		b.Fatalf("benchmark pair does not collide: %v vs %v", a.Shape, other.Shape)
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = Collide(a, other)
+	}
+}
+
+func BenchmarkNarrowphaseSphereSphere(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Radius: 1}),
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.5}, Radius: 1}))
+}
+
+func BenchmarkNarrowphaseSpherePlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 0.75}, Radius: 1}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseSphereBox(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 1.4}, Radius: 0.5}),
+		NewCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 2, Depth: 2}))
+}
+
+func BenchmarkNarrowphaseBoxPlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: 0.4}, Width: 1, Height: 1, Depth: 1}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseBoxBoxFace(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 2, Depth: 2}),
+		NewCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: 1.8}, Width: 2, Height: 2, Depth: 2}))
+}
+
+func BenchmarkNarrowphaseBoxBoxEdge(b *testing.B) {
+	rotY := QuatFromAxisAngle(Vec3{Y: 1}, math.Pi/4)
+	rotX := QuatFromAxisAngle(Vec3{X: 1}, math.Pi/4)
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1}),
+		NewCollider(ColliderConfig{
+			Shape: ShapeBox, Offset: Vec3{Y: 1.1}, Rotation: rotX.Mul(rotY),
+			Width: 1, Height: 1, Depth: 1,
+		}))
+}
+
+func BenchmarkNarrowphaseSphereCapsule(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 0.8}, Radius: 0.4}),
+		NewCollider(ColliderConfig{Shape: ShapeCapsule, Height: 2, Radius: 0.5}))
+}
+
+func BenchmarkNarrowphaseCapsulePlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCapsule, Offset: Vec3{Y: 0.45}, Height: 2, Radius: 0.5}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseCapsuleCapsule(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCapsule, Height: 1, Radius: 0.5}),
+		NewCollider(ColliderConfig{Shape: ShapeCapsule, Offset: Vec3{X: 0.8}, Height: 1, Radius: 0.5}))
+}
+
+func BenchmarkNarrowphaseCylinderPlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 0.9}, Radius: 0.5, Height: 2}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseCylinderSphere(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4}),
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.2}, Radius: 0.5}))
+}
+
+func BenchmarkNarrowphaseCylinderBox(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 1.9}, Radius: 0.5, Height: 2}))
+}
+
+func BenchmarkNarrowphaseCylinderCylinder(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4}),
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{X: 1.7}, Radius: 1, Height: 4}))
+}
+
+func BenchmarkNarrowphaseCylinderCapsule(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4}),
+		NewCollider(ColliderConfig{Shape: ShapeCapsule, Offset: Vec3{X: 1.4}, Radius: 0.5, Height: 2}))
+}
+
+func BenchmarkNarrowphaseConePlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeCone, Offset: Vec3{Y: 0.9}, Radius: 1, Height: 2}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseConeBox(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+		NewCollider(ColliderConfig{
+			Shape: ShapeCone, Offset: Vec3{Y: 1.95}, Radius: 1, Height: 2,
+			Rotation: QuatFromAxisAngle(Vec3{X: 1}, math.Pi),
+		}))
+}
+
+func BenchmarkNarrowphaseHullPlane(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{
+			Shape: ShapeConvexHull, Offset: Vec3{Y: 0.4},
+			Vertices: benchBoxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5}),
+		}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkNarrowphaseHullHull(b *testing.B) {
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeConvexHull, Vertices: benchBoxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5})}),
+		NewCollider(ColliderConfig{
+			Shape: ShapeConvexHull, Offset: Vec3{Y: 0.9},
+			Vertices: benchBoxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5}),
+		}))
+}
+
+// benchmarkCollideAll measures a pair that can produce several manifolds.
+func benchmarkCollideAll(b *testing.B, a, other *Collider) {
+	if len(CollideAll(a, other, nil)) == 0 {
+		b.Fatalf("benchmark pair does not collide: %v vs %v", a.Shape, other.Shape)
+	}
+	out := make([]ContactManifold, 0, meshMaxManifolds)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		out = CollideAll(a, other, out[:0])
+	}
+}
+
+func BenchmarkNarrowphaseMeshSphere(b *testing.B) {
+	vertices, indices := benchGridMesh(16, 32)
+	benchmarkCollideAll(b,
+		NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices}),
+		NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 0.4}, Radius: 0.5}))
+}
+
+func BenchmarkNarrowphaseMeshBox(b *testing.B) {
+	vertices, indices := benchGridMesh(16, 32)
+	benchmarkCollideAll(b,
+		NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices}),
+		NewCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: 0.4}, Width: 1, Height: 1, Depth: 1}))
+}
+
+func BenchmarkNarrowphaseMeshPlane(b *testing.B) {
+	vertices, indices := benchGridMesh(16, 32)
+	benchmarkCollide(b,
+		NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices, Offset: Vec3{Y: -0.1}}),
+		NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}}))
+}
+
+func BenchmarkTriangleMeshBuild(b *testing.B) {
+	vertices, indices := benchGridMesh(64, 128)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if newTriangleMesh(vertices, indices) == nil {
+			b.Fatal("mesh build failed")
+		}
+	}
+}
+
+func BenchmarkRaycastMesh8kTriangles(b *testing.B) {
+	vertices, indices := benchGridMesh(64, 128)
+	mesh := NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	if len(mesh.mesh.tris) < 8000 {
+		b.Fatalf("mesh has %d triangles, want at least 8000", len(mesh.mesh.tris))
+	}
+	ray := Ray{Origin: Vec3{X: 3, Y: 10, Z: -7}, Direction: Vec3{Y: -1}}
+	if _, ok := mesh.Raycast(ray, 0); !ok {
+		b.Fatal("benchmark ray misses the mesh")
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = mesh.Raycast(ray, 0)
+	}
+}
+
+func benchBoxVertices(half Vec3) []Vec3 {
+	return []Vec3{
+		{X: -half.X, Y: -half.Y, Z: -half.Z},
+		{X: half.X, Y: -half.Y, Z: -half.Z},
+		{X: -half.X, Y: half.Y, Z: -half.Z},
+		{X: half.X, Y: half.Y, Z: -half.Z},
+		{X: -half.X, Y: -half.Y, Z: half.Z},
+		{X: half.X, Y: -half.Y, Z: half.Z},
+		{X: -half.X, Y: half.Y, Z: half.Z},
+		{X: half.X, Y: half.Y, Z: half.Z},
+	}
+}
+
+func benchGridMesh(cells int, size float64) ([]Vec3, []int) {
+	step := size / float64(cells)
+	start := -size / 2
+	vertices := make([]Vec3, 0, (cells+1)*(cells+1))
+	for iz := 0; iz <= cells; iz++ {
+		for ix := 0; ix <= cells; ix++ {
+			vertices = append(vertices, Vec3{X: start + float64(ix)*step, Z: start + float64(iz)*step})
+		}
+	}
+	indices := make([]int, 0, cells*cells*6)
+	stride := cells + 1
+	for iz := 0; iz < cells; iz++ {
+		for ix := 0; ix < cells; ix++ {
+			a := iz*stride + ix
+			b := a + 1
+			c := a + stride
+			d := c + 1
+			indices = append(indices, a, c, b, b, c, d)
+		}
+	}
+	return vertices, indices
+}
+
+func BenchmarkRaycast10kColliders(b *testing.B) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0})
+	for i := 0; i < 10000; i++ {
+		world.AddCollider(ColliderConfig{
+			Shape:  ShapeBox,
+			Offset: Vec3{X: 10 + float64(i%100), Y: float64(i / 100), Z: 0},
+			Width:  0.5, Height: 0.5, Depth: 0.5,
+		})
+	}
+	world.AddCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 2}, Radius: 0.25})
+
+	ray := Ray{Origin: Vec3{}, Direction: Vec3{X: 1}}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = world.Raycast(ray, 0)
+	}
+}

--- a/physics/body.go
+++ b/physics/body.go
@@ -14,6 +14,16 @@ type BodyConfig struct {
 	AngularDamping  float64
 	IsKinematic     bool
 	CanSleep        bool
+
+	// Inertia overrides the principal moments the collider shapes imply. Leave
+	// it zero to derive the tensor from the attached colliders. Give it
+	// positive entries to model a mass distribution the shapes do not describe.
+	Inertia Vec3
+
+	// LockRotation makes the body refuse every angular impulse. Contacts and
+	// constraints still change its linear velocity. Use it for characters and
+	// for props that must never tip over.
+	LockRotation bool
 }
 
 // RigidBody is a simulation body with linear and angular state.
@@ -31,6 +41,9 @@ type RigidBody struct {
 	AngularDamping  float64
 	IsKinematic     bool
 	CanSleep        bool
+	// LockRotation stops every angular impulse. Set it through BodyConfig or
+	// through SetLockRotation, never by hand, so the cached tensors stay right.
+	LockRotation bool
 
 	force     Vec3
 	torque    Vec3
@@ -38,6 +51,34 @@ type RigidBody struct {
 	index     int
 	sleeping  bool
 	colliders []*Collider
+
+	// inertiaOverride holds the caller-supplied principal moments. A zero value
+	// means the collider shapes decide the tensor.
+	inertiaOverride Vec3
+	// invInertiaLocal is the inverse inertia tensor in the body frame. It is
+	// zero for a static, kinematic or rotation-locked body.
+	invInertiaLocal mat3
+	// invInertiaWorld is invInertiaLocal rotated into world space. The world
+	// refreshes it once per step, before contacts are solved.
+	invInertiaWorld mat3
+	// invInertiaRotation is the rotation invInertiaWorld was built from. A body
+	// that does not turn keeps its tensor, which saves two matrix products per
+	// step for every resting body in the scene.
+	invInertiaRotation Quat
+	// pseudoActive marks a body that received a position pass impulse this
+	// step. It keeps the pass proportional to the contacts, not to the world.
+	pseudoActive bool
+	// sleepTimer counts how long the body has stayed below the sleep speeds.
+	sleepTimer float64
+	// sleepSlow and sleepBlocked are per-step scratch of the sleep pass.
+	sleepSlow    bool
+	sleepBlocked bool
+
+	// pseudoVelocity and pseudoAngular carry the position pass. They exist only
+	// between the solver and the integrator, and they never leak into the
+	// reported body velocity.
+	pseudoVelocity Vec3
+	pseudoAngular  Vec3
 }
 
 func NewRigidBody(config BodyConfig) *RigidBody {
@@ -59,6 +100,8 @@ func NewRigidBody(config BodyConfig) *RigidBody {
 		AngularDamping:  config.AngularDamping,
 		IsKinematic:     config.IsKinematic,
 		CanSleep:        config.CanSleep,
+		LockRotation:    config.LockRotation,
+		inertiaOverride: config.Inertia,
 	}
 	body.setMass(config.Mass)
 	return body
@@ -68,9 +111,106 @@ func (b *RigidBody) setMass(mass float64) {
 	b.Mass = mass
 	if mass > 0 && !b.IsKinematic {
 		b.InvMass = 1 / mass
+	} else {
+		b.InvMass = 0
+	}
+	b.UpdateInertia()
+}
+
+// SetMass changes the body mass and rebuilds the inertia tensor.
+func (b *RigidBody) SetMass(mass float64) {
+	if b == nil {
 		return
 	}
-	b.InvMass = 0
+	b.setMass(mass)
+}
+
+// SetInertia replaces the principal moments the collider shapes imply. Pass a
+// zero vector to go back to the derived tensor.
+func (b *RigidBody) SetInertia(inertia Vec3) {
+	if b == nil {
+		return
+	}
+	b.inertiaOverride = inertia
+	b.UpdateInertia()
+}
+
+// SetLockRotation turns the angular response of the body on or off.
+func (b *RigidBody) SetLockRotation(locked bool) {
+	if b == nil {
+		return
+	}
+	b.LockRotation = locked
+	b.UpdateInertia()
+}
+
+// UpdateInertia rebuilds the body-local inverse inertia tensor from the current
+// mass and colliders. AddCollider and setMass already call it; call it by hand
+// only after changing a collider's size in place.
+func (b *RigidBody) UpdateInertia() {
+	if b == nil {
+		return
+	}
+	b.invInertiaLocal = mat3{}
+	b.invInertiaWorld = mat3{}
+	b.invInertiaRotation = Quat{}
+	if b.InvMass <= 0 || b.LockRotation {
+		return
+	}
+
+	var tensor mat3
+	if b.inertiaOverride.X > 0 || b.inertiaOverride.Y > 0 || b.inertiaOverride.Z > 0 {
+		tensor = mat3Diagonal(b.inertiaOverride)
+	} else {
+		tensor = inertiaTensorFromColliders(b.Mass, b.colliders)
+	}
+	inverse, ok := tensor.inverse()
+	if !ok {
+		return
+	}
+	b.invInertiaLocal = inverse
+	b.refreshWorldInertia()
+}
+
+// refreshWorldInertia rebuilds the world-space inverse inertia tensor from the
+// current rotation. It returns at once when the rotation has not changed since
+// the last rebuild.
+func (b *RigidBody) refreshWorldInertia() {
+	if b == nil {
+		return
+	}
+	if b.invInertiaLocal.isZero() {
+		b.invInertiaWorld = mat3{}
+		return
+	}
+	if b.Rotation == b.invInertiaRotation {
+		return
+	}
+	b.invInertiaWorld = rotateTensor(mat3FromQuat(b.Rotation), b.invInertiaLocal)
+	b.invInertiaRotation = b.Rotation
+}
+
+// InverseInertiaWorld returns the world-space inverse inertia tensor entries as
+// three column vectors. A static, kinematic or rotation-locked body returns
+// three zero vectors.
+func (b *RigidBody) InverseInertiaWorld() (Vec3, Vec3, Vec3) {
+	if b == nil {
+		return Vec3{}, Vec3{}, Vec3{}
+	}
+	return b.invInertiaWorld.x, b.invInertiaWorld.y, b.invInertiaWorld.z
+}
+
+// Inertia returns the body-local principal moments the solver uses. It returns
+// a zero vector when the body cannot rotate.
+func (b *RigidBody) Inertia() Vec3 {
+	if b == nil || b.invInertiaLocal.isZero() {
+		return Vec3{}
+	}
+	tensor, ok := b.invInertiaLocal.inverse()
+	if !ok {
+		return Vec3{}
+	}
+	return Vec3{X: tensor.x.X, Y: tensor.y.Y, Z: tensor.z.Z}
 }
 
 func (b *RigidBody) IsStatic() bool {
@@ -85,15 +225,18 @@ func (b *RigidBody) IsSleeping() bool {
 	return b != nil && b.sleeping
 }
 
+// Wake ends sleep and restarts the countdown that leads back to it.
 func (b *RigidBody) Wake() {
 	if b != nil {
 		b.sleeping = false
+		b.sleepTimer = 0
 	}
 }
 
 func (b *RigidBody) AddCollider(config ColliderConfig) *Collider {
 	collider := newCollider(b, config)
 	b.colliders = append(b.colliders, collider)
+	b.UpdateInertia()
 	if b.world != nil {
 		b.world.registerCollider(collider)
 	}
@@ -125,15 +268,27 @@ func (b *RigidBody) ApplyTorque(torque Vec3) {
 	b.Wake()
 }
 
+// ApplyImpulse adds a linear impulse at a world point. An impulse that does not
+// pass through the centre of mass also changes the angular velocity, through
+// the world inverse inertia tensor.
 func (b *RigidBody) ApplyImpulse(impulse, worldPoint Vec3) {
 	if !b.IsDynamic() {
 		return
 	}
 	b.Velocity = b.Velocity.Add(impulse.Mul(b.InvMass))
 	r := worldPoint.Sub(b.Position)
-	if r.Len2() > epsilon {
-		b.AngularVelocity = b.AngularVelocity.Add(r.Cross(impulse).Mul(b.InvMass))
+	if r.Len2() > epsilon && !b.invInertiaWorld.isZero() {
+		b.AngularVelocity = b.AngularVelocity.Add(b.invInertiaWorld.mul(r.Cross(impulse)))
 	}
+	b.Wake()
+}
+
+// ApplyAngularImpulse adds an impulse that changes only the angular velocity.
+func (b *RigidBody) ApplyAngularImpulse(impulse Vec3) {
+	if !b.IsDynamic() || b.invInertiaWorld.isZero() {
+		return
+	}
+	b.AngularVelocity = b.AngularVelocity.Add(b.invInertiaWorld.mul(impulse))
 	b.Wake()
 }
 

--- a/physics/bounds_test.go
+++ b/physics/bounds_test.go
@@ -1,0 +1,391 @@
+package physics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// fibonacciDirections returns count unit vectors spread evenly over the sphere.
+func fibonacciDirections(count int) []Vec3 {
+	golden := math.Pi * (3 - math.Sqrt(5))
+	out := make([]Vec3, 0, count)
+	for i := 0; i < count; i++ {
+		y := 1 - 2*(float64(i)+0.5)/float64(count)
+		radius := math.Sqrt(math.Max(0, 1-y*y))
+		theta := golden * float64(i)
+		out = append(out, Vec3{X: math.Cos(theta) * radius, Y: y, Z: math.Sin(theta) * radius})
+	}
+	return out
+}
+
+// shapeSample names one collider configuration used by the bound and grazing
+// tests. All eight declared shapes appear here.
+type shapeSample struct {
+	name   string
+	config ColliderConfig
+}
+
+func allShapeSamples() []shapeSample {
+	meshVertices, meshIndices := gridMesh(3, 4)
+	return []shapeSample{
+		{name: "box", config: ColliderConfig{Shape: ShapeBox, Width: 1.2, Height: 0.8, Depth: 1.6}},
+		{name: "sphere", config: ColliderConfig{Shape: ShapeSphere, Radius: 0.7}},
+		{name: "capsule", config: ColliderConfig{Shape: ShapeCapsule, Radius: 0.4, Height: 1.1}},
+		{name: "cylinder", config: ColliderConfig{Shape: ShapeCylinder, Radius: 0.6, Height: 1.3}},
+		{name: "cone", config: ColliderConfig{Shape: ShapeCone, Radius: 0.55, Height: 1.7}},
+		{name: "convexhull", config: ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.5, Y: 0.9, Z: 0.4})}},
+		{name: "trianglemesh", config: ColliderConfig{Shape: ShapeTriangleMesh, Vertices: meshVertices, Indices: meshIndices}},
+	}
+}
+
+// TestColliderAABBNeverUnderstatesGeometry is the guard against the worst kind
+// of bound bug: a box that is too small makes the broadphase drop real
+// contacts, and nothing in the simulation reports it.
+//
+// The support function is the authority on where a shape reaches. Every support
+// point, in every direction, must lie inside the reported bounds.
+func TestColliderAABBNeverUnderstatesGeometry(t *testing.T) {
+	rng := rand.New(rand.NewSource(1234))
+	directions := fibonacciDirections(2000)
+	// The axis directions are the tight corners of any AABB, so test them too.
+	directions = append(directions,
+		Vec3{X: 1}, Vec3{X: -1}, Vec3{Y: 1}, Vec3{Y: -1}, Vec3{Z: 1}, Vec3{Z: -1})
+
+	for _, sample := range allShapeSamples() {
+		t.Run(sample.name, func(t *testing.T) {
+			for trial := 0; trial < 25; trial++ {
+				config := sample.config
+				config.Rotation = randomUnitQuat(rng)
+				config.Offset = Vec3{
+					X: (rng.Float64() - 0.5) * 8,
+					Y: (rng.Float64() - 0.5) * 8,
+					Z: (rng.Float64() - 0.5) * 8,
+				}
+				collider := NewCollider(config)
+				if err := collider.Err(); err != nil {
+					t.Fatalf("collider is invalid: %v", err)
+				}
+				box := collider.AABB()
+				if !box.IsFinite() {
+					t.Fatalf("trial %d: AABB = %+v, want finite", trial, box)
+				}
+
+				// A mesh has no support function, so check its vertices instead.
+				if collider.Shape == ShapeTriangleMesh {
+					center := collider.WorldCenter()
+					basis := mat3FromQuat(collider.WorldRotation())
+					for index, tri := range collider.mesh.tris {
+						for corner, local := range [3]Vec3{tri.a, tri.b, tri.c} {
+							world := center.Add(basis.mul(local))
+							if !box.Expand(1e-9).Contains(world) {
+								t.Fatalf("trial %d: triangle %d corner %d at %+v escapes AABB %+v",
+									trial, index, corner, world, box)
+							}
+						}
+					}
+					continue
+				}
+
+				shape, ok := newConvexShape(collider)
+				if !ok {
+					t.Fatalf("trial %d: newConvexShape failed", trial)
+				}
+				padded := box.Expand(1e-9)
+				for _, dir := range directions {
+					point := shape.support(dir)
+					if !padded.Contains(point) {
+						t.Fatalf("trial %d: support point %+v along %+v escapes AABB %+v",
+							trial, point, dir, box)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestAABBOverlapIsNecessaryForContact closes the loop from the bound to the
+// broadphase. The grid only tests pairs whose bounds overlap, so any contact the
+// narrowphase can report must also have overlapping bounds. A failure here means
+// the broadphase silently drops real contacts.
+func TestAABBOverlapIsNecessaryForContact(t *testing.T) {
+	rng := rand.New(rand.NewSource(555))
+	samples := allShapeSamples()
+	contacts := 0
+	for trial := 0; trial < 6000; trial++ {
+		sampleA := samples[trial%len(samples)]
+		sampleB := samples[(trial/len(samples))%len(samples)]
+
+		configA := sampleA.config
+		configA.Rotation = randomUnitQuat(rng)
+		configB := sampleB.config
+		configB.Rotation = randomUnitQuat(rng)
+		configB.Offset = Vec3{
+			X: (rng.Float64() - 0.5) * 5,
+			Y: (rng.Float64() - 0.5) * 5,
+			Z: (rng.Float64() - 0.5) * 5,
+		}
+
+		a := NewCollider(configA)
+		b := NewCollider(configB)
+		manifolds := CollideAll(a, b, nil)
+		if len(manifolds) == 0 {
+			continue
+		}
+		contacts++
+		if !a.AABB().Overlaps(b.AABB()) {
+			t.Fatalf("trial %d (%s vs %s): contact reported but bounds %+v and %+v do not overlap",
+				trial, sampleA.name, sampleB.name, a.AABB(), b.AABB())
+		}
+		for _, manifold := range manifolds {
+			for i := 0; i < manifold.PointCount; i++ {
+				point := manifold.Points[i].Point
+				// The contact point must lie in the union of the two bounds,
+				// widened by the penetration depth.
+				slack := manifold.Points[i].Penetration + 1e-6
+				union := a.AABB().Union(b.AABB()).Expand(slack)
+				if !union.Contains(point) {
+					t.Fatalf("trial %d (%s vs %s): contact point %+v lies outside the widened bounds %+v",
+						trial, sampleA.name, sampleB.name, point, union)
+				}
+			}
+		}
+	}
+	if contacts < 500 {
+		t.Fatalf("only %d contacts across 6000 random pairs; the test is not exercising the narrowphase", contacts)
+	}
+}
+
+// TestGrazingContactsAreNotMissed places every pair at a barely-overlapping pose
+// and then at a clearly separated pose. A grazing overlap must report a shallow
+// contact, and a clear gap must report none.
+func TestGrazingContactsAreNotMissed(t *testing.T) {
+	const (
+		grazeOverlap = 1e-4
+		clearGap     = 1e-2
+	)
+
+	// Each case places B along +Y above A. touchY is the centre height at which
+	// the two surfaces exactly touch.
+	cases := []struct {
+		name   string
+		a      ColliderConfig
+		b      ColliderConfig
+		touchY float64
+	}{
+		{
+			name:   "cylinder cap on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2},
+			touchY: 1,
+		},
+		{
+			name:   "cylinder side on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2, Rotation: QuatFromAxisAngle(Vec3{Z: 1}, math.Pi/2)},
+			touchY: 0.5,
+		},
+		{
+			name:   "cone base on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2},
+			touchY: 1,
+		},
+		{
+			name:   "cone apex on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2, Rotation: QuatFromAxisAngle(Vec3{X: 1}, math.Pi)},
+			touchY: 1,
+		},
+		{
+			name:   "hull on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5})},
+			touchY: 0.5,
+		},
+		{
+			name:   "mesh on plane",
+			a:      ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}},
+			b:      ColliderConfig{Shape: ShapeTriangleMesh, Vertices: mustGridVertices(), Indices: mustGridIndices()},
+			touchY: 0,
+		},
+		{
+			name:   "sphere on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeSphere, Radius: 0.5},
+			touchY: 1.5,
+		},
+		{
+			name:   "box on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1},
+			touchY: 1.5,
+		},
+		{
+			name:   "capsule on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeCapsule, Radius: 0.4, Height: 1},
+			touchY: 1.9,
+		},
+		{
+			name:   "cylinder on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1},
+			touchY: 1.5,
+		},
+		{
+			name:   "cone on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeCone, Radius: 0.5, Height: 1},
+			touchY: 1.5,
+		},
+		{
+			name:   "hull on cylinder cap",
+			a:      ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:      ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.4, Y: 0.4, Z: 0.4})},
+			touchY: 1.4,
+		},
+		{
+			name:   "sphere on cone base rim",
+			a:      ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2, Rotation: QuatFromAxisAngle(Vec3{X: 1}, math.Pi)},
+			b:      ColliderConfig{Shape: ShapeSphere, Radius: 0.5},
+			touchY: 1.5,
+		},
+		{
+			name:   "sphere on mesh floor",
+			a:      ColliderConfig{Shape: ShapeTriangleMesh, Vertices: mustGridVertices(), Indices: mustGridIndices()},
+			b:      ColliderConfig{Shape: ShapeSphere, Radius: 0.5},
+			touchY: 0.5,
+		},
+		{
+			name:   "box on mesh floor",
+			a:      ColliderConfig{Shape: ShapeTriangleMesh, Vertices: mustGridVertices(), Indices: mustGridIndices()},
+			b:      ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1},
+			touchY: 0.5,
+		},
+		{
+			name:   "cylinder on mesh floor",
+			a:      ColliderConfig{Shape: ShapeTriangleMesh, Vertices: mustGridVertices(), Indices: mustGridIndices()},
+			b:      ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1},
+			touchY: 0.5,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			a := NewCollider(testCase.a)
+			if err := a.Err(); err != nil {
+				t.Fatalf("collider A is invalid: %v", err)
+			}
+
+			grazing := testCase.b
+			grazing.Offset = grazing.Offset.Add(Vec3{Y: testCase.touchY - grazeOverlap})
+			overlapping := NewCollider(grazing)
+			if err := overlapping.Err(); err != nil {
+				t.Fatalf("collider B is invalid: %v", err)
+			}
+			manifolds := CollideAll(a, overlapping, nil)
+			if len(manifolds) == 0 {
+				t.Fatalf("grazing overlap of %v was missed; a missed grazing contact lets a body sink", grazeOverlap)
+			}
+			deepest := 0.0
+			for _, manifold := range manifolds {
+				for i := 0; i < manifold.PointCount; i++ {
+					deepest = maxFloat(deepest, manifold.Points[i].Penetration)
+				}
+			}
+			if deepest > 10*grazeOverlap {
+				t.Fatalf("grazing penetration = %v, want no more than %v", deepest, 10*grazeOverlap)
+			}
+
+			separated := testCase.b
+			separated.Offset = separated.Offset.Add(Vec3{Y: testCase.touchY + clearGap})
+			clear := NewCollider(separated)
+			if got := CollideAll(a, clear, nil); len(got) != 0 {
+				t.Fatalf("a %v gap still reported %d contacts with penetration %v",
+					clearGap, len(got), got[0].Points[0].Penetration)
+			}
+		})
+	}
+}
+
+func mustGridVertices() []Vec3 {
+	vertices, _ := gridMesh(4, 8)
+	return vertices
+}
+
+func mustGridIndices() []int {
+	_, indices := gridMesh(4, 8)
+	return indices
+}
+
+// TestSweptBoundNeverUnderstatesTheSweep guards the CCD candidate box the same
+// way. Every point the swept sphere can reach must lie inside the query box, or
+// the swept pass drops a real hit and a fast body tunnels.
+func TestSweptBoundNeverUnderstatesTheSweep(t *testing.T) {
+	rng := rand.New(rand.NewSource(808))
+	for trial := 0; trial < 500; trial++ {
+		origin := Vec3{
+			X: (rng.Float64() - 0.5) * 20,
+			Y: (rng.Float64() - 0.5) * 20,
+			Z: (rng.Float64() - 0.5) * 20,
+		}
+		radius := 0.01 + rng.Float64()*2
+		direction := Vec3{
+			X: rng.Float64() - 0.5,
+			Y: rng.Float64() - 0.5,
+			Z: rng.Float64() - 0.5,
+		}.Normalize()
+		if direction.Len2() <= epsilon {
+			continue
+		}
+		distance := rng.Float64() * 30
+
+		box := sweptSphereBounds(origin, radius, direction, distance)
+		if !box.IsFinite() {
+			t.Fatalf("trial %d: swept bound %+v is not finite", trial, box)
+		}
+		padded := box.Expand(1e-9)
+		for step := 0; step <= 40; step++ {
+			t95 := distance * float64(step) / 40
+			center := origin.Add(direction.Mul(t95))
+			for _, dir := range fibonacciDirections(64) {
+				surface := center.Add(dir.Mul(radius))
+				if !padded.Contains(surface) {
+					t.Fatalf("trial %d: swept sphere surface point %+v escapes bound %+v",
+						trial, surface, box)
+				}
+			}
+		}
+	}
+}
+
+// TestCCDGrazingSweepFindsTheStaticTarget checks that a sweep which barely
+// clips a static box is still reported. This is where an understated candidate
+// box would show up as a tunnelling body.
+func TestCCDGrazingSweepFindsTheStaticTarget(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, BroadPhaseCell: 2})
+	// A thin static wall standing at x=0, and a bullet flying along +X that
+	// grazes its top edge.
+	world.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 0.2, Height: 2, Depth: 4})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: -10}})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.25})
+
+	world.broadphase.Rebuild(world.colliders)
+	world.broadphaseStep = world.steps
+
+	// Sweep at the height where the swept sphere just reaches the wall top at
+	// y=1. Anything below y = 1 + radius must hit.
+	for _, height := range []float64{0, 0.5, 0.99, 1.0, 1.2, 1.249} {
+		body.Position = Vec3{X: -10, Y: height}
+		if _, ok := world.sweepBody(body, Vec3{X: 20}); !ok {
+			t.Fatalf("sweep at height %v missed the wall; the candidate box understates the sweep", height)
+		}
+	}
+	for _, height := range []float64{1.3, 2, 5} {
+		body.Position = Vec3{X: -10, Y: height}
+		if _, ok := world.sweepBody(body, Vec3{X: 20}); ok {
+			t.Fatalf("sweep at height %v hit the wall, which tops out at y=1", height)
+		}
+	}
+}

--- a/physics/broadphase.go
+++ b/physics/broadphase.go
@@ -2,6 +2,7 @@ package physics
 
 import (
 	"math"
+	"slices"
 	"sort"
 )
 
@@ -10,10 +11,42 @@ type ColliderPair struct {
 	B *Collider
 }
 
+// spatialEntry caches one collider's world bounds for the duration of a step.
+// AABB() rotates vectors, so computing it once per step instead of once per
+// candidate pair removes most of the broadphase cost.
+type spatialEntry struct {
+	collider *Collider
+	aabb     AABB
+	stamp    uint64
+}
+
+// SpatialHash is a uniform-grid broadphase. One rebuild per step fills two cell
+// maps: cells holds every collider, staticCells holds only the immovable,
+// non-trigger colliders that the swept pass needs.
 type SpatialHash struct {
 	cellSize float64
-	cells    map[cellKey][]*Collider
 	skin     float64
+
+	cells       map[cellKey][]int32
+	staticCells map[cellKey][]int32
+	usedKeys    []cellKey
+	staticKeys  []cellKey
+
+	entries        []spatialEntry
+	infinite       []int32
+	staticInfinite []int32
+
+	pairKeys []uint64
+	pairs    []ColliderPair
+
+	// indexOrdered records whether entries are already sorted by collider
+	// index. When they are, sorting the packed pair keys also sorts the pairs,
+	// so the final comparison sort is skipped.
+	indexOrdered bool
+
+	queryGen uint64
+	// built counts rebuilds. Callers use it to detect a stale grid.
+	built uint64
 }
 
 type cellKey struct {
@@ -27,75 +60,229 @@ func NewSpatialHash(cellSize float64) *SpatialHash {
 		cellSize = 2
 	}
 	return &SpatialHash{
-		cellSize: cellSize,
-		cells:    make(map[cellKey][]*Collider),
-		skin:     0.001,
+		cellSize:    cellSize,
+		cells:       make(map[cellKey][]int32),
+		staticCells: make(map[cellKey][]int32),
+		skin:        0.001,
 	}
 }
 
-func (s *SpatialHash) CandidatePairs(colliders []*Collider) []ColliderPair {
+// Rebuild refills the grid from the given colliders. Call it once per step
+// before any query.
+func (s *SpatialHash) Rebuild(colliders []*Collider) {
 	if s == nil {
-		s = NewSpatialHash(2)
+		return
 	}
-	for key := range s.cells {
-		delete(s.cells, key)
-	}
+	s.reset(len(colliders))
 
-	var infinite []*Collider
+	lastIndex := math.MinInt
+	s.indexOrdered = true
 	for _, collider := range colliders {
 		if collider == nil {
 			continue
 		}
 		aabb := collider.AABB().Expand(s.skin)
-		if !aabb.IsFinite() {
-			infinite = append(infinite, collider)
-			continue
+		index := int32(len(s.entries))
+		s.entries = append(s.entries, spatialEntry{collider: collider, aabb: aabb})
+		if collider.index < lastIndex {
+			s.indexOrdered = false
 		}
+		lastIndex = collider.index
+
+		// The swept pass only ever looks at immovable, solid colliders, so the
+		// filter happens here, at insert time, and not inside the sweep loop.
+		isStatic := immovableCollider(collider) && !collider.IsTrigger
+
 		minCell, maxCell, ok := s.cellRange(aabb)
-		if !ok {
-			infinite = append(infinite, collider)
+		if !aabb.IsFinite() || !ok {
+			s.infinite = append(s.infinite, index)
+			if isStatic {
+				s.staticInfinite = append(s.staticInfinite, index)
+			}
 			continue
 		}
 		for x := minCell.x; x <= maxCell.x; x++ {
 			for y := minCell.y; y <= maxCell.y; y++ {
 				for z := minCell.z; z <= maxCell.z; z++ {
 					key := cellKey{x: x, y: y, z: z}
-					s.cells[key] = append(s.cells[key], collider)
+					s.insert(s.cells, &s.usedKeys, key, index)
+					if isStatic {
+						s.insert(s.staticCells, &s.staticKeys, key, index)
+					}
 				}
 			}
 		}
 	}
+	s.built++
+}
 
-	pairMap := make(map[uint64]ColliderPair)
-	for _, cellColliders := range s.cells {
-		for i := 0; i < len(cellColliders); i++ {
-			for j := i + 1; j < len(cellColliders); j++ {
-				addCandidatePair(pairMap, cellColliders[i], cellColliders[j])
+// Built reports how many times the grid was rebuilt. A caller compares it
+// against its own step counter to notice a stale grid.
+func (s *SpatialHash) Built() uint64 {
+	if s == nil {
+		return 0
+	}
+	return s.built
+}
+
+// reset empties the grid but keeps the per-cell slices, so a steady-state
+// simulation stops allocating after the first few steps.
+func (s *SpatialHash) reset(colliderCount int) {
+	// A world whose bodies travel far leaves empty cells behind. Rebuild the
+	// maps when the bookkeeping outgrows the live data.
+	limit := 8*colliderCount + 4096
+	if len(s.cells) > limit {
+		s.cells = make(map[cellKey][]int32, len(s.usedKeys))
+	} else {
+		for _, key := range s.usedKeys {
+			s.cells[key] = s.cells[key][:0]
+		}
+	}
+	if len(s.staticCells) > limit {
+		s.staticCells = make(map[cellKey][]int32, len(s.staticKeys))
+	} else {
+		for _, key := range s.staticKeys {
+			s.staticCells[key] = s.staticCells[key][:0]
+		}
+	}
+	s.usedKeys = s.usedKeys[:0]
+	s.staticKeys = s.staticKeys[:0]
+	s.entries = s.entries[:0]
+	s.infinite = s.infinite[:0]
+	s.staticInfinite = s.staticInfinite[:0]
+}
+
+func (s *SpatialHash) insert(cells map[cellKey][]int32, keys *[]cellKey, key cellKey, index int32) {
+	bucket, exists := cells[key]
+	if !exists || len(bucket) == 0 {
+		*keys = append(*keys, key)
+	}
+	cells[key] = append(bucket, index)
+}
+
+// CandidatePairs rebuilds the grid and returns the overlapping pairs, ordered
+// by collider index. The returned slice is owned by the hash and is reused by
+// the next call.
+func (s *SpatialHash) CandidatePairs(colliders []*Collider) []ColliderPair {
+	if s == nil {
+		return nil
+	}
+	s.Rebuild(colliders)
+	return s.pairsFromGrid()
+}
+
+func (s *SpatialHash) pairsFromGrid() []ColliderPair {
+	s.pairKeys = s.pairKeys[:0]
+	for _, key := range s.usedKeys {
+		bucket := s.cells[key]
+		for i := 0; i < len(bucket); i++ {
+			for j := i + 1; j < len(bucket); j++ {
+				s.appendPairKey(bucket[i], bucket[j])
 			}
 		}
 	}
-	for _, inf := range infinite {
-		for _, collider := range colliders {
-			if inf == collider {
-				continue
-			}
-			addCandidatePair(pairMap, inf, collider)
+	for _, index := range s.infinite {
+		for other := range s.entries {
+			s.appendPairKey(index, int32(other))
 		}
 	}
 
-	pairs := make([]ColliderPair, 0, len(pairMap))
-	for _, pair := range pairMap {
-		pairs = append(pairs, pair)
-	}
-	sort.Slice(pairs, func(i, j int) bool {
-		ai, bi := orderedColliderIndexes(pairs[i].A, pairs[i].B)
-		aj, bj := orderedColliderIndexes(pairs[j].A, pairs[j].B)
-		if ai == aj {
-			return bi < bj
+	// A packed key is (lowEntry << 32 | highEntry), so a numeric sort followed
+	// by a single dedupe pass replaces the old map plus comparison sort.
+	slices.Sort(s.pairKeys)
+	s.pairs = s.pairs[:0]
+	for i, key := range s.pairKeys {
+		if i > 0 && key == s.pairKeys[i-1] {
+			continue
 		}
-		return ai < aj
-	})
-	return pairs
+		a := s.entries[key>>32].collider
+		b := s.entries[key&0xffffffff].collider
+		if b.index < a.index {
+			a, b = b, a
+		}
+		s.pairs = append(s.pairs, ColliderPair{A: a, B: b})
+	}
+	if !s.indexOrdered {
+		sort.Slice(s.pairs, func(i, j int) bool {
+			ai, bi := orderedColliderIndexes(s.pairs[i].A, s.pairs[i].B)
+			aj, bj := orderedColliderIndexes(s.pairs[j].A, s.pairs[j].B)
+			if ai == aj {
+				return bi < bj
+			}
+			return ai < aj
+		})
+	}
+	return s.pairs
+}
+
+func (s *SpatialHash) appendPairKey(i, j int32) {
+	if i == j {
+		return
+	}
+	if j < i {
+		i, j = j, i
+	}
+	if !validEntryPair(s.entries[i], s.entries[j]) {
+		return
+	}
+	s.pairKeys = append(s.pairKeys, uint64(uint32(i))<<32|uint64(uint32(j)))
+}
+
+// QueryAABB appends every collider whose cached bounds overlap box. Rebuild
+// must have run for the current step.
+func (s *SpatialHash) QueryAABB(box AABB, out []*Collider) []*Collider {
+	return s.query(s.cells, s.infinite, box, out)
+}
+
+// QueryStaticAABB appends every immovable, non-trigger collider whose cached
+// bounds overlap box.
+func (s *SpatialHash) QueryStaticAABB(box AABB, out []*Collider) []*Collider {
+	return s.query(s.staticCells, s.staticInfinite, box, out)
+}
+
+func (s *SpatialHash) query(cells map[cellKey][]int32, unbounded []int32, box AABB, out []*Collider) []*Collider {
+	if s == nil || len(s.entries) == 0 {
+		return out
+	}
+	s.queryGen++
+	generation := s.queryGen
+
+	minCell, maxCell, ok := s.cellRange(box)
+	if !box.IsFinite() || !ok {
+		// The query box spans too many cells to walk. Fall back to a linear
+		// scan, which is still one pass instead of one pass per cell.
+		for i := range s.entries {
+			out = s.take(int32(i), generation, box, out, false)
+		}
+		return out
+	}
+	for x := minCell.x; x <= maxCell.x; x++ {
+		for y := minCell.y; y <= maxCell.y; y++ {
+			for z := minCell.z; z <= maxCell.z; z++ {
+				for _, index := range cells[cellKey{x: x, y: y, z: z}] {
+					out = s.take(index, generation, box, out, true)
+				}
+			}
+		}
+	}
+	for _, index := range unbounded {
+		out = s.take(index, generation, box, out, false)
+	}
+	return out
+}
+
+// take appends one entry to out unless this query already reported it. The
+// stamp lives on the entry, so deduplication needs no map.
+func (s *SpatialHash) take(index int32, generation uint64, box AABB, out []*Collider, checkBounds bool) []*Collider {
+	entry := &s.entries[index]
+	if entry.stamp == generation {
+		return out
+	}
+	entry.stamp = generation
+	if checkBounds && !entry.aabb.Overlaps(box) {
+		return out
+	}
+	return append(out, entry.collider)
 }
 
 func (s *SpatialHash) cellRange(aabb AABB) (cellKey, cellKey, bool) {
@@ -119,38 +306,21 @@ func (s *SpatialHash) cellRange(aabb AABB) (cellKey, cellKey, bool) {
 	return minCell, maxCell, true
 }
 
-func addCandidatePair(pairs map[uint64]ColliderPair, a, b *Collider) {
-	if !validCandidatePair(a, b) {
-		return
-	}
-	if b.index < a.index {
-		a, b = b, a
-	}
-	pairs[pairKey(a, b)] = ColliderPair{A: a, B: b}
-}
-
-func validCandidatePair(a, b *Collider) bool {
-	if a == nil || b == nil || a == b {
+func validEntryPair(a, b spatialEntry) bool {
+	if a.collider == nil || b.collider == nil || a.collider == b.collider {
 		return false
 	}
-	if a.Body != nil && a.Body == b.Body {
+	if a.collider.Body != nil && a.collider.Body == b.collider.Body {
 		return false
 	}
-	if immovableCollider(a) && immovableCollider(b) {
+	if immovableCollider(a.collider) && immovableCollider(b.collider) {
 		return false
 	}
-	aabbA := a.AABB()
-	aabbB := b.AABB()
-	return !aabbA.IsFinite() || !aabbB.IsFinite() || aabbA.Overlaps(aabbB)
+	return !a.aabb.IsFinite() || !b.aabb.IsFinite() || a.aabb.Overlaps(b.aabb)
 }
 
 func immovableCollider(c *Collider) bool {
 	return c == nil || c.Body == nil || !c.Body.IsDynamic()
-}
-
-func pairKey(a, b *Collider) uint64 {
-	ai, bi := orderedColliderIndexes(a, b)
-	return uint64(uint32(ai))<<32 | uint64(uint32(bi))
 }
 
 func orderedColliderIndexes(a, b *Collider) (int, int) {

--- a/physics/broadphase_test.go
+++ b/physics/broadphase_test.go
@@ -1,0 +1,316 @@
+package physics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// bruteForcePairs is the reference broadphase: every pair, filtered by the same
+// rules the grid uses, ordered by collider index.
+func bruteForcePairs(colliders []*Collider, skin float64) []ColliderPair {
+	var pairs []ColliderPair
+	for i := 0; i < len(colliders); i++ {
+		for j := i + 1; j < len(colliders); j++ {
+			a := colliders[i]
+			b := colliders[j]
+			if a == nil || b == nil || a == b {
+				continue
+			}
+			if a.Body != nil && a.Body == b.Body {
+				continue
+			}
+			if immovableCollider(a) && immovableCollider(b) {
+				continue
+			}
+			boxA := a.AABB().Expand(skin)
+			boxB := b.AABB().Expand(skin)
+			if boxA.IsFinite() && boxB.IsFinite() && !boxA.Overlaps(boxB) {
+				continue
+			}
+			if b.index < a.index {
+				a, b = b, a
+			}
+			pairs = append(pairs, ColliderPair{A: a, B: b})
+		}
+	}
+	return pairs
+}
+
+func pairSetKey(p ColliderPair) [2]int {
+	return [2]int{colliderIndex(p.A), colliderIndex(p.B)}
+}
+
+func TestCandidatePairsMatchBruteForce(t *testing.T) {
+	rng := rand.New(rand.NewSource(3))
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -9.81}, FixedTimestep: 1.0 / 60.0, BroadPhaseCell: 2})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	world.AddCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: -1}, Width: 40, Height: 1, Depth: 40})
+	for i := 0; i < 120; i++ {
+		body := world.AddBody(BodyConfig{
+			Mass: 1,
+			Position: Vec3{
+				X: (rng.Float64() - 0.5) * 20,
+				Y: rng.Float64() * 6,
+				Z: (rng.Float64() - 0.5) * 20,
+			},
+			Velocity: Vec3{X: rng.Float64() - 0.5, Z: rng.Float64() - 0.5},
+		})
+		switch i % 4 {
+		case 0:
+			body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.4 + rng.Float64()*0.4})
+		case 1:
+			body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 0.8, Height: 0.8, Depth: 0.8})
+		case 2:
+			body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.4, Height: 1})
+		case 3:
+			body.AddCollider(ColliderConfig{Shape: ShapeCone, Radius: 0.4, Height: 1})
+		}
+	}
+
+	for step := 0; step < 20; step++ {
+		got := world.CandidatePairs()
+		want := bruteForcePairs(world.colliders, world.broadphase.skin)
+
+		if len(got) != len(want) {
+			t.Fatalf("step %d: grid returned %d pairs, brute force found %d", step, len(got), len(want))
+		}
+		wantSet := make(map[[2]int]bool, len(want))
+		for _, pair := range want {
+			wantSet[pairSetKey(pair)] = true
+		}
+		for _, pair := range got {
+			if !wantSet[pairSetKey(pair)] {
+				t.Fatalf("step %d: grid produced pair %v that brute force did not", step, pairSetKey(pair))
+			}
+			if colliderIndex(pair.A) > colliderIndex(pair.B) {
+				t.Fatalf("step %d: pair %v is not ordered by collider index", step, pairSetKey(pair))
+			}
+		}
+		// The pair order must be stable and sorted, because replay determinism
+		// depends on the contact order.
+		for i := 1; i < len(got); i++ {
+			prevA, prevB := orderedColliderIndexes(got[i-1].A, got[i-1].B)
+			currA, currB := orderedColliderIndexes(got[i].A, got[i].B)
+			if prevA > currA || (prevA == currA && prevB >= currB) {
+				t.Fatalf("step %d: pairs are not sorted at index %d: (%d,%d) then (%d,%d)",
+					step, i, prevA, prevB, currA, currB)
+			}
+		}
+		world.StepFixed()
+	}
+}
+
+func TestCandidatePairsReturnsCopySafeSlice(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 0.4}})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	first := world.CandidatePairs()
+	if len(first) == 0 {
+		t.Fatal("expected at least one candidate pair")
+	}
+	kept := first[0]
+	_ = world.CandidatePairs()
+	if first[0] != kept {
+		t.Fatal("CandidatePairs must return a slice the next call cannot overwrite")
+	}
+}
+
+func TestSpatialHashQueryStaticAABBFindsOnlySolidStatics(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, BroadPhaseCell: 2})
+	staticBox := world.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 2, Depth: 2})
+	plane := world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}, Distance: -10})
+	trigger := world.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 2, Depth: 2, IsTrigger: true})
+	farBox := world.AddCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{X: 60}, Width: 2, Height: 2, Depth: 2})
+	dynamic := world.AddBody(BodyConfig{Mass: 1})
+	dynamicCollider := dynamic.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	world.broadphase.Rebuild(world.colliders)
+	found := world.broadphase.QueryStaticAABB(NewAABB(Vec3{X: -1, Y: -1, Z: -1}, Vec3{X: 1, Y: 1, Z: 1}), nil)
+
+	seen := make(map[*Collider]int, len(found))
+	for _, collider := range found {
+		seen[collider]++
+	}
+	for _, collider := range found {
+		if seen[collider] != 1 {
+			t.Fatalf("collider %d appears %d times; the query must deduplicate", collider.index, seen[collider])
+		}
+	}
+	if seen[staticBox] != 1 {
+		t.Fatal("query missed the overlapping static box")
+	}
+	if seen[plane] != 1 {
+		t.Fatal("query missed the plane, which has unbounded extent")
+	}
+	if seen[trigger] != 0 {
+		t.Fatal("query must skip trigger colliders")
+	}
+	if seen[farBox] != 0 {
+		t.Fatal("query must skip a static box outside the box")
+	}
+	if seen[dynamicCollider] != 0 {
+		t.Fatal("query must skip dynamic colliders")
+	}
+}
+
+func TestSpatialHashQueryAABBMatchesBruteForce(t *testing.T) {
+	rng := rand.New(rand.NewSource(11))
+	var colliders []*Collider
+	hash := NewSpatialHash(2)
+	for i := 0; i < 200; i++ {
+		body := NewRigidBody(BodyConfig{Mass: 1, Position: Vec3{
+			X: (rng.Float64() - 0.5) * 40,
+			Y: (rng.Float64() - 0.5) * 40,
+			Z: (rng.Float64() - 0.5) * 40,
+		}})
+		collider := body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.3 + rng.Float64()})
+		collider.index = i + 1
+		colliders = append(colliders, collider)
+	}
+	hash.Rebuild(colliders)
+
+	for trial := 0; trial < 50; trial++ {
+		center := Vec3{
+			X: (rng.Float64() - 0.5) * 44,
+			Y: (rng.Float64() - 0.5) * 44,
+			Z: (rng.Float64() - 0.5) * 44,
+		}
+		half := 1 + rng.Float64()*5
+		box := AABBFromCenterHalfExtents(center, Vec3{X: half, Y: half, Z: half})
+
+		got := hash.QueryAABB(box, nil)
+		gotSet := make(map[*Collider]bool, len(got))
+		for _, collider := range got {
+			gotSet[collider] = true
+		}
+		for _, collider := range colliders {
+			want := collider.AABB().Expand(hash.skin).Overlaps(box)
+			if want && !gotSet[collider] {
+				t.Fatalf("trial %d: query missed collider %d", trial, collider.index)
+			}
+			if !want && gotSet[collider] {
+				t.Fatalf("trial %d: query returned collider %d, which does not overlap", trial, collider.index)
+			}
+		}
+	}
+}
+
+// TestSweepBodyMatchesFullStaticScan pins the CCD change: the grid-driven
+// candidate lookup must find exactly the same nearest hit that a scan over
+// every static collider finds.
+func TestSweepBodyMatchesFullStaticScan(t *testing.T) {
+	rng := rand.New(rand.NewSource(23))
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, BroadPhaseCell: 2})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}, Distance: -5})
+	for i := 0; i < 200; i++ {
+		world.AddCollider(ColliderConfig{
+			Shape: ShapeBox,
+			Offset: Vec3{
+				X: (rng.Float64() - 0.5) * 30,
+				Y: (rng.Float64() - 0.5) * 30,
+				Z: (rng.Float64() - 0.5) * 30,
+			},
+			Width: 1 + rng.Float64(), Height: 1 + rng.Float64(), Depth: 1 + rng.Float64(),
+		})
+		world.AddCollider(ColliderConfig{
+			Shape: ShapeSphere,
+			Offset: Vec3{
+				X: (rng.Float64() - 0.5) * 30,
+				Y: (rng.Float64() - 0.5) * 30,
+				Z: (rng.Float64() - 0.5) * 30,
+			},
+			Radius: 0.5 + rng.Float64(),
+		})
+	}
+	body := world.AddBody(BodyConfig{Mass: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.4})
+
+	world.broadphase.Rebuild(world.colliders)
+	world.broadphaseStep = world.steps
+	checked := 0
+	for trial := 0; trial < 500; trial++ {
+		body.Position = Vec3{
+			X: (rng.Float64() - 0.5) * 30,
+			Y: (rng.Float64() - 0.5) * 30,
+			Z: (rng.Float64() - 0.5) * 30,
+		}
+		displacement := Vec3{
+			X: (rng.Float64() - 0.5) * 12,
+			Y: (rng.Float64() - 0.5) * 12,
+			Z: (rng.Float64() - 0.5) * 12,
+		}
+		gotHit, gotOK := world.sweepBody(body, displacement)
+		wantHit, wantOK := referenceSweepBody(world, body, displacement)
+		if gotOK != wantOK {
+			t.Fatalf("trial %d: grid sweep hit=%v, full scan hit=%v", trial, gotOK, wantOK)
+		}
+		if !gotOK {
+			continue
+		}
+		checked++
+		if math.Abs(gotHit.Distance-wantHit.Distance) > 1e-12 {
+			t.Fatalf("trial %d: grid distance %v, full scan distance %v", trial, gotHit.Distance, wantHit.Distance)
+		}
+		if gotHit.Collider != wantHit.Collider {
+			t.Fatalf("trial %d: grid hit collider %d, full scan hit collider %d",
+				trial, colliderIndex(gotHit.Collider), colliderIndex(wantHit.Collider))
+		}
+	}
+	if checked < 50 {
+		t.Fatalf("only %d trials produced a hit; the test is not exercising the sweep", checked)
+	}
+}
+
+// referenceSweepBody is the pre-optimisation sweep: scan every collider and
+// filter inside the loop.
+func referenceSweepBody(w *World, body *RigidBody, displacement Vec3) (ccdHit, bool) {
+	if displacement.Len2() <= epsilon {
+		return ccdHit{}, false
+	}
+	distance := displacement.Len()
+	direction := displacement.Div(distance)
+	best := ccdHit{Distance: math.Inf(1)}
+	found := false
+	for _, moving := range body.colliders {
+		if moving == nil || moving.IsTrigger {
+			continue
+		}
+		origin := moving.WorldCenter()
+		radius, ok := movingSweepRadius(moving)
+		if !ok {
+			continue
+		}
+		for _, target := range w.colliders {
+			if target == nil || target == moving || target.Body == body || target.IsTrigger || !staticCollider(target) {
+				continue
+			}
+			hit, ok := sweepSphereLikeCollider(origin, radius, direction, distance, target)
+			if !ok {
+				continue
+			}
+			if !found || closerSweepHit(hit, best) {
+				best = hit
+				found = true
+			}
+		}
+	}
+	return best, found
+}
+
+func TestSweepUsesFreshPosesAfterPositionSolve(t *testing.T) {
+	// A fast bullet must not tunnel even though the broadphase was filled
+	// before the position solve moved bodies.
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: -1}, Width: 100, Height: 2, Depth: 100})
+	bullet := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Velocity: Vec3{Y: -600}})
+	bullet.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.05})
+
+	world.StepFixed()
+
+	if bullet.Position.Y < 0 {
+		t.Fatalf("bullet tunneled through the static box to y=%v", bullet.Position.Y)
+	}
+}

--- a/physics/ccd.go
+++ b/physics/ccd.go
@@ -4,12 +4,56 @@ import "math"
 
 const ccdSlop = 1e-4
 
+// ccdMotionRatio is the share of a body's own radius that one step of motion
+// must exceed before the swept pass runs.
+//
+// A body that moves less than half its own radius cannot pass through anything,
+// so the discrete contacts already hold it. Skipping the sweep for such a body
+// does two things: it removes the cost of the sweep from every resting body,
+// and it stops the sweep from clamping the lateral motion of a body that leans
+// on a static box.
+const ccdMotionRatio = 0.5
+
 type ccdHit struct {
 	Collider *Collider
 	Normal   Vec3
 	Distance float64
 }
 
+// bodyNeedsSweep reports whether one step of the given displacement is long
+// enough to justify a swept test.
+func bodyNeedsSweep(body *RigidBody, displacement Vec3) bool {
+	if body == nil {
+		return false
+	}
+	travel2 := displacement.Len2()
+	if travel2 <= epsilon {
+		return false
+	}
+	largest := 0.0
+	for _, collider := range body.colliders {
+		radius, ok := movingSweepRadius(collider)
+		if !ok || collider.IsTrigger {
+			continue
+		}
+		if radius > largest {
+			largest = radius
+		}
+	}
+	if largest <= 0 {
+		return false
+	}
+	threshold := ccdMotionRatio * largest
+	return travel2 > threshold*threshold
+}
+
+// sweepBody finds the nearest static collider that the body's swept volume
+// reaches this step.
+//
+// Candidates come from the broadphase's static cell map, which holds only
+// immovable, non-trigger colliders. That keeps the per-body cost proportional
+// to the swept volume instead of to the whole collider list. The caller must
+// have rebuilt the broadphase for the current step; ensureBroadphase does that.
 func (w *World) sweepBody(body *RigidBody, displacement Vec3) (ccdHit, bool) {
 	if w == nil || body == nil || displacement.Len2() <= epsilon {
 		return ccdHit{}, false
@@ -27,21 +71,48 @@ func (w *World) sweepBody(body *RigidBody, displacement Vec3) (ccdHit, bool) {
 		if !ok {
 			continue
 		}
-		for _, target := range w.colliders {
-			if target == nil || target == moving || target.Body == body || target.IsTrigger || !staticCollider(target) {
+		w.sweepTargets = w.broadphase.QueryStaticAABB(
+			sweptSphereBounds(origin, radius, direction, distance),
+			w.sweepTargets[:0],
+		)
+		for _, target := range w.sweepTargets {
+			if target == moving || target.Body == body {
 				continue
 			}
 			hit, ok := sweepSphereLikeCollider(origin, radius, direction, distance, target)
 			if !ok {
 				continue
 			}
-			if !found || hit.Distance < best.Distance {
+			if !found || closerSweepHit(hit, best) {
 				best = hit
 				found = true
 			}
 		}
 	}
 	return best, found
+}
+
+// closerSweepHit decides which of two swept hits wins. Ties break on the lower
+// collider index so the result does not depend on the order the broadphase
+// happens to report candidates in. Replay determinism needs that.
+func closerSweepHit(candidate, best ccdHit) bool {
+	if candidate.Distance < best.Distance-epsilon {
+		return true
+	}
+	if candidate.Distance > best.Distance+epsilon {
+		return false
+	}
+	return colliderIndex(candidate.Collider) < colliderIndex(best.Collider)
+}
+
+// sweptSphereBounds returns the world box that encloses a sphere swept from
+// origin along direction for the given distance. Every point the sweep can
+// touch lies inside this box, so it is safe to reject anything outside it.
+func sweptSphereBounds(origin Vec3, radius float64, direction Vec3, distance float64) AABB {
+	end := origin.Add(direction.Mul(distance))
+	box := AABB{Min: origin.Min(end), Max: origin.Max(end)}
+	pad := math.Abs(radius)
+	return box.Expand(pad)
 }
 
 func staticCollider(c *Collider) bool {
@@ -82,7 +153,10 @@ func sweepSpherePlane(origin Vec3, radius float64, direction Vec3, maxDistance f
 	normal, planeDistance := target.Plane()
 	signed := normal.Dot(origin) - planeDistance
 	if signed <= radius {
-		return ccdHit{Collider: target, Normal: normal, Distance: 0}, true
+		// The sphere already touches the plane. Report no swept hit and leave
+		// the case to the discrete contact solver. A zero-distance hit here
+		// would clamp the whole step, which freezes a resting body sideways.
+		return ccdHit{}, false
 	}
 	denom := normal.Dot(direction)
 	if denom >= -epsilon {
@@ -102,11 +176,8 @@ func sweepSphereSphere(origin Vec3, radius float64, direction Vec3, maxDistance 
 	b := m.Dot(direction)
 	c := m.Dot(m) - combined*combined
 	if c <= 0 {
-		normal := origin.Sub(center).Normalize()
-		if normal.Len2() <= epsilon {
-			normal = direction.Neg()
-		}
-		return ccdHit{Collider: target, Normal: normal, Distance: 0}, true
+		// Already overlapping. The discrete solver owns this case.
+		return ccdHit{}, false
 	}
 	if b > 0 {
 		return ccdHit{}, false
@@ -174,7 +245,10 @@ func sweepSphereBox(origin Vec3, radius float64, direction Vec3, maxDistance flo
 			return ccdHit{}, false
 		}
 	}
-	if tMin < 0 || tMin > maxDistance {
+	if tMin <= 0 || tMin > maxDistance {
+		// tMin stays at zero when the swept sphere starts inside the expanded
+		// box. Report no hit there: a zero-distance hit clamps the whole step
+		// and freezes a body that rests on the box.
 		return ccdHit{}, false
 	}
 	normal := rotation.Rotate(enterNormal).Normalize()

--- a/physics/ccd_rest_test.go
+++ b/physics/ccd_rest_test.go
@@ -1,0 +1,156 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// The swept pass used to report a zero distance hit whenever a body already
+// touched a static collider. integrateVelocities then clamped the whole step,
+// so a body resting on a static box could not move sideways at all. These tests
+// pin the fixed behaviour and guard the tunnelling case the sweep exists for.
+
+// TestBodyRestingOnStaticBoxSlidesFreely is the headline of the fix. A ball put
+// down on a static box with a lateral push must travel.
+func TestBodyRestingOnStaticBoxSlidesFreely(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	ground := world.AddBody(BodyConfig{Mass: 0})
+	ground.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 40, Height: 2, Depth: 40})
+
+	ball := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 1.6}, Velocity: Vec3{X: 3}})
+	ball.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+
+	if ball.Position.X < 5.5 {
+		t.Fatalf("the ball froze on the static box: x = %v after 2 seconds at 3 m/s", ball.Position.X)
+	}
+	if math.Abs(ball.Velocity.X-3) > 0.05 {
+		t.Fatalf("the ball lost speed with no friction: %v m/s", ball.Velocity.X)
+	}
+	if ball.Position.Y < 1.49 || ball.Position.Y > 1.51 {
+		t.Fatalf("the ball left the box surface: y = %v, want near 1.5", ball.Position.Y)
+	}
+}
+
+// TestBodyRestingOnPlaneSlidesFreely covers the same fix for a plane, which is
+// the other collider the sweep reports a zero distance hit against.
+func TestBodyRestingOnPlaneSlidesFreely(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	ball := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 0.6}, Velocity: Vec3{Z: 2}})
+	ball.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+
+	if ball.Position.Z < 3.7 {
+		t.Fatalf("the ball froze on the plane: z = %v after 2 seconds at 2 m/s", ball.Position.Z)
+	}
+	if ball.Position.Y < 0.498 {
+		t.Fatalf("the ball sank into the plane: y = %v", ball.Position.Y)
+	}
+}
+
+// TestDiscreteResolutionAloneHoldsABodyUp removes the swept pass entirely. The
+// discrete contacts plus the position pass must still stop a falling ball on
+// the surface, which is what makes the sweep free to ignore resting bodies.
+func TestDiscreteResolutionAloneHoldsABodyUp(t *testing.T) {
+	world := NewWorld(WorldConfig{
+		Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 8, DisableCCD: true,
+	})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	ball := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 4}})
+	ball.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 300; i++ {
+		world.StepFixed()
+	}
+
+	if ball.Position.Y < 0.499 {
+		t.Fatalf("discrete resolution let the ball sink to y = %v", ball.Position.Y)
+	}
+	if ball.Position.Y > 0.5 {
+		t.Fatalf("the ball floats above the plane at y = %v", ball.Position.Y)
+	}
+	if math.Abs(ball.Velocity.Y) > 1e-6 {
+		t.Fatalf("the ball is not at rest, velocity = %+v", ball.Velocity)
+	}
+}
+
+// TestSweepSkipsSlowBodiesAndKeepsFastOnes pins the motion gate directly. A body
+// that moves less than half its own radius in a step cannot tunnel, so it must
+// skip the sweep; a bullet must not.
+func TestSweepSkipsSlowBodiesAndKeepsFastOnes(t *testing.T) {
+	body := NewRigidBody(BodyConfig{Mass: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	cases := []struct {
+		name         string
+		displacement Vec3
+		want         bool
+	}{
+		{"still", Vec3{}, false},
+		{"creeping", Vec3{X: 0.001}, false},
+		{"walking", Vec3{X: 0.2}, false},
+		{"just under the gate", Vec3{X: 0.24}, false},
+		{"just over the gate", Vec3{X: 0.26}, true},
+		{"bullet", Vec3{Y: -4}, true},
+	}
+	for _, testCase := range cases {
+		if got := bodyNeedsSweep(body, testCase.displacement); got != testCase.want {
+			t.Fatalf("%s: bodyNeedsSweep(%+v) = %v, want %v",
+				testCase.name, testCase.displacement, got, testCase.want)
+		}
+	}
+}
+
+// TestSweepReportsNoHitWhenAlreadyTouching pins the other half of the fix. Every
+// swept shape test must decline a target it already overlaps, so the caller
+// never clamps a whole step to zero.
+func TestSweepReportsNoHitWhenAlreadyTouching(t *testing.T) {
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	if _, ok := sweepSpherePlane(Vec3{Y: 0.4}, 0.5, Vec3{X: 1}, 1, plane); ok {
+		t.Fatal("a sphere already through the plane must report no swept hit")
+	}
+	if _, ok := sweepSpherePlane(Vec3{Y: 2}, 0.5, Vec3{Y: -1}, 3, plane); !ok {
+		t.Fatal("a sphere falling toward the plane must still report a swept hit")
+	}
+
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Radius: 1})
+	if _, ok := sweepSphereSphere(Vec3{X: 0.5}, 1, Vec3{X: 1}, 2, sphere); ok {
+		t.Fatal("two overlapping spheres must report no swept hit")
+	}
+	if _, ok := sweepSphereSphere(Vec3{X: -5}, 1, Vec3{X: 1}, 10, sphere); !ok {
+		t.Fatal("a sphere approaching from outside must still report a swept hit")
+	}
+
+	box := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 2, Depth: 2})
+	if _, ok := sweepSphereBox(Vec3{Y: 1.2}, 0.5, Vec3{X: 1}, 2, box); ok {
+		t.Fatal("a sphere resting on the box must report no swept hit")
+	}
+	if _, ok := sweepSphereBox(Vec3{Y: 5}, 0.5, Vec3{Y: -1}, 10, box); !ok {
+		t.Fatal("a sphere falling toward the box must still report a swept hit")
+	}
+}
+
+// TestFastBodiesStillCannotTunnel is the regression guard for the gate. Every
+// speed above the gate must still be caught by the sweep.
+func TestFastBodiesStillCannotTunnel(t *testing.T) {
+	for _, speed := range []float64{-40, -120, -240, -600, -2000} {
+		world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, SolverIterations: 8})
+		world.AddCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: -1}, Width: 100, Height: 2, Depth: 100})
+		bullet := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Velocity: Vec3{Y: speed}})
+		bullet.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.05})
+
+		for i := 0; i < 30; i++ {
+			world.StepFixed()
+		}
+		if bullet.Position.Y < 0 {
+			t.Fatalf("a bullet at %v m/s tunneled to y = %v", speed, bullet.Position.Y)
+		}
+	}
+}

--- a/physics/collider.go
+++ b/physics/collider.go
@@ -1,6 +1,9 @@
 package physics
 
-import "math"
+import (
+	"fmt"
+	"math"
+)
 
 type ColliderShape int
 
@@ -15,6 +18,30 @@ const (
 	ShapeTriangleMesh
 )
 
+// String names the shape for diagnostics.
+func (s ColliderShape) String() string {
+	switch s {
+	case ShapeBox:
+		return "box"
+	case ShapeSphere:
+		return "sphere"
+	case ShapeCapsule:
+		return "capsule"
+	case ShapePlane:
+		return "plane"
+	case ShapeCylinder:
+		return "cylinder"
+	case ShapeCone:
+		return "cone"
+	case ShapeConvexHull:
+		return "convexhull"
+	case ShapeTriangleMesh:
+		return "trianglemesh"
+	default:
+		return fmt.Sprintf("shape(%d)", int(s))
+	}
+}
+
 type ColliderConfig struct {
 	Shape     ColliderShape
 	Offset    Vec3
@@ -26,6 +53,15 @@ type ColliderConfig struct {
 	Radius    float64
 	Normal    Vec3
 	Distance  float64
+
+	// Vertices supplies collider-local geometry. ShapeConvexHull reads it as
+	// the hull point cloud. ShapeTriangleMesh reads it as the vertex buffer
+	// that Indices refers to. Every other shape ignores it.
+	Vertices []Vec3
+
+	// Indices lists triangle corners for ShapeTriangleMesh, three per
+	// triangle. Every other shape ignores it.
+	Indices []int
 }
 
 type Collider struct {
@@ -42,6 +78,19 @@ type Collider struct {
 	Distance  float64
 
 	index int
+
+	// hull holds the local-space convex point cloud for ShapeConvexHull.
+	hull []Vec3
+	// mesh holds the local-space triangle soup plus its BVH for
+	// ShapeTriangleMesh.
+	mesh *triangleMesh
+	// localBounds is the collider-local bounding box of hull or mesh
+	// geometry. AABB projects it into world space.
+	localBounds AABB
+	// invalid records why the collider cannot collide. A non-nil value makes
+	// every narrowphase and raycast call reject the collider, and makes
+	// World.Diagnostics report it.
+	invalid error
 }
 
 func NewCollider(config ColliderConfig) *Collider {
@@ -59,7 +108,7 @@ func newCollider(body *RigidBody, config ColliderConfig) *Collider {
 		normal = Vec3{Y: 1}
 	}
 
-	return &Collider{
+	c := &Collider{
 		Shape:     config.Shape,
 		Body:      body,
 		Offset:    config.Offset,
@@ -72,6 +121,95 @@ func newCollider(body *RigidBody, config ColliderConfig) *Collider {
 		Normal:    normal.Normalize(),
 		Distance:  config.Distance,
 	}
+	c.buildGeometry(config)
+	c.invalid = c.validate()
+	return c
+}
+
+// buildGeometry copies the caller's vertex data and precomputes the local
+// bounds plus the triangle BVH. The collider never aliases caller slices, so
+// later edits by the caller cannot corrupt the simulation.
+func (c *Collider) buildGeometry(config ColliderConfig) {
+	switch c.Shape {
+	case ShapeConvexHull:
+		if len(config.Vertices) == 0 {
+			return
+		}
+		c.hull = make([]Vec3, len(config.Vertices))
+		copy(c.hull, config.Vertices)
+		c.localBounds = boundsOfPoints(c.hull)
+		// Indices are optional for a hull. When present they describe the
+		// triangulated surface, which is what a raycast needs.
+		if len(config.Indices) >= 3 {
+			c.mesh = newTriangleMesh(c.hull, config.Indices)
+		}
+	case ShapeTriangleMesh:
+		c.mesh = newTriangleMesh(config.Vertices, config.Indices)
+		if c.mesh != nil {
+			c.localBounds = c.mesh.bounds
+		}
+	}
+}
+
+// Err reports why the collider cannot take part in collision, or nil when the
+// collider is usable. A collider with a non-nil Err never generates contacts,
+// so callers must treat it as a configuration mistake and not as a shape that
+// simply misses.
+func (c *Collider) Err() error {
+	if c == nil {
+		return nil
+	}
+	return c.invalid
+}
+
+// validate rejects shapes whose parameters cannot describe a volume. Returning
+// an error here is what stops a mis-declared collider from passing silently
+// through every other body in the world.
+func (c *Collider) validate() error {
+	switch c.Shape {
+	case ShapeBox:
+		half := c.halfExtents()
+		if half.X <= 0 || half.Y <= 0 || half.Z <= 0 {
+			return fmt.Errorf("physics: box collider needs Width, Height and Depth > 0, got %v x %v x %v",
+				c.Width, c.Height, c.Depth)
+		}
+	case ShapeSphere:
+		if math.Abs(c.Radius) <= 0 {
+			return fmt.Errorf("physics: sphere collider needs Radius > 0")
+		}
+	case ShapeCapsule:
+		if math.Abs(c.Radius) <= 0 {
+			return fmt.Errorf("physics: capsule collider needs Radius > 0")
+		}
+	case ShapePlane:
+		if c.Normal.Len2() <= epsilon {
+			return fmt.Errorf("physics: plane collider needs a nonzero Normal")
+		}
+	case ShapeCylinder:
+		if math.Abs(c.Radius) <= 0 || math.Abs(c.Height) <= 0 {
+			return fmt.Errorf("physics: cylinder collider needs Radius > 0 and Height > 0, got radius %v height %v",
+				c.Radius, c.Height)
+		}
+	case ShapeCone:
+		if math.Abs(c.Radius) <= 0 || math.Abs(c.Height) <= 0 {
+			return fmt.Errorf("physics: cone collider needs Radius > 0 and Height > 0, got radius %v height %v",
+				c.Radius, c.Height)
+		}
+	case ShapeConvexHull:
+		if len(c.hull) < 4 {
+			return fmt.Errorf("physics: convex hull collider needs at least 4 Vertices, got %d", len(c.hull))
+		}
+		if !hullHasVolume(c.hull) {
+			return fmt.Errorf("physics: convex hull collider Vertices are coplanar, which has no volume")
+		}
+	case ShapeTriangleMesh:
+		if c.mesh == nil || len(c.mesh.tris) == 0 {
+			return fmt.Errorf("physics: triangle mesh collider needs Vertices plus Indices in multiples of 3 that name valid corners")
+		}
+	default:
+		return fmt.Errorf("physics: unknown collider shape %d", int(c.Shape))
+	}
+	return nil
 }
 
 func (c *Collider) WorldCenter() Vec3 {
@@ -108,24 +246,20 @@ func (c *Collider) AABB() AABB {
 	if c == nil {
 		return EmptyAABB()
 	}
+	// An unusable collider still needs a finite, tiny box. An infinite box
+	// would put it in the broadphase's unbounded list, where it pairs against
+	// every other collider every step while never producing a contact.
+	if c.invalid != nil {
+		center := c.WorldCenter()
+		return AABB{Min: center, Max: center}
+	}
 
 	switch c.Shape {
 	case ShapeSphere:
 		radius := math.Abs(c.Radius)
 		return AABBFromCenterHalfExtents(c.WorldCenter(), Vec3{X: radius, Y: radius, Z: radius})
 	case ShapeBox:
-		center := c.WorldCenter()
-		half := c.halfExtents()
-		rotation := c.WorldRotation()
-		axisX := rotation.Rotate(Vec3{X: 1}).Abs()
-		axisY := rotation.Rotate(Vec3{Y: 1}).Abs()
-		axisZ := rotation.Rotate(Vec3{Z: 1}).Abs()
-		extents := Vec3{
-			X: axisX.X*half.X + axisY.X*half.Y + axisZ.X*half.Z,
-			Y: axisX.Y*half.X + axisY.Y*half.Y + axisZ.Y*half.Z,
-			Z: axisX.Z*half.X + axisY.Z*half.Y + axisZ.Z*half.Z,
-		}
-		return AABBFromCenterHalfExtents(center, extents)
+		return obbAABB(c.WorldCenter(), c.WorldRotation(), c.halfExtents())
 	case ShapePlane:
 		return AABB{
 			Min: Vec3{X: math.Inf(-1), Y: math.Inf(-1), Z: math.Inf(-1)},
@@ -145,9 +279,59 @@ func (c *Collider) AABB() AABB {
 			Z: math.Abs(axisWorld.Z) + radius,
 		}
 		return AABBFromCenterHalfExtents(center, halfExt)
+	case ShapeCylinder:
+		// A cylinder of half height h and radius r around unit axis u spans
+		// h*|u.e| + r*sqrt(1 - (u.e)^2) along each world axis e. That is the
+		// tight bound, not the bound of the enclosing box.
+		radius := math.Abs(c.Radius)
+		half := math.Abs(c.Height) * 0.5
+		axis := c.WorldAxis()
+		return AABBFromCenterHalfExtents(c.WorldCenter(), Vec3{
+			X: half*math.Abs(axis.X) + radius*discExtent(axis.X),
+			Y: half*math.Abs(axis.Y) + radius*discExtent(axis.Y),
+			Z: half*math.Abs(axis.Z) + radius*discExtent(axis.Z),
+		})
+	case ShapeCone:
+		// The cone is the convex hull of its apex point and its base disc, so
+		// the bound is the union of the apex and the base disc bound.
+		radius := math.Abs(c.Radius)
+		half := math.Abs(c.Height) * 0.5
+		axis := c.WorldAxis()
+		center := c.WorldCenter()
+		apex := center.Add(axis.Mul(half))
+		base := center.Sub(axis.Mul(half))
+		discHalf := Vec3{
+			X: radius * discExtent(axis.X),
+			Y: radius * discExtent(axis.Y),
+			Z: radius * discExtent(axis.Z),
+		}
+		return AABB{Min: apex, Max: apex}.Union(AABBFromCenterHalfExtents(base, discHalf))
+	case ShapeConvexHull, ShapeTriangleMesh:
+		// Project the local bounds through the world rotation. Slightly loose
+		// for a rotated hull, and O(1) instead of O(vertices).
+		center := c.WorldCenter()
+		rotation := c.WorldRotation()
+		localCenter := c.localBounds.Center()
+		localHalf := c.localBounds.Size().Mul(0.5)
+		box := obbAABB(center.Add(rotation.Rotate(localCenter)), rotation, localHalf)
+		return box
 	default:
-		return EmptyAABB()
+		center := c.WorldCenter()
+		return AABB{Min: center, Max: center}
 	}
+}
+
+// WorldAxis returns the collider's local +Y axis in world space. Capsule,
+// cylinder and cone are all built around that axis.
+func (c *Collider) WorldAxis() Vec3 {
+	if c == nil {
+		return Vec3{Y: 1}
+	}
+	axis := c.WorldRotation().Rotate(Vec3{Y: 1})
+	if axis.Len2() <= epsilon {
+		return Vec3{Y: 1}
+	}
+	return axis.Normalize()
 }
 
 // CapsuleAxisEndpoints returns the two hemisphere-center endpoints of a
@@ -164,10 +348,136 @@ func (c *Collider) CapsuleAxisEndpoints() (Vec3, Vec3) {
 	return center.Sub(axisWorld), center.Add(axisWorld)
 }
 
+// CylinderCapCenters returns the two cap-disc centers of a cylinder collider
+// in world space, bottom first.
+func (c *Collider) CylinderCapCenters() (Vec3, Vec3) {
+	center := c.WorldCenter()
+	if c == nil || c.Shape != ShapeCylinder {
+		return center, center
+	}
+	offset := c.WorldAxis().Mul(math.Abs(c.Height) * 0.5)
+	return center.Sub(offset), center.Add(offset)
+}
+
+// ConeApexAndBase returns the world-space apex point and base-disc center of a
+// cone collider. The apex sits on the collider's local +Y side, which matches
+// the renderer's cone orientation.
+func (c *Collider) ConeApexAndBase() (Vec3, Vec3) {
+	center := c.WorldCenter()
+	if c == nil || c.Shape != ShapeCone {
+		return center, center
+	}
+	offset := c.WorldAxis().Mul(math.Abs(c.Height) * 0.5)
+	return center.Add(offset), center.Sub(offset)
+}
+
+// BoundingRadius returns the radius of a sphere centred on WorldCenter that
+// encloses the collider. Planes have no finite bound and report 0.
+func (c *Collider) BoundingRadius() float64 {
+	if c == nil || c.invalid != nil {
+		return 0
+	}
+	switch c.Shape {
+	case ShapeSphere:
+		return math.Abs(c.Radius)
+	case ShapeCapsule:
+		return math.Abs(c.Radius) + math.Abs(c.Height)*0.5
+	case ShapeBox:
+		return c.halfExtents().Len()
+	case ShapeCylinder, ShapeCone:
+		half := math.Abs(c.Height) * 0.5
+		return math.Sqrt(half*half + c.Radius*c.Radius)
+	case ShapeConvexHull, ShapeTriangleMesh:
+		// The local bounds are not centred on the collider origin, so measure
+		// to the farthest corner rather than to the box centre.
+		return math.Max(c.localBounds.Min.Len(), c.localBounds.Max.Len())
+	default:
+		return 0
+	}
+}
+
 func (c *Collider) halfExtents() Vec3 {
 	return Vec3{
 		X: math.Abs(c.Width) * 0.5,
 		Y: math.Abs(c.Height) * 0.5,
 		Z: math.Abs(c.Depth) * 0.5,
 	}
+}
+
+// discExtent returns sqrt(1 - component^2), the half-width of a unit disc
+// whose normal has the given component along a world axis.
+func discExtent(component float64) float64 {
+	rest := 1 - component*component
+	if rest <= 0 {
+		return 0
+	}
+	return math.Sqrt(rest)
+}
+
+// obbAABB returns the world AABB of an oriented box.
+func obbAABB(center Vec3, rotation Quat, half Vec3) AABB {
+	axisX := rotation.Rotate(Vec3{X: 1}).Abs()
+	axisY := rotation.Rotate(Vec3{Y: 1}).Abs()
+	axisZ := rotation.Rotate(Vec3{Z: 1}).Abs()
+	extents := Vec3{
+		X: axisX.X*half.X + axisY.X*half.Y + axisZ.X*half.Z,
+		Y: axisX.Y*half.X + axisY.Y*half.Y + axisZ.Y*half.Z,
+		Z: axisX.Z*half.X + axisY.Z*half.Y + axisZ.Z*half.Z,
+	}
+	return AABBFromCenterHalfExtents(center, extents)
+}
+
+func boundsOfPoints(points []Vec3) AABB {
+	if len(points) == 0 {
+		return AABB{}
+	}
+	bounds := AABB{Min: points[0], Max: points[0]}
+	for _, p := range points[1:] {
+		bounds.Min = bounds.Min.Min(p)
+		bounds.Max = bounds.Max.Max(p)
+	}
+	return bounds
+}
+
+// hullHasVolume reports whether the point cloud spans three dimensions. A flat
+// cloud cannot seed the EPA tetrahedron, so it is rejected at construction.
+func hullHasVolume(points []Vec3) bool {
+	if len(points) < 4 {
+		return false
+	}
+	const areaTolerance = 1e-12
+	const volumeTolerance = 1e-9
+	base := points[0]
+	var edge1 Vec3
+	found1 := false
+	for _, p := range points[1:] {
+		d := p.Sub(base)
+		if d.Len2() > areaTolerance {
+			edge1 = d
+			found1 = true
+			break
+		}
+	}
+	if !found1 {
+		return false
+	}
+	var normal Vec3
+	found2 := false
+	for _, p := range points[1:] {
+		n := edge1.Cross(p.Sub(base))
+		if n.Len2() > areaTolerance {
+			normal = n.Normalize()
+			found2 = true
+			break
+		}
+	}
+	if !found2 {
+		return false
+	}
+	for _, p := range points[1:] {
+		if math.Abs(normal.Dot(p.Sub(base))) > volumeTolerance {
+			return true
+		}
+	}
+	return false
 }

--- a/physics/constraint.go
+++ b/physics/constraint.go
@@ -21,14 +21,124 @@ type Constraint interface {
 	SolvePosition()
 }
 
+const (
+	// constraintBaumgarte is the share of a constraint's position error that
+	// one step feeds back as a velocity bias.
+	constraintBaumgarte = 0.2
+	// constraintSlop is the position error a constraint leaves alone.
+	constraintSlop = 0.005
+	// constraintMaxBias caps the bias velocity in metres or radians per second.
+	constraintMaxBias = 4.0
+)
+
+// jointAnchor holds the per-step world state that every anchored joint needs.
+type jointAnchor struct {
+	worldA Vec3
+	worldB Vec3
+	rA     Vec3
+	rB     Vec3
+	invIA  mat3
+	invIB  mat3
+	invMA  float64
+	invMB  float64
+}
+
+// prepareAnchor rebuilds the world attach points and the cached inverse mass
+// terms of a two body joint.
+func prepareAnchor(bodyA, bodyB *RigidBody, attachA, attachB Vec3) jointAnchor {
+	var anchor jointAnchor
+	anchor.worldA = attachA
+	anchor.worldB = attachB
+	if bodyA != nil {
+		anchor.worldA = bodyA.Position.Add(bodyA.Rotation.Rotate(attachA))
+		anchor.rA = anchor.worldA.Sub(bodyA.Position)
+	}
+	if bodyB != nil {
+		anchor.worldB = bodyB.Position.Add(bodyB.Rotation.Rotate(attachB))
+		anchor.rB = anchor.worldB.Sub(bodyB.Position)
+	}
+	anchor.invMA = inverseMass(bodyA)
+	anchor.invMB = inverseMass(bodyB)
+	anchor.invIA = inverseInertiaWorld(bodyA)
+	anchor.invIB = inverseInertiaWorld(bodyB)
+	return anchor
+}
+
+// linearEffectiveMassMatrix returns the 3x3 effective mass of a point to point
+// constraint. It is (1/mA + 1/mB) * E - skew(rA) * IA * skew(rA) - the same for
+// B, written without an explicit skew matrix.
+func linearEffectiveMassMatrix(a jointAnchor) mat3 {
+	k := mat3Identity().scale(a.invMA + a.invMB)
+	k = k.add(skewInertiaTerm(a.invIA, a.rA))
+	k = k.add(skewInertiaTerm(a.invIB, a.rB))
+	return k
+}
+
+// skewInertiaTerm returns -skew(r) * invI * skew(r), the angular share of a
+// point constraint's effective mass.
+func skewInertiaTerm(invI mat3, r Vec3) mat3 {
+	if invI.isZero() {
+		return mat3{}
+	}
+	s := skewMatrix(r)
+	// -S * I * S is symmetric positive semi definite for a positive definite I.
+	return s.mulMat(invI).mulMat(s).scale(-1)
+}
+
+// skewMatrix returns the matrix S with S * v = r x v.
+func skewMatrix(r Vec3) mat3 {
+	return mat3{
+		x: Vec3{Y: r.Z, Z: -r.Y},
+		y: Vec3{X: -r.Z, Z: r.X},
+		z: Vec3{X: r.Y, Y: -r.X},
+	}
+}
+
+// applyJointImpulse pushes a world impulse through a two body joint.
+func applyJointImpulse(bodyA, bodyB *RigidBody, impulse, rA, rB Vec3) {
+	applyImpulseAtOffset(bodyA, impulse.Neg(), rA)
+	applyImpulseAtOffset(bodyB, impulse, rB)
+}
+
+// applyJointAngularImpulse pushes an angular impulse through a two body joint.
+func applyJointAngularImpulse(bodyA, bodyB *RigidBody, impulse Vec3) {
+	if bodyA != nil && bodyA.IsDynamic() && !bodyA.invInertiaWorld.isZero() {
+		bodyA.AngularVelocity = bodyA.AngularVelocity.Sub(bodyA.invInertiaWorld.mul(impulse))
+	}
+	if bodyB != nil && bodyB.IsDynamic() && !bodyB.invInertiaWorld.isZero() {
+		bodyB.AngularVelocity = bodyB.AngularVelocity.Add(bodyB.invInertiaWorld.mul(impulse))
+	}
+}
+
+func jointAngularVelocity(body *RigidBody) Vec3 {
+	if body == nil || body.IsSleeping() {
+		return Vec3{}
+	}
+	return body.AngularVelocity
+}
+
+func biasFromError(err, dt float64) float64 {
+	if dt <= 0 {
+		return 0
+	}
+	bias := 0.0
+	if err > constraintSlop {
+		bias = constraintBaumgarte * (err - constraintSlop) / dt
+	} else if err < -constraintSlop {
+		bias = constraintBaumgarte * (err + constraintSlop) / dt
+	}
+	return clampFloat(bias, -constraintMaxBias, constraintMaxBias)
+}
+
 // DistanceConstraint keeps two bodies' attach points a fixed distance apart.
 // The attach points are given in body-local coordinates; world-space attach
 // points are recomputed every step from the current body transforms.
 //
 // Softness > 0 acts as a spring-like compliance: zero gives a rigid rod,
-// larger values allow the constraint to "give" under load. The angular
-// contribution to effective mass is approximated — point-mass constraints
-// work well for typical rope/chain scenarios.
+// larger values allow the constraint to "give" under load.
+//
+// The effective mass carries the angular term of both bodies, so a rod attached
+// away from the centre of mass now spins the body it pulls.
 type DistanceConstraint struct {
 	BodyA, BodyB   *RigidBody
 	AttachA        Vec3    // body-local on A
@@ -37,8 +147,7 @@ type DistanceConstraint struct {
 	Softness       float64 // >= 0; 0 = rigid
 
 	// Cached per-step state.
-	worldA   Vec3
-	worldB   Vec3
+	anchor   jointAnchor
 	axis     Vec3    // unit direction from A to B
 	distance float64 // current world-space distance
 	effMass  float64 // effective mass along axis
@@ -53,10 +162,9 @@ func (c *DistanceConstraint) Prepare(dt float64) {
 		return
 	}
 
-	c.worldA = c.BodyA.Position.Add(c.BodyA.Rotation.Rotate(c.AttachA))
-	c.worldB = c.BodyB.Position.Add(c.BodyB.Rotation.Rotate(c.AttachB))
+	c.anchor = prepareAnchor(c.BodyA, c.BodyB, c.AttachA, c.AttachB)
 
-	delta := c.worldB.Sub(c.worldA)
+	delta := c.anchor.worldB.Sub(c.anchor.worldA)
 	c.distance = delta.Len()
 	if c.distance > epsilon {
 		c.axis = delta.Div(c.distance)
@@ -64,11 +172,11 @@ func (c *DistanceConstraint) Prepare(dt float64) {
 		c.axis = Vec3{Y: 1}
 	}
 
-	invMassA := inverseMass(c.BodyA)
-	invMassB := inverseMass(c.BodyB)
-	invMassSum := invMassA + invMassB + math.Max(0, c.Softness)
-	if invMassSum > 0 {
-		c.effMass = 1 / invMassSum
+	k := effectiveMassAlong(c.axis, c.anchor.invMA, c.anchor.invMB,
+		c.anchor.invIA, c.anchor.invIB, c.anchor.rA, c.anchor.rB) +
+		math.Max(0, c.Softness)
+	if k > epsilon {
+		c.effMass = 1 / k
 	} else {
 		c.effMass = 0
 	}
@@ -76,37 +184,18 @@ func (c *DistanceConstraint) Prepare(dt float64) {
 	// Baumgarte bias: fraction of positional error fed back as velocity.
 	// The bias sign matches the position error (drift) so that
 	// lambda = -(vRel + bias) * effMass
-	// drives bodies together when stretched (drift > 0 → bias > 0 → lambda
-	// more negative → impulse pulls B toward A) and apart when compressed.
-	// Clamped to maxBiasVelocity to prevent explosive impulses when the
-	// constraint gets far out of line (e.g., a horizontal-rod pendulum
-	// without angular coupling drifts past its rest length under gravity).
-	drift := c.distance - c.TargetDistance
-	const baumgarte = 0.2
-	const allowedSlop = 0.005
-	const maxBiasVelocity = 2.0
-	if dt > 0 && c.effMass > 0 {
-		if drift > allowedSlop {
-			c.bias = baumgarte * (drift - allowedSlop) / dt
-		} else if drift < -allowedSlop {
-			c.bias = baumgarte * (drift + allowedSlop) / dt
-		} else {
-			c.bias = 0
-		}
-		if c.bias > maxBiasVelocity {
-			c.bias = maxBiasVelocity
-		} else if c.bias < -maxBiasVelocity {
-			c.bias = -maxBiasVelocity
-		}
+	// drives bodies together when stretched and apart when compressed. The
+	// clamp stops an explosive impulse when the rod is far out of line.
+	if c.effMass > 0 {
+		c.bias = biasFromError(c.distance-c.TargetDistance, dt)
 	} else {
 		c.bias = 0
 	}
 
-	// Warm-start: apply cached impulse along axis.
+	// Warm-start: apply the cached impulse along the axis.
 	if c.accumImpulse != 0 && c.effMass > 0 {
 		impulse := c.axis.Mul(c.accumImpulse)
-		applyLinearImpulse(c.BodyA, impulse.Neg())
-		applyLinearImpulse(c.BodyB, impulse)
+		applyJointImpulse(c.BodyA, c.BodyB, impulse, c.anchor.rA, c.anchor.rB)
 	}
 }
 
@@ -114,21 +203,447 @@ func (c *DistanceConstraint) SolveVelocity() {
 	if c == nil || c.effMass == 0 {
 		return
 	}
-	vA := velocityAt(c.BodyA, c.worldA)
-	vB := velocityAt(c.BodyB, c.worldB)
-	vRel := vB.Sub(vA).Dot(c.axis)
+	vRel := relativeVelocityAt(c.BodyA, c.BodyB, c.anchor.rA, c.anchor.rB).Dot(c.axis)
 	lambda := -(vRel + c.bias) * c.effMass
 
 	c.accumImpulse += lambda
-	impulse := c.axis.Mul(lambda)
-	applyLinearImpulse(c.BodyA, impulse.Neg())
-	applyLinearImpulse(c.BodyB, impulse)
+	applyJointImpulse(c.BodyA, c.BodyB, c.axis.Mul(lambda), c.anchor.rA, c.anchor.rB)
 }
 
 func (c *DistanceConstraint) SolvePosition() {
-	// Velocity Baumgarte above handles most drift; additional explicit
-	// position correction is usually unneeded for point-mass rods. Left as
-	// a hook for future constraint types that want NGS position solvers.
+	// The velocity Baumgarte term above handles the drift of a rod. Position
+	// solvers matter far more for the joints below, which lock more axes.
+}
+
+// PointConstraint is a ball and socket joint. It holds one point of body A on
+// one point of body B and leaves all three rotation axes free.
+//
+// Use it for a pendulum, a chain link, or a ragdoll shoulder.
+type PointConstraint struct {
+	BodyA, BodyB *RigidBody
+	AttachA      Vec3 // body-local on A
+	AttachB      Vec3 // body-local on B
+
+	anchor   jointAnchor
+	effMass  mat3
+	solvable bool
+	bias     Vec3
+
+	accumImpulse Vec3
+}
+
+func (c *PointConstraint) Prepare(dt float64) {
+	if c == nil || c.BodyA == nil || c.BodyB == nil {
+		return
+	}
+	c.anchor = prepareAnchor(c.BodyA, c.BodyB, c.AttachA, c.AttachB)
+	k := linearEffectiveMassMatrix(c.anchor)
+	inverse, ok := k.inverse()
+	c.solvable = ok && (c.anchor.invMA+c.anchor.invMB) > 0
+	if !c.solvable {
+		c.bias = Vec3{}
+		return
+	}
+	c.effMass = inverse
+
+	drift := c.anchor.worldB.Sub(c.anchor.worldA)
+	c.bias = Vec3{
+		X: biasFromError(drift.X, dt),
+		Y: biasFromError(drift.Y, dt),
+		Z: biasFromError(drift.Z, dt),
+	}
+
+	if c.accumImpulse.Len2() > 0 {
+		applyJointImpulse(c.BodyA, c.BodyB, c.accumImpulse, c.anchor.rA, c.anchor.rB)
+	}
+}
+
+func (c *PointConstraint) SolveVelocity() {
+	if c == nil || !c.solvable {
+		return
+	}
+	vRel := relativeVelocityAt(c.BodyA, c.BodyB, c.anchor.rA, c.anchor.rB)
+	lambda := c.effMass.mul(vRel.Add(c.bias).Neg())
+	c.accumImpulse = c.accumImpulse.Add(lambda)
+	applyJointImpulse(c.BodyA, c.BodyB, lambda, c.anchor.rA, c.anchor.rB)
+}
+
+func (c *PointConstraint) SolvePosition() {}
+
+// HingeConstraint is a revolute joint. It holds one point of body A on one
+// point of body B and allows rotation about one axis only.
+//
+// The axis is given in each body's local frame, so the joint knows the pose the
+// two bodies must keep. Set MotorEnabled to drive the joint at MotorSpeed with
+// at most MaxMotorTorque. Set LimitEnabled to stop the joint between LowerLimit
+// and UpperLimit, both in radians measured from the reference frame.
+type HingeConstraint struct {
+	BodyA, BodyB *RigidBody
+	AttachA      Vec3 // body-local on A
+	AttachB      Vec3 // body-local on B
+	AxisA        Vec3 // body-local hinge axis on A
+	AxisB        Vec3 // body-local hinge axis on B
+
+	// RefA and RefB are body-local reference directions perpendicular to the
+	// axis. They define the zero angle. Leave them zero to let the joint pick a
+	// perpendicular pair, which makes the zero angle the pose at first use.
+	RefA Vec3
+	RefB Vec3
+
+	MotorEnabled   bool
+	MotorSpeed     float64 // radians per second about the hinge axis
+	MaxMotorTorque float64 // newton metres; zero means unlimited
+
+	LimitEnabled bool
+	LowerLimit   float64 // radians
+	UpperLimit   float64 // radians
+
+	anchor      jointAnchor
+	pointMass   mat3
+	pointBias   Vec3
+	worldAxis   Vec3
+	perp        [2]Vec3
+	angularMass [2]float64
+	angularBias [2]float64
+	motorMass   float64
+	limitMass   float64
+	limitBias   float64
+	limitSign   float64
+	solvable    bool
+	refReady    bool
+
+	accumPoint   Vec3
+	accumAngular [2]float64
+	accumMotor   float64
+	accumLimit   float64
+}
+
+// Angle returns the current hinge angle in radians, measured from the reference
+// frame. It returns zero when the joint is not usable.
+func (c *HingeConstraint) Angle() float64 {
+	if c == nil || c.BodyA == nil || c.BodyB == nil {
+		return 0
+	}
+	c.ensureReference()
+	axis := c.BodyA.Rotation.Rotate(c.AxisA).Normalize()
+	refA := c.BodyA.Rotation.Rotate(c.RefA)
+	refB := c.BodyB.Rotation.Rotate(c.RefB)
+	refA = refA.Sub(axis.Mul(axis.Dot(refA)))
+	refB = refB.Sub(axis.Mul(axis.Dot(refB)))
+	if refA.Len2() <= epsilon || refB.Len2() <= epsilon {
+		return 0
+	}
+	refA = refA.Normalize()
+	refB = refB.Normalize()
+	cross := axis.Cross(refA)
+	return math.Atan2(cross.Dot(refB), refA.Dot(refB))
+}
+
+// ensureReference fills in the reference directions the first time the joint
+// runs. The pose at that moment becomes the zero angle.
+func (c *HingeConstraint) ensureReference() {
+	if c.refReady {
+		return
+	}
+	if c.AxisA.Len2() <= epsilon {
+		c.AxisA = Vec3{Y: 1}
+	}
+	if c.AxisB.Len2() <= epsilon {
+		c.AxisB = c.AxisA
+	}
+	c.AxisA = c.AxisA.Normalize()
+	c.AxisB = c.AxisB.Normalize()
+	if c.RefA.Len2() <= epsilon || c.RefB.Len2() <= epsilon {
+		refA, _ := orthonormalBasis(c.AxisA)
+		c.RefA = refA
+		// Express the same world direction in B's frame, so the joint starts at
+		// angle zero whatever pose the bodies hold now.
+		world := refA
+		if c.BodyA != nil {
+			world = c.BodyA.Rotation.Rotate(refA)
+		}
+		if c.BodyB != nil {
+			c.RefB = c.BodyB.Rotation.Inverse().Rotate(world)
+		} else {
+			c.RefB = world
+		}
+	}
+	c.RefA = c.RefA.Normalize()
+	c.RefB = c.RefB.Normalize()
+	c.refReady = true
+}
+
+func (c *HingeConstraint) Prepare(dt float64) {
+	if c == nil || c.BodyA == nil || c.BodyB == nil {
+		return
+	}
+	c.ensureReference()
+	c.anchor = prepareAnchor(c.BodyA, c.BodyB, c.AttachA, c.AttachB)
+	c.solvable = (c.anchor.invMA + c.anchor.invMB) > 0
+	if !c.solvable {
+		return
+	}
+
+	pointMass, ok := linearEffectiveMassMatrix(c.anchor).inverse()
+	if !ok {
+		c.solvable = false
+		return
+	}
+	c.pointMass = pointMass
+	drift := c.anchor.worldB.Sub(c.anchor.worldA)
+	c.pointBias = Vec3{
+		X: biasFromError(drift.X, dt),
+		Y: biasFromError(drift.Y, dt),
+		Z: biasFromError(drift.Z, dt),
+	}
+
+	// Angular rows: lock the two axes perpendicular to the hinge. The error is
+	// the cross product of the two world axes, which is zero when they align.
+	axisA := c.BodyA.Rotation.Rotate(c.AxisA).Normalize()
+	axisB := c.BodyB.Rotation.Rotate(c.AxisB).Normalize()
+	c.worldAxis = axisA
+	p0, p1 := orthonormalBasis(axisA)
+	c.perp = [2]Vec3{p0, p1}
+	alignment := axisA.Cross(axisB)
+	for i := 0; i < 2; i++ {
+		k := angularEffectiveMass(c.perp[i], c.anchor.invIA, c.anchor.invIB)
+		if k > epsilon {
+			c.angularMass[i] = 1 / k
+		} else {
+			c.angularMass[i] = 0
+		}
+		c.angularBias[i] = biasFromError(-alignment.Dot(c.perp[i]), dt)
+	}
+
+	axialMass := angularEffectiveMass(axisA, c.anchor.invIA, c.anchor.invIB)
+	if axialMass > epsilon {
+		c.motorMass = 1 / axialMass
+		c.limitMass = c.motorMass
+	} else {
+		c.motorMass = 0
+		c.limitMass = 0
+	}
+
+	c.limitSign = 0
+	c.limitBias = 0
+	if c.LimitEnabled && c.limitMass > 0 {
+		angle := c.Angle()
+		switch {
+		case angle < c.LowerLimit:
+			c.limitSign = 1
+			c.limitBias = biasFromError(c.LowerLimit-angle, dt)
+		case angle > c.UpperLimit:
+			c.limitSign = -1
+			c.limitBias = biasFromError(angle-c.UpperLimit, dt)
+		}
+	}
+	if c.limitSign == 0 {
+		c.accumLimit = 0
+	}
+	if !c.MotorEnabled {
+		c.accumMotor = 0
+	}
+
+	// Warm start every row.
+	if c.accumPoint.Len2() > 0 {
+		applyJointImpulse(c.BodyA, c.BodyB, c.accumPoint, c.anchor.rA, c.anchor.rB)
+	}
+	angular := c.perp[0].Mul(c.accumAngular[0]).Add(c.perp[1].Mul(c.accumAngular[1]))
+	angular = angular.Add(axisA.Mul(c.accumMotor + c.accumLimit))
+	if angular.Len2() > 0 {
+		applyJointAngularImpulse(c.BodyA, c.BodyB, angular)
+	}
+}
+
+func (c *HingeConstraint) SolveVelocity() {
+	if c == nil || !c.solvable {
+		return
+	}
+	relativeAngular := jointAngularVelocity(c.BodyB).Sub(jointAngularVelocity(c.BodyA))
+
+	// Motor row first: it is bounded, so later rows correct any overshoot.
+	if c.MotorEnabled && c.motorMass > 0 {
+		error := relativeAngular.Dot(c.worldAxis) - c.MotorSpeed
+		lambda := -error * c.motorMass
+		old := c.accumMotor
+		next := old + lambda
+		if c.MaxMotorTorque > 0 {
+			limit := c.MaxMotorTorque
+			next = clampFloat(next, -limit, limit)
+		}
+		delta := next - old
+		c.accumMotor = next
+		if delta != 0 {
+			applyJointAngularImpulse(c.BodyA, c.BodyB, c.worldAxis.Mul(delta))
+		}
+		relativeAngular = jointAngularVelocity(c.BodyB).Sub(jointAngularVelocity(c.BodyA))
+	}
+
+	if c.limitSign != 0 && c.limitMass > 0 {
+		speed := relativeAngular.Dot(c.worldAxis) * c.limitSign
+		lambda := -(speed - c.limitBias) * c.limitMass
+		old := c.accumLimit * c.limitSign
+		next := old + lambda
+		if next < 0 {
+			next = 0
+		}
+		delta := next - old
+		c.accumLimit = next * c.limitSign
+		if delta != 0 {
+			applyJointAngularImpulse(c.BodyA, c.BodyB, c.worldAxis.Mul(delta*c.limitSign))
+		}
+		relativeAngular = jointAngularVelocity(c.BodyB).Sub(jointAngularVelocity(c.BodyA))
+	}
+
+	for i := 0; i < 2; i++ {
+		if c.angularMass[i] <= 0 {
+			continue
+		}
+		speed := relativeAngular.Dot(c.perp[i])
+		lambda := -(speed + c.angularBias[i]) * c.angularMass[i]
+		c.accumAngular[i] += lambda
+		applyJointAngularImpulse(c.BodyA, c.BodyB, c.perp[i].Mul(lambda))
+		relativeAngular = jointAngularVelocity(c.BodyB).Sub(jointAngularVelocity(c.BodyA))
+	}
+
+	vRel := relativeVelocityAt(c.BodyA, c.BodyB, c.anchor.rA, c.anchor.rB)
+	lambda := c.pointMass.mul(vRel.Add(c.pointBias).Neg())
+	c.accumPoint = c.accumPoint.Add(lambda)
+	applyJointImpulse(c.BodyA, c.BodyB, lambda, c.anchor.rA, c.anchor.rB)
+}
+
+func (c *HingeConstraint) SolvePosition() {}
+
+// FixedConstraint locks two bodies together. It holds one point of each body on
+// the other and keeps their relative rotation at the value the joint recorded
+// when it first ran.
+//
+// Use it to weld two parts into one rigid assembly that a large enough impulse
+// can still bend, or to attach a prop to a moving platform.
+type FixedConstraint struct {
+	BodyA, BodyB *RigidBody
+	AttachA      Vec3 // body-local on A
+	AttachB      Vec3 // body-local on B
+
+	// RelativeRotation is the rotation of B in A's frame that the joint holds.
+	// Leave it zero to record the pose at first use.
+	RelativeRotation Quat
+
+	anchor      jointAnchor
+	pointMass   mat3
+	pointBias   Vec3
+	angularMass mat3
+	angularBias Vec3
+	solvable    bool
+	poseReady   bool
+
+	accumPoint   Vec3
+	accumAngular Vec3
+}
+
+func (c *FixedConstraint) ensurePose() {
+	if c.poseReady {
+		return
+	}
+	zero := c.RelativeRotation
+	if zero.X == 0 && zero.Y == 0 && zero.Z == 0 && zero.W == 0 {
+		if c.BodyA != nil && c.BodyB != nil {
+			c.RelativeRotation = c.BodyA.Rotation.Inverse().Mul(c.BodyB.Rotation).Normalize()
+		} else {
+			c.RelativeRotation = IdentityQuat()
+		}
+	} else {
+		c.RelativeRotation = zero.Normalize()
+	}
+	c.poseReady = true
+}
+
+func (c *FixedConstraint) Prepare(dt float64) {
+	if c == nil || c.BodyA == nil || c.BodyB == nil {
+		return
+	}
+	c.ensurePose()
+	c.anchor = prepareAnchor(c.BodyA, c.BodyB, c.AttachA, c.AttachB)
+	c.solvable = (c.anchor.invMA + c.anchor.invMB) > 0
+	if !c.solvable {
+		return
+	}
+
+	pointMass, ok := linearEffectiveMassMatrix(c.anchor).inverse()
+	if !ok {
+		c.solvable = false
+		return
+	}
+	c.pointMass = pointMass
+	drift := c.anchor.worldB.Sub(c.anchor.worldA)
+	c.pointBias = Vec3{
+		X: biasFromError(drift.X, dt),
+		Y: biasFromError(drift.Y, dt),
+		Z: biasFromError(drift.Z, dt),
+	}
+
+	angularMass, ok := c.anchor.invIA.add(c.anchor.invIB).inverse()
+	if !ok {
+		// Neither body can rotate. Keep the point rows and drop the angular
+		// rows instead of failing the whole joint.
+		c.angularMass = mat3{}
+		c.angularBias = Vec3{}
+		return
+	}
+	c.angularMass = angularMass
+
+	// Rotation error as a small rotation vector. q maps the pose the joint wants
+	// onto the pose it has; the vector part of q is half the error axis angle.
+	want := c.BodyA.Rotation.Mul(c.RelativeRotation)
+	error := c.BodyB.Rotation.Mul(want.Inverse()).Normalize()
+	if error.W < 0 {
+		error = Quat{X: -error.X, Y: -error.Y, Z: -error.Z, W: -error.W}
+	}
+	axis := Vec3{X: error.X, Y: error.Y, Z: error.Z}.Mul(2)
+	c.angularBias = Vec3{
+		X: biasFromError(axis.X, dt),
+		Y: biasFromError(axis.Y, dt),
+		Z: biasFromError(axis.Z, dt),
+	}
+
+	if c.accumPoint.Len2() > 0 {
+		applyJointImpulse(c.BodyA, c.BodyB, c.accumPoint, c.anchor.rA, c.anchor.rB)
+	}
+	if c.accumAngular.Len2() > 0 {
+		applyJointAngularImpulse(c.BodyA, c.BodyB, c.accumAngular)
+	}
+}
+
+func (c *FixedConstraint) SolveVelocity() {
+	if c == nil || !c.solvable {
+		return
+	}
+	if !c.angularMass.isZero() {
+		relative := jointAngularVelocity(c.BodyB).Sub(jointAngularVelocity(c.BodyA))
+		lambda := c.angularMass.mul(relative.Add(c.angularBias).Neg())
+		c.accumAngular = c.accumAngular.Add(lambda)
+		applyJointAngularImpulse(c.BodyA, c.BodyB, lambda)
+	}
+
+	vRel := relativeVelocityAt(c.BodyA, c.BodyB, c.anchor.rA, c.anchor.rB)
+	lambda := c.pointMass.mul(vRel.Add(c.pointBias).Neg())
+	c.accumPoint = c.accumPoint.Add(lambda)
+	applyJointImpulse(c.BodyA, c.BodyB, lambda, c.anchor.rA, c.anchor.rB)
+}
+
+func (c *FixedConstraint) SolvePosition() {}
+
+// angularEffectiveMass returns the inverse effective mass of an angular
+// constraint row about a unit axis.
+func angularEffectiveMass(axis Vec3, invIA, invIB mat3) float64 {
+	k := 0.0
+	if !invIA.isZero() {
+		k += invIA.mul(axis).Dot(axis)
+	}
+	if !invIB.isZero() {
+		k += invIB.mul(axis).Dot(axis)
+	}
+	return k
 }
 
 // AddConstraint registers a constraint with the world. The constraint will

--- a/physics/constraint_joints_test.go
+++ b/physics/constraint_joints_test.go
@@ -1,0 +1,345 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// Joint tests check closed-form behaviour and invariants, not screenshots.
+// A pendulum has a known period bound, a hinge has one free axis and two locked
+// ones, and a weld holds a relative pose whatever the load.
+
+// --- Ball and socket ---------------------------------------------------------
+
+// TestPointConstraintHoldsAPendulumOnItsAnchor checks the three linear rows. The
+// bob must stay on a sphere of the rod radius around the anchor, and it must
+// swing rather than hang still.
+func TestPointConstraintHoldsAPendulumOnItsAnchor(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 20})
+	anchor := world.AddBody(BodyConfig{Mass: 0, Position: Vec3{Y: 4}})
+	bob := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 1.5, Y: 4}})
+	bob.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.2})
+
+	// The joint holds the bob's own local point (-1.5, 0, 0) on the anchor, so
+	// the bob centre traces a sphere of radius 1.5 around it.
+	world.AddConstraint(&PointConstraint{
+		BodyA:   anchor,
+		BodyB:   bob,
+		AttachA: Vec3{},
+		AttachB: Vec3{X: -1.5},
+	})
+
+	lowest := math.Inf(1)
+	for i := 0; i < 2400; i++ {
+		world.StepFixed()
+		offset := bob.Position.Sub(anchor.Position)
+		if math.Abs(offset.Len()-1.5) > 0.02 {
+			t.Fatalf("step %d: bob left the sphere of radius 1.5, distance = %v", i, offset.Len())
+		}
+		lowest = math.Min(lowest, bob.Position.Y)
+	}
+	if lowest > 2.7 {
+		t.Fatalf("the pendulum never swung down, lowest y = %v", lowest)
+	}
+	if !anchor.Position.Near(Vec3{Y: 4}, 1e-12) {
+		t.Fatalf("a static anchor must not move, got %+v", anchor.Position)
+	}
+}
+
+// TestPointConstraintChainHangsStraight checks that a chain of ball joints holds
+// its links together and settles under gravity.
+func TestPointConstraintChainHangsStraight(t *testing.T) {
+	const links = 5
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 24})
+	anchor := world.AddBody(BodyConfig{Mass: 0, Position: Vec3{Y: 6}})
+
+	// Each link is 0.5 tall and hangs from the one above by its top face, so
+	// link i sits at y = 5.75 - i*0.5 and link zero's top touches the anchor.
+	linkHeight := func(i int) float64 { return 5.75 - float64(i)*0.5 }
+
+	previous := anchor
+	bodies := make([]*RigidBody, 0, links)
+	for i := 0; i < links; i++ {
+		link := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: linkHeight(i)}, LinearDamping: 0.4, AngularDamping: 0.4})
+		link.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 0.2, Height: 0.5, Depth: 0.2})
+		attachA := Vec3{Y: -0.25}
+		if i == 0 {
+			attachA = Vec3{}
+		}
+		world.AddConstraint(&PointConstraint{
+			BodyA: previous, BodyB: link,
+			AttachA: attachA, AttachB: Vec3{Y: 0.25},
+		})
+		previous = link
+		bodies = append(bodies, link)
+	}
+
+	for i := 0; i < 4000; i++ {
+		world.StepFixed()
+	}
+
+	for i, link := range bodies {
+		want := linkHeight(i)
+		if math.Abs(link.Position.Y-want) > 0.06 {
+			t.Fatalf("link %d hangs at y=%v, want near %v", i, link.Position.Y, want)
+		}
+		if lateral := math.Hypot(link.Position.X, link.Position.Z); lateral > 0.06 {
+			t.Fatalf("link %d drifted %v sideways", i, lateral)
+		}
+	}
+}
+
+// --- Hinge -------------------------------------------------------------------
+
+// TestHingeAllowsOneAxisAndLocksTwo is the defining property of a revolute
+// joint. A torque about the hinge axis must spin the door; a torque about a
+// perpendicular axis must not tilt it.
+func TestHingeAllowsOneAxisAndLocksTwo(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 240.0, SolverIterations: 24})
+	frame := world.AddBody(BodyConfig{Mass: 0})
+	door := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 0.5}})
+	door.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 2, Depth: 0.1})
+
+	world.AddConstraint(&HingeConstraint{
+		BodyA:   frame,
+		BodyB:   door,
+		AttachA: Vec3{},
+		AttachB: Vec3{X: -0.5},
+		AxisA:   Vec3{Y: 1},
+		AxisB:   Vec3{Y: 1},
+	})
+
+	for i := 0; i < 240; i++ {
+		door.ApplyTorque(Vec3{X: 8, Y: 4, Z: 8})
+		world.StepFixed()
+	}
+
+	if door.AngularVelocity.Y <= 0.2 {
+		t.Fatalf("the hinge must turn about its own axis, angular velocity = %+v", door.AngularVelocity)
+	}
+	if math.Abs(door.AngularVelocity.X) > 0.02 || math.Abs(door.AngularVelocity.Z) > 0.02 {
+		t.Fatalf("the hinge must lock the other two axes, angular velocity = %+v", door.AngularVelocity)
+	}
+	// The hinge point must not drift away from the frame.
+	if math.Abs(door.Position.Len()-0.5) > 0.02 {
+		t.Fatalf("the door left its hinge point, position = %+v", door.Position)
+	}
+}
+
+// TestHingeMotorReachesTargetSpeed checks the motor row. It must reach the
+// commanded speed and hold it against gravity.
+func TestHingeMotorReachesTargetSpeed(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 20})
+	frame := world.AddBody(BodyConfig{Mass: 0})
+	arm := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 0.5}})
+	arm.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 0.1, Depth: 0.1})
+
+	hinge := &HingeConstraint{
+		BodyA: frame, BodyB: arm,
+		AttachA: Vec3{}, AttachB: Vec3{X: -0.5},
+		AxisA: Vec3{Z: 1}, AxisB: Vec3{Z: 1},
+		MotorEnabled: true, MotorSpeed: 2.5, MaxMotorTorque: 60,
+	}
+	world.AddConstraint(hinge)
+
+	for i := 0; i < 1200; i++ {
+		world.StepFixed()
+	}
+
+	if math.Abs(arm.AngularVelocity.Z-2.5) > 0.15 {
+		t.Fatalf("motor should hold 2.5 rad/s, got %v", arm.AngularVelocity.Z)
+	}
+	if math.Abs(arm.AngularVelocity.X) > 0.05 || math.Abs(arm.AngularVelocity.Y) > 0.05 {
+		t.Fatalf("motor must not leak into the locked axes, angular velocity = %+v", arm.AngularVelocity)
+	}
+}
+
+// TestHingeMotorRespectsItsTorqueBudget checks the other half of the motor. A
+// weak motor must fail to lift a heavy arm against gravity.
+func TestHingeMotorRespectsItsTorqueBudget(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 20})
+	frame := world.AddBody(BodyConfig{Mass: 0})
+	arm := world.AddBody(BodyConfig{Mass: 20, Position: Vec3{X: 1}})
+	arm.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 0.1, Depth: 0.1})
+
+	world.AddConstraint(&HingeConstraint{
+		BodyA: frame, BodyB: arm,
+		AttachA: Vec3{}, AttachB: Vec3{X: -1},
+		AxisA: Vec3{Z: 1}, AxisB: Vec3{Z: 1},
+		MotorEnabled: true, MotorSpeed: 4, MaxMotorTorque: 0.05,
+	})
+
+	for i := 0; i < 480; i++ {
+		world.StepFixed()
+	}
+
+	if arm.Position.Y > -0.2 {
+		t.Fatalf("a motor capped at 0.05 N m cannot hold a 20 kg arm, y = %v", arm.Position.Y)
+	}
+}
+
+// TestHingeLimitStopsTheJoint checks the limit rows. The arm must swing down
+// under gravity and stop at the lower limit.
+func TestHingeLimitStopsTheJoint(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 24})
+	frame := world.AddBody(BodyConfig{Mass: 0})
+	arm := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 1}, AngularDamping: 0.4})
+	arm.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 0.1, Depth: 0.1})
+
+	hinge := &HingeConstraint{
+		BodyA: frame, BodyB: arm,
+		AttachA: Vec3{}, AttachB: Vec3{X: -1},
+		AxisA: Vec3{Z: 1}, AxisB: Vec3{Z: 1},
+		LimitEnabled: true,
+		LowerLimit:   -0.6,
+		UpperLimit:   0.6,
+	}
+	world.AddConstraint(hinge)
+
+	worst := 0.0
+	for i := 0; i < 3000; i++ {
+		world.StepFixed()
+		angle := hinge.Angle()
+		if angle < -0.6 {
+			worst = math.Min(worst, angle+0.6)
+		}
+	}
+
+	final := hinge.Angle()
+	if final > -0.5 {
+		t.Fatalf("gravity should push the arm onto the lower limit, angle = %v", final)
+	}
+	if worst < -0.12 {
+		t.Fatalf("the arm broke through the limit by %v radians", -worst)
+	}
+}
+
+// --- Fixed / weld ------------------------------------------------------------
+
+// TestFixedConstraintWeldsTwoBodiesIntoOne checks that a weld keeps both the
+// offset and the relative rotation while the pair tumbles.
+func TestFixedConstraintWeldsTwoBodiesIntoOne(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 240.0, SolverIterations: 24, DisableCCD: true})
+	a := world.AddBody(BodyConfig{Mass: 1, AngularVelocity: Vec3{X: 1.5, Y: 0.8, Z: -1.1}})
+	a.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+	b := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 1}})
+	b.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	world.AddConstraint(&FixedConstraint{
+		BodyA: a, BodyB: b,
+		AttachA: Vec3{X: 0.5}, AttachB: Vec3{X: -0.5},
+	})
+
+	wantRelative := a.Rotation.Inverse().Mul(b.Rotation).Normalize()
+	for i := 0; i < 2400; i++ {
+		world.StepFixed()
+
+		offset := b.Position.Sub(a.Position)
+		want := a.Rotation.Rotate(Vec3{X: 1})
+		if offset.Sub(want).Len() > 0.03 {
+			t.Fatalf("step %d: the weld slipped, offset = %+v want %+v", i, offset, want)
+		}
+		relative := a.Rotation.Inverse().Mul(b.Rotation).Normalize()
+		if angleBetweenQuats(relative, wantRelative) > 0.05 {
+			t.Fatalf("step %d: the weld twisted by %v radians", i, angleBetweenQuats(relative, wantRelative))
+		}
+	}
+}
+
+// TestFixedConstraintCarriesLoadToAStaticAnchor checks that a weld to a static
+// body holds a cantilever up against gravity.
+func TestFixedConstraintCarriesLoadToAStaticAnchor(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 24})
+	wall := world.AddBody(BodyConfig{Mass: 0})
+	beam := world.AddBody(BodyConfig{Mass: 2, Position: Vec3{X: 1}})
+	beam.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 2, Height: 0.2, Depth: 0.2})
+
+	world.AddConstraint(&FixedConstraint{
+		BodyA: wall, BodyB: beam,
+		AttachA: Vec3{}, AttachB: Vec3{X: -1},
+	})
+
+	for i := 0; i < 2400; i++ {
+		world.StepFixed()
+	}
+
+	if math.Abs(beam.Position.Y) > 0.05 {
+		t.Fatalf("the cantilever sagged to y = %v", beam.Position.Y)
+	}
+	tilt := math.Hypot(math.Hypot(beam.Rotation.X, beam.Rotation.Y), beam.Rotation.Z)
+	if tilt > 0.05 {
+		t.Fatalf("the cantilever rotated, rotation vector part = %v", tilt)
+	}
+}
+
+// --- Lifecycle and spec ------------------------------------------------------
+
+func TestRemoveBodyDropsEveryJointKind(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, SolverIter: 4})
+	a := world.AddBody(BodyConfig{Mass: 1})
+	b := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 1}})
+
+	world.AddConstraint(&DistanceConstraint{BodyA: a, BodyB: b, TargetDistance: 1})
+	world.AddConstraint(&PointConstraint{BodyA: a, BodyB: b})
+	world.AddConstraint(&HingeConstraint{BodyA: a, BodyB: b, AxisA: Vec3{Y: 1}, AxisB: Vec3{Y: 1}})
+	world.AddConstraint(&FixedConstraint{BodyA: a, BodyB: b})
+	if got := len(world.Constraints()); got != 4 {
+		t.Fatalf("Constraints() = %d, want 4", got)
+	}
+
+	world.RemoveBody(b)
+	if got := len(world.Constraints()); got != 0 {
+		t.Fatalf("after RemoveBody, Constraints() = %d, want 0", got)
+	}
+}
+
+func TestBuildWorldAddsEveryJointKind(t *testing.T) {
+	world := BuildWorld(WorldSpec{
+		Config: WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0, SolverIter: 4},
+		Bodies: []BodySpec{
+			{Body: BodyConfig{ID: "anchor", Mass: 0}},
+			{Body: BodyConfig{ID: "bob", Mass: 1, Position: Vec3{X: 2}}},
+		},
+		Constraints: []ConstraintSpec{
+			{Kind: "point", BodyAID: "anchor", BodyBID: "bob"},
+			{
+				Kind: "hinge", BodyAID: "anchor", BodyBID: "bob",
+				AxisA: Vec3{Z: 1}, AxisB: Vec3{Z: 1},
+				MotorEnabled: true, MotorSpeed: 1.25, MaxMotorTorque: 9,
+				LimitEnabled: true, LowerLimit: -1, UpperLimit: 1,
+			},
+			{Kind: "fixed", BodyAID: "anchor", BodyBID: "bob"},
+		},
+	})
+
+	constraints := world.Constraints()
+	if len(constraints) != 3 {
+		t.Fatalf("BuildWorld constraints = %d, want 3", len(constraints))
+	}
+	if _, ok := constraints[0].(*PointConstraint); !ok {
+		t.Fatalf("constraint 0 type = %T", constraints[0])
+	}
+	hinge, ok := constraints[1].(*HingeConstraint)
+	if !ok {
+		t.Fatalf("constraint 1 type = %T", constraints[1])
+	}
+	if hinge.MotorSpeed != 1.25 || hinge.MaxMotorTorque != 9 {
+		t.Fatalf("hinge motor = %v rad/s, %v N m", hinge.MotorSpeed, hinge.MaxMotorTorque)
+	}
+	if !hinge.LimitEnabled || hinge.LowerLimit != -1 || hinge.UpperLimit != 1 {
+		t.Fatalf("hinge limits = %v..%v enabled=%v", hinge.LowerLimit, hinge.UpperLimit, hinge.LimitEnabled)
+	}
+	if _, ok := constraints[2].(*FixedConstraint); !ok {
+		t.Fatalf("constraint 2 type = %T", constraints[2])
+	}
+}
+
+// angleBetweenQuats returns the smallest rotation angle between two unit
+// quaternions, in radians.
+func angleBetweenQuats(a, b Quat) float64 {
+	dot := math.Abs(a.X*b.X + a.Y*b.Y + a.Z*b.Z + a.W*b.W)
+	if dot > 1 {
+		dot = 1
+	}
+	return 2 * math.Acos(dot)
+}

--- a/physics/diagnostics.go
+++ b/physics/diagnostics.go
@@ -1,0 +1,108 @@
+package physics
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+// Diagnostic reports one collider or collider pair that cannot take part in
+// collision. A diagnostic always means a configuration mistake: the shape was
+// declared, the world accepted it, and it will never produce a contact.
+//
+// Read diagnostics with World.Diagnostics or World.Err, or let
+// BuildWorldChecked return them as one error.
+type Diagnostic struct {
+	// ColliderIndex is the world-assigned index of the offending collider, or
+	// 0 when the diagnostic is about the world as a whole.
+	ColliderIndex int
+	// BodyID names the owning body when the collider is attached to one.
+	BodyID string
+	// Shape is the declared shape of the offending collider.
+	Shape ColliderShape
+	// Err explains what is wrong.
+	Err error
+}
+
+func (d Diagnostic) Error() string {
+	var b strings.Builder
+	b.WriteString(d.Err.Error())
+	if d.ColliderIndex != 0 {
+		fmt.Fprintf(&b, " (collider %d, shape %s", d.ColliderIndex, d.Shape)
+		if d.BodyID != "" {
+			fmt.Fprintf(&b, ", body %q", d.BodyID)
+		}
+		b.WriteString(")")
+	}
+	return b.String()
+}
+
+func (d Diagnostic) Unwrap() error {
+	return d.Err
+}
+
+// ErrMeshPairUnsupported reports that two triangle mesh colliders were declared
+// in a way that would need mesh-against-mesh collision, which is not
+// implemented.
+var ErrMeshPairUnsupported = errors.New("physics: triangle mesh against triangle mesh collision is not implemented")
+
+// Diagnostics lists every collider in the world that cannot collide, plus every
+// unsupported pairing. An empty result means every declared shape works.
+//
+// Call this after building a world. A collider that appears here is silent in
+// the simulation: it passes through everything.
+func (w *World) Diagnostics() []Diagnostic {
+	if w == nil {
+		return nil
+	}
+	var out []Diagnostic
+	dynamicMeshes := 0
+	meshes := 0
+	for _, collider := range w.colliders {
+		if collider == nil {
+			continue
+		}
+		if err := collider.invalid; err != nil {
+			out = append(out, Diagnostic{
+				ColliderIndex: collider.index,
+				BodyID:        colliderBodyID(collider),
+				Shape:         collider.Shape,
+				Err:           err,
+			})
+			continue
+		}
+		if collider.Shape == ShapeTriangleMesh {
+			meshes++
+			if !immovableCollider(collider) {
+				dynamicMeshes++
+			}
+		}
+	}
+	// Two static meshes never pair in the broadphase, so only a moving mesh
+	// can reach the unsupported combination.
+	if dynamicMeshes > 0 && meshes > 1 {
+		out = append(out, Diagnostic{Err: ErrMeshPairUnsupported})
+	}
+	return out
+}
+
+// Err joins every diagnostic into one error, or returns nil when the world is
+// fully supported.
+func (w *World) Err() error {
+	diagnostics := w.Diagnostics()
+	if len(diagnostics) == 0 {
+		return nil
+	}
+	errs := make([]error, len(diagnostics))
+	for i, d := range diagnostics {
+		errs[i] = d
+	}
+	return errors.Join(errs...)
+}
+
+func colliderBodyID(c *Collider) string {
+	if c == nil || c.Body == nil {
+		return ""
+	}
+	return c.Body.ID
+}

--- a/physics/diagnostics_test.go
+++ b/physics/diagnostics_test.go
@@ -1,0 +1,240 @@
+package physics
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestColliderValidationRejectsUnusableShapes(t *testing.T) {
+	cases := []struct {
+		name    string
+		config  ColliderConfig
+		wantErr string
+	}{
+		{
+			name:    "cylinder without radius",
+			config:  ColliderConfig{Shape: ShapeCylinder, Height: 2},
+			wantErr: "cylinder collider needs Radius > 0",
+		},
+		{
+			name:    "cylinder without height",
+			config:  ColliderConfig{Shape: ShapeCylinder, Radius: 1},
+			wantErr: "cylinder collider needs Radius > 0",
+		},
+		{
+			name:    "cone without radius",
+			config:  ColliderConfig{Shape: ShapeCone, Height: 2},
+			wantErr: "cone collider needs Radius > 0",
+		},
+		{
+			name:    "convex hull with no vertices",
+			config:  ColliderConfig{Shape: ShapeConvexHull},
+			wantErr: "convex hull collider needs at least 4 Vertices",
+		},
+		{
+			name: "convex hull with three vertices",
+			config: ColliderConfig{Shape: ShapeConvexHull, Vertices: []Vec3{
+				{}, {X: 1}, {Y: 1},
+			}},
+			wantErr: "convex hull collider needs at least 4 Vertices",
+		},
+		{
+			name: "coplanar convex hull",
+			config: ColliderConfig{Shape: ShapeConvexHull, Vertices: []Vec3{
+				{}, {X: 1}, {Z: 1}, {X: 1, Z: 1},
+			}},
+			wantErr: "Vertices are coplanar",
+		},
+		{
+			name:    "triangle mesh with no geometry",
+			config:  ColliderConfig{Shape: ShapeTriangleMesh},
+			wantErr: "triangle mesh collider needs Vertices plus Indices",
+		},
+		{
+			name: "triangle mesh with out-of-range indices",
+			config: ColliderConfig{
+				Shape:    ShapeTriangleMesh,
+				Vertices: []Vec3{{}, {X: 1}, {Z: 1}},
+				Indices:  []int{0, 1, 9},
+			},
+			wantErr: "triangle mesh collider needs Vertices plus Indices",
+		},
+		{
+			name:    "box with zero depth",
+			config:  ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1},
+			wantErr: "box collider needs Width, Height and Depth > 0",
+		},
+		{
+			name:    "sphere with zero radius",
+			config:  ColliderConfig{Shape: ShapeSphere},
+			wantErr: "sphere collider needs Radius > 0",
+		},
+		{
+			name:    "unknown shape",
+			config:  ColliderConfig{Shape: ColliderShape(42)},
+			wantErr: "unknown collider shape 42",
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			collider := NewCollider(testCase.config)
+			err := collider.Err()
+			if err == nil {
+				t.Fatalf("Err() = nil, want an error mentioning %q", testCase.wantErr)
+			}
+			if !strings.Contains(err.Error(), testCase.wantErr) {
+				t.Fatalf("Err() = %q, want it to mention %q", err.Error(), testCase.wantErr)
+			}
+			// An unusable collider must never poison the broadphase with an
+			// unbounded box.
+			box := collider.AABB()
+			if !box.IsFinite() {
+				t.Fatalf("AABB = %+v, want a finite box for an unusable collider", box)
+			}
+			// It must also never generate a contact.
+			ground := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+			if _, ok := Collide(collider, ground); ok {
+				t.Fatal("an unusable collider must not produce a contact")
+			}
+			if _, ok := Collide(ground, collider); ok {
+				t.Fatal("an unusable collider must not produce a contact in either order")
+			}
+		})
+	}
+}
+
+func TestWorldDiagnosticsReportUnusableColliders(t *testing.T) {
+	world := NewWorld(DefaultWorldConfig())
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	body := world.AddBody(BodyConfig{ID: "wheel", Mass: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5}) // no height
+
+	diagnostics := world.Diagnostics()
+	if len(diagnostics) != 1 {
+		t.Fatalf("Diagnostics() returned %d entries, want 1: %v", len(diagnostics), diagnostics)
+	}
+	entry := diagnostics[0]
+	if entry.Shape != ShapeCylinder {
+		t.Fatalf("diagnostic shape = %v, want cylinder", entry.Shape)
+	}
+	if entry.BodyID != "wheel" {
+		t.Fatalf("diagnostic body = %q, want \"wheel\"", entry.BodyID)
+	}
+	if entry.ColliderIndex == 0 {
+		t.Fatal("diagnostic must carry the collider index")
+	}
+	message := entry.Error()
+	for _, want := range []string{"cylinder", "wheel"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("diagnostic message %q must mention %q", message, want)
+		}
+	}
+	if world.Err() == nil {
+		t.Fatal("Err() must be non-nil when diagnostics exist")
+	}
+}
+
+func TestWorldDiagnosticsEmptyForSupportedShapes(t *testing.T) {
+	vertices, indices := gridMesh(2, 4)
+	world := NewWorld(DefaultWorldConfig())
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	body := world.AddBody(BodyConfig{Mass: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeCone, Radius: 0.5, Height: 1})
+	body.AddCollider(ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 1, Y: 1, Z: 1})})
+
+	if diagnostics := world.Diagnostics(); len(diagnostics) != 0 {
+		t.Fatalf("Diagnostics() = %v, want none", diagnostics)
+	}
+	if err := world.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil", err)
+	}
+}
+
+func TestWorldDiagnosticsReportMeshAgainstMesh(t *testing.T) {
+	vertices, indices := gridMesh(2, 4)
+	world := NewWorld(DefaultWorldConfig())
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 5}})
+	body.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+
+	err := world.Err()
+	if err == nil {
+		t.Fatal("Err() must report the unsupported mesh pairing")
+	}
+	if !errors.Is(err, ErrMeshPairUnsupported) {
+		t.Fatalf("Err() = %v, want it to wrap ErrMeshPairUnsupported", err)
+	}
+}
+
+func TestWorldDiagnosticsAllowTwoStaticMeshes(t *testing.T) {
+	// Two immovable meshes never pair in the broadphase, so they are not a
+	// problem.
+	vertices, indices := gridMesh(2, 4)
+	world := NewWorld(DefaultWorldConfig())
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices, Offset: Vec3{X: 10}})
+
+	if err := world.Err(); err != nil {
+		t.Fatalf("Err() = %v, want nil for two static meshes", err)
+	}
+}
+
+func TestBuildWorldCheckedSurfacesSpecDiagnostics(t *testing.T) {
+	spec := WorldSpec{
+		Config: DefaultWorldConfig(),
+		Static: []ColliderConfig{{Shape: ShapePlane, Normal: Vec3{Y: 1}}},
+		Bodies: []BodySpec{{
+			Body:      BodyConfig{ID: "crate", Mass: 1},
+			Colliders: []ColliderConfig{{Shape: ShapeCone, Radius: 1}}, // no height
+		}},
+		Diagnostics: []string{"collider shape \"blob\" is not a known shape"},
+	}
+
+	world, err := BuildWorldChecked(spec)
+	if world == nil {
+		t.Fatal("BuildWorldChecked must still return the world")
+	}
+	if err == nil {
+		t.Fatal("BuildWorldChecked must report both problems")
+	}
+	message := err.Error()
+	for _, want := range []string{"blob", "cone collider needs Radius > 0"} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("error %q must mention %q", message, want)
+		}
+	}
+}
+
+func TestBuildWorldCheckedReturnsNilErrorForCleanSpec(t *testing.T) {
+	spec := WorldSpec{
+		Config: DefaultWorldConfig(),
+		Static: []ColliderConfig{{Shape: ShapePlane, Normal: Vec3{Y: 1}}},
+		Bodies: []BodySpec{{
+			Body:      BodyConfig{ID: "crate", Mass: 1},
+			Colliders: []ColliderConfig{{Shape: ShapeCylinder, Radius: 0.5, Height: 1}},
+		}},
+	}
+	world, err := BuildWorldChecked(spec)
+	if err != nil {
+		t.Fatalf("BuildWorldChecked() error = %v, want nil", err)
+	}
+	if len(world.Colliders()) != 2 {
+		t.Fatalf("collider count = %d, want 2", len(world.Colliders()))
+	}
+}
+
+func TestUnusableColliderStaysOutOfTheUnboundedBroadphaseList(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0})
+	world.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1}) // no height
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: 50}})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	pairs := world.CandidatePairs()
+	if len(pairs) != 0 {
+		t.Fatalf("candidate pairs = %d, want 0; an unusable collider must not pair with distant bodies", len(pairs))
+	}
+}

--- a/physics/gjk.go
+++ b/physics/gjk.go
@@ -1,0 +1,550 @@
+package physics
+
+import (
+	"math"
+	"sync"
+)
+
+// GJK plus EPA over support-mapped convex shapes. GJK answers "do these two
+// volumes overlap"; EPA turns an overlapping simplex into a penetration normal,
+// a depth and one witness point on each surface.
+//
+// Sign convention: the Minkowski difference is supportA(d) - supportB(-d), so
+// the EPA normal points from A toward B. That matches the manifold normal that
+// makeContactManifold expects.
+
+// EPA limits. A polytope with V vertices has 2V-4 faces, so the face budget
+// bounds the vertex budget. Flat shapes such as boxes, hulls and triangles
+// converge exactly in a handful of expansions. A curved surface converges
+// toward an inscribed polytope, so the budget sets the depth accuracy: better
+// than 0.3% of the depth for the worst pair of two spheres, and better than
+// 1e-6 for anything with a flat contact feature.
+//
+// The buffers live in a pool rather than on the stack. Declaring arrays this
+// large in the frame would make Go clear about 12 kB on every narrowphase call.
+const (
+	gjkMaxIterations = 32
+	epaMaxIterations = 96
+	epaMaxVerts      = 128
+	epaMaxFaces      = 256
+	epaMaxHorizon    = 64
+	// epaTolerance is the absolute floor on the remaining gap.
+	epaTolerance = 1e-9
+	// epaRelativeTolerance stops the expansion once the remaining gap falls
+	// below this fraction of the smaller shape's bounding radius.
+	//
+	// Scaling by the shape size and not by the penetration depth matters: a
+	// resting contact has a depth near the solver's slop, and a depth-relative
+	// target would demand an absurd absolute accuracy on the most common
+	// contact of all. Taking the smaller of the two radii keeps a large floor
+	// triangle from loosening the tolerance for a small ball rolling on it.
+	//
+	// A flat contact feature closes the gap to zero on the first probe, so
+	// boxes, hulls, triangles and cylinder caps stay exact. Only a curved
+	// surface stops early.
+	epaRelativeTolerance = 1e-4
+	// epaMonotoneSlack absorbs rounding when comparing face distances against
+	// the previous best, and when deciding that a face is coplanar with a new
+	// vertex.
+	epaMonotoneSlack = 1e-12
+)
+
+// minkowskiPoint is one vertex of the Minkowski difference together with the
+// two surface points that produced it.
+type minkowskiPoint struct {
+	diff Vec3
+	onA  Vec3
+	onB  Vec3
+}
+
+func minkowskiSupport(a, b convexShape, dir Vec3) minkowskiPoint {
+	pa := a.support(dir)
+	pb := b.support(dir.Neg())
+	return minkowskiPoint{diff: pa.Sub(pb), onA: pa, onB: pb}
+}
+
+type gjkSimplex struct {
+	points [4]minkowskiPoint
+	count  int
+}
+
+// gjkOverlap reports whether the two shapes intersect. On a true result the
+// simplex holds a tetrahedron that encloses the origin, ready for EPA.
+func gjkOverlap(a, b convexShape) (gjkSimplex, bool) {
+	var simplex gjkSimplex
+
+	dir := b.center.Sub(a.center)
+	if dir.Len2() <= epsilon {
+		dir = Vec3{X: 1}
+	}
+	simplex.points[0] = minkowskiSupport(a, b, dir)
+	simplex.count = 1
+
+	dir = simplex.points[0].diff.Neg()
+	if dir.Len2() <= epsilon {
+		// The first support point is the origin. The shapes touch with zero
+		// depth, which EPA cannot expand from.
+		return simplex, false
+	}
+
+	for i := 0; i < gjkMaxIterations; i++ {
+		next := minkowskiSupport(a, b, dir)
+		if next.diff.Dot(dir) < 0 {
+			return simplex, false
+		}
+		simplex.points[simplex.count] = next
+		simplex.count++
+
+		contains, newDir := gjkReduce(&simplex)
+		if contains {
+			return simplex, true
+		}
+		if newDir.Len2() <= epsilon {
+			return simplex, false
+		}
+		dir = newDir
+	}
+	return simplex, false
+}
+
+// gjkReduce drops the simplex features that cannot contain the origin and
+// returns the next search direction. It reports true when the simplex is a
+// tetrahedron that encloses the origin.
+func gjkReduce(s *gjkSimplex) (bool, Vec3) {
+	switch s.count {
+	case 2:
+		return false, gjkReduceLine(s)
+	case 3:
+		return false, gjkReduceTriangle(s)
+	case 4:
+		return gjkReduceTetrahedron(s)
+	}
+	return false, s.points[0].diff.Neg()
+}
+
+func gjkReduceLine(s *gjkSimplex) Vec3 {
+	newest := s.points[1]
+	other := s.points[0]
+	ao := newest.diff.Neg()
+	ab := other.diff.Sub(newest.diff)
+	if ab.Dot(ao) > 0 {
+		dir := ab.Cross(ao).Cross(ab)
+		if dir.Len2() <= epsilon {
+			dir = anyPerpendicular(ab)
+		}
+		return dir
+	}
+	s.points[0] = newest
+	s.count = 1
+	return ao
+}
+
+func gjkReduceTriangle(s *gjkSimplex) Vec3 {
+	a := s.points[2]
+	b := s.points[1]
+	c := s.points[0]
+	ao := a.diff.Neg()
+	ab := b.diff.Sub(a.diff)
+	ac := c.diff.Sub(a.diff)
+	abc := ab.Cross(ac)
+
+	if abc.Cross(ac).Dot(ao) > 0 {
+		if ac.Dot(ao) > 0 {
+			s.points[0] = c
+			s.points[1] = a
+			s.count = 2
+			dir := ac.Cross(ao).Cross(ac)
+			if dir.Len2() <= epsilon {
+				dir = anyPerpendicular(ac)
+			}
+			return dir
+		}
+		return gjkReduceTriangleEdgeAB(s, a, b, ab, ao)
+	}
+	if ab.Cross(abc).Dot(ao) > 0 {
+		return gjkReduceTriangleEdgeAB(s, a, b, ab, ao)
+	}
+
+	if abc.Len2() <= epsilon {
+		// Degenerate triangle. Fall back to the edge case.
+		return gjkReduceTriangleEdgeAB(s, a, b, ab, ao)
+	}
+	if abc.Dot(ao) > 0 {
+		s.points[0] = c
+		s.points[1] = b
+		s.points[2] = a
+		s.count = 3
+		return abc
+	}
+	s.points[0] = b
+	s.points[1] = c
+	s.points[2] = a
+	s.count = 3
+	return abc.Neg()
+}
+
+func gjkReduceTriangleEdgeAB(s *gjkSimplex, a, b minkowskiPoint, ab, ao Vec3) Vec3 {
+	if ab.Dot(ao) > 0 {
+		s.points[0] = b
+		s.points[1] = a
+		s.count = 2
+		dir := ab.Cross(ao).Cross(ab)
+		if dir.Len2() <= epsilon {
+			dir = anyPerpendicular(ab)
+		}
+		return dir
+	}
+	s.points[0] = a
+	s.count = 1
+	return ao
+}
+
+func gjkReduceTetrahedron(s *gjkSimplex) (bool, Vec3) {
+	a := s.points[3]
+	b := s.points[2]
+	c := s.points[1]
+	d := s.points[0]
+
+	// Each face is oriented away from the vertex it does not contain, so the
+	// test works whatever winding the simplex arrived in.
+	if faceSeparatesOrigin(a.diff, b.diff, c.diff, d.diff) {
+		s.points[0] = c
+		s.points[1] = b
+		s.points[2] = a
+		s.count = 3
+		return false, gjkReduceTriangle(s)
+	}
+	if faceSeparatesOrigin(a.diff, c.diff, d.diff, b.diff) {
+		s.points[0] = d
+		s.points[1] = c
+		s.points[2] = a
+		s.count = 3
+		return false, gjkReduceTriangle(s)
+	}
+	if faceSeparatesOrigin(a.diff, d.diff, b.diff, c.diff) {
+		s.points[0] = b
+		s.points[1] = d
+		s.points[2] = a
+		s.count = 3
+		return false, gjkReduceTriangle(s)
+	}
+	return true, Vec3{}
+}
+
+// faceSeparatesOrigin reports whether the origin sits on the outward side of
+// triangle (p0,p1,p2), where outward means away from inner.
+func faceSeparatesOrigin(p0, p1, p2, inner Vec3) bool {
+	normal := p1.Sub(p0).Cross(p2.Sub(p0))
+	if normal.Len2() <= 1e-24 {
+		return false
+	}
+	if normal.Dot(inner.Sub(p0)) > 0 {
+		normal = normal.Neg()
+	}
+	return normal.Dot(p0.Neg()) > 0
+}
+
+func anyPerpendicular(v Vec3) Vec3 {
+	axis := Vec3{X: 1}
+	if math.Abs(v.X) > math.Abs(v.Y) {
+		axis = Vec3{Y: 1}
+	}
+	perp := v.Cross(axis)
+	if perp.Len2() <= epsilon {
+		perp = v.Cross(Vec3{Z: 1})
+	}
+	return perp
+}
+
+// epaResult carries the penetration data of one overlapping pair.
+type epaResult struct {
+	// Normal is a unit vector that points from A toward B.
+	Normal Vec3
+	// Depth is the penetration distance along Normal.
+	Depth float64
+	// PointA and PointB are the witness points on the two surfaces.
+	PointA Vec3
+	PointB Vec3
+}
+
+// ContactPoint returns the midpoint between the two witness points, which is
+// the convention the other narrowphase routines use.
+func (r epaResult) ContactPoint() Vec3 {
+	return r.PointA.Add(r.PointB).Mul(0.5)
+}
+
+type epaFace struct {
+	a      int
+	b      int
+	c      int
+	normal Vec3
+	dist   float64
+}
+
+type epaEdge struct {
+	from int
+	to   int
+}
+
+// epaWorkspace holds the reusable polytope buffers of one EPA run.
+type epaWorkspace struct {
+	verts   []minkowskiPoint
+	faces   []epaFace
+	horizon []epaEdge
+}
+
+var epaPool = sync.Pool{
+	New: func() any {
+		return &epaWorkspace{
+			verts:   make([]minkowskiPoint, 0, epaMaxVerts),
+			faces:   make([]epaFace, 0, epaMaxFaces),
+			horizon: make([]epaEdge, 0, epaMaxHorizon),
+		}
+	},
+}
+
+// epaPenetration expands the GJK tetrahedron until it touches the boundary of
+// the Minkowski difference, then reports the penetration normal, depth and
+// witness points.
+func epaPenetration(a, b convexShape, simplex gjkSimplex) (epaResult, bool) {
+	if simplex.count != 4 {
+		return epaResult{}, false
+	}
+
+	workspace := epaPool.Get().(*epaWorkspace)
+	defer epaPool.Put(workspace)
+
+	verts := workspace.verts[:0]
+	verts = append(verts, simplex.points[0], simplex.points[1], simplex.points[2], simplex.points[3])
+
+	tolerance := epaGapTolerance(a, b)
+
+	faces := workspace.faces[:0]
+	tetra := [4][4]int{
+		{1, 2, 3, 0},
+		{0, 2, 3, 1},
+		{0, 1, 3, 2},
+		{0, 1, 2, 3},
+	}
+	for _, face := range tetra {
+		f, ok := makeSeedFace(verts, face[0], face[1], face[2], verts[face[3]].diff)
+		if !ok {
+			return epaResult{}, false
+		}
+		faces = append(faces, f)
+	}
+
+	// While the polytope stays closed and holds the origin, the closest-face
+	// distance never decreases and never drops below zero. Recording the best
+	// face and stopping the moment either invariant breaks means a numerically
+	// broken polytope reports a slightly conservative depth instead of a bogus
+	// one. A zero depth would be the worst outcome: the solver would accept the
+	// contact and then correct nothing.
+	var best epaFace
+	haveBest := false
+
+	for iteration := 0; iteration < epaMaxIterations; iteration++ {
+		index := closestFace(faces)
+		if index < 0 {
+			break
+		}
+		face := faces[index]
+		// A closest face at distance zero is legitimate: the origin can sit on
+		// the seed tetrahedron's boundary, and the expansion then moves it
+		// inward. Only a clearly negative distance means the polytope broke.
+		if face.dist < -epaMonotoneSlack || (haveBest && face.dist < best.dist-epaMonotoneSlack) {
+			break
+		}
+		best = face
+		haveBest = true
+
+		next := minkowskiSupport(a, b, face.normal)
+		if next.diff.Dot(face.normal)-face.dist < tolerance {
+			break
+		}
+		if len(verts) >= epaMaxVerts || len(faces)+epaMaxHorizon > epaMaxFaces {
+			// Out of room. The current closest face is the best answer we have.
+			break
+		}
+		if vertexAlreadyPresent(verts, next.diff) {
+			break
+		}
+
+		newIndex := len(verts)
+		verts = append(verts, next)
+
+		horizon := workspace.horizon[:0]
+		kept := faces[:0]
+		overflow := false
+		for _, candidate := range faces {
+			// Treat a face that the new vertex is coplanar with as visible.
+			// Keeping such a face leaves a zero-area sliver, and the sliver makes
+			// the polytope non-convex a few expansions later.
+			if candidate.normal.Dot(next.diff)-candidate.dist > -epaMonotoneSlack {
+				if len(horizon)+3 > epaMaxHorizon {
+					overflow = true
+					break
+				}
+				horizon = addHorizonEdge(horizon, candidate.a, candidate.b)
+				horizon = addHorizonEdge(horizon, candidate.b, candidate.c)
+				horizon = addHorizonEdge(horizon, candidate.c, candidate.a)
+				continue
+			}
+			kept = append(kept, candidate)
+		}
+		if overflow {
+			break
+		}
+		faces = kept
+		degenerate := false
+		for _, edge := range horizon {
+			// The horizon edges keep the winding of the faces they came from,
+			// so the new faces inherit the outward orientation of the seed
+			// tetrahedron. Re-deriving the orientation here would break edge
+			// cancellation on the next expansion.
+			f, ok := makeWoundFace(verts, edge.from, edge.to, newIndex)
+			if !ok {
+				// Skipping a face would leave a hole, and a holed polytope no
+				// longer bounds the origin.
+				degenerate = true
+				break
+			}
+			faces = append(faces, f)
+		}
+		if degenerate || len(faces) == 0 {
+			break
+		}
+	}
+
+	if !haveBest {
+		return epaResult{}, false
+	}
+	return extractEPAResult(verts, best), true
+}
+
+// makeSeedFace builds one face of the starting tetrahedron with its normal
+// turned away from the opposite vertex. Doing this for all four faces gives the
+// polytope a single consistent outward winding.
+func makeSeedFace(verts []minkowskiPoint, ia, ib, ic int, inner Vec3) (epaFace, bool) {
+	normal, ok := faceNormal(verts, ia, ib, ic)
+	if !ok {
+		return epaFace{}, false
+	}
+	p0 := verts[ia].diff
+	if normal.Dot(inner.Sub(p0)) > 0 {
+		normal = normal.Neg()
+		ib, ic = ic, ib
+	}
+	return epaFace{a: ia, b: ib, c: ic, normal: normal, dist: normal.Dot(p0)}, true
+}
+
+// makeWoundFace builds a face and trusts the given winding to already point
+// outward.
+func makeWoundFace(verts []minkowskiPoint, ia, ib, ic int) (epaFace, bool) {
+	normal, ok := faceNormal(verts, ia, ib, ic)
+	if !ok {
+		return epaFace{}, false
+	}
+	return epaFace{a: ia, b: ib, c: ic, normal: normal, dist: normal.Dot(verts[ia].diff)}, true
+}
+
+func faceNormal(verts []minkowskiPoint, ia, ib, ic int) (Vec3, bool) {
+	p0 := verts[ia].diff
+	normal := verts[ib].diff.Sub(p0).Cross(verts[ic].diff.Sub(p0))
+	length2 := normal.Len2()
+	if length2 <= 1e-24 {
+		return Vec3{}, false
+	}
+	return normal.Div(math.Sqrt(length2)), true
+}
+
+// epaGapTolerance returns the gap below which the expansion stops.
+func epaGapTolerance(a, b convexShape) float64 {
+	scale := math.Min(a.bound, b.bound)
+	relative := epaRelativeTolerance * scale
+	if relative > epaTolerance {
+		return relative
+	}
+	return epaTolerance
+}
+
+func closestFace(faces []epaFace) int {
+	best := -1
+	bestDist := math.Inf(1)
+	for i, face := range faces {
+		if face.dist < bestDist {
+			bestDist = face.dist
+			best = i
+		}
+	}
+	return best
+}
+
+// addHorizonEdge keeps only the edges on the silhouette. An edge shared by two
+// removed faces appears twice with opposite orientation and cancels.
+func addHorizonEdge(horizon []epaEdge, from, to int) []epaEdge {
+	for i, edge := range horizon {
+		if edge.from == to && edge.to == from {
+			horizon = append(horizon[:i], horizon[i+1:]...)
+			return horizon
+		}
+	}
+	return append(horizon, epaEdge{from: from, to: to})
+}
+
+func vertexAlreadyPresent(verts []minkowskiPoint, p Vec3) bool {
+	for _, v := range verts {
+		if v.diff.Sub(p).Len2() <= 1e-20 {
+			return true
+		}
+	}
+	return false
+}
+
+// extractEPAResult reads the penetration off the closest face. The origin is
+// projected onto the face plane, and the barycentric weights of that projection
+// blend the stored surface points into one witness point per shape.
+func extractEPAResult(verts []minkowskiPoint, face epaFace) epaResult {
+	projected := face.normal.Mul(face.dist)
+	u, v, w := barycentric(verts[face.a].diff, verts[face.b].diff, verts[face.c].diff, projected)
+	pointA := verts[face.a].onA.Mul(u).
+		Add(verts[face.b].onA.Mul(v)).
+		Add(verts[face.c].onA.Mul(w))
+	pointB := verts[face.a].onB.Mul(u).
+		Add(verts[face.b].onB.Mul(v)).
+		Add(verts[face.c].onB.Mul(w))
+	return epaResult{
+		Normal: face.normal,
+		Depth:  maxFloat(face.dist, 0),
+		PointA: pointA,
+		PointB: pointB,
+	}
+}
+
+// barycentric returns clamped, normalized weights of q inside triangle
+// (p0,p1,p2).
+func barycentric(p0, p1, p2, q Vec3) (float64, float64, float64) {
+	v0 := p1.Sub(p0)
+	v1 := p2.Sub(p0)
+	v2 := q.Sub(p0)
+	d00 := v0.Dot(v0)
+	d01 := v0.Dot(v1)
+	d11 := v1.Dot(v1)
+	d20 := v2.Dot(v0)
+	d21 := v2.Dot(v1)
+	denom := d00*d11 - d01*d01
+	if math.Abs(denom) <= 1e-24 {
+		return 1, 0, 0
+	}
+	v := (d11*d20 - d01*d21) / denom
+	w := (d00*d21 - d01*d20) / denom
+	u := 1 - v - w
+	u = clampFloat(u, 0, 1)
+	v = clampFloat(v, 0, 1)
+	w = clampFloat(w, 0, 1)
+	sum := u + v + w
+	if sum <= epsilon {
+		return 1, 0, 0
+	}
+	return u / sum, v / sum, w / sum
+}

--- a/physics/gjk_test.go
+++ b/physics/gjk_test.go
@@ -1,0 +1,478 @@
+package physics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// randomUnitQuat returns a uniformly distributed rotation.
+func randomUnitQuat(rng *rand.Rand) Quat {
+	u1 := rng.Float64()
+	u2 := rng.Float64() * 2 * math.Pi
+	u3 := rng.Float64() * 2 * math.Pi
+	s1 := math.Sqrt(1 - u1)
+	s2 := math.Sqrt(u1)
+	return Quat{
+		X: s1 * math.Sin(u2),
+		Y: s1 * math.Cos(u2),
+		Z: s2 * math.Sin(u3),
+		W: s2 * math.Cos(u3),
+	}.Normalize()
+}
+
+func mustShape(t *testing.T, c *Collider) convexShape {
+	t.Helper()
+	shape, ok := newConvexShape(c)
+	if !ok {
+		t.Fatalf("newConvexShape(%v) failed: %v", c.Shape, c.Err())
+	}
+	return shape
+}
+
+func TestGJKSphereSphereMatchesAnalyticPenetration(t *testing.T) {
+	a := NewCollider(ColliderConfig{Shape: ShapeSphere, Radius: 1})
+	b := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.5}, Radius: 1})
+
+	simplex, overlap := gjkOverlap(mustShape(t, a), mustShape(t, b))
+	if !overlap {
+		t.Fatal("gjkOverlap missed two overlapping spheres")
+	}
+	result, ok := epaPenetration(mustShape(t, a), mustShape(t, b), simplex)
+	if !ok {
+		t.Fatal("epaPenetration failed on two overlapping spheres")
+	}
+	// Two curved surfaces are the worst case for EPA, because the polytope is
+	// inscribed in a ball and the depth converges from below. The error stays
+	// under 0.3% of the depth at the shipped tolerance, and the normal stays
+	// within 0.6 degrees. Production never routes a sphere pair here;
+	// collideSphereSphere is analytic.
+	if math.Abs(result.Depth-0.5) > 2e-3 {
+		t.Fatalf("depth = %v, want 0.5", result.Depth)
+	}
+	if result.Normal.Dot(Vec3{X: 1}) < 0.99995 {
+		t.Fatalf("normal = %+v, want within 0.6 degrees of +X (A toward B)", result.Normal)
+	}
+	if !result.ContactPoint().Near(Vec3{X: 0.75}, 5e-3) {
+		t.Fatalf("contact point = %+v, want (0.75,0,0)", result.ContactPoint())
+	}
+}
+
+// TestGJKCylinderSphereMatchesAnalyticPenetration pins the accuracy of a pair
+// that production really does route through GJK. The cylinder's lateral surface
+// is flat along its axis, so EPA lands on it almost exactly.
+func TestGJKCylinderSphereMatchesAnalyticPenetration(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.2}, Radius: 0.5})
+
+	manifold, ok := Collide(cylinder, sphere)
+	if !ok {
+		t.Fatal("expected a cylinder-sphere contact")
+	}
+	// Radial distance 1.2, radii sum 1.5, so the overlap is 0.3.
+	if got := manifold.Points[0].Penetration; math.Abs(got-0.3) > 1e-4 {
+		t.Fatalf("penetration = %v, want 0.3", got)
+	}
+	if manifold.Normal.Dot(Vec3{X: 1}) < 0.9999 {
+		t.Fatalf("normal = %+v, want +X (cylinder toward sphere)", manifold.Normal)
+	}
+	// The contact sits between the cylinder wall at x=1 and the sphere wall at
+	// x=0.7, so the midpoint is x=0.85.
+	if got := manifold.Points[0].Point; math.Abs(got.X-0.85) > 1e-3 {
+		t.Fatalf("contact point = %+v, want x near 0.85", got)
+	}
+}
+
+func TestGJKSeparatedShapesReportNoOverlap(t *testing.T) {
+	a := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+	b := NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{X: 5}, Radius: 0.5, Height: 2})
+	if _, overlap := gjkOverlap(mustShape(t, a), mustShape(t, b)); overlap {
+		t.Fatal("gjkOverlap reported overlap for shapes 5 units apart")
+	}
+}
+
+// TestGJKEPAProducesMinimumTranslationVector checks the EPA result the way a
+// solver uses it: moving B by normal*depth must just separate the pair, and
+// moving it by slightly less must not.
+func TestGJKEPAProducesMinimumTranslationVector(t *testing.T) {
+	rng := rand.New(rand.NewSource(20260726))
+	cases := 0
+	for trial := 0; trial < 400; trial++ {
+		rotA := randomUnitQuat(rng)
+		rotB := randomUnitQuat(rng)
+		offset := Vec3{
+			X: (rng.Float64() - 0.5) * 2.4,
+			Y: (rng.Float64() - 0.5) * 2.4,
+			Z: (rng.Float64() - 0.5) * 2.4,
+		}
+		a := NewCollider(ColliderConfig{Shape: ShapeBox, Rotation: rotA, Width: 1.4, Height: 1, Depth: 0.8})
+		b := NewCollider(ColliderConfig{Shape: ShapeBox, Rotation: rotB, Offset: offset, Width: 1, Height: 1.2, Depth: 1})
+
+		shapeA := mustShape(t, a)
+		shapeB := mustShape(t, b)
+		simplex, overlap := gjkOverlap(shapeA, shapeB)
+		if !overlap {
+			continue
+		}
+		result, ok := epaPenetration(shapeA, shapeB, simplex)
+		if !ok {
+			t.Fatalf("trial %d: epaPenetration failed on an overlapping pair", trial)
+		}
+		if result.Depth <= 1e-4 {
+			continue
+		}
+		cases++
+
+		// Pushing B along the normal by the full depth separates the pair.
+		pushed := NewCollider(ColliderConfig{
+			Shape: ShapeBox, Rotation: rotB,
+			Offset: offset.Add(result.Normal.Mul(result.Depth + 1e-6)),
+			Width:  1, Height: 1.2, Depth: 1,
+		})
+		if _, still := gjkOverlap(shapeA, mustShape(t, pushed)); still {
+			t.Fatalf("trial %d: pair still overlaps after moving B by normal*depth (depth=%v normal=%+v)",
+				trial, result.Depth, result.Normal)
+		}
+
+		// Pushing by 80% of the depth must leave them overlapping, which proves
+		// the depth is not an overestimate.
+		short := NewCollider(ColliderConfig{
+			Shape: ShapeBox, Rotation: rotB,
+			Offset: offset.Add(result.Normal.Mul(result.Depth * 0.8)),
+			Width:  1, Height: 1.2, Depth: 1,
+		})
+		if _, still := gjkOverlap(shapeA, mustShape(t, short)); !still {
+			t.Fatalf("trial %d: pair separated after moving B by only 80%% of depth %v",
+				trial, result.Depth)
+		}
+	}
+	if cases < 100 {
+		t.Fatalf("only %d overlapping trials produced a usable depth; the test is not exercising EPA", cases)
+	}
+}
+
+// TestGJKEPAAgreesWithReferenceSAT compares GJK and EPA against an independent
+// brute-force separating-axis test over all 15 box axes. The reference makes no
+// use of the shipped SAT code, so the two paths cannot share a mistake.
+func TestGJKEPAAgreesWithReferenceSAT(t *testing.T) {
+	rng := rand.New(rand.NewSource(7))
+	compared := 0
+	for trial := 0; trial < 500; trial++ {
+		rotA := randomUnitQuat(rng)
+		rotB := randomUnitQuat(rng)
+		offset := Vec3{
+			X: (rng.Float64() - 0.5) * 2.2,
+			Y: (rng.Float64() - 0.5) * 2.2,
+			Z: (rng.Float64() - 0.5) * 2.2,
+		}
+		a := NewCollider(ColliderConfig{Shape: ShapeBox, Rotation: rotA, Width: 1, Height: 1, Depth: 1})
+		b := NewCollider(ColliderConfig{Shape: ShapeBox, Rotation: rotB, Offset: offset, Width: 1, Height: 1, Depth: 1})
+
+		wantNormal, wantDepth, wantOverlap := referenceBoxSAT(a, b)
+		gjk, gjkOK := collideConvexGJK(a, b)
+		if !wantOverlap {
+			if gjkOK && gjk.Points[0].Penetration > 1e-6 {
+				t.Fatalf("trial %d: GJK reported depth %v but the reference found separation",
+					trial, gjk.Points[0].Penetration)
+			}
+			continue
+		}
+		if wantDepth <= 1e-4 {
+			continue
+		}
+		if !gjkOK {
+			t.Fatalf("trial %d: reference found depth %v but GJK found no overlap", trial, wantDepth)
+		}
+		compared++
+		if math.Abs(gjk.Points[0].Penetration-wantDepth) > 1e-6 {
+			t.Fatalf("trial %d: GJK depth %v, reference depth %v", trial, gjk.Points[0].Penetration, wantDepth)
+		}
+		if gjk.Normal.Dot(wantNormal) < 0.999 {
+			t.Fatalf("trial %d: GJK normal %+v, reference normal %+v (depth %v)",
+				trial, gjk.Normal, wantNormal, wantDepth)
+		}
+	}
+	if compared < 100 {
+		t.Fatalf("only %d comparable trials; the test is not exercising EPA", compared)
+	}
+}
+
+// referenceBoxSAT is a deliberately simple separating-axis test. It projects
+// every box vertex onto each of the 15 candidate axes, which are the face
+// normals of the Minkowski difference of two boxes, and keeps the axis that
+// needs the shortest translation. The returned normal points from A toward B,
+// and translating B along it by the returned depth separates the pair.
+//
+// Note that the translation along one axis is min(maxA-minB, maxB-minA), not
+// the length of the interval overlap. The two agree only when neither
+// projection contains the other.
+func referenceBoxSAT(a, b *Collider) (Vec3, float64, bool) {
+	vertsA := worldBoxVertices(a)
+	vertsB := worldBoxVertices(b)
+	rotA := a.WorldRotation()
+	rotB := b.WorldRotation()
+	axesA := [3]Vec3{rotA.Rotate(Vec3{X: 1}), rotA.Rotate(Vec3{Y: 1}), rotA.Rotate(Vec3{Z: 1})}
+	axesB := [3]Vec3{rotB.Rotate(Vec3{X: 1}), rotB.Rotate(Vec3{Y: 1}), rotB.Rotate(Vec3{Z: 1})}
+
+	axes := make([]Vec3, 0, 15)
+	axes = append(axes, axesA[0], axesA[1], axesA[2], axesB[0], axesB[1], axesB[2])
+	for i := 0; i < 3; i++ {
+		for j := 0; j < 3; j++ {
+			cross := axesA[i].Cross(axesB[j])
+			if cross.Len2() > 1e-10 {
+				axes = append(axes, cross.Normalize())
+			}
+		}
+	}
+
+	bestDepth := math.Inf(1)
+	bestAxis := Vec3{}
+	for _, axis := range axes {
+		minA, maxA := projectPoints(vertsA, axis)
+		minB, maxB := projectPoints(vertsB, axis)
+		pushForward := maxA - minB
+		pushBackward := maxB - minA
+		if pushForward <= 0 || pushBackward <= 0 {
+			return Vec3{}, 0, false
+		}
+		if pushForward <= pushBackward {
+			if pushForward < bestDepth {
+				bestDepth = pushForward
+				bestAxis = axis
+			}
+			continue
+		}
+		if pushBackward < bestDepth {
+			bestDepth = pushBackward
+			bestAxis = axis.Neg()
+		}
+	}
+	return bestAxis, bestDepth, true
+}
+
+func worldBoxVertices(c *Collider) []Vec3 {
+	center := c.WorldCenter()
+	rotation := c.WorldRotation()
+	out := make([]Vec3, 0, 8)
+	for _, local := range boxVertices(c.halfExtents()) {
+		out = append(out, center.Add(rotation.Rotate(local)))
+	}
+	return out
+}
+
+func projectPoints(points []Vec3, axis Vec3) (float64, float64) {
+	low := math.Inf(1)
+	high := math.Inf(-1)
+	for _, p := range points {
+		d := axis.Dot(p)
+		low = math.Min(low, d)
+		high = math.Max(high, d)
+	}
+	return low, high
+}
+
+func deepestPenetration(m ContactManifold) float64 {
+	deepest := 0.0
+	for i := 0; i < m.PointCount; i++ {
+		deepest = maxFloat(deepest, m.Points[i].Penetration)
+	}
+	return deepest
+}
+
+// TestConvexHullMatchesEquivalentBox uses an eight-vertex hull that describes
+// the same volume as a box collider and checks the two agree.
+func TestConvexHullMatchesEquivalentBox(t *testing.T) {
+	half := Vec3{X: 0.5, Y: 0.6, Z: 0.7}
+	hullVerts := boxVertices(half)
+	rng := rand.New(rand.NewSource(99))
+	compared := 0
+	for trial := 0; trial < 200; trial++ {
+		rotation := randomUnitQuat(rng)
+		offset := Vec3{
+			X: (rng.Float64() - 0.5) * 2,
+			Y: (rng.Float64() - 0.5) * 2,
+			Z: (rng.Float64() - 0.5) * 2,
+		}
+		sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.4})
+		box := NewCollider(ColliderConfig{
+			Shape: ShapeBox, Rotation: rotation, Offset: offset,
+			Width: 1, Height: 1.2, Depth: 1.4,
+		})
+		hull := NewCollider(ColliderConfig{
+			Shape: ShapeConvexHull, Rotation: rotation, Offset: offset,
+			Vertices: hullVerts,
+		})
+
+		boxManifold, boxOK := Collide(sphere, box)
+		hullManifold, hullOK := Collide(sphere, hull)
+		if boxOK != hullOK {
+			if boxOK && deepestPenetration(boxManifold) > 1e-3 {
+				t.Fatalf("trial %d: box collided (depth %v) but the equivalent hull did not",
+					trial, deepestPenetration(boxManifold))
+			}
+			continue
+		}
+		if !boxOK {
+			continue
+		}
+		boxDepth := deepestPenetration(boxManifold)
+		if boxDepth <= 1e-3 {
+			continue
+		}
+		compared++
+		if math.Abs(deepestPenetration(hullManifold)-boxDepth) > 3e-3 {
+			t.Fatalf("trial %d: hull depth %v disagrees with box depth %v",
+				trial, deepestPenetration(hullManifold), boxDepth)
+		}
+		// EPA's depth converges much faster than its normal: the depth error is
+		// quadratic in the facet angle, the normal error only linear. Compare
+		// normals up to half the sphere radius of penetration, which is far
+		// beyond anything the solver leaves standing. Deeper than that, require
+		// only that the reported vector really separates the pair.
+		if boxDepth <= 0.2 {
+			if hullManifold.Normal.Dot(boxManifold.Normal) < 0.98 {
+				t.Fatalf("trial %d: hull normal %+v disagrees with box normal %+v at depth %v",
+					trial, hullManifold.Normal, boxManifold.Normal, boxDepth)
+			}
+			continue
+		}
+		hullDepth := deepestPenetration(hullManifold)
+		pushed := NewCollider(ColliderConfig{
+			Shape: ShapeSphere, Radius: 0.4,
+			Offset: hullManifold.Normal.Neg().Mul(hullDepth + 1e-3),
+		})
+		if _, still := Collide(pushed, hull); still {
+			t.Fatalf("trial %d: pair still in contact after moving the sphere by the reported depth %v along %+v",
+				trial, hullDepth, hullManifold.Normal)
+		}
+	}
+	if compared < 40 {
+		t.Fatalf("only %d comparable trials; the hull path is not being exercised", compared)
+	}
+}
+
+func boxVertices(half Vec3) []Vec3 {
+	return []Vec3{
+		{X: -half.X, Y: -half.Y, Z: -half.Z},
+		{X: half.X, Y: -half.Y, Z: -half.Z},
+		{X: -half.X, Y: half.Y, Z: -half.Z},
+		{X: half.X, Y: half.Y, Z: -half.Z},
+		{X: -half.X, Y: -half.Y, Z: half.Z},
+		{X: half.X, Y: -half.Y, Z: half.Z},
+		{X: -half.X, Y: half.Y, Z: half.Z},
+		{X: half.X, Y: half.Y, Z: half.Z},
+	}
+}
+
+func TestSupportFunctionsReturnExtremePoints(t *testing.T) {
+	cylinder := mustShape(t, NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 2, Height: 4}))
+	if got := cylinder.support(Vec3{Y: 1}); !got.Near(Vec3{Y: 2}, 1e-12) {
+		t.Fatalf("cylinder support +Y = %+v, want (0,2,0) on the rim plane", got)
+	}
+	if got := cylinder.support(Vec3{X: 1}); !got.Near(Vec3{X: 2}, 1e-12) {
+		t.Fatalf("cylinder support +X = %+v, want (2,0,0)", got)
+	}
+	if got := cylinder.support(Vec3{X: 1, Y: 1}); !got.Near(Vec3{X: 2, Y: 2}, 1e-12) {
+		t.Fatalf("cylinder support +X+Y = %+v, want the top rim corner (2,2,0)", got)
+	}
+
+	cone := mustShape(t, NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 2, Height: 4}))
+	if got := cone.support(Vec3{Y: 1}); !got.Near(Vec3{Y: 2}, 1e-12) {
+		t.Fatalf("cone support +Y = %+v, want the apex (0,2,0)", got)
+	}
+	if got := cone.support(Vec3{Y: -1}); !got.Near(Vec3{Y: -2}, 1e-12) {
+		t.Fatalf("cone support -Y = %+v, want a base point at y=-2", got)
+	}
+	if got := cone.support(Vec3{X: 1}); !got.Near(Vec3{X: 2, Y: -2}, 1e-12) {
+		t.Fatalf("cone support +X = %+v, want the base rim (2,-2,0)", got)
+	}
+
+	capsule := mustShape(t, NewCollider(ColliderConfig{Shape: ShapeCapsule, Radius: 0.5, Height: 2}))
+	if got := capsule.support(Vec3{Y: 1}); !got.Near(Vec3{Y: 1.5}, 1e-12) {
+		t.Fatalf("capsule support +Y = %+v, want (0,1.5,0)", got)
+	}
+	// Along +X the whole lateral surface is extreme, so any y is a valid
+	// support point. The segment support picks y = 0.
+	if got := capsule.support(Vec3{X: 1}); !got.Near(Vec3{X: 0.5}, 1e-12) {
+		t.Fatalf("capsule support +X = %+v, want (0.5,0,0)", got)
+	}
+}
+
+// TestNarrowphaseSurvivesRandomShapePairs hammers every shape combination with
+// random poses. It checks that no pair panics and that every reported contact
+// carries finite, usable numbers.
+func TestNarrowphaseSurvivesRandomShapePairs(t *testing.T) {
+	rng := rand.New(rand.NewSource(4242))
+	meshVertices, meshIndices := gridMesh(3, 6)
+
+	build := func(kind int, rotation Quat, offset Vec3) *Collider {
+		switch kind {
+		case 0:
+			return NewCollider(ColliderConfig{Shape: ShapeSphere, Rotation: rotation, Offset: offset, Radius: 0.6})
+		case 1:
+			return NewCollider(ColliderConfig{Shape: ShapeBox, Rotation: rotation, Offset: offset, Width: 1, Height: 1.2, Depth: 0.8})
+		case 2:
+			return NewCollider(ColliderConfig{Shape: ShapeCapsule, Rotation: rotation, Offset: offset, Radius: 0.4, Height: 1})
+		case 3:
+			return NewCollider(ColliderConfig{Shape: ShapeCylinder, Rotation: rotation, Offset: offset, Radius: 0.5, Height: 1.4})
+		case 4:
+			return NewCollider(ColliderConfig{Shape: ShapeCone, Rotation: rotation, Offset: offset, Radius: 0.6, Height: 1.6})
+		case 5:
+			return NewCollider(ColliderConfig{Shape: ShapeConvexHull, Rotation: rotation, Offset: offset,
+				Vertices: boxVertices(Vec3{X: 0.5, Y: 0.7, Z: 0.4})})
+		case 6:
+			return NewCollider(ColliderConfig{Shape: ShapePlane, Rotation: rotation, Offset: offset, Normal: Vec3{Y: 1}})
+		default:
+			return NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Rotation: rotation, Offset: offset,
+				Vertices: meshVertices, Indices: meshIndices})
+		}
+	}
+
+	const kinds = 8
+	contacts := 0
+	for trial := 0; trial < 4000; trial++ {
+		kindA := trial % kinds
+		kindB := (trial / kinds) % kinds
+		offset := Vec3{
+			X: (rng.Float64() - 0.5) * 4,
+			Y: (rng.Float64() - 0.5) * 4,
+			Z: (rng.Float64() - 0.5) * 4,
+		}
+		a := build(kindA, randomUnitQuat(rng), Vec3{})
+		b := build(kindB, randomUnitQuat(rng), offset)
+
+		for _, manifold := range CollideAll(a, b, nil) {
+			contacts++
+			if manifold.PointCount <= 0 || manifold.PointCount > len(manifold.Points) {
+				t.Fatalf("trial %d (%v vs %v): PointCount = %d", trial, a.Shape, b.Shape, manifold.PointCount)
+			}
+			if !isFiniteVec(manifold.Normal) {
+				t.Fatalf("trial %d (%v vs %v): normal = %+v", trial, a.Shape, b.Shape, manifold.Normal)
+			}
+			if length := manifold.Normal.Len(); math.Abs(length-1) > 1e-9 {
+				t.Fatalf("trial %d (%v vs %v): normal length = %v", trial, a.Shape, b.Shape, length)
+			}
+			for i := 0; i < manifold.PointCount; i++ {
+				point := manifold.Points[i]
+				if !isFiniteVec(point.Point) {
+					t.Fatalf("trial %d (%v vs %v): contact point = %+v", trial, a.Shape, b.Shape, point.Point)
+				}
+				if point.Penetration < 0 || math.IsNaN(point.Penetration) || math.IsInf(point.Penetration, 0) {
+					t.Fatalf("trial %d (%v vs %v): penetration = %v", trial, a.Shape, b.Shape, point.Penetration)
+				}
+			}
+		}
+	}
+	if contacts < 500 {
+		t.Fatalf("only %d contacts across 4000 random pairs; the sweep is not exercising the narrowphase", contacts)
+	}
+}
+
+func isFiniteVec(v Vec3) bool {
+	for _, component := range [3]float64{v.X, v.Y, v.Z} {
+		if math.IsNaN(component) || math.IsInf(component, 0) {
+			return false
+		}
+	}
+	return true
+}

--- a/physics/inertia.go
+++ b/physics/inertia.go
@@ -1,0 +1,173 @@
+package physics
+
+import "math"
+
+// Inertia tensors derived from collider geometry.
+//
+// Every body carries one body-local inverse inertia tensor. The world inverse
+// tensor is rebuilt each step from the body rotation, and the contact solver
+// uses it to turn an impulse at a contact point into an angular velocity change.
+//
+// A body with several colliders splits its mass between them in proportion to
+// volume, then sums the shifted tensors with the parallel axis theorem. Convex
+// hulls and triangle meshes use the inertia of their local bounding box, which
+// overstates the true tensor but never reports a body that cannot rotate.
+
+// defaultInertiaRadius sizes the fallback tensor of a body that carries no
+// collider. Such a body still answers ApplyTorque, which several callers rely
+// on for simple spin control.
+const defaultInertiaRadius = 0.5
+
+// inertiaTensorFromColliders returns the body-local inertia tensor for the
+// given mass. It returns a zero matrix when no collider encloses a volume.
+func inertiaTensorFromColliders(mass float64, colliders []*Collider) mat3 {
+	if mass <= 0 {
+		return mat3{}
+	}
+
+	total := 0.0
+	for _, c := range colliders {
+		total += colliderVolume(c)
+	}
+	if total <= 0 {
+		// No collider with volume. Use a solid sphere so torque still works.
+		i := 0.4 * mass * defaultInertiaRadius * defaultInertiaRadius
+		return mat3Diagonal(Vec3{X: i, Y: i, Z: i})
+	}
+
+	tensor := mat3{}
+	for _, c := range colliders {
+		volume := colliderVolume(c)
+		if volume <= 0 {
+			continue
+		}
+		share := mass * volume / total
+		local := mat3Diagonal(colliderPrincipalInertia(c, share))
+		// Turn the collider frame into the body frame, then shift the tensor
+		// from the collider centre to the body origin.
+		basis := mat3FromQuat(c.Rotation)
+		tensor = tensor.add(rotateTensor(basis, local))
+		tensor = tensor.add(parallelAxisTerm(share, c.Offset))
+	}
+	return tensor
+}
+
+// parallelAxisTerm returns m * (|d|^2 * E - d dᵀ), the tensor a point mass adds
+// when it sits at offset d from the origin.
+func parallelAxisTerm(mass float64, d Vec3) mat3 {
+	d2 := d.Len2()
+	if mass <= 0 || d2 <= 0 {
+		return mat3{}
+	}
+	return mat3Identity().scale(mass * d2).add(outerProduct(d).scale(-mass))
+}
+
+// colliderVolume returns the enclosed volume of one collider. A plane, a
+// trigger and an unusable collider all report zero, so none of them can move
+// the mass distribution.
+func colliderVolume(c *Collider) float64 {
+	if c == nil || c.invalid != nil || c.IsTrigger {
+		return 0
+	}
+	switch c.Shape {
+	case ShapeBox:
+		half := c.halfExtents()
+		return 8 * half.X * half.Y * half.Z
+	case ShapeSphere:
+		r := math.Abs(c.Radius)
+		return 4.0 / 3.0 * math.Pi * r * r * r
+	case ShapeCapsule:
+		r := math.Abs(c.Radius)
+		h := math.Abs(c.Height)
+		return math.Pi*r*r*h + 4.0/3.0*math.Pi*r*r*r
+	case ShapeCylinder:
+		r := math.Abs(c.Radius)
+		return math.Pi * r * r * math.Abs(c.Height)
+	case ShapeCone:
+		r := math.Abs(c.Radius)
+		return math.Pi * r * r * math.Abs(c.Height) / 3
+	case ShapeConvexHull, ShapeTriangleMesh:
+		size := c.localBounds.Size()
+		return math.Abs(size.X * size.Y * size.Z)
+	default:
+		return 0
+	}
+}
+
+// colliderPrincipalInertia returns the diagonal inertia of one collider about
+// its own centre, in its own frame, for the given mass. Capsule, cylinder and
+// cone run along local Y, which matches the support functions.
+func colliderPrincipalInertia(c *Collider, mass float64) Vec3 {
+	if c == nil || mass <= 0 {
+		return Vec3{}
+	}
+	switch c.Shape {
+	case ShapeBox:
+		half := c.halfExtents()
+		x2 := 4 * half.X * half.X
+		y2 := 4 * half.Y * half.Y
+		z2 := 4 * half.Z * half.Z
+		return Vec3{
+			X: mass * (y2 + z2) / 12,
+			Y: mass * (x2 + z2) / 12,
+			Z: mass * (x2 + y2) / 12,
+		}
+	case ShapeSphere:
+		r := math.Abs(c.Radius)
+		i := 0.4 * mass * r * r
+		return Vec3{X: i, Y: i, Z: i}
+	case ShapeCylinder:
+		r := math.Abs(c.Radius)
+		h := math.Abs(c.Height)
+		axial := 0.5 * mass * r * r
+		radial := mass * (3*r*r + h*h) / 12
+		return Vec3{X: radial, Y: axial, Z: radial}
+	case ShapeCone:
+		// A solid cone with the body origin at mid height. The centroid sits a
+		// quarter height above the base, so the transverse term carries a
+		// parallel axis shift of h/4.
+		r := math.Abs(c.Radius)
+		h := math.Abs(c.Height)
+		axial := 0.3 * mass * r * r
+		radial := 0.15*mass*r*r + mass*h*h/10
+		return Vec3{X: radial, Y: axial, Z: radial}
+	case ShapeCapsule:
+		return capsuleInertia(mass, math.Abs(c.Radius), math.Abs(c.Height))
+	case ShapeConvexHull, ShapeTriangleMesh:
+		// Use the local bounding box. The result overstates a thin hull but it
+		// is never zero and never negative, so the solver stays stable.
+		size := c.localBounds.Size()
+		box := Vec3{
+			X: mass * (size.Y*size.Y + size.Z*size.Z) / 12,
+			Y: mass * (size.X*size.X + size.Z*size.Z) / 12,
+			Z: mass * (size.X*size.X + size.Y*size.Y) / 12,
+		}
+		return box
+	default:
+		return Vec3{}
+	}
+}
+
+// capsuleInertia returns the diagonal inertia of a capsule along local Y. The
+// capsule is one cylinder of height h plus two hemisphere caps of radius r.
+func capsuleInertia(mass, r, h float64) Vec3 {
+	cylinderVolume := math.Pi * r * r * h
+	capVolume := 2.0 / 3.0 * math.Pi * r * r * r // one hemisphere
+	total := cylinderVolume + 2*capVolume
+	if total <= 0 {
+		i := 0.4 * mass * r * r
+		return Vec3{X: i, Y: i, Z: i}
+	}
+	cylinderMass := mass * cylinderVolume / total
+	capMass := mass * capVolume / total
+
+	axial := 0.5*cylinderMass*r*r + 2*(0.4*capMass*r*r)
+
+	// A hemisphere has 2/5 m r^2 about a transverse axis through the centre of
+	// its flat face, and its centroid sits 3r/8 from that face.
+	capAboutOwnCentre := capMass*r*r*0.4 - capMass*(3*r/8)*(3*r/8)
+	capOffset := h/2 + 3*r/8
+	radial := cylinderMass*(h*h/12+r*r/4) +
+		2*(capAboutOwnCentre+capMass*capOffset*capOffset)
+	return Vec3{X: radial, Y: axial, Z: radial}
+}

--- a/physics/lifecycle.go
+++ b/physics/lifecycle.go
@@ -112,6 +112,12 @@ func constraintTouchesBody(constraint Constraint, body *RigidBody) bool {
 	switch c := constraint.(type) {
 	case *DistanceConstraint:
 		return c.BodyA == body || c.BodyB == body
+	case *PointConstraint:
+		return c.BodyA == body || c.BodyB == body
+	case *HingeConstraint:
+		return c.BodyA == body || c.BodyB == body
+	case *FixedConstraint:
+		return c.BodyA == body || c.BodyB == body
 	}
 	return false
 }
@@ -122,10 +128,13 @@ func (w *World) pruneContactState(removed map[*Collider]struct{}) {
 	}
 	contacts := w.contacts[:0]
 	for _, contact := range w.contacts {
-		if _, drop := removed[contact.ColliderA]; drop {
-			continue
-		}
-		if _, drop := removed[contact.ColliderB]; drop {
+		_, dropA := removed[contact.ColliderA]
+		_, dropB := removed[contact.ColliderB]
+		if dropA || dropB {
+			// The support under a sleeping body may have just gone. Wake both
+			// sides so the next step decides again.
+			contact.BodyA.Wake()
+			contact.BodyB.Wake()
 			continue
 		}
 		contacts = append(contacts, contact)

--- a/physics/mat3.go
+++ b/physics/mat3.go
@@ -1,0 +1,87 @@
+package physics
+
+import "math"
+
+// General 3x3 matrix helpers. mat3 stores three world-space column vectors, so
+// mat3{x, y, z} is the matrix whose first column is x. support.go builds a mat3
+// from a quaternion; the operations here let the solver treat the same type as
+// an inertia tensor.
+
+func mat3Identity() mat3 {
+	return mat3{x: Vec3{X: 1}, y: Vec3{Y: 1}, z: Vec3{Z: 1}}
+}
+
+// mat3Diagonal returns the diagonal matrix with the given entries.
+func mat3Diagonal(d Vec3) mat3 {
+	return mat3{x: Vec3{X: d.X}, y: Vec3{Y: d.Y}, z: Vec3{Z: d.Z}}
+}
+
+func (m mat3) add(o mat3) mat3 {
+	return mat3{x: m.x.Add(o.x), y: m.y.Add(o.y), z: m.z.Add(o.z)}
+}
+
+func (m mat3) scale(s float64) mat3 {
+	return mat3{x: m.x.Mul(s), y: m.y.Mul(s), z: m.z.Mul(s)}
+}
+
+func (m mat3) transpose() mat3 {
+	return mat3{
+		x: Vec3{X: m.x.X, Y: m.y.X, Z: m.z.X},
+		y: Vec3{X: m.x.Y, Y: m.y.Y, Z: m.z.Y},
+		z: Vec3{X: m.x.Z, Y: m.y.Z, Z: m.z.Z},
+	}
+}
+
+// mulMat returns m * o.
+func (m mat3) mulMat(o mat3) mat3 {
+	return mat3{x: m.mul(o.x), y: m.mul(o.y), z: m.mul(o.z)}
+}
+
+func (m mat3) isZero() bool {
+	return m.x.Len2() == 0 && m.y.Len2() == 0 && m.z.Len2() == 0
+}
+
+// determinant returns the scalar determinant of the matrix.
+func (m mat3) determinant() float64 {
+	return m.x.Dot(m.y.Cross(m.z))
+}
+
+// inverse returns the matrix inverse. It reports false when the matrix is
+// singular, which tells the caller to treat the body as unable to rotate.
+func (m mat3) inverse() (mat3, bool) {
+	c0 := m.y.Cross(m.z)
+	c1 := m.z.Cross(m.x)
+	c2 := m.x.Cross(m.y)
+	det := m.x.Dot(c0)
+	if math.Abs(det) <= 1e-18 {
+		return mat3{}, false
+	}
+	inv := 1 / det
+	// The inverse is the transposed cofactor matrix divided by the determinant.
+	return mat3{
+		x: Vec3{X: c0.X * inv, Y: c1.X * inv, Z: c2.X * inv},
+		y: Vec3{X: c0.Y * inv, Y: c1.Y * inv, Z: c2.Y * inv},
+		z: Vec3{X: c0.Z * inv, Y: c1.Z * inv, Z: c2.Z * inv},
+	}, true
+}
+
+// outerProduct returns v * vᵀ, the matrix whose entry (i,j) is v_i * v_j.
+func outerProduct(v Vec3) mat3 {
+	return mat3{x: v.Mul(v.X), y: v.Mul(v.Y), z: v.Mul(v.Z)}
+}
+
+// rotateTensor returns R * t * Rᵀ, which moves a body-local tensor into world
+// space. The solver calls this once per dynamic body per step.
+func rotateTensor(r mat3, t mat3) mat3 {
+	return r.mulMat(t).mulMat(r.transpose())
+}
+
+// solveSymmetric3 solves m * x = b for a symmetric positive definite m. It
+// reports false when m is singular.
+func solveSymmetric3(m mat3, b Vec3) (Vec3, bool) {
+	inv, ok := m.inverse()
+	if !ok {
+		return Vec3{}, false
+	}
+	return inv.mul(b), true
+}

--- a/physics/mesh.go
+++ b/physics/mesh.go
@@ -1,0 +1,400 @@
+package physics
+
+import "math"
+
+// Triangle mesh collider storage plus a median-split bounding volume hierarchy
+// over the triangles. The mesh is stored in collider-local space and built
+// once at construction, so a step only transforms the candidate triangles that
+// a query actually reaches.
+
+const (
+	// meshLeafSize is the largest triangle count kept in one leaf. Small
+	// leaves deepen the tree; large leaves widen the per-leaf scan.
+	meshLeafSize = 4
+	// meshMaxDepth bounds the recursion so degenerate meshes cannot blow the
+	// stack.
+	meshMaxDepth = 32
+)
+
+type meshTriangle struct {
+	a Vec3
+	b Vec3
+	c Vec3
+	// normal is the unit face normal, following the winding of a, b and c.
+	normal Vec3
+	// edgeFiltered marks the edges whose neighbour makes a flat or a concave
+	// join. Bit 0 is edge a-b, bit 1 is edge b-c and bit 2 is edge c-a. A
+	// contact on such an edge must use the face normal, never the edge normal.
+	edgeFiltered uint8
+}
+
+// filteredEdgeEndpoints returns the two corners of one edge and reports whether
+// the internal edge filter covers it.
+func (t meshTriangle) filteredEdgeEndpoints(edge int) (Vec3, Vec3, bool) {
+	if t.edgeFiltered&(1<<uint(edge)) == 0 {
+		return Vec3{}, Vec3{}, false
+	}
+	switch edge {
+	case 0:
+		return t.a, t.b, true
+	case 1:
+		return t.b, t.c, true
+	default:
+		return t.c, t.a, true
+	}
+}
+
+func (t meshTriangle) bounds() AABB {
+	return AABB{
+		Min: t.a.Min(t.b).Min(t.c),
+		Max: t.a.Max(t.b).Max(t.c),
+	}
+}
+
+func (t meshTriangle) center() Vec3 {
+	return t.a.Add(t.b).Add(t.c).Div(3)
+}
+
+// meshNode is one node of the flattened BVH. Leaves carry a triangle range;
+// interior nodes carry the index of their right child, with the left child
+// always sitting at the next slot.
+type meshNode struct {
+	bounds AABB
+	start  int
+	count  int
+	right  int
+}
+
+func (n meshNode) leaf() bool {
+	return n.count > 0
+}
+
+type triangleMesh struct {
+	tris   []meshTriangle
+	nodes  []meshNode
+	bounds AABB
+}
+
+// newTriangleMesh copies the vertex and index buffers and builds the BVH. It
+// returns nil when the buffers cannot describe at least one triangle, which the
+// collider turns into a validation error.
+func newTriangleMesh(vertices []Vec3, indices []int) *triangleMesh {
+	if len(vertices) < 3 {
+		return nil
+	}
+	if len(indices) == 0 {
+		// No index buffer means the vertices are already triangle corners.
+		indices = make([]int, len(vertices)-len(vertices)%3)
+		for i := range indices {
+			indices[i] = i
+		}
+	}
+	if len(indices) < 3 {
+		return nil
+	}
+
+	tris := make([]meshTriangle, 0, len(indices)/3)
+	corners := make([][3]int, 0, len(indices)/3)
+	for i := 0; i+2 < len(indices); i += 3 {
+		ia, ib, ic := indices[i], indices[i+1], indices[i+2]
+		if ia < 0 || ib < 0 || ic < 0 ||
+			ia >= len(vertices) || ib >= len(vertices) || ic >= len(vertices) {
+			continue
+		}
+		tri := meshTriangle{a: vertices[ia], b: vertices[ib], c: vertices[ic]}
+		// Drop zero-area triangles. They carry no surface and would produce
+		// degenerate support directions.
+		cross := tri.b.Sub(tri.a).Cross(tri.c.Sub(tri.a))
+		if cross.Len2() <= 1e-24 {
+			continue
+		}
+		tri.normal = cross.Normalize()
+		tris = append(tris, tri)
+		corners = append(corners, [3]int{ia, ib, ic})
+	}
+	if len(tris) == 0 {
+		return nil
+	}
+	markInternalEdges(tris, corners)
+
+	mesh := &triangleMesh{tris: tris}
+	mesh.nodes = make([]meshNode, 0, 2*len(tris)/meshLeafSize+2)
+	mesh.build(0, len(tris), 0)
+	mesh.bounds = mesh.nodes[0].bounds
+	return mesh
+}
+
+// meshEdgeKey names one undirected edge by its two vertex indices, lower first.
+type meshEdgeKey struct {
+	lo int
+	hi int
+}
+
+// markInternalEdges records, for every triangle edge, whether the neighbour
+// across that edge makes a flat or a concave join.
+//
+// A body that slides across such an edge must keep pushing along the face
+// normal. Without the mark, the narrowphase can hand the solver the edge normal
+// instead, which points sideways and throws the body off the surface. That is
+// the hitch a player feels when crossing a triangle boundary on a mesh floor.
+//
+// A convex ridge keeps its edge contacts, because there the edge normal is the
+// real surface direction.
+func markInternalEdges(tris []meshTriangle, corners [][3]int) {
+	if len(tris) != len(corners) {
+		return
+	}
+	type edgeOwner struct {
+		tri  int
+		edge int
+	}
+	owners := make(map[meshEdgeKey]edgeOwner, len(tris)*3)
+	for t := range tris {
+		for e := 0; e < 3; e++ {
+			a := corners[t][e]
+			b := corners[t][(e+1)%3]
+			key := meshEdgeKey{lo: a, hi: b}
+			if key.lo > key.hi {
+				key.lo, key.hi = key.hi, key.lo
+			}
+			other, seen := owners[key]
+			if !seen {
+				owners[key] = edgeOwner{tri: t, edge: e}
+				continue
+			}
+			// The edge is shared. Decide convexity from the dihedral: the join
+			// is convex when the neighbour's third corner lies behind this
+			// triangle's face plane.
+			if !edgeIsConvex(tris[t], tris[other.tri]) {
+				tris[t].edgeFiltered |= 1 << uint(e)
+				tris[other.tri].edgeFiltered |= 1 << uint(other.edge)
+			}
+			delete(owners, key)
+		}
+	}
+}
+
+// edgeIsConvex reports whether two triangles that share an edge form a ridge
+// that bulges away from the surface.
+func edgeIsConvex(tri, neighbour meshTriangle) bool {
+	const flatTolerance = 1e-7
+	// The join bulges outward when the neighbour folds away from this face, so
+	// its centre lies behind this triangle's plane. A concave valley puts the
+	// neighbour in front of the plane, and a flat join puts it on the plane.
+	offset := tri.normal.Dot(neighbour.center().Sub(tri.a))
+	return offset < -flatTolerance
+}
+
+// build recursively splits the triangle range [start,end) at the median of the
+// widest axis and appends the node in depth-first order. It returns the index
+// of the node it created.
+func (m *triangleMesh) build(start, end, depth int) int {
+	bounds := m.rangeBounds(start, end)
+	index := len(m.nodes)
+	m.nodes = append(m.nodes, meshNode{bounds: bounds})
+
+	count := end - start
+	if count <= meshLeafSize || depth >= meshMaxDepth {
+		m.nodes[index].start = start
+		m.nodes[index].count = count
+		return index
+	}
+
+	axis := widestAxis(bounds.Size())
+	mid := start + count/2
+	nthElementByCenter(m.tris[start:end], mid-start, axis)
+
+	m.build(start, mid, depth+1)
+	right := m.build(mid, end, depth+1)
+	m.nodes[index].right = right
+	return index
+}
+
+func (m *triangleMesh) rangeBounds(start, end int) AABB {
+	bounds := m.tris[start].bounds()
+	for i := start + 1; i < end; i++ {
+		bounds = bounds.Union(m.tris[i].bounds())
+	}
+	return bounds
+}
+
+// queryAABB appends the indexes of every triangle whose bounds overlap box.
+// The builder emits the left subtree immediately after its parent, so the left
+// child of node i is always node i+1.
+func (m *triangleMesh) queryAABB(box AABB, out []int) []int {
+	if m == nil || len(m.nodes) == 0 {
+		return out
+	}
+	var stack [meshMaxDepth * 2]int
+	top := 0
+	stack[top] = 0
+	top++
+	for top > 0 {
+		top--
+		index := stack[top]
+		node := m.nodes[index]
+		if !node.bounds.Overlaps(box) {
+			continue
+		}
+		if node.leaf() {
+			for i := node.start; i < node.start+node.count; i++ {
+				if m.tris[i].bounds().Overlaps(box) {
+					out = append(out, i)
+				}
+			}
+			continue
+		}
+		if top+2 > len(stack) {
+			continue
+		}
+		stack[top] = node.right
+		top++
+		stack[top] = index + 1
+		top++
+	}
+	return out
+}
+
+// queryRay calls visit for every triangle index in a leaf whose bounds the ray
+// enters within maxDistance. visit may lower the search distance by returning a
+// smaller limit, which prunes the rest of the walk.
+func (m *triangleMesh) queryRay(origin, direction Vec3, maxDistance float64, visit func(index int, limit float64) float64) {
+	if m == nil || len(m.nodes) == 0 || visit == nil {
+		return
+	}
+	limit := maxDistance
+	var stack [meshMaxDepth * 2]int
+	top := 0
+	stack[top] = 0
+	top++
+	for top > 0 {
+		top--
+		index := stack[top]
+		node := m.nodes[index]
+		if !rayHitsAABB(node.bounds, origin, direction, limit) {
+			continue
+		}
+		if node.leaf() {
+			for i := node.start; i < node.start+node.count; i++ {
+				limit = visit(i, limit)
+			}
+			continue
+		}
+		if top+2 > len(stack) {
+			continue
+		}
+		stack[top] = node.right
+		top++
+		stack[top] = index + 1
+		top++
+	}
+}
+
+// rayHitsAABB runs the slab test for a ray against a box.
+func rayHitsAABB(box AABB, origin, direction Vec3, maxDistance float64) bool {
+	tMin := 0.0
+	tMax := maxDistance
+	mins := [3]float64{box.Min.X, box.Min.Y, box.Min.Z}
+	maxs := [3]float64{box.Max.X, box.Max.Y, box.Max.Z}
+	origins := [3]float64{origin.X, origin.Y, origin.Z}
+	dirs := [3]float64{direction.X, direction.Y, direction.Z}
+	for i := 0; i < 3; i++ {
+		if math.Abs(dirs[i]) <= epsilon {
+			if origins[i] < mins[i] || origins[i] > maxs[i] {
+				return false
+			}
+			continue
+		}
+		inv := 1 / dirs[i]
+		t1 := (mins[i] - origins[i]) * inv
+		t2 := (maxs[i] - origins[i]) * inv
+		if t1 > t2 {
+			t1, t2 = t2, t1
+		}
+		if t1 > tMin {
+			tMin = t1
+		}
+		if t2 < tMax {
+			tMax = t2
+		}
+		if tMin > tMax {
+			return false
+		}
+	}
+	return true
+}
+
+func widestAxis(size Vec3) int {
+	axis := 0
+	extent := size.X
+	if size.Y > extent {
+		axis = 1
+		extent = size.Y
+	}
+	if size.Z > extent {
+		axis = 2
+	}
+	return axis
+}
+
+func axisComponent(v Vec3, axis int) float64 {
+	switch axis {
+	case 0:
+		return v.X
+	case 1:
+		return v.Y
+	default:
+		return v.Z
+	}
+}
+
+// nthElementByCenter partially orders triangles so that the element at index n
+// is the one that a full sort would place there, comparing triangle centers on
+// the given axis. This is quickselect, so the split costs O(count) instead of
+// O(count log count).
+func nthElementByCenter(tris []meshTriangle, n, axis int) {
+	low := 0
+	high := len(tris) - 1
+	for low < high {
+		pivot := axisComponent(tris[(low+high)/2].center(), axis)
+		i := low
+		j := high
+		for i <= j {
+			for axisComponent(tris[i].center(), axis) < pivot {
+				i++
+			}
+			for axisComponent(tris[j].center(), axis) > pivot {
+				j--
+			}
+			if i <= j {
+				tris[i], tris[j] = tris[j], tris[i]
+				i++
+				j--
+			}
+		}
+		if n <= j {
+			high = j
+		} else if n >= i {
+			low = i
+		} else {
+			return
+		}
+	}
+}
+
+// localAABBFromWorld converts a world AABB into a conservative AABB in the
+// collider's local frame. Rotating a box never shrinks it, so the result may be
+// larger than needed but never misses a triangle.
+func (c *Collider) localAABBFromWorld(box AABB) AABB {
+	center := c.WorldCenter()
+	basis := mat3FromQuat(c.WorldRotation())
+	localCenter := basis.mulT(box.Center().Sub(center))
+	half := box.Size().Mul(0.5)
+	// Project the world half extents onto the local axes.
+	localHalf := Vec3{
+		X: math.Abs(basis.x.X)*half.X + math.Abs(basis.x.Y)*half.Y + math.Abs(basis.x.Z)*half.Z,
+		Y: math.Abs(basis.y.X)*half.X + math.Abs(basis.y.Y)*half.Y + math.Abs(basis.y.Z)*half.Z,
+		Z: math.Abs(basis.z.X)*half.X + math.Abs(basis.z.Y)*half.Y + math.Abs(basis.z.Z)*half.Z,
+	}
+	return AABBFromCenterHalfExtents(localCenter, localHalf)
+}

--- a/physics/mesh_edge_test.go
+++ b/physics/mesh_edge_test.go
@@ -1,0 +1,176 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// buildFlatMeshFloor returns a square grid mesh in the XZ plane at y = 0. Every
+// interior edge is shared by two coplanar triangles, which is exactly the case
+// the internal edge filter must cover.
+func buildFlatMeshFloor(cells int, size float64) ([]Vec3, []int) {
+	step := size / float64(cells)
+	start := -size / 2
+	vertices := make([]Vec3, 0, (cells+1)*(cells+1))
+	for iz := 0; iz <= cells; iz++ {
+		for ix := 0; ix <= cells; ix++ {
+			vertices = append(vertices, Vec3{X: start + float64(ix)*step, Z: start + float64(iz)*step})
+		}
+	}
+	indices := make([]int, 0, cells*cells*6)
+	stride := cells + 1
+	for iz := 0; iz < cells; iz++ {
+		for ix := 0; ix < cells; ix++ {
+			a := iz*stride + ix
+			b := a + 1
+			c := a + stride
+			d := c + 1
+			indices = append(indices, a, c, b, b, c, d)
+		}
+	}
+	return vertices, indices
+}
+
+// TestFlatMeshMarksEveryInteriorEdgeAsInternal checks the build-time pass. A
+// flat floor has no convex ridge anywhere, so every shared edge must carry the
+// filter mark and every boundary edge must not.
+func TestFlatMeshMarksEveryInteriorEdgeAsInternal(t *testing.T) {
+	vertices, indices := buildFlatMeshFloor(4, 8)
+	mesh := newTriangleMesh(vertices, indices)
+	if mesh == nil {
+		t.Fatal("mesh build failed")
+	}
+
+	shared := 0
+	boundary := 0
+	for _, tri := range mesh.tris {
+		for edge := 0; edge < 3; edge++ {
+			if tri.edgeFiltered&(1<<uint(edge)) != 0 {
+				shared++
+			} else {
+				boundary++
+			}
+		}
+	}
+	// A 4x4 grid has 32 triangles, 96 directed edges. 16 of them lie on the
+	// outer boundary, so 80 belong to a shared, coplanar join.
+	if shared != 80 {
+		t.Fatalf("filtered edge count = %d, want 80", shared)
+	}
+	if boundary != 16 {
+		t.Fatalf("unfiltered edge count = %d, want 16", boundary)
+	}
+}
+
+// TestConvexRidgeKeepsItsEdgeContacts checks the negative case. A tent roof
+// bulges outward at its ridge, so that edge is a real surface feature and the
+// filter must leave it alone.
+func TestConvexRidgeKeepsItsEdgeContacts(t *testing.T) {
+	// Two slopes meeting at a ridge along Z at y = 1, both facing upward.
+	vertices := []Vec3{
+		{X: -1, Y: 0, Z: -1}, {X: -1, Y: 0, Z: 1},
+		{X: 0, Y: 1, Z: -1}, {X: 0, Y: 1, Z: 1},
+		{X: 1, Y: 0, Z: -1}, {X: 1, Y: 0, Z: 1},
+	}
+	indices := []int{
+		0, 1, 2, 2, 1, 3, // left slope
+		2, 3, 4, 4, 3, 5, // right slope
+	}
+	mesh := newTriangleMesh(vertices, indices)
+	if mesh == nil {
+		t.Fatal("mesh build failed")
+	}
+
+	filtered := 0
+	for _, tri := range mesh.tris {
+		for edge := 0; edge < 3; edge++ {
+			if tri.edgeFiltered&(1<<uint(edge)) != 0 {
+				filtered++
+			}
+		}
+	}
+	// Each slope has one internal edge of its own two triangles, which is flat
+	// and therefore filtered. The ridge join is convex and must stay open, so
+	// exactly four directed edges carry the mark.
+	if filtered != 4 {
+		t.Fatalf("filtered edge count = %d, want 4; a convex ridge must keep its edge contacts", filtered)
+	}
+}
+
+// TestSphereSlidingAcrossMeshEdgesKeepsItsHeight is the behavioural test. A ball
+// sliding along a flat mesh floor must never receive a sideways normal when it
+// crosses a triangle boundary.
+//
+// Without the filter the ball is thrown upward and its forward speed drops each
+// time it crosses an edge. The test measures both.
+func TestSphereSlidingAcrossMeshEdgesKeepsItsHeight(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 12})
+	vertices, indices := buildFlatMeshFloor(16, 32)
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+
+	ball := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: -8, Y: 0.5, Z: 0.3}, Velocity: Vec3{X: 6}})
+	ball.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	// Let the ball settle onto the floor before measuring.
+	for i := 0; i < 60; i++ {
+		world.StepFixed()
+	}
+
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	minSpeed := math.Inf(1)
+	for i := 0; i < 500; i++ {
+		world.StepFixed()
+		minY = math.Min(minY, ball.Position.Y)
+		maxY = math.Max(maxY, ball.Position.Y)
+		minSpeed = math.Min(minSpeed, ball.Velocity.X)
+	}
+
+	if ball.Position.X < 0 {
+		t.Fatalf("the ball did not cross the mesh, x = %v", ball.Position.X)
+	}
+	if maxY-minY > 0.01 {
+		t.Fatalf("the ball hopped %v while crossing triangle edges; the internal edge filter is not working",
+			maxY-minY)
+	}
+	if minSpeed < 5.9 {
+		t.Fatalf("edge contacts braked the ball to %v m/s, want no loss from a frictionless floor", minSpeed)
+	}
+	if math.Abs(ball.Velocity.Z) > 0.01 {
+		t.Fatalf("edge normals pushed the ball sideways at %v m/s", ball.Velocity.Z)
+	}
+}
+
+// TestBoxSlidingAcrossMeshEdgesStaysFlat covers the same case for a shape that
+// runs through GJK instead of the analytic sphere path.
+func TestBoxSlidingAcrossMeshEdgesStaysFlat(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 240.0, SolverIterations: 12})
+	vertices, indices := buildFlatMeshFloor(16, 32)
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{X: -8, Y: 0.5, Z: 0.3}, Velocity: Vec3{X: 5}})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 60; i++ {
+		world.StepFixed()
+	}
+
+	maxTilt := 0.0
+	minY, maxY := math.Inf(1), math.Inf(-1)
+	for i := 0; i < 500; i++ {
+		world.StepFixed()
+		minY = math.Min(minY, box.Position.Y)
+		maxY = math.Max(maxY, box.Position.Y)
+		tilt := math.Hypot(math.Hypot(box.Rotation.X, box.Rotation.Y), box.Rotation.Z)
+		maxTilt = math.Max(maxTilt, tilt)
+	}
+
+	if box.Position.X < 0 {
+		t.Fatalf("the box did not cross the mesh, x = %v", box.Position.X)
+	}
+	if maxY-minY > 0.05 {
+		t.Fatalf("the box hopped %v while crossing triangle edges", maxY-minY)
+	}
+	if maxTilt > 0.05 {
+		t.Fatalf("edge normals tipped the box, rotation vector part = %v", maxTilt)
+	}
+}

--- a/physics/mesh_test.go
+++ b/physics/mesh_test.go
@@ -1,0 +1,410 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// gridMesh returns a flat square mesh on the y=0 plane, made of cells*cells
+// quads split into two triangles each. The mesh spans [-size/2, size/2] on X
+// and Z.
+func gridMesh(cells int, size float64) ([]Vec3, []int) {
+	step := size / float64(cells)
+	start := -size / 2
+	vertices := make([]Vec3, 0, (cells+1)*(cells+1))
+	for iz := 0; iz <= cells; iz++ {
+		for ix := 0; ix <= cells; ix++ {
+			vertices = append(vertices, Vec3{
+				X: start + float64(ix)*step,
+				Z: start + float64(iz)*step,
+			})
+		}
+	}
+	indices := make([]int, 0, cells*cells*6)
+	stride := cells + 1
+	for iz := 0; iz < cells; iz++ {
+		for ix := 0; ix < cells; ix++ {
+			a := iz*stride + ix
+			b := a + 1
+			c := a + stride
+			d := c + 1
+			indices = append(indices, a, c, b, b, c, d)
+		}
+	}
+	return vertices, indices
+}
+
+func TestTriangleMeshBuildsBVHOverAllTriangles(t *testing.T) {
+	vertices, indices := gridMesh(8, 16)
+	mesh := newTriangleMesh(vertices, indices)
+	if mesh == nil {
+		t.Fatal("newTriangleMesh returned nil for a valid grid")
+	}
+	if want := len(indices) / 3; len(mesh.tris) != want {
+		t.Fatalf("triangle count = %d, want %d", len(mesh.tris), want)
+	}
+	if len(mesh.nodes) == 0 {
+		t.Fatal("BVH has no nodes")
+	}
+
+	// Every triangle must sit in exactly one leaf, and the leaf ranges must
+	// cover the whole triangle list without overlap.
+	covered := make([]int, len(mesh.tris))
+	for _, node := range mesh.nodes {
+		if !node.leaf() {
+			continue
+		}
+		for i := node.start; i < node.start+node.count; i++ {
+			covered[i]++
+		}
+	}
+	for i, count := range covered {
+		if count != 1 {
+			t.Fatalf("triangle %d appears in %d leaves, want 1", i, count)
+		}
+	}
+
+	// Every node's bounds must contain the bounds of its triangles.
+	for index, node := range mesh.nodes {
+		if !node.leaf() {
+			continue
+		}
+		for i := node.start; i < node.start+node.count; i++ {
+			bounds := mesh.tris[i].bounds()
+			if !node.bounds.Contains(bounds.Min) || !node.bounds.Contains(bounds.Max) {
+				t.Fatalf("node %d bounds %+v do not contain triangle %d bounds %+v",
+					index, node.bounds, i, bounds)
+			}
+		}
+	}
+}
+
+func TestTriangleMeshQueryAABBMatchesBruteForce(t *testing.T) {
+	vertices, indices := gridMesh(10, 20)
+	mesh := newTriangleMesh(vertices, indices)
+
+	boxes := []AABB{
+		NewAABB(Vec3{X: -1, Y: -1, Z: -1}, Vec3{X: 1, Y: 1, Z: 1}),
+		NewAABB(Vec3{X: 7, Y: -0.5, Z: 7}, Vec3{X: 12, Y: 0.5, Z: 12}),
+		NewAABB(Vec3{X: -30, Y: -30, Z: -30}, Vec3{X: 30, Y: 30, Z: 30}),
+		NewAABB(Vec3{X: 100, Y: 0, Z: 100}, Vec3{X: 101, Y: 1, Z: 101}),
+	}
+	for _, box := range boxes {
+		got := mesh.queryAABB(box, nil)
+		want := make([]int, 0, len(mesh.tris))
+		for i := range mesh.tris {
+			if mesh.tris[i].bounds().Overlaps(box) {
+				want = append(want, i)
+			}
+		}
+		if len(got) != len(want) {
+			t.Fatalf("box %+v: query returned %d triangles, brute force found %d", box, len(got), len(want))
+		}
+		found := make(map[int]bool, len(got))
+		for _, index := range got {
+			found[index] = true
+		}
+		for _, index := range want {
+			if !found[index] {
+				t.Fatalf("box %+v: query missed triangle %d", box, index)
+			}
+		}
+	}
+}
+
+func TestCollideMeshSphereOnFloor(t *testing.T) {
+	vertices, indices := gridMesh(4, 8)
+	mesh := NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	if err := mesh.Err(); err != nil {
+		t.Fatalf("mesh collider is invalid: %v", err)
+	}
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 0.4}, Radius: 0.5})
+
+	manifolds := CollideAll(mesh, sphere, nil)
+	if len(manifolds) == 0 {
+		t.Fatal("expected a mesh-sphere contact")
+	}
+	best := manifolds[0]
+	for _, m := range manifolds {
+		if m.Points[0].Penetration > best.Points[0].Penetration {
+			best = m
+		}
+	}
+	if best.Normal.Dot(Vec3{Y: 1}) < 0.999 {
+		t.Fatalf("normal = %+v, want +Y (mesh toward sphere)", best.Normal)
+	}
+	if got := best.Points[0].Penetration; math.Abs(got-0.1) > 1e-12 {
+		t.Fatalf("penetration = %v, want 0.1", got)
+	}
+	// The floor is at y=0 and the sphere surface reaches y=-0.1, so the contact
+	// midpoint is y=-0.05.
+	if got := best.Points[0].Point.Y; math.Abs(got+0.05) > 1e-12 {
+		t.Fatalf("contact Y = %v, want -0.05", got)
+	}
+}
+
+func TestCollideMeshFlipsManifoldWhenMeshIsSecond(t *testing.T) {
+	vertices, indices := gridMesh(2, 4)
+	mesh := NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 0.4}, Radius: 0.5})
+
+	forward := CollideAll(mesh, sphere, nil)
+	reverse := CollideAll(sphere, mesh, nil)
+	if len(forward) == 0 || len(reverse) == 0 {
+		t.Fatalf("expected contacts both ways, got %d and %d", len(forward), len(reverse))
+	}
+	if reverse[0].ColliderA != sphere || reverse[0].ColliderB != mesh {
+		t.Fatal("reversed call must report the sphere as A and the mesh as B")
+	}
+	if !reverse[0].Normal.Near(forward[0].Normal.Neg(), 1e-12) {
+		t.Fatalf("reversed normal = %+v, want %+v", reverse[0].Normal, forward[0].Normal.Neg())
+	}
+}
+
+func TestCollideMeshPlaneKeepsDeepestVertices(t *testing.T) {
+	// A mesh tilted so its corners sit at different depths below the plane.
+	vertices := []Vec3{
+		{X: -1, Y: -0.3, Z: -1},
+		{X: 1, Y: -0.2, Z: -1},
+		{X: -1, Y: 0.5, Z: 1},
+		{X: 1, Y: 0.6, Z: 1},
+	}
+	indices := []int{0, 2, 1, 1, 2, 3}
+	mesh := NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(mesh, plane)
+	if !ok {
+		t.Fatal("expected a mesh-plane contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: -1}, 1e-12) {
+		t.Fatalf("normal = %+v, want -Y", contact.Normal)
+	}
+	deepest := 0.0
+	for i := 0; i < contact.PointCount; i++ {
+		deepest = maxFloat(deepest, contact.Points[i].Penetration)
+	}
+	if math.Abs(deepest-0.3) > 1e-12 {
+		t.Fatalf("deepest penetration = %v, want 0.3", deepest)
+	}
+}
+
+func TestWorldSphereRestsOnMeshFloor(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	vertices, indices := gridMesh(4, 10)
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+	if err := world.Err(); err != nil {
+		t.Fatalf("world reports diagnostics: %v", err)
+	}
+
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.5})
+
+	for i := 0; i < 300; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if body.Position.Y < 0.45 || body.Position.Y > 0.56 {
+		t.Fatalf("sphere should rest near y=0.5 on the mesh floor, got y=%v", body.Position.Y)
+	}
+	if math.Abs(body.Velocity.Y) > 0.25 {
+		t.Fatalf("sphere should be near rest, velocity=%+v", body.Velocity)
+	}
+}
+
+func TestWorldBoxRestsOnMeshFloor(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 10})
+	vertices, indices := gridMesh(4, 10)
+	world.AddCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 400; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if body.Position.Y < 0.45 || body.Position.Y > 0.58 {
+		t.Fatalf("box should rest near y=0.5 on the mesh floor, got y=%v", body.Position.Y)
+	}
+}
+
+func TestRaycastMeshHitsClosestTriangle(t *testing.T) {
+	vertices, indices := gridMesh(8, 16)
+	mesh := NewCollider(ColliderConfig{Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices})
+
+	hit, ok := mesh.Raycast(Ray{Origin: Vec3{X: 1, Y: 5, Z: -2}, Direction: Vec3{Y: -1}}, 0)
+	if !ok {
+		t.Fatal("expected a mesh raycast hit")
+	}
+	if math.Abs(hit.Distance-5) > 1e-9 {
+		t.Fatalf("distance = %v, want 5", hit.Distance)
+	}
+	if !hit.Point.Near(Vec3{X: 1, Y: 0, Z: -2}, 1e-9) {
+		t.Fatalf("point = %+v, want (1,0,-2)", hit.Point)
+	}
+	if hit.Normal.Dot(Vec3{Y: 1}) < 0.999 {
+		t.Fatalf("normal = %+v, want +Y", hit.Normal)
+	}
+
+	if _, ok := mesh.Raycast(Ray{Origin: Vec3{X: 100, Y: 5}, Direction: Vec3{Y: -1}}, 0); ok {
+		t.Fatal("a ray outside the mesh footprint must miss")
+	}
+}
+
+func TestRaycastMeshHonoursRotationAndOffset(t *testing.T) {
+	vertices, indices := gridMesh(2, 4)
+	rotation := QuatFromAxisAngle(Vec3{X: 1}, math.Pi/2)
+	mesh := NewCollider(ColliderConfig{
+		Shape: ShapeTriangleMesh, Vertices: vertices, Indices: indices,
+		Offset: Vec3{X: 3}, Rotation: rotation,
+	})
+	// After rotating 90 degrees about X the floor becomes a wall at x=3 facing
+	// -Z, so a ray along +Z from the origin must hit it.
+	hit, ok := mesh.Raycast(Ray{Origin: Vec3{X: 3, Y: 0, Z: -4}, Direction: Vec3{Z: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the rotated mesh")
+	}
+	if math.Abs(hit.Distance-4) > 1e-9 {
+		t.Fatalf("distance = %v, want 4", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{Z: -1}) < 0.999 {
+		t.Fatalf("normal = %+v, want -Z", hit.Normal)
+	}
+}
+
+func TestConvexHullRaycastNeedsIndices(t *testing.T) {
+	withoutIndices := NewCollider(ColliderConfig{
+		Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 1, Y: 1, Z: 1}),
+	})
+	if withoutIndices.RaycastSupported() {
+		t.Fatal("a hull with no Indices must report that raycast cannot hit it")
+	}
+	if _, ok := withoutIndices.Raycast(Ray{Origin: Vec3{X: -5}, Direction: Vec3{X: 1}}, 0); ok {
+		t.Fatal("a hull with no triangulated surface must not report a hit")
+	}
+
+	withIndices := NewCollider(ColliderConfig{
+		Shape:    ShapeConvexHull,
+		Vertices: boxVertices(Vec3{X: 1, Y: 1, Z: 1}),
+		Indices:  boxTriangleIndices(),
+	})
+	if !withIndices.RaycastSupported() {
+		t.Fatal("a hull with Indices must support raycast")
+	}
+	hit, ok := withIndices.Raycast(Ray{Origin: Vec3{X: -5}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the triangulated hull")
+	}
+	if math.Abs(hit.Distance-4) > 1e-9 {
+		t.Fatalf("distance = %v, want 4", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{X: -1}) < 0.999 {
+		t.Fatalf("normal = %+v, want -X", hit.Normal)
+	}
+}
+
+// boxTriangleIndices triangulates the eight corners that boxVertices returns.
+// The corner order is (x, y, z) with x fastest.
+func boxTriangleIndices() []int {
+	const (
+		nnn = 0 // -x -y -z
+		pnn = 1 // +x -y -z
+		npn = 2 // -x +y -z
+		ppn = 3 // +x +y -z
+		nnp = 4 // -x -y +z
+		pnp = 5 // +x -y +z
+		npp = 6 // -x +y +z
+		ppp = 7 // +x +y +z
+	)
+	return []int{
+		nnn, npn, pnn, pnn, npn, ppn, // -Z face
+		nnp, pnp, npp, npp, pnp, ppp, // +Z face
+		nnn, nnp, npn, npn, nnp, npp, // -X face
+		pnn, ppn, pnp, pnp, ppn, ppp, // +X face
+		nnn, pnn, nnp, nnp, pnn, pnp, // -Y face
+		npn, npp, ppn, ppn, npp, ppp, // +Y face
+	}
+}
+
+func TestClosestPointOnTriangleCoversEveryVoronoiRegion(t *testing.T) {
+	a := Vec3{}
+	b := Vec3{X: 4}
+	c := Vec3{Z: 3}
+
+	cases := []struct {
+		name  string
+		point Vec3
+		want  Vec3
+	}{
+		{name: "vertex a", point: Vec3{X: -2, Z: -2}, want: a},
+		{name: "vertex b", point: Vec3{X: 7, Z: -2}, want: b},
+		{name: "vertex c", point: Vec3{X: -2, Z: 6}, want: c},
+		{name: "edge ab", point: Vec3{X: 2, Y: 5, Z: -3}, want: Vec3{X: 2}},
+		{name: "edge ac", point: Vec3{X: -3, Z: 1.5}, want: Vec3{Z: 1.5}},
+		{name: "face interior", point: Vec3{X: 1, Y: 9, Z: 0.5}, want: Vec3{X: 1, Z: 0.5}},
+		{name: "face interior below", point: Vec3{X: 1, Y: -9, Z: 0.5}, want: Vec3{X: 1, Z: 0.5}},
+	}
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			got := closestPointOnTriangle(testCase.point, a, b, c)
+			if !got.Near(testCase.want, 1e-9) {
+				t.Fatalf("closestPointOnTriangle = %+v, want %+v", got, testCase.want)
+			}
+		})
+	}
+
+	// Edge bc: the point sits beyond the hypotenuse midpoint.
+	got := closestPointOnTriangle(Vec3{X: 5, Z: 4}, a, b, c)
+	if got.X <= 0 || got.Z <= 0 || got.X >= 4 || got.Z >= 3 {
+		t.Fatalf("edge bc closest point = %+v, want a point strictly inside edge bc", got)
+	}
+	// A point on edge bc must satisfy x/4 + z/3 = 1.
+	if math.Abs(got.X/4+got.Z/3-1) > 1e-9 {
+		t.Fatalf("edge bc closest point %+v is not on the hypotenuse", got)
+	}
+}
+
+func TestCollideSphereTriangleMatchesGJK(t *testing.T) {
+	// The analytic path replaced GJK for sphere-triangle pairs. Check that the
+	// two still agree wherever GJK reports a contact.
+	a := Vec3{X: -1, Z: -1}
+	b := Vec3{X: 1, Z: -1}
+	c := Vec3{Z: 1}
+	tri := triangleShape(a, b, c)
+
+	centers := []Vec3{
+		{Y: 0.4},
+		{X: 0.3, Y: 0.35, Z: 0.1},
+		{X: 1.1, Y: 0.2, Z: -1.1},
+		{X: -0.9, Y: 0.1, Z: -0.95},
+		{Y: -0.45},
+		{X: 0.2, Y: 0.49, Z: 0.2},
+	}
+	const radius = 0.5
+	for _, center := range centers {
+		sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: center, Radius: radius})
+		shape, _ := newConvexShape(sphere)
+		simplex, overlap := gjkOverlap(tri, shape)
+		analytic, analyticOK := collideSphereTriangle(center, radius, a, b, c)
+		if !overlap {
+			if analyticOK && analytic.Depth > 1e-6 {
+				t.Fatalf("center %+v: analytic depth %v but GJK found no overlap", center, analytic.Depth)
+			}
+			continue
+		}
+		if !analyticOK {
+			t.Fatalf("center %+v: GJK found overlap but the analytic path did not", center)
+		}
+		epa, ok := epaPenetration(tri, shape, simplex)
+		if !ok {
+			continue
+		}
+		if math.Abs(epa.Depth-analytic.Depth) > 2e-3 {
+			t.Fatalf("center %+v: analytic depth %v, EPA depth %v", center, analytic.Depth, epa.Depth)
+		}
+		if epa.Normal.Dot(analytic.Normal) < 0.99 {
+			t.Fatalf("center %+v: analytic normal %+v, EPA normal %+v", center, analytic.Normal, epa.Normal)
+		}
+	}
+}

--- a/physics/narrowphase.go
+++ b/physics/narrowphase.go
@@ -4,8 +4,56 @@ import "math"
 
 const contactTolerance = 1e-6
 
+// Collide returns the first contact manifold between two colliders. Use
+// CollideAll when either collider is a triangle mesh, because a mesh pair can
+// produce one manifold per contacting triangle.
 func Collide(a, b *Collider) (ContactManifold, bool) {
 	if a == nil || b == nil {
+		return ContactManifold{}, false
+	}
+	if a.Shape == ShapeTriangleMesh || b.Shape == ShapeTriangleMesh {
+		manifolds := CollideAll(a, b, nil)
+		if len(manifolds) == 0 {
+			return ContactManifold{}, false
+		}
+		return manifolds[0], true
+	}
+	return collidePair(a, b)
+}
+
+// CollideAll appends every contact manifold between two colliders to out.
+// Every pair except a triangle mesh produces at most one manifold.
+//
+// A collider that failed validation produces no manifolds. Check Collider.Err
+// or World.Diagnostics to find such a collider; it never collides with
+// anything.
+func CollideAll(a, b *Collider, out []ContactManifold) []ContactManifold {
+	if a == nil || b == nil || a.invalid != nil || b.invalid != nil {
+		return out
+	}
+	switch {
+	case a.Shape == ShapeTriangleMesh && b.Shape == ShapeTriangleMesh:
+		// Not implemented. World.Diagnostics reports the pair.
+		return out
+	case a.Shape == ShapeTriangleMesh:
+		return collideMeshShape(a, b, out)
+	case b.Shape == ShapeTriangleMesh:
+		start := len(out)
+		out = collideMeshShape(b, a, out)
+		for i := start; i < len(out); i++ {
+			out[i] = flipManifold(out[i])
+		}
+		return out
+	}
+	manifold, ok := collidePair(a, b)
+	if !ok {
+		return out
+	}
+	return append(out, manifold)
+}
+
+func collidePair(a, b *Collider) (ContactManifold, bool) {
+	if a.invalid != nil || b.invalid != nil {
 		return ContactManifold{}, false
 	}
 
@@ -56,6 +104,20 @@ func Collide(a, b *Collider) (ContactManifold, bool) {
 		return flipManifold(manifold), true
 	case a.Shape == ShapeCapsule && b.Shape == ShapeCapsule:
 		return collideCapsuleCapsule(a, b)
+	case a.Shape == ShapePlane && b.Shape == ShapePlane:
+		// Two half-spaces overlap everywhere. There is no useful contact and
+		// the broadphase never pairs two immovable colliders anyway.
+		return ContactManifold{}, false
+	case a.Shape == ShapePlane && isSupportShape(b):
+		manifold, ok := collideConvexPlane(b, a)
+		if !ok {
+			return ContactManifold{}, false
+		}
+		return flipManifold(manifold), true
+	case b.Shape == ShapePlane && isSupportShape(a):
+		return collideConvexPlane(a, b)
+	case isSupportShape(a) && isSupportShape(b):
+		return collideConvexGJK(a, b)
 	default:
 		return ContactManifold{}, false
 	}

--- a/physics/narrowphase_boxbox.go
+++ b/physics/narrowphase_boxbox.go
@@ -214,21 +214,24 @@ func clipBoxFace(refCol, incCol *Collider,
 		return nil
 	}
 
-	contacts := make([]ContactPoint, 0, 4)
+	// Clipping a face against a face of the same size lands several points on
+	// the same corner. Collect every point below the reference plane, then let
+	// reduceContactPatch pick four that spread over the whole patch.
+	candidates := make([]ContactPoint, 0, len(poly))
 	for _, p := range poly {
 		signed := refFaceNormal.Dot(p) - refDist
 		if signed > contactTolerance {
 			continue
 		}
-		penetration := -signed
-		contacts = append(contacts, makeContactPoint(refCol, incCol, p, penetration))
-		if len(contacts) >= 4 {
-			break
-		}
+		candidates = append(candidates, makeContactPoint(refCol, incCol, p, -signed))
 	}
-	if len(contacts) > 4 {
-		contacts = contacts[:4]
+	if len(candidates) == 0 {
+		return nil
 	}
+	var kept [4]ContactPoint
+	count := reduceContactPatch(candidates, &kept)
+	contacts := make([]ContactPoint, count)
+	copy(contacts, kept[:count])
 	return contacts
 }
 

--- a/physics/narrowphase_convex.go
+++ b/physics/narrowphase_convex.go
@@ -1,0 +1,521 @@
+package physics
+
+import "math"
+
+// Narrowphase for the shapes that a support function describes: cylinder, cone
+// and convex hull, plus the triangle mesh built from those. Overlap and
+// penetration come from GJK and EPA; the plane cases stay analytic because a
+// half-space has no support function.
+
+const (
+	// meshMaxManifolds bounds how many triangle contacts one mesh pair feeds
+	// to the solver. The deepest contacts win.
+	meshMaxManifolds = 4
+	// meshCandidateBuffer sizes the stack buffer for BVH query results.
+	meshCandidateBuffer = 64
+	// planeParallelTolerance decides when a cap disc counts as parallel to a
+	// plane, which is when the contact is a whole rim instead of one point.
+	planeParallelTolerance = 1e-6
+)
+
+// isSupportShape reports whether the collider has a support function, which is
+// every finite convex primitive.
+func isSupportShape(c *Collider) bool {
+	if c == nil {
+		return false
+	}
+	switch c.Shape {
+	case ShapeBox, ShapeSphere, ShapeCapsule, ShapeCylinder, ShapeCone, ShapeConvexHull:
+		return true
+	default:
+		return false
+	}
+}
+
+// collideConvexGJK builds a manifold from the GJK and EPA penetration of two
+// support-mapped shapes.
+//
+// EPA gives one normal and one point. The face expansion pass then clips the
+// two support faces against each other and returns the whole contact patch. A
+// patch matters because contact impulses now carry angular terms: one point
+// against a flat face lets the body rock about that point.
+//
+// A curved feature such as a sphere or a cylinder rim keeps the single EPA
+// point, which is its true contact.
+func collideConvexGJK(a, b *Collider) (ContactManifold, bool) {
+	shapeA, okA := newConvexShape(a)
+	shapeB, okB := newConvexShape(b)
+	if !okA || !okB {
+		return ContactManifold{}, false
+	}
+	simplex, overlap := gjkOverlap(shapeA, shapeB)
+	if !overlap {
+		return ContactManifold{}, false
+	}
+	result, ok := epaPenetration(shapeA, shapeB, simplex)
+	if !ok || result.Normal.Len2() <= epsilon {
+		return ContactManifold{}, false
+	}
+
+	var storage [4]ContactPoint
+	if patch, expanded := expandConvexManifold(a, b, result.Normal, result.Depth, storage[:0]); expanded {
+		return makeContactManifold(a, b, result.Normal, patch), true
+	}
+	return makeContactManifold(a, b, result.Normal, []ContactPoint{
+		makeContactPoint(a, b, result.ContactPoint(), result.Depth),
+	}), true
+}
+
+// collideConvexPlane collides any finite convex collider against a plane. The
+// normal points from the convex shape toward the plane, matching the box and
+// capsule plane cases.
+func collideConvexPlane(convex, plane *Collider) (ContactManifold, bool) {
+	if convex == nil || plane == nil || convex.Shape == ShapePlane {
+		return ContactManifold{}, false
+	}
+	planeNormal, planeDistance := plane.Plane()
+
+	var candidateStorage [8]Vec3
+	candidates := candidateStorage[:0]
+	switch convex.Shape {
+	case ShapeCylinder:
+		candidates = cylinderPlaneCandidates(convex, planeNormal, candidates)
+	case ShapeCone:
+		candidates = conePlaneCandidates(convex, planeNormal, candidates)
+	case ShapeConvexHull:
+		return collideHullPlane(convex, plane, planeNormal, planeDistance)
+	default:
+		return ContactManifold{}, false
+	}
+
+	var points [4]ContactPoint
+	count := 0
+	for _, candidate := range candidates {
+		signed := planeNormal.Dot(candidate) - planeDistance
+		if signed > contactTolerance {
+			continue
+		}
+		point := makeContactPoint(convex, plane, candidate, maxFloat(-signed, 0))
+		count = keepDeepestPoint(&points, count, point)
+	}
+	if count == 0 {
+		return ContactManifold{}, false
+	}
+	contacts := make([]ContactPoint, count)
+	copy(contacts, points[:count])
+	return makeContactManifold(convex, plane, planeNormal.Neg(), contacts), true
+}
+
+// cylinderPlaneCandidates lists the cylinder points that can touch the plane
+// first. Two rim points cover the general and the side-resting cases; four rim
+// points cover a cap that lies flat on the plane.
+func cylinderPlaneCandidates(cylinder *Collider, planeNormal Vec3, out []Vec3) []Vec3 {
+	axis := cylinder.WorldAxis()
+	bottom, top := cylinder.CylinderCapCenters()
+	radius := math.Abs(cylinder.Radius)
+
+	inward := planeNormal.Neg()
+	perp := inward.Sub(axis.Mul(axis.Dot(inward)))
+	if perp.Len2() > planeParallelTolerance {
+		radial := perp.Normalize().Mul(radius)
+		return append(out, bottom.Add(radial), top.Add(radial))
+	}
+
+	// The caps are parallel to the plane. Emit four points around the rim of
+	// the cap that faces the plane.
+	lower := bottom
+	if planeNormal.Dot(top) < planeNormal.Dot(bottom) {
+		lower = top
+	}
+	u, v := orthonormalBasis(axis)
+	u = u.Mul(radius)
+	v = v.Mul(radius)
+	return append(out, lower.Add(u), lower.Sub(u), lower.Add(v), lower.Sub(v))
+}
+
+// conePlaneCandidates lists the apex plus the base rim points that can touch
+// the plane first.
+func conePlaneCandidates(cone *Collider, planeNormal Vec3, out []Vec3) []Vec3 {
+	axis := cone.WorldAxis()
+	apex, base := cone.ConeApexAndBase()
+	radius := math.Abs(cone.Radius)
+
+	out = append(out, apex)
+
+	inward := planeNormal.Neg()
+	perp := inward.Sub(axis.Mul(axis.Dot(inward)))
+	if perp.Len2() > planeParallelTolerance {
+		return append(out, base.Add(perp.Normalize().Mul(radius)))
+	}
+	u, v := orthonormalBasis(axis)
+	u = u.Mul(radius)
+	v = v.Mul(radius)
+	return append(out, base.Add(u), base.Sub(u), base.Add(v), base.Sub(v))
+}
+
+func collideHullPlane(hull, plane *Collider, planeNormal Vec3, planeDistance float64) (ContactManifold, bool) {
+	center := hull.WorldCenter()
+	basis := mat3FromQuat(hull.WorldRotation())
+
+	var points [4]ContactPoint
+	count := 0
+	for _, local := range hull.hull {
+		world := center.Add(basis.mul(local))
+		signed := planeNormal.Dot(world) - planeDistance
+		if signed > contactTolerance {
+			continue
+		}
+		point := makeContactPoint(hull, plane, world, maxFloat(-signed, 0))
+		count = keepDeepestPoint(&points, count, point)
+	}
+	if count == 0 {
+		return ContactManifold{}, false
+	}
+	contacts := make([]ContactPoint, count)
+	copy(contacts, points[:count])
+	return makeContactManifold(hull, plane, planeNormal.Neg(), contacts), true
+}
+
+// keepDeepestPoint stores point in the fixed manifold slot list, replacing the
+// shallowest entry once the list is full.
+func keepDeepestPoint(points *[4]ContactPoint, count int, point ContactPoint) int {
+	if count < len(points) {
+		points[count] = point
+		return count + 1
+	}
+	shallowest := 0
+	for i := 1; i < len(points); i++ {
+		if points[i].Penetration < points[shallowest].Penetration {
+			shallowest = i
+		}
+	}
+	if point.Penetration > points[shallowest].Penetration {
+		points[shallowest] = point
+	}
+	return count
+}
+
+// orthonormalBasis returns two unit vectors perpendicular to axis and to each
+// other.
+func orthonormalBasis(axis Vec3) (Vec3, Vec3) {
+	reference := Vec3{X: 1}
+	if math.Abs(axis.X) > 0.7 {
+		reference = Vec3{Y: 1}
+	}
+	u := axis.Cross(reference)
+	if u.Len2() <= epsilon {
+		u = axis.Cross(Vec3{Z: 1})
+	}
+	u = u.Normalize()
+	return u, axis.Cross(u).Normalize()
+}
+
+// collideMeshShape collides a triangle mesh against any other collider. The
+// mesh always takes the A slot of the manifolds it returns; the caller flips
+// them when the original pair order was reversed.
+//
+// Each contacting triangle produces its own manifold because one manifold
+// carries one normal. The deepest meshMaxManifolds contacts survive, so a body
+// wedged in a valley still receives an impulse from every distinct face it
+// touches.
+func collideMeshShape(mesh, other *Collider, out []ContactManifold) []ContactManifold {
+	if mesh == nil || mesh.mesh == nil || other == nil {
+		return out
+	}
+	if other.Shape == ShapePlane {
+		if manifold, ok := collideMeshPlane(mesh, other); ok {
+			return append(out, manifold)
+		}
+		return out
+	}
+	if other.Shape == ShapeTriangleMesh {
+		// Mesh against mesh is not implemented. World.Diagnostics reports the
+		// pair so the configuration fails loudly instead of passing through.
+		return out
+	}
+
+	otherShape, ok := newConvexShape(other)
+	if !ok {
+		return out
+	}
+	box := other.AABB()
+	if !box.IsFinite() {
+		return out
+	}
+
+	var candidateStorage [meshCandidateBuffer]int
+	candidates := mesh.mesh.queryAABB(mesh.localAABBFromWorld(box.Expand(contactTolerance)), candidateStorage[:0])
+	if len(candidates) == 0 {
+		return out
+	}
+
+	center := mesh.WorldCenter()
+	basis := mat3FromQuat(mesh.WorldRotation())
+	// A sphere against a triangle has a closed-form answer. Use it: a ball
+	// rolling on mesh terrain is the most common mesh contact of all, and the
+	// analytic form is both exact and about fifty times faster than GJK on a
+	// curved surface.
+	sphereRadius, sphereIsBall := 0.0, other.Shape == ShapeSphere
+	if sphereIsBall {
+		sphereRadius = math.Abs(other.Radius)
+	}
+	sphereCenter := other.WorldCenter()
+
+	var best [meshMaxManifolds]epaResult
+	bestCount := 0
+	for _, index := range candidates {
+		local := mesh.mesh.tris[index]
+		worldA := center.Add(basis.mul(local.a))
+		worldB := center.Add(basis.mul(local.b))
+		worldC := center.Add(basis.mul(local.c))
+
+		worldTri := meshTriangle{
+			a: worldA, b: worldB, c: worldC,
+			normal:       basis.mul(local.normal),
+			edgeFiltered: local.edgeFiltered,
+		}
+
+		if sphereIsBall {
+			result, ok := collideSphereTriangle(sphereCenter, sphereRadius, worldA, worldB, worldC)
+			if ok {
+				result.Normal = filterMeshContactNormal(worldTri, result.PointA, result.Normal)
+				bestCount = keepDeepestResult(&best, bestCount, result)
+			}
+			continue
+		}
+
+		tri := triangleShape(worldA, worldB, worldC)
+		simplex, overlap := gjkOverlap(tri, otherShape)
+		if !overlap {
+			continue
+		}
+		result, ok := epaPenetration(tri, otherShape, simplex)
+		if !ok || result.Normal.Len2() <= epsilon {
+			continue
+		}
+		result.Normal = filterMeshContactNormal(worldTri, result.PointA, result.Normal)
+		bestCount = keepDeepestResult(&best, bestCount, result)
+	}
+	for i := 0; i < bestCount; i++ {
+		out = append(out, makeContactManifold(mesh, other, best[i].Normal, []ContactPoint{
+			makeContactPoint(mesh, other, best[i].ContactPoint(), best[i].Depth),
+		}))
+	}
+	return out
+}
+
+const (
+	// meshFaceNormalTolerance is the cosine below which a contact normal counts
+	// as an edge normal rather than a face normal.
+	meshFaceNormalTolerance = 0.999
+	// meshEdgeSnapDistance2 is the squared distance within which a contact
+	// counts as sitting on a triangle edge.
+	meshEdgeSnapDistance2 = 1e-8
+)
+
+// filterMeshContactNormal replaces an internal edge normal with the face normal
+// of the triangle that produced it.
+//
+// A mesh floor made of triangles has shared edges everywhere. A body that
+// crosses one can receive the edge normal, which points sideways and throws the
+// body off the surface. The mesh marks every edge whose neighbour makes a flat
+// or a concave join at build time; a contact on such an edge pushes along the
+// face instead. A convex ridge keeps its edge normal, because there the edge is
+// the real surface.
+func filterMeshContactNormal(tri meshTriangle, contactOnTriangle, normal Vec3) Vec3 {
+	if tri.edgeFiltered == 0 || tri.normal.Len2() <= epsilon {
+		return normal
+	}
+	face := tri.normal.Normalize()
+	if face.Dot(normal) < 0 {
+		face = face.Neg()
+	}
+	if normal.Dot(face) >= meshFaceNormalTolerance {
+		return normal
+	}
+	for edge := 0; edge < 3; edge++ {
+		start, end, filtered := tri.filteredEdgeEndpoints(edge)
+		if !filtered {
+			continue
+		}
+		closest, _ := closestPointOnSegment(start, end, contactOnTriangle)
+		if closest.Sub(contactOnTriangle).Len2() <= meshEdgeSnapDistance2 {
+			return face
+		}
+	}
+	return normal
+}
+
+// collideSphereTriangle solves a ball against one triangle in closed form. The
+// returned normal points from the triangle toward the sphere, which matches the
+// A-to-B convention with the mesh in the A slot.
+func collideSphereTriangle(center Vec3, radius float64, a, b, c Vec3) (epaResult, bool) {
+	closest := closestPointOnTriangle(center, a, b, c)
+	delta := center.Sub(closest)
+	distance2 := delta.Len2()
+	reach := radius + contactTolerance
+	if distance2 > reach*reach {
+		return epaResult{}, false
+	}
+
+	distance := math.Sqrt(distance2)
+	var normal Vec3
+	if distance > epsilon {
+		normal = delta.Div(distance)
+	} else {
+		// The sphere centre sits on the triangle. Fall back to the face normal.
+		normal = b.Sub(a).Cross(c.Sub(a)).Normalize()
+		if normal.Len2() <= epsilon {
+			return epaResult{}, false
+		}
+	}
+	depth := maxFloat(radius-distance, 0)
+	return epaResult{
+		Normal: normal,
+		Depth:  depth,
+		PointA: closest,
+		PointB: center.Sub(normal.Mul(radius)),
+	}, true
+}
+
+// closestPointOnTriangle returns the point of triangle (a,b,c) nearest to p.
+// This is Ericson's Voronoi-region formulation: test the three vertex regions,
+// then the three edge regions, then fall through to the face interior.
+func closestPointOnTriangle(p, a, b, c Vec3) Vec3 {
+	ab := b.Sub(a)
+	ac := c.Sub(a)
+	ap := p.Sub(a)
+	d1 := ab.Dot(ap)
+	d2 := ac.Dot(ap)
+	if d1 <= 0 && d2 <= 0 {
+		return a
+	}
+
+	bp := p.Sub(b)
+	d3 := ab.Dot(bp)
+	d4 := ac.Dot(bp)
+	if d3 >= 0 && d4 <= d3 {
+		return b
+	}
+
+	vc := d1*d4 - d3*d2
+	if vc <= 0 && d1 >= 0 && d3 <= 0 {
+		denom := d1 - d3
+		if denom <= epsilon {
+			return a
+		}
+		return a.Add(ab.Mul(d1 / denom))
+	}
+
+	cp := p.Sub(c)
+	d5 := ab.Dot(cp)
+	d6 := ac.Dot(cp)
+	if d6 >= 0 && d5 <= d6 {
+		return c
+	}
+
+	vb := d5*d2 - d1*d6
+	if vb <= 0 && d2 >= 0 && d6 <= 0 {
+		denom := d2 - d6
+		if denom <= epsilon {
+			return a
+		}
+		return a.Add(ac.Mul(d2 / denom))
+	}
+
+	va := d3*d6 - d5*d4
+	if va <= 0 && (d4-d3) >= 0 && (d5-d6) >= 0 {
+		denom := (d4 - d3) + (d5 - d6)
+		if denom <= epsilon {
+			return b
+		}
+		return b.Add(c.Sub(b).Mul((d4 - d3) / denom))
+	}
+
+	denom := va + vb + vc
+	if math.Abs(denom) <= epsilon {
+		return a
+	}
+	return a.Add(ab.Mul(vb / denom)).Add(ac.Mul(vc / denom))
+}
+
+func keepDeepestResult(best *[meshMaxManifolds]epaResult, count int, result epaResult) int {
+	if count < len(best) {
+		best[count] = result
+		return count + 1
+	}
+	shallowest := 0
+	for i := 1; i < len(best); i++ {
+		if best[i].Depth < best[shallowest].Depth {
+			shallowest = i
+		}
+	}
+	if result.Depth > best[shallowest].Depth {
+		best[shallowest] = result
+	}
+	return count
+}
+
+// collideMeshPlane keeps the deepest four mesh vertices that sit below the
+// plane. The BVH prunes whole subtrees that stay above the plane.
+func collideMeshPlane(mesh, plane *Collider) (ContactManifold, bool) {
+	planeNormal, planeDistance := plane.Plane()
+	center := mesh.WorldCenter()
+	basis := mat3FromQuat(mesh.WorldRotation())
+
+	// Move the plane into mesh-local space so the BVH bounds can be tested
+	// directly.
+	localNormal := basis.mulT(planeNormal)
+	localDistance := planeDistance - planeNormal.Dot(center)
+
+	var points [4]ContactPoint
+	count := 0
+	var stack [meshMaxDepth * 2]int
+	top := 0
+	stack[top] = 0
+	top++
+	for top > 0 {
+		top--
+		index := stack[top]
+		node := mesh.mesh.nodes[index]
+		if boxMinAlong(node.bounds, localNormal) > localDistance+contactTolerance {
+			continue
+		}
+		if node.leaf() {
+			for i := node.start; i < node.start+node.count; i++ {
+				tri := mesh.mesh.tris[i]
+				for _, local := range [3]Vec3{tri.a, tri.b, tri.c} {
+					signed := localNormal.Dot(local) - localDistance
+					if signed > contactTolerance {
+						continue
+					}
+					world := center.Add(basis.mul(local))
+					point := makeContactPoint(mesh, plane, world, maxFloat(-signed, 0))
+					count = keepDeepestPoint(&points, count, point)
+				}
+			}
+			continue
+		}
+		if top+2 > len(stack) {
+			continue
+		}
+		stack[top] = node.right
+		top++
+		stack[top] = index + 1
+		top++
+	}
+	if count == 0 {
+		return ContactManifold{}, false
+	}
+	contacts := make([]ContactPoint, count)
+	copy(contacts, points[:count])
+	return makeContactManifold(mesh, plane, planeNormal.Neg(), contacts), true
+}
+
+// boxMinAlong returns the smallest dot product of normal with any point of box.
+func boxMinAlong(box AABB, normal Vec3) float64 {
+	center := box.Center()
+	half := box.Size().Mul(0.5)
+	return normal.Dot(center) -
+		(math.Abs(normal.X)*half.X + math.Abs(normal.Y)*half.Y + math.Abs(normal.Z)*half.Z)
+}

--- a/physics/narrowphase_convex_test.go
+++ b/physics/narrowphase_convex_test.go
@@ -1,0 +1,501 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// --- Cylinder ---------------------------------------------------------------
+
+func TestCollideCylinderPlaneRestingOnCap(t *testing.T) {
+	// Cylinder radius 0.5, height 2, centre at y=0.9. The bottom cap sits at
+	// y=-0.1, so it dips 0.1 below the +Y plane at the origin.
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2, Offset: Vec3{Y: 0.9}})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(cylinder, plane)
+	if !ok {
+		t.Fatal("expected a cylinder-plane contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: -1}, 1e-12) {
+		t.Fatalf("normal = %+v, want -Y (cylinder toward plane)", contact.Normal)
+	}
+	if contact.PointCount != 4 {
+		t.Fatalf("PointCount = %d, want 4 rim points for a flat cap", contact.PointCount)
+	}
+	for i := 0; i < contact.PointCount; i++ {
+		point := contact.Points[i]
+		if math.Abs(point.Penetration-0.1) > 1e-12 {
+			t.Fatalf("point[%d] penetration = %v, want 0.1", i, point.Penetration)
+		}
+		if math.Abs(point.Point.Y-(-0.1)) > 1e-12 {
+			t.Fatalf("point[%d] Y = %v, want -0.1 on the cap plane", i, point.Point.Y)
+		}
+		radial := math.Hypot(point.Point.X, point.Point.Z)
+		if math.Abs(radial-0.5) > 1e-12 {
+			t.Fatalf("point[%d] radial distance = %v, want 0.5 on the rim", i, radial)
+		}
+	}
+}
+
+func TestCollideCylinderPlaneRestingOnSide(t *testing.T) {
+	// Rotate the cylinder 90 degrees about Z so it lies on its side. The lowest
+	// line of the lateral surface then touches the plane along two rim points.
+	rotation := QuatFromAxisAngle(Vec3{Z: 1}, math.Pi/2)
+	cylinder := NewCollider(ColliderConfig{
+		Shape: ShapeCylinder, Radius: 0.5, Height: 2,
+		Offset: Vec3{Y: 0.45}, Rotation: rotation,
+	})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(cylinder, plane)
+	if !ok {
+		t.Fatal("expected a cylinder-plane side contact")
+	}
+	if contact.PointCount != 2 {
+		t.Fatalf("PointCount = %d, want 2 contacts at the two cap rims", contact.PointCount)
+	}
+	for i := 0; i < contact.PointCount; i++ {
+		if got := contact.Points[i].Penetration; math.Abs(got-0.05) > 1e-9 {
+			t.Fatalf("point[%d] penetration = %v, want 0.05", i, got)
+		}
+	}
+}
+
+func TestCollideCylinderPlaneSeparated(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2, Offset: Vec3{Y: 1.5}})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	if _, ok := Collide(cylinder, plane); ok {
+		t.Fatal("expected no contact for a cylinder 0.5 above the plane")
+	}
+}
+
+func TestCollideCylinderSphereOnSide(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Z: 1.3}, Radius: 0.5})
+
+	contact, ok := Collide(cylinder, sphere)
+	if !ok {
+		t.Fatal("expected a cylinder-sphere contact")
+	}
+	if contact.Normal.Dot(Vec3{Z: 1}) < 0.9999 {
+		t.Fatalf("normal = %+v, want +Z", contact.Normal)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.2) > 1e-4 {
+		t.Fatalf("penetration = %v, want 0.2", got)
+	}
+}
+
+func TestCollideCylinderSphereOnCap(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 1.4}, Radius: 0.5})
+
+	contact, ok := Collide(cylinder, sphere)
+	if !ok {
+		t.Fatal("expected a cylinder cap contact")
+	}
+	if contact.Normal.Dot(Vec3{Y: 1}) < 0.9999 {
+		t.Fatalf("normal = %+v, want +Y", contact.Normal)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.1) > 1e-4 {
+		t.Fatalf("penetration = %v, want 0.1", got)
+	}
+	// The cap sits at y=1 and the sphere surface at y=0.9, so the midpoint is
+	// y=0.95.
+	if got := contact.Points[0].Point.Y; math.Abs(got-0.95) > 1e-3 {
+		t.Fatalf("contact Y = %v, want 0.95", got)
+	}
+}
+
+func TestCollideCylinderSphereSeparated(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 3}, Radius: 0.5})
+	if _, ok := Collide(cylinder, sphere); ok {
+		t.Fatal("expected no contact for a sphere 1.5 units clear of the cylinder")
+	}
+}
+
+func TestCollideCylinderBoxFaceContact(t *testing.T) {
+	box := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4})
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2, Offset: Vec3{Y: 1.9}})
+
+	contact, ok := Collide(box, cylinder)
+	if !ok {
+		t.Fatal("expected a box-cylinder contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: 1}, 1e-9) {
+		t.Fatalf("normal = %+v, want +Y (box toward cylinder)", contact.Normal)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.1) > 1e-9 {
+		t.Fatalf("penetration = %v, want 0.1", got)
+	}
+	if got := contact.Points[0].Point.Y; math.Abs(got-0.95) > 1e-6 {
+		t.Fatalf("contact Y = %v, want 0.95 midway between the two surfaces", got)
+	}
+}
+
+func TestCollideCylinderCylinderSideBySide(t *testing.T) {
+	a := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4})
+	b := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4, Offset: Vec3{X: 1.7}})
+
+	contact, ok := Collide(a, b)
+	if !ok {
+		t.Fatal("expected a cylinder-cylinder contact")
+	}
+	if contact.Normal.Dot(Vec3{X: 1}) < 0.999 {
+		t.Fatalf("normal = %+v, want +X", contact.Normal)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.3) > 3e-3 {
+		t.Fatalf("penetration = %v, want 0.3", got)
+	}
+}
+
+func TestCollideCylinderCapsule(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4})
+	capsule := NewCollider(ColliderConfig{Shape: ShapeCapsule, Radius: 0.5, Height: 2, Offset: Vec3{X: 1.4}})
+
+	contact, ok := Collide(cylinder, capsule)
+	if !ok {
+		t.Fatal("expected a cylinder-capsule contact")
+	}
+	if contact.Normal.Dot(Vec3{X: 1}) < 0.999 {
+		t.Fatalf("normal = %+v, want +X", contact.Normal)
+	}
+	// Cylinder wall at x=1, capsule segment at x=1.4 with radius 0.5, so the
+	// capsule wall reaches x=0.9 and the overlap is 0.1.
+	if got := contact.Points[0].Penetration; math.Abs(got-0.1) > 2e-3 {
+		t.Fatalf("penetration = %v, want 0.1", got)
+	}
+}
+
+// --- Cone -------------------------------------------------------------------
+
+func TestCollideConePlaneRestingOnBase(t *testing.T) {
+	// Cone radius 1, height 2, apex on +Y. Centre at y=0.9 puts the base disc
+	// at y=-0.1, so it dips 0.1 below the plane.
+	cone := NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2, Offset: Vec3{Y: 0.9}})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(cone, plane)
+	if !ok {
+		t.Fatal("expected a cone-plane contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: -1}, 1e-12) {
+		t.Fatalf("normal = %+v, want -Y", contact.Normal)
+	}
+	if contact.PointCount != 4 {
+		t.Fatalf("PointCount = %d, want 4 base rim points", contact.PointCount)
+	}
+	for i := 0; i < contact.PointCount; i++ {
+		if got := contact.Points[i].Penetration; math.Abs(got-0.1) > 1e-12 {
+			t.Fatalf("point[%d] penetration = %v, want 0.1", i, got)
+		}
+	}
+}
+
+func TestCollideConePlaneApexDown(t *testing.T) {
+	// Flip the cone so the apex points at the plane. Only the apex touches.
+	rotation := QuatFromAxisAngle(Vec3{X: 1}, math.Pi)
+	cone := NewCollider(ColliderConfig{
+		Shape: ShapeCone, Radius: 1, Height: 2,
+		Offset: Vec3{Y: 0.95}, Rotation: rotation,
+	})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(cone, plane)
+	if !ok {
+		t.Fatal("expected a cone apex contact")
+	}
+	if contact.PointCount != 1 {
+		t.Fatalf("PointCount = %d, want 1 apex contact", contact.PointCount)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.05) > 1e-9 {
+		t.Fatalf("penetration = %v, want 0.05", got)
+	}
+	if got := contact.Points[0].Point; math.Abs(got.X) > 1e-9 || math.Abs(got.Z) > 1e-9 {
+		t.Fatalf("apex contact = %+v, want it on the Y axis", got)
+	}
+}
+
+func TestCollideConeSphereOnBaseRim(t *testing.T) {
+	cone := NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2})
+	// The base rim sits at (1,-1,0). Place a sphere just outside it along +X.
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.4, Y: -1}, Radius: 0.5})
+
+	contact, ok := Collide(cone, sphere)
+	if !ok {
+		t.Fatal("expected a cone-sphere rim contact")
+	}
+	if got := contact.Points[0].Penetration; got <= 0 || got > 0.2 {
+		t.Fatalf("penetration = %v, want a shallow rim overlap", got)
+	}
+	if contact.Normal.X <= 0 {
+		t.Fatalf("normal = %+v, want a positive X component (cone toward sphere)", contact.Normal)
+	}
+}
+
+func TestCollideConeBoxApexContact(t *testing.T) {
+	// Cone apex points down at a box top face.
+	rotation := QuatFromAxisAngle(Vec3{X: 1}, math.Pi)
+	box := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4})
+	cone := NewCollider(ColliderConfig{
+		Shape: ShapeCone, Radius: 1, Height: 2,
+		Offset: Vec3{Y: 1.95}, Rotation: rotation,
+	})
+
+	contact, ok := Collide(box, cone)
+	if !ok {
+		t.Fatal("expected a box-cone contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: 1}, 1e-6) {
+		t.Fatalf("normal = %+v, want +Y", contact.Normal)
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.05) > 1e-6 {
+		t.Fatalf("penetration = %v, want 0.05", got)
+	}
+}
+
+func TestCollideConeSeparated(t *testing.T) {
+	cone := NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2})
+	box := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1, Offset: Vec3{X: 4}})
+	if _, ok := Collide(cone, box); ok {
+		t.Fatal("expected no contact for shapes 4 units apart")
+	}
+}
+
+// --- Convex hull ------------------------------------------------------------
+
+func TestCollideConvexHullPlaneRestsOnFace(t *testing.T) {
+	hull := NewCollider(ColliderConfig{
+		Shape:    ShapeConvexHull,
+		Offset:   Vec3{Y: 0.4},
+		Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5}),
+	})
+	plane := NewCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	contact, ok := Collide(hull, plane)
+	if !ok {
+		t.Fatal("expected a hull-plane contact")
+	}
+	if !contact.Normal.Near(Vec3{Y: -1}, 1e-12) {
+		t.Fatalf("normal = %+v, want -Y", contact.Normal)
+	}
+	if contact.PointCount != 4 {
+		t.Fatalf("PointCount = %d, want the 4 bottom corners", contact.PointCount)
+	}
+	for i := 0; i < contact.PointCount; i++ {
+		if got := contact.Points[i].Penetration; math.Abs(got-0.1) > 1e-12 {
+			t.Fatalf("point[%d] penetration = %v, want 0.1", i, got)
+		}
+	}
+}
+
+func TestCollideConvexHullTetrahedronAgainstSphere(t *testing.T) {
+	// A regular-ish tetrahedron with one face on the y=0 plane and its apex up.
+	hull := NewCollider(ColliderConfig{
+		Shape: ShapeConvexHull,
+		Vertices: []Vec3{
+			{X: -1, Y: 0, Z: -1},
+			{X: 1, Y: 0, Z: -1},
+			{X: 0, Y: 0, Z: 1},
+			{X: 0, Y: 2, Z: 0},
+		},
+	})
+	sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 2.4}, Radius: 0.5})
+
+	contact, ok := Collide(hull, sphere)
+	if !ok {
+		t.Fatal("expected a hull apex contact")
+	}
+	if got := contact.Points[0].Penetration; math.Abs(got-0.1) > 1e-4 {
+		t.Fatalf("penetration = %v, want 0.1", got)
+	}
+	if contact.Normal.Dot(Vec3{Y: 1}) < 0.999 {
+		t.Fatalf("normal = %+v, want +Y", contact.Normal)
+	}
+}
+
+// --- Resting behaviour ------------------------------------------------------
+
+func TestWorldCylinderRestsOnPlane(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+
+	for i := 0; i < 300; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if body.Position.Y < 0.45 || body.Position.Y > 0.55 {
+		t.Fatalf("cylinder should rest with its centre near y=0.5, got y=%v", body.Position.Y)
+	}
+	if math.Abs(body.Velocity.Y) > 0.2 {
+		t.Fatalf("cylinder should be near rest, velocity=%+v", body.Velocity)
+	}
+}
+
+func TestWorldConeRestsOnPlane(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeCone, Radius: 0.5, Height: 1})
+
+	for i := 0; i < 300; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if body.Position.Y < 0.45 || body.Position.Y > 0.55 {
+		t.Fatalf("cone should rest with its centre near y=0.5, got y=%v", body.Position.Y)
+	}
+}
+
+func TestWorldConvexHullRestsOnPlane(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5})})
+
+	for i := 0; i < 300; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if body.Position.Y < 0.45 || body.Position.Y > 0.55 {
+		t.Fatalf("hull should rest with its centre near y=0.5, got y=%v", body.Position.Y)
+	}
+}
+
+func TestWorldCylinderStackOnPlane(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	bottom := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Restitution: 0, Friction: 0.5})
+	bottom.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+	top := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 5}, Restitution: 0, Friction: 0.5})
+	top.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+
+	for i := 0; i < 600; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	if bottom.Position.Y < 0.45 || bottom.Position.Y > 0.6 {
+		t.Fatalf("bottom cylinder should rest near y=0.5, got y=%v", bottom.Position.Y)
+	}
+	if top.Position.Y < 1.4 || top.Position.Y > 1.65 {
+		t.Fatalf("top cylinder should stack near y=1.5, got y=%v", top.Position.Y)
+	}
+	if math.Abs(top.Velocity.Y) > 0.3 {
+		t.Fatalf("top cylinder should approach rest, got velocity=%+v", top.Velocity)
+	}
+}
+
+func TestWorldCylinderRestsOnStaticBox(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIter: 10})
+	ground := world.AddBody(BodyConfig{Mass: 0})
+	ground.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 6, Height: 2, Depth: 6})
+
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 3}, Restitution: 0, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+
+	for i := 0; i < 400; i++ {
+		world.Step(1.0 / 60.0)
+	}
+
+	// The box top is at y=1 and the cylinder half height is 0.5.
+	if body.Position.Y < 1.45 || body.Position.Y > 1.56 {
+		t.Fatalf("cylinder should rest near y=1.5 on the box, got y=%v", body.Position.Y)
+	}
+}
+
+// --- AABB -------------------------------------------------------------------
+
+func TestColliderAABBIsFiniteAndTightForEveryShape(t *testing.T) {
+	cases := []struct {
+		name   string
+		config ColliderConfig
+		want   AABB
+	}{
+		{
+			name:   "cylinder upright",
+			config: ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2},
+			want:   AABB{Min: Vec3{X: -0.5, Y: -1, Z: -0.5}, Max: Vec3{X: 0.5, Y: 1, Z: 0.5}},
+		},
+		{
+			name: "cylinder rotated onto X",
+			config: ColliderConfig{
+				Shape: ShapeCylinder, Radius: 0.5, Height: 2,
+				Rotation: QuatFromAxisAngle(Vec3{Z: 1}, math.Pi/2),
+			},
+			want: AABB{Min: Vec3{X: -1, Y: -0.5, Z: -0.5}, Max: Vec3{X: 1, Y: 0.5, Z: 0.5}},
+		},
+		{
+			name:   "cone upright",
+			config: ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2},
+			want:   AABB{Min: Vec3{X: -1, Y: -1, Z: -1}, Max: Vec3{X: 1, Y: 1, Z: 1}},
+		},
+		{
+			name:   "convex hull",
+			config: ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 1, Y: 2, Z: 3})},
+			want:   AABB{Min: Vec3{X: -1, Y: -2, Z: -3}, Max: Vec3{X: 1, Y: 2, Z: 3}},
+		},
+		{
+			name: "triangle mesh",
+			config: ColliderConfig{
+				Shape:    ShapeTriangleMesh,
+				Vertices: []Vec3{{X: -2, Z: -2}, {X: 2, Z: -2}, {X: 0, Y: 1, Z: 2}},
+				Indices:  []int{0, 1, 2},
+			},
+			want: AABB{Min: Vec3{X: -2, Y: 0, Z: -2}, Max: Vec3{X: 2, Y: 1, Z: 2}},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			collider := NewCollider(testCase.config)
+			if err := collider.Err(); err != nil {
+				t.Fatalf("collider is invalid: %v", err)
+			}
+			box := collider.AABB()
+			if !box.IsFinite() {
+				t.Fatalf("AABB = %+v, want a finite box", box)
+			}
+			if !box.Min.Near(testCase.want.Min, 1e-9) || !box.Max.Near(testCase.want.Max, 1e-9) {
+				t.Fatalf("AABB = %+v, want %+v", box, testCase.want)
+			}
+		})
+	}
+}
+
+func TestColliderAABBContainsSupportPoints(t *testing.T) {
+	// Sample many directions and check the support point never escapes the
+	// reported bounds. This catches a bound that is too tight.
+	configs := []ColliderConfig{
+		{Shape: ShapeCylinder, Radius: 0.7, Height: 1.4, Rotation: QuatFromAxisAngle(Vec3{X: 1, Y: 1}, 0.9)},
+		{Shape: ShapeCone, Radius: 0.6, Height: 2.2, Rotation: QuatFromAxisAngle(Vec3{X: 1, Z: 2}, 2.1)},
+		{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.4, Y: 0.9, Z: 1.3}),
+			Rotation: QuatFromAxisAngle(Vec3{Y: 1, Z: 1}, 0.4)},
+	}
+	for _, config := range configs {
+		collider := NewCollider(config)
+		shape, ok := newConvexShape(collider)
+		if !ok {
+			t.Fatalf("%v: newConvexShape failed", config.Shape)
+		}
+		box := collider.AABB().Expand(1e-9)
+		for i := 0; i < 500; i++ {
+			angle := float64(i) * 0.37
+			dir := Vec3{
+				X: math.Cos(angle),
+				Y: math.Sin(angle * 1.7),
+				Z: math.Sin(angle),
+			}
+			if dir.Len2() <= epsilon {
+				continue
+			}
+			point := shape.support(dir)
+			if !box.Contains(point) {
+				t.Fatalf("%v: support point %+v escapes AABB %+v", config.Shape, point, box)
+			}
+		}
+	}
+}

--- a/physics/narrowphase_manifold.go
+++ b/physics/narrowphase_manifold.go
@@ -1,0 +1,450 @@
+package physics
+
+import "math"
+
+// Manifold expansion for the GJK narrowphase.
+//
+// GJK with EPA returns one point and one normal. One point is enough to stop
+// two shapes overlapping, but it cannot hold a flat face at rest: an angular
+// contact impulse at a single point lets the body rock about that point. This
+// file turns the EPA normal into a contact patch by clipping the two support
+// faces against each other, the same way the box against box path does.
+//
+// A shape whose extreme feature along the normal is a single point, such as a
+// sphere, keeps the single EPA contact. That is the physically correct answer.
+
+const (
+	// faceAngleTolerance decides when a face counts as perpendicular to the
+	// contact normal. It is the cosine of about four degrees.
+	faceAngleTolerance = 0.9976
+	// faceFlatTolerance decides when a direction counts as parallel to a cap
+	// disc, which is the sine of about four degrees.
+	faceFlatTolerance = 0.07
+	// hullFaceTolerance is the distance below the extreme support value that a
+	// hull vertex may sit and still count as part of the support face.
+	hullFaceTolerance = 1e-4
+	// maxFacePoints bounds one support face.
+	maxFacePoints = 8
+)
+
+// patchMergeDistance is the smallest gap between two contact points of one
+// manifold. Clipping a face against an identical face lands several points on
+// the same corner, and duplicate points give one corner several times the grip
+// of the others.
+const patchMergeDistance = 1e-5
+
+// reduceContactPatch keeps at most four well spread points from a clipped
+// polygon and appends them to out.
+//
+// The deepest point comes first, then farthest point sampling adds the points
+// that are farthest from everything already kept. That rule is deterministic
+// and it never returns two points on the same corner, so the four normal
+// impulses of a resting box stay balanced from step to step.
+func reduceContactPatch(src []ContactPoint, out *[4]ContactPoint) int {
+	if len(src) == 0 {
+		return 0
+	}
+	deepest := 0
+	for i := 1; i < len(src); i++ {
+		if src[i].Penetration > src[deepest].Penetration {
+			deepest = i
+		}
+	}
+	out[0] = src[deepest]
+	count := 1
+
+	for count < len(out) {
+		best := -1
+		bestSpread := patchMergeDistance * patchMergeDistance
+		for i := range src {
+			spread := math.Inf(1)
+			for k := 0; k < count; k++ {
+				if d := src[i].Point.Sub(out[k].Point).Len2(); d < spread {
+					spread = d
+				}
+			}
+			if spread > bestSpread {
+				bestSpread = spread
+				best = i
+			}
+		}
+		if best < 0 {
+			break
+		}
+		out[count] = src[best]
+		count++
+	}
+	return count
+}
+
+// contactFace is the extreme feature of one collider along a world direction,
+// ordered around its own centroid.
+type contactFace struct {
+	points [maxFacePoints]Vec3
+	count  int
+}
+
+func (f *contactFace) add(p Vec3) {
+	if f.count < len(f.points) {
+		f.points[f.count] = p
+		f.count++
+	}
+}
+
+func (f contactFace) centroid() Vec3 {
+	if f.count == 0 {
+		return Vec3{}
+	}
+	sum := Vec3{}
+	for i := 0; i < f.count; i++ {
+		sum = sum.Add(f.points[i])
+	}
+	return sum.Div(float64(f.count))
+}
+
+// expandConvexManifold returns the contact patch of two convex colliders for a
+// known contact normal and penetration depth. It reports false when the pair
+// has no patch, which tells the caller to keep the single EPA point.
+//
+// normal points from a toward b, which is the manifold convention.
+//
+// The patch is accepted only when its deepest point agrees with the EPA depth.
+// EPA is validated against two independent oracles, so treating it as the
+// authority stops a clipping mistake from quietly weakening the solver.
+func expandConvexManifold(a, b *Collider, normal Vec3, depth float64, points []ContactPoint) ([]ContactPoint, bool) {
+	faceA := supportFace(a, normal)
+	faceB := supportFace(b, normal.Neg())
+	if faceA.count < 2 || faceB.count < 2 {
+		return points, false
+	}
+
+	// The reference feature must be a real face. Two edges meet at one point,
+	// and expanding that pair invents contacts that are not there.
+	reference, incident := faceA, faceB
+	refNormal := normal
+	if faceB.count > faceA.count {
+		reference, incident = faceB, faceA
+		refNormal = normal.Neg()
+	}
+	if reference.count < 3 {
+		return points, false
+	}
+
+	var clipped [maxFacePoints * 2]Vec3
+	polygon := clipAgainstFace(reference, refNormal, incident, clipped[:0])
+	if len(polygon) < 2 {
+		return points, false
+	}
+
+	// Measure from the reference support plane, which is the plane through the
+	// farthest reference point along the normal. The face centroid would sit
+	// behind that plane whenever the face is not square to the normal, and the
+	// patch would then understate every penetration.
+	planeDistance := refNormal.Dot(reference.points[0])
+	for i := 1; i < reference.count; i++ {
+		if d := refNormal.Dot(reference.points[i]); d > planeDistance {
+			planeDistance = d
+		}
+	}
+
+	var candidateStorage [maxFacePoints * 2]ContactPoint
+	candidates := candidateStorage[:0]
+	deepest := 0.0
+	for _, p := range polygon {
+		separation := refNormal.Dot(p) - planeDistance
+		if separation > contactTolerance {
+			continue
+		}
+		penetration := -separation
+		if penetration > deepest {
+			deepest = penetration
+		}
+		// Place the contact midway between the two surfaces, which is where the
+		// single-point EPA path puts it too.
+		world := p.Add(refNormal.Mul(penetration * 0.5))
+		candidates = append(candidates, makeContactPoint(a, b, world, penetration))
+	}
+	var kept [4]ContactPoint
+	count := reduceContactPatch(candidates, &kept)
+	if count < 2 {
+		return points, false
+	}
+
+	// Reject a patch that disagrees with EPA. Feature selection uses angle
+	// tolerances, so a near-edge case can clip away the true deepest point.
+	if math.Abs(deepest-depth) > maxFloat(1e-4, depth*0.05) {
+		return points, false
+	}
+
+	// Shift the whole patch so its deepest point carries the EPA depth exactly.
+	// EPA is the validated authority on penetration; clipping only decides
+	// where the patch lies and how the depth varies across it.
+	// reduceContactPatch already put the deepest point in slot zero.
+	shift := depth - deepest
+	for i := 0; i < count; i++ {
+		kept[i].Penetration = maxFloat(0, kept[i].Penetration+shift)
+		points = append(points, kept[i])
+	}
+	return points, true
+}
+
+// clipAgainstFace clips the incident polygon against the side planes of the
+// reference face and appends the result to out.
+func clipAgainstFace(reference contactFace, refNormal Vec3, incident contactFace, out []Vec3) []Vec3 {
+	for i := 0; i < incident.count; i++ {
+		out = append(out, incident.points[i])
+	}
+	if reference.count == 2 {
+		// A reference edge bounds the patch along its own direction only.
+		edge := reference.points[1].Sub(reference.points[0])
+		length := edge.Len()
+		if length <= epsilon {
+			return out
+		}
+		direction := edge.Div(length)
+		out = clipHalfSpace(out, direction, direction.Dot(reference.points[1]))
+		out = clipHalfSpace(out, direction.Neg(), -direction.Dot(reference.points[0]))
+		return out
+	}
+
+	centre := reference.centroid()
+	for i := 0; i < reference.count; i++ {
+		start := reference.points[i]
+		end := reference.points[(i+1)%reference.count]
+		side := end.Sub(start).Cross(refNormal)
+		if side.Len2() <= epsilon {
+			continue
+		}
+		side = side.Normalize()
+		if side.Dot(centre.Sub(start)) > 0 {
+			side = side.Neg()
+		}
+		out = clipHalfSpace(out, side, side.Dot(start))
+		if len(out) == 0 {
+			return out
+		}
+	}
+	return out
+}
+
+// supportFace returns the extreme feature of a collider along a world
+// direction. A curved feature reports one point, an edge reports two, and a
+// flat face reports three or more ordered around the centroid.
+func supportFace(c *Collider, dir Vec3) contactFace {
+	var face contactFace
+	if c == nil || dir.Len2() <= epsilon {
+		return face
+	}
+	direction := dir.Normalize()
+	rotation := c.WorldRotation()
+	centre := c.WorldCenter()
+
+	switch c.Shape {
+	case ShapeBox:
+		boxSupportFace(c, centre, rotation, direction, &face)
+	case ShapeConvexHull:
+		hullSupportFace(c, centre, rotation, direction, &face)
+	case ShapeCylinder:
+		cylinderSupportFace(c, centre, direction, &face)
+	case ShapeCone:
+		coneSupportFace(c, direction, &face)
+	case ShapeCapsule:
+		capsuleSupportFace(c, direction, &face)
+	}
+	return face
+}
+
+// boxSupportFace returns the true extreme feature of a box along dir. An axis
+// that is close to perpendicular to dir leaves the feature free along that
+// axis, so the box reports a vertex, an edge or a face as the geometry demands.
+func boxSupportFace(c *Collider, centre Vec3, rotation Quat, dir Vec3, face *contactFace) {
+	half := c.halfExtents()
+	axes := [3]Vec3{
+		rotation.Rotate(Vec3{X: 1}),
+		rotation.Rotate(Vec3{Y: 1}),
+		rotation.Rotate(Vec3{Z: 1}),
+	}
+	extents := [3]float64{half.X, half.Y, half.Z}
+
+	base := centre
+	var free [3]int
+	freeCount := 0
+	for i := 0; i < 3; i++ {
+		along := axes[i].Dot(dir)
+		if math.Abs(along) <= faceFlatTolerance {
+			free[freeCount] = i
+			freeCount++
+			continue
+		}
+		sign := 1.0
+		if along < 0 {
+			sign = -1
+		}
+		base = base.Add(axes[i].Mul(sign * extents[i]))
+	}
+
+	switch freeCount {
+	case 0:
+		face.add(base)
+	case 1:
+		offset := axes[free[0]].Mul(extents[free[0]])
+		face.add(base.Sub(offset))
+		face.add(base.Add(offset))
+	case 2:
+		u := axes[free[0]].Mul(extents[free[0]])
+		v := axes[free[1]].Mul(extents[free[1]])
+		face.add(base.Add(u).Add(v))
+		face.add(base.Sub(u).Add(v))
+		face.add(base.Sub(u).Sub(v))
+		face.add(base.Add(u).Sub(v))
+	}
+}
+
+func hullSupportFace(c *Collider, centre Vec3, rotation Quat, dir Vec3, face *contactFace) {
+	if len(c.hull) == 0 {
+		return
+	}
+	basis := mat3FromQuat(rotation)
+	local := basis.mulT(dir)
+	best := local.Dot(c.hull[0])
+	for _, v := range c.hull[1:] {
+		if d := local.Dot(v); d > best {
+			best = d
+		}
+	}
+	var collected [maxFacePoints]Vec3
+	count := 0
+	for _, v := range c.hull {
+		if local.Dot(v) < best-hullFaceTolerance {
+			continue
+		}
+		if count < len(collected) {
+			collected[count] = centre.Add(basis.mul(v))
+			count++
+		}
+	}
+	orderFacePoints(collected[:count], dir, face)
+}
+
+func cylinderSupportFace(c *Collider, centre Vec3, dir Vec3, face *contactFace) {
+	axis := c.WorldAxis()
+	radius := math.Abs(c.Radius)
+	half := math.Abs(c.Height) * 0.5
+	along := axis.Dot(dir)
+
+	if math.Abs(along) >= faceAngleTolerance {
+		// A cap disc faces the other shape. Sample four rim points using a
+		// basis built from the contact direction, so two facing cylinders
+		// sample the same directions and their patches overlap.
+		sign := 1.0
+		if along < 0 {
+			sign = -1
+		}
+		capCentre := centre.Add(axis.Mul(sign * half))
+		u, v := orthonormalBasis(axis)
+		u = u.Mul(radius)
+		v = v.Mul(radius)
+		face.add(capCentre.Add(u))
+		face.add(capCentre.Add(v))
+		face.add(capCentre.Sub(u))
+		face.add(capCentre.Sub(v))
+		return
+	}
+	if math.Abs(along) <= faceFlatTolerance {
+		// The cylinder lies on its side. The extreme feature is the line where
+		// the barrel touches, which runs from cap to cap.
+		radial := dir.Sub(axis.Mul(along))
+		if radial.Len2() <= epsilon {
+			return
+		}
+		radial = radial.Normalize().Mul(radius)
+		face.add(centre.Sub(axis.Mul(half)).Add(radial))
+		face.add(centre.Add(axis.Mul(half)).Add(radial))
+	}
+}
+
+func coneSupportFace(c *Collider, dir Vec3, face *contactFace) {
+	axis := c.WorldAxis()
+	apex, base := c.ConeApexAndBase()
+	radius := math.Abs(c.Radius)
+	along := axis.Dot(dir)
+
+	if along <= -faceAngleTolerance {
+		// The base disc faces the other shape.
+		u, v := orthonormalBasis(axis)
+		u = u.Mul(radius)
+		v = v.Mul(radius)
+		face.add(base.Add(u))
+		face.add(base.Add(v))
+		face.add(base.Sub(u))
+		face.add(base.Sub(v))
+		return
+	}
+	if along >= faceAngleTolerance {
+		// The apex is a single point.
+		return
+	}
+	radial := dir.Sub(axis.Mul(along))
+	if radial.Len2() <= epsilon {
+		return
+	}
+	radial = radial.Normalize().Mul(radius)
+	face.add(apex)
+	face.add(base.Add(radial))
+}
+
+func capsuleSupportFace(c *Collider, dir Vec3, face *contactFace) {
+	axis := c.WorldAxis()
+	along := axis.Dot(dir)
+	if math.Abs(along) > faceFlatTolerance {
+		// A hemisphere cap touches, which is a single point.
+		return
+	}
+	p0, p1 := c.CapsuleAxisEndpoints()
+	offset := dir.Mul(math.Abs(c.Radius))
+	face.add(p0.Add(offset))
+	face.add(p1.Add(offset))
+}
+
+// orderFacePoints sorts coplanar points around their centroid in the plane
+// whose normal is dir, then copies them into face. Sutherland-Hodgman clipping
+// needs an ordered polygon.
+func orderFacePoints(points []Vec3, dir Vec3, face *contactFace) {
+	if len(points) == 0 {
+		return
+	}
+	if len(points) <= 2 {
+		for _, p := range points {
+			face.add(p)
+		}
+		return
+	}
+	centre := Vec3{}
+	for _, p := range points {
+		centre = centre.Add(p)
+	}
+	centre = centre.Div(float64(len(points)))
+	u, v := orthonormalBasis(dir)
+
+	var angles [maxFacePoints]float64
+	for i, p := range points {
+		d := p.Sub(centre)
+		angles[i] = math.Atan2(v.Dot(d), u.Dot(d))
+	}
+	// Insertion sort. The list never holds more than maxFacePoints entries.
+	for i := 1; i < len(points); i++ {
+		angle := angles[i]
+		point := points[i]
+		j := i - 1
+		for j >= 0 && angles[j] > angle {
+			angles[j+1] = angles[j]
+			points[j+1] = points[j]
+			j--
+		}
+		angles[j+1] = angle
+		points[j+1] = point
+	}
+	for _, p := range points {
+		face.add(p)
+	}
+}

--- a/physics/narrowphase_manifold_test.go
+++ b/physics/narrowphase_manifold_test.go
@@ -1,0 +1,210 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// Angular contact impulses make a single point manifold inadequate: one point
+// lets a flat face rock about it. These tests check that the GJK path now
+// returns a contact patch, that the patch still agrees with EPA on depth, and
+// that a curved feature still returns the one point it really has.
+
+func manifoldPointCount(t *testing.T, a, b *Collider) (ContactManifold, int) {
+	t.Helper()
+	manifold, ok := Collide(a, b)
+	if !ok {
+		t.Fatalf("expected %v and %v to collide", a.Shape, b.Shape)
+	}
+	return manifold, manifold.PointCount
+}
+
+func TestConvexPairsReportAContactPatch(t *testing.T) {
+	hullBox := func(half Vec3, offset Vec3) *Collider {
+		return NewCollider(ColliderConfig{
+			Shape:  ShapeConvexHull,
+			Offset: offset,
+			Vertices: []Vec3{
+				{X: -half.X, Y: -half.Y, Z: -half.Z}, {X: half.X, Y: -half.Y, Z: -half.Z},
+				{X: -half.X, Y: half.Y, Z: -half.Z}, {X: half.X, Y: half.Y, Z: -half.Z},
+				{X: -half.X, Y: -half.Y, Z: half.Z}, {X: half.X, Y: -half.Y, Z: half.Z},
+				{X: -half.X, Y: half.Y, Z: half.Z}, {X: half.X, Y: half.Y, Z: half.Z},
+			},
+		})
+	}
+
+	cases := []struct {
+		name string
+		a    *Collider
+		b    *Collider
+		want int
+	}{
+		{
+			name: "cylinder cap on a box face",
+			a:    NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+			b:    NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 1.45}, Radius: 0.5, Height: 1}),
+			want: 4,
+		},
+		{
+			name: "cylinder cap on a cylinder cap",
+			a:    NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1}),
+			b:    NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 0.95}, Radius: 0.5, Height: 1}),
+			want: 4,
+		},
+		{
+			name: "hull face on a box face",
+			a:    NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+			b:    hullBox(Vec3{X: 0.5, Y: 0.5, Z: 0.5}, Vec3{Y: 1.45}),
+			want: 4,
+		},
+		{
+			name: "hull face on a hull face",
+			a:    hullBox(Vec3{X: 0.5, Y: 0.5, Z: 0.5}, Vec3{}),
+			b:    hullBox(Vec3{X: 0.5, Y: 0.5, Z: 0.5}, Vec3{Y: 0.95}),
+			want: 4,
+		},
+		{
+			// The cone apex sits on local +Y, so the default pose puts the base
+			// disc down onto the box.
+			name: "cone base on a box face",
+			a:    NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+			b:    NewCollider(ColliderConfig{Shape: ShapeCone, Offset: Vec3{Y: 1.45}, Radius: 0.5, Height: 1}),
+			want: 4,
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			manifold, count := manifoldPointCount(t, testCase.a, testCase.b)
+			if count < testCase.want {
+				t.Fatalf("manifold has %d points, want at least %d", count, testCase.want)
+			}
+			// The patch must spread. Two points on the same spot carry the load
+			// of one and let the body rock.
+			spread := 0.0
+			for i := 0; i < count; i++ {
+				for j := i + 1; j < count; j++ {
+					spread = math.Max(spread, manifold.Points[i].Point.Distance(manifold.Points[j].Point))
+				}
+			}
+			if spread < 0.2 {
+				t.Fatalf("contact patch spans only %v; the points are nearly coincident", spread)
+			}
+		})
+	}
+}
+
+func TestCurvedFeaturesKeepASinglePoint(t *testing.T) {
+	cases := []struct {
+		name string
+		a    *Collider
+		b    *Collider
+	}{
+		{
+			name: "sphere on a box",
+			a:    NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+			b:    NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 1.45}, Radius: 0.5}),
+		},
+		{
+			name: "sphere on a cylinder",
+			a:    NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2}),
+			b:    NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.4}, Radius: 0.5}),
+		},
+		{
+			// Turn the cone over so its apex, a single point, meets the box.
+			name: "cone apex on a box",
+			a:    NewCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4}),
+			b: NewCollider(ColliderConfig{
+				Shape: ShapeCone, Offset: Vec3{Y: 1.45}, Radius: 0.5, Height: 1,
+				Rotation: QuatFromAxisAngle(Vec3{X: 1}, math.Pi),
+			}),
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, count := manifoldPointCount(t, testCase.a, testCase.b)
+			if count != 1 {
+				t.Fatalf("a curved feature touches at one point, got %d", count)
+			}
+		})
+	}
+}
+
+// TestExpandedPatchAgreesWithEPADepth guards the acceptance gate. Whatever the
+// clipping does, the deepest point of the manifold must still report the
+// penetration EPA found, because EPA is what two independent oracles validate.
+func TestExpandedPatchAgreesWithEPADepth(t *testing.T) {
+	for _, gap := range []float64{0.99, 0.95, 0.9, 0.8, 0.6} {
+		a := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+		b := NewCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: gap}, Radius: 0.5, Height: 1})
+
+		shapeA, _ := newConvexShape(a)
+		shapeB, _ := newConvexShape(b)
+		simplex, overlap := gjkOverlap(shapeA, shapeB)
+		if !overlap {
+			t.Fatalf("gap %v: shapes must overlap", gap)
+		}
+		want, ok := epaPenetration(shapeA, shapeB, simplex)
+		if !ok {
+			t.Fatalf("gap %v: EPA failed", gap)
+		}
+
+		manifold, _ := manifoldPointCount(t, a, b)
+		deepest := 0.0
+		for i := 0; i < manifold.PointCount; i++ {
+			deepest = math.Max(deepest, manifold.Points[i].Penetration)
+		}
+		if math.Abs(deepest-want.Depth) > 1e-9 {
+			t.Fatalf("gap %v: manifold depth %v, EPA depth %v", gap, deepest, want.Depth)
+		}
+	}
+}
+
+// TestCylinderRestsUprightOnAStaticBox is the behaviour the patch exists for. A
+// single point manifold plus angular impulses lets the cylinder rock over; a
+// patch holds it.
+func TestCylinderRestsUprightOnAStaticBox(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 120.0, SolverIterations: 12})
+	ground := world.AddBody(BodyConfig{Mass: 0})
+	ground.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 10, Height: 2, Depth: 10})
+
+	body := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 1.6}, Friction: 0.5})
+	body.AddCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 1})
+
+	for i := 0; i < 2400; i++ {
+		world.StepFixed()
+	}
+
+	if body.Position.Y < 1.49 || body.Position.Y > 1.51 {
+		t.Fatalf("cylinder should rest near y=1.5, got %v", body.Position.Y)
+	}
+	tilt := math.Hypot(math.Hypot(body.Rotation.X, body.Rotation.Y), body.Rotation.Z)
+	if tilt > 0.02 {
+		t.Fatalf("cylinder tipped over, rotation vector part = %v", tilt)
+	}
+	if body.AngularVelocity.Len() > 0.02 {
+		t.Fatalf("cylinder should be still, angular velocity = %+v", body.AngularVelocity)
+	}
+}
+
+// TestBoxBoxPatchNeverRepeatsAPoint pins the patch reduction. Clipping a face
+// against an identical face lands points on the same corner, and a duplicate
+// gives that corner double the grip.
+func TestBoxBoxPatchNeverRepeatsAPoint(t *testing.T) {
+	a := NewCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+	b := NewCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{Y: 0.999}, Width: 1, Height: 1, Depth: 1})
+
+	manifold, count := manifoldPointCount(t, a, b)
+	if count != 4 {
+		t.Fatalf("two aligned box faces meet at four corners, got %d", count)
+	}
+	for i := 0; i < count; i++ {
+		for j := i + 1; j < count; j++ {
+			if manifold.Points[i].Point.Distance(manifold.Points[j].Point) < 0.1 {
+				t.Fatalf("points %d and %d are duplicates: %+v and %+v",
+					i, j, manifold.Points[i].Point, manifold.Points[j].Point)
+			}
+		}
+	}
+}

--- a/physics/oracle_test.go
+++ b/physics/oracle_test.go
@@ -1,0 +1,409 @@
+package physics
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+)
+
+// Independent penetration oracle.
+//
+// The penetration depth of two convex shapes is, by definition, the smallest
+// value of the Minkowski difference's support function over all unit directions:
+//
+//	depth = min over |n|=1 of ( supportA(n) - supportB(-n) ) . n
+//
+// and the minimising n is the contact normal pointing from A toward B. The
+// oracle below computes that minimum directly with a coarse sweep over the
+// sphere followed by a shrinking local search. It shares no code with GJK or
+// EPA, so the two cannot agree on a shared mistake. Only the support functions
+// are common, and TestSupportFunctionsReturnExtremePoints pins those.
+
+// supportGap returns the Minkowski support distance along a unit direction.
+func supportGap(a, b convexShape, dir Vec3) float64 {
+	return a.support(dir).Sub(b.support(dir.Neg())).Dot(dir)
+}
+
+// penetrationBySupportSearch returns the oracle normal and depth.
+//
+// The support gap over the sphere can hold several local minima, so the coarse
+// sweep keeps its best oracleStarts directions and refines all of them. A single
+// start can settle in a shallow valley and then overstate the depth.
+func penetrationBySupportSearch(a, b convexShape, coarse int) (Vec3, float64) {
+	const oracleStarts = 12
+	type candidate struct {
+		dir Vec3
+		gap float64
+	}
+	starts := make([]candidate, 0, oracleStarts+1)
+	insert := func(dir Vec3, gap float64) {
+		at := len(starts)
+		for at > 0 && starts[at-1].gap > gap {
+			at--
+		}
+		if at >= oracleStarts {
+			return
+		}
+		starts = append(starts, candidate{})
+		copy(starts[at+1:], starts[at:])
+		starts[at] = candidate{dir: dir, gap: gap}
+		if len(starts) > oracleStarts {
+			starts = starts[:oracleStarts]
+		}
+	}
+	for _, dir := range fibonacciDirections(coarse) {
+		insert(dir, supportGap(a, b, dir))
+	}
+
+	spread := 4 * math.Pi / math.Sqrt(float64(coarse))
+	best := math.Inf(1)
+	bestDir := Vec3{X: 1}
+	for _, start := range starts {
+		dir, gap := refineSupportMinimum(a, b, start.dir, start.gap, spread)
+		if gap < best {
+			best = gap
+			bestDir = dir
+		}
+	}
+	return bestDir, best
+}
+
+// refineSupportMinimum walks a ring around the current direction and halves the
+// ring radius whenever no sample improves. Forty halvings take the angular step
+// from the coarse spacing down to machine precision.
+func refineSupportMinimum(a, b convexShape, dir Vec3, gap, spread float64) (Vec3, float64) {
+	const ringSamples = 24
+	for round := 0; round < 40; round++ {
+		u, v := orthonormalBasis(dir)
+		improved := false
+		for i := 0; i < ringSamples; i++ {
+			angle := 2 * math.Pi * float64(i) / ringSamples
+			candidate := dir.
+				Add(u.Mul(spread * math.Cos(angle))).
+				Add(v.Mul(spread * math.Sin(angle))).
+				Normalize()
+			if candidate.Len2() <= epsilon {
+				continue
+			}
+			if probe := supportGap(a, b, candidate); probe < gap {
+				gap = probe
+				dir = candidate
+				improved = true
+			}
+		}
+		if !improved {
+			spread *= 0.5
+		}
+	}
+	return dir, gap
+}
+
+// TestEPAMatchesIndependentSupportOracle checks every shape pair that routes
+// through GJK against the oracle. It covers curved-against-curved contacts,
+// which no other test in this package can verify from first principles.
+func TestEPAMatchesIndependentSupportOracle(t *testing.T) {
+	cases := []struct {
+		name string
+		a    ColliderConfig
+		b    ColliderConfig
+	}{
+		{
+			name: "cylinder side against sphere",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4},
+			b:    ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.2}, Radius: 0.5},
+		},
+		{
+			name: "cylinder cap against sphere",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:    ColliderConfig{Shape: ShapeSphere, Offset: Vec3{Y: 1.4}, Radius: 0.5},
+		},
+		{
+			name: "cylinder rim against sphere",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:    ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 1.2, Y: 1.2}, Radius: 0.5},
+		},
+		{
+			name: "cylinder against box face",
+			a:    ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4},
+			b:    ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 1.9}, Radius: 0.5, Height: 2},
+		},
+		{
+			name: "cylinder against tilted box",
+			a: ColliderConfig{
+				Shape: ShapeBox, Width: 2, Height: 2, Depth: 2,
+				Rotation: QuatFromAxisAngle(Vec3{X: 1, Z: 1}, 0.6),
+			},
+			b: ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 1.9}, Radius: 0.5, Height: 2},
+		},
+		{
+			name: "cylinder against cylinder",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4},
+			b:    ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{X: 1.7}, Radius: 1, Height: 4},
+		},
+		{
+			name: "crossed cylinders",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 4},
+			b: ColliderConfig{
+				Shape: ShapeCylinder, Offset: Vec3{Y: 0.9}, Radius: 0.5, Height: 4,
+				Rotation: QuatFromAxisAngle(Vec3{Z: 1}, math.Pi/2),
+			},
+		},
+		{
+			name: "cylinder against capsule",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 4},
+			b:    ColliderConfig{Shape: ShapeCapsule, Offset: Vec3{X: 1.4}, Radius: 0.5, Height: 2},
+		},
+		{
+			name: "cone against sphere on the flank",
+			a:    ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2},
+			b:    ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 0.9, Y: -0.2}, Radius: 0.5},
+		},
+		{
+			name: "cone apex against box",
+			a:    ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4},
+			b: ColliderConfig{
+				Shape: ShapeCone, Offset: Vec3{Y: 1.95}, Radius: 1, Height: 2,
+				Rotation: QuatFromAxisAngle(Vec3{X: 1}, math.Pi),
+			},
+		},
+		{
+			name: "cone against cone",
+			a:    ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2},
+			b:    ColliderConfig{Shape: ShapeCone, Offset: Vec3{X: 1.2, Y: 0.3}, Radius: 1, Height: 2},
+		},
+		{
+			name: "cone against cylinder",
+			a:    ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2},
+			b:    ColliderConfig{Shape: ShapeCone, Offset: Vec3{Y: 1.4}, Radius: 0.7, Height: 1.4},
+		},
+		{
+			name: "hull against hull",
+			a:    ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5})},
+			b: ColliderConfig{
+				Shape: ShapeConvexHull, Offset: Vec3{Y: 0.9},
+				Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5}),
+			},
+		},
+		{
+			name: "hull against sphere",
+			a:    ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(Vec3{X: 0.5, Y: 0.5, Z: 0.5})},
+			b:    ColliderConfig{Shape: ShapeSphere, Offset: Vec3{X: 0.8, Y: 0.4}, Radius: 0.5},
+		},
+		{
+			name: "tetrahedron hull against cylinder",
+			a: ColliderConfig{Shape: ShapeConvexHull, Vertices: []Vec3{
+				{X: -1, Z: -1}, {X: 1, Z: -1}, {Z: 1}, {Y: 2},
+			}},
+			b: ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{Y: 2.3}, Radius: 0.6, Height: 1},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			a := NewCollider(testCase.a)
+			b := NewCollider(testCase.b)
+			if err := a.Err(); err != nil {
+				t.Fatalf("collider A invalid: %v", err)
+			}
+			if err := b.Err(); err != nil {
+				t.Fatalf("collider B invalid: %v", err)
+			}
+
+			shapeA := mustShape(t, a)
+			shapeB := mustShape(t, b)
+			wantNormal, wantDepth := penetrationBySupportSearch(shapeA, shapeB, 8000)
+			if wantDepth <= 0 {
+				t.Fatalf("oracle reports no overlap (depth %v); the case is not exercising EPA", wantDepth)
+			}
+
+			manifold, ok := Collide(a, b)
+			if !ok {
+				t.Fatalf("narrowphase found no contact, oracle depth = %v", wantDepth)
+			}
+			gotDepth := deepestPenetration(manifold)
+
+			// EPA stops once the remaining gap falls under its tolerance, so
+			// allow twice that plus a small absolute margin.
+			tolerance := 2*epaGapTolerance(shapeA, shapeB) + 1e-9
+			if math.Abs(gotDepth-wantDepth) > tolerance {
+				t.Fatalf("depth = %v, oracle = %v, difference %v exceeds tolerance %v",
+					gotDepth, wantDepth, math.Abs(gotDepth-wantDepth), tolerance)
+			}
+			if manifold.Normal.Dot(wantNormal) < 0.999 {
+				t.Fatalf("normal = %+v, oracle normal = %+v (dot %v)",
+					manifold.Normal, wantNormal, manifold.Normal.Dot(wantNormal))
+			}
+
+			// The reported depth must be a real minimum translation: pushing B
+			// by it separates the pair, and pushing by less does not.
+			pushed := testCase.b
+			pushed.Offset = pushed.Offset.Add(manifold.Normal.Mul(gotDepth + tolerance + 1e-6))
+			if _, still := Collide(a, NewCollider(pushed)); still {
+				t.Fatalf("pair still in contact after moving B by the reported depth %v", gotDepth)
+			}
+			short := testCase.b
+			short.Offset = short.Offset.Add(manifold.Normal.Mul(gotDepth * 0.5))
+			if _, still := Collide(a, NewCollider(short)); !still {
+				t.Fatalf("pair separated after moving B by only half the reported depth %v", gotDepth)
+			}
+		})
+	}
+}
+
+// TestEPAMatchesOracleOnRandomCurvedPairs runs the oracle over random poses of
+// the shapes that have no analytic narrowphase. Random poses reach the rim and
+// apex features that hand-written cases tend to miss.
+func TestEPAMatchesOracleOnRandomCurvedPairs(t *testing.T) {
+	rng := rand.New(rand.NewSource(31337))
+	builders := []func(Quat, Vec3) ColliderConfig{
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{Shape: ShapeCylinder, Rotation: r, Offset: o, Radius: 0.6, Height: 1.4}
+		},
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{Shape: ShapeCone, Rotation: r, Offset: o, Radius: 0.7, Height: 1.6}
+		},
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{Shape: ShapeSphere, Rotation: r, Offset: o, Radius: 0.5}
+		},
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{Shape: ShapeCapsule, Rotation: r, Offset: o, Radius: 0.35, Height: 0.9}
+		},
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{Shape: ShapeBox, Rotation: r, Offset: o, Width: 1, Height: 0.8, Depth: 1.2}
+		},
+		func(r Quat, o Vec3) ColliderConfig {
+			return ColliderConfig{
+				Shape: ShapeConvexHull, Rotation: r, Offset: o,
+				Vertices: boxVertices(Vec3{X: 0.45, Y: 0.6, Z: 0.35}),
+			}
+		},
+	}
+
+	checked := 0
+	for trial := 0; trial < 240; trial++ {
+		buildA := builders[trial%len(builders)]
+		buildB := builders[(trial/len(builders))%len(builders)]
+		configA := buildA(randomUnitQuat(rng), Vec3{})
+		configB := buildB(randomUnitQuat(rng), Vec3{
+			X: (rng.Float64() - 0.5) * 2.2,
+			Y: (rng.Float64() - 0.5) * 2.2,
+			Z: (rng.Float64() - 0.5) * 2.2,
+		})
+		// Skip the pairs that have their own analytic routine; the oracle has
+		// nothing to add there and the analytic tolerance differs.
+		if hasAnalyticNarrowphase(configA.Shape, configB.Shape) {
+			continue
+		}
+
+		a := NewCollider(configA)
+		b := NewCollider(configB)
+		shapeA := mustShape(t, a)
+		shapeB := mustShape(t, b)
+
+		_, wantDepth := penetrationBySupportSearch(shapeA, shapeB, 4000)
+		manifold, ok := Collide(a, b)
+		tolerance := 4*epaGapTolerance(shapeA, shapeB) + 1e-6
+
+		if wantDepth <= tolerance {
+			// Grazing or separated. Only require that any reported contact is
+			// shallow, because the two paths disagree inside the tolerance band.
+			if ok && deepestPenetration(manifold) > wantDepth+tolerance {
+				t.Fatalf("trial %d (%v vs %v): reported depth %v, oracle %v",
+					trial, configA.Shape, configB.Shape, deepestPenetration(manifold), wantDepth)
+			}
+			continue
+		}
+		if !ok {
+			t.Fatalf("trial %d: oracle depth %v but no contact reported\nA: %#v\nB: %#v",
+				trial, wantDepth, configA, configB)
+		}
+		checked++
+		if math.Abs(deepestPenetration(manifold)-wantDepth) > tolerance {
+			t.Fatalf("trial %d: depth %v, oracle %v, tolerance %v\nA: %#v\nB: %#v",
+				trial, deepestPenetration(manifold), wantDepth, tolerance, configA, configB)
+		}
+	}
+	if checked < 40 {
+		t.Fatalf("only %d overlapping trials; the test is not exercising EPA", checked)
+	}
+}
+
+// hasAnalyticNarrowphase reports whether collidePair routes the pair to a
+// hand-written routine instead of to GJK.
+func hasAnalyticNarrowphase(a, b ColliderShape) bool {
+	pair := func(x, y ColliderShape) bool {
+		return (a == x && b == y) || (a == y && b == x)
+	}
+	return pair(ShapeSphere, ShapeSphere) ||
+		pair(ShapeSphere, ShapeBox) ||
+		pair(ShapeSphere, ShapeCapsule) ||
+		pair(ShapeBox, ShapeBox) ||
+		pair(ShapeCapsule, ShapeCapsule)
+}
+
+// TestEPANormalAccuracyAcrossPenetrationDepths pins the accuracy that the rest
+// of the engine relies on. The contact feature here is a rounded hull corner,
+// which is the slowest case for the normal to converge.
+//
+// Depth converges quadratically in the facet angle; the normal only linearly.
+// The measured guarantee is a normal within one degree and a depth within 1e-4
+// for penetrations up to half the sphere radius. The solver's position pass
+// keeps steady-state penetration near positionSlop, which is three orders of
+// magnitude shallower than that.
+func TestEPANormalAccuracyAcrossPenetrationDepths(t *testing.T) {
+	half := Vec3{X: 0.5, Y: 0.6, Z: 0.7}
+	diagonal := Vec3{X: 1, Y: 1, Z: 1}.Normalize()
+	corner := Vec3{X: half.X, Y: half.Y, Z: half.Z}
+	const radius = 0.4
+
+	for _, depth := range []float64{0.001, 0.005, 0.02, 0.08, 0.2} {
+		center := corner.Add(diagonal.Mul(radius - depth))
+		hull := NewCollider(ColliderConfig{Shape: ShapeConvexHull, Vertices: boxVertices(half)})
+		sphere := NewCollider(ColliderConfig{Shape: ShapeSphere, Offset: center, Radius: radius})
+
+		manifold, ok := Collide(hull, sphere)
+		if !ok {
+			t.Fatalf("depth %v: no contact reported", depth)
+		}
+		got := deepestPenetration(manifold)
+		if math.Abs(got-depth) > 1e-4 {
+			t.Fatalf("depth %v: reported %v, error %v exceeds 1e-4", depth, got, math.Abs(got-depth))
+		}
+		// The true normal at a rounded corner points along the corner diagonal.
+		if angle := math.Acos(math.Min(1, manifold.Normal.Dot(diagonal))) * 180 / math.Pi; angle > 1 {
+			t.Fatalf("depth %v: normal %+v is %.3f degrees off the corner diagonal", depth, manifold.Normal, angle)
+		}
+	}
+}
+
+// TestEPAReportsRealDepthForDeepHullCylinderOverlap is a regression test. This
+// pose used to make the expanding polytope break and report a depth of exactly
+// zero, which the solver accepts as a contact and then corrects by nothing.
+func TestEPAReportsRealDepthForDeepHullCylinderOverlap(t *testing.T) {
+	hull := NewCollider(ColliderConfig{
+		Shape:    ShapeConvexHull,
+		Rotation: Quat{X: 0.16342987615306065, Y: -0.6007282588088927, Z: -0.1671327005334652, W: 0.7645148102302678},
+		Vertices: boxVertices(Vec3{X: 0.45, Y: 0.6, Z: 0.35}),
+	})
+	cylinder := NewCollider(ColliderConfig{
+		Shape:    ShapeCylinder,
+		Offset:   Vec3{X: -0.5960293182063598, Y: -0.8544812946397902, Z: -0.5209598076617685},
+		Rotation: Quat{X: 0.7655625128648598, Y: -0.456207171894925, Z: 0.28749552202947987, W: -0.3509065117957669},
+		Radius:   0.6, Height: 1.4,
+	})
+
+	manifold, ok := Collide(hull, cylinder)
+	if !ok {
+		t.Fatal("expected a contact for a pair that overlaps by 0.46")
+	}
+	depth := deepestPenetration(manifold)
+	if depth <= 0 {
+		t.Fatalf("penetration = %v; a contact with no depth resolves nothing", depth)
+	}
+	shapeA := mustShape(t, hull)
+	shapeB := mustShape(t, cylinder)
+	_, want := penetrationBySupportSearch(shapeA, shapeB, 8000)
+	if math.Abs(depth-want) > 2*epaGapTolerance(shapeA, shapeB)+1e-9 {
+		t.Fatalf("penetration = %v, oracle = %v", depth, want)
+	}
+}

--- a/physics/raycast.go
+++ b/physics/raycast.go
@@ -37,7 +37,7 @@ func (w *World) Raycast(ray Ray, maxDistance float64) (RaycastHit, bool) {
 // Raycast returns the closest hit against this collider. maxDistance <= 0
 // means unbounded.
 func (c *Collider) Raycast(ray Ray, maxDistance float64) (RaycastHit, bool) {
-	if c == nil {
+	if c == nil || c.invalid != nil {
 		return RaycastHit{}, false
 	}
 	direction := ray.Direction.Normalize()
@@ -56,6 +56,22 @@ func (c *Collider) Raycast(ray Ray, maxDistance float64) (RaycastHit, bool) {
 		hit, ok = raycastPlane(c, r, limit)
 	case ShapeBox:
 		hit, ok = raycastBox(c, r, limit)
+	case ShapeCapsule:
+		hit, ok = raycastCapsule(c, r, limit)
+	case ShapeCylinder:
+		hit, ok = raycastCylinder(c, r, limit)
+	case ShapeCone:
+		hit, ok = raycastCone(c, r, limit)
+	case ShapeTriangleMesh:
+		hit, ok = raycastMesh(c, r, limit)
+	case ShapeConvexHull:
+		// A hull is stored as a point cloud with no face list, so there is no
+		// surface to intersect. Supply Indices to also get a triangulated
+		// surface, which RaycastSupported then reports as usable.
+		if c.mesh == nil {
+			return RaycastHit{}, false
+		}
+		hit, ok = raycastMesh(c, r, limit)
 	default:
 		return RaycastHit{}, false
 	}
@@ -65,6 +81,23 @@ func (c *Collider) Raycast(ray Ray, maxDistance float64) (RaycastHit, bool) {
 	hit.Collider = c
 	hit.Body = c.Body
 	return hit, true
+}
+
+// RaycastSupported reports whether Raycast can hit this collider. A convex hull
+// declared without Indices has no triangulated surface, so a raycast against it
+// always misses. Check this instead of reading a miss as an answer.
+func (c *Collider) RaycastSupported() bool {
+	if c == nil || c.invalid != nil {
+		return false
+	}
+	switch c.Shape {
+	case ShapeSphere, ShapePlane, ShapeBox, ShapeCapsule, ShapeCylinder, ShapeCone, ShapeTriangleMesh:
+		return true
+	case ShapeConvexHull:
+		return c.mesh != nil
+	default:
+		return false
+	}
 }
 
 func raycastSphere(c *Collider, ray Ray, maxDistance float64) (RaycastHit, bool) {

--- a/physics/raycast_shapes.go
+++ b/physics/raycast_shapes.go
@@ -1,0 +1,290 @@
+package physics
+
+import "math"
+
+// Raycast routines for capsule, cylinder, cone and triangle mesh colliders.
+// Every routine works in collider-local space, where the shape axis is local Y,
+// and reports distances that are already world distances because the transform
+// is a rotation plus a translation.
+
+// localRay converts a world ray into the collider's local frame.
+func localRay(c *Collider, ray Ray) (Vec3, Vec3, mat3) {
+	basis := mat3FromQuat(c.WorldRotation())
+	origin := basis.mulT(ray.Origin.Sub(c.WorldCenter()))
+	direction := basis.mulT(ray.Direction)
+	return origin, direction, basis
+}
+
+func insideHit(ray Ray) (RaycastHit, bool) {
+	return RaycastHit{Point: ray.Origin, Normal: ray.Direction.Neg(), Distance: 0}, true
+}
+
+func raycastCapsule(c *Collider, ray Ray, maxDistance float64) (RaycastHit, bool) {
+	radius := math.Abs(c.Radius)
+	half := math.Abs(c.Height) * 0.5
+	if radius <= 0 {
+		return RaycastHit{}, false
+	}
+	origin, direction, basis := localRay(c, ray)
+
+	// A ray that starts inside reports zero distance, which matches the box
+	// and sphere routines.
+	axisPoint := Vec3{Y: clampFloat(origin.Y, -half, half)}
+	if origin.Sub(axisPoint).Len2() <= radius*radius {
+		return insideHit(ray)
+	}
+
+	best := math.Inf(1)
+	var bestNormal Vec3
+
+	// Lateral tube of the capsule.
+	a := direction.X*direction.X + direction.Z*direction.Z
+	b := origin.X*direction.X + origin.Z*direction.Z
+	cc := origin.X*origin.X + origin.Z*origin.Z - radius*radius
+	if a > epsilon {
+		discriminant := b*b - a*cc
+		if discriminant >= 0 {
+			root := math.Sqrt(discriminant)
+			t := (-b - root) / a
+			if t >= 0 && t <= maxDistance {
+				y := origin.Y + t*direction.Y
+				if math.Abs(y) <= half {
+					best = t
+					bestNormal = Vec3{X: origin.X + t*direction.X, Z: origin.Z + t*direction.Z}.Normalize()
+				}
+			}
+		}
+	}
+
+	// Hemisphere caps.
+	for _, capY := range [2]float64{-half, half} {
+		center := Vec3{Y: capY}
+		m := origin.Sub(center)
+		mb := m.Dot(direction)
+		mc := m.Dot(m) - radius*radius
+		discriminant := mb*mb - mc
+		if discriminant < 0 {
+			continue
+		}
+		t := -mb - math.Sqrt(discriminant)
+		if t < 0 || t > maxDistance || t >= best {
+			continue
+		}
+		point := origin.Add(direction.Mul(t))
+		if capY > 0 && point.Y < half {
+			continue
+		}
+		if capY < 0 && point.Y > -half {
+			continue
+		}
+		best = t
+		bestNormal = point.Sub(center).Normalize()
+	}
+
+	if math.IsInf(best, 1) {
+		return RaycastHit{}, false
+	}
+	return finishLocalHit(c, ray, basis, bestNormal, best)
+}
+
+func raycastCylinder(c *Collider, ray Ray, maxDistance float64) (RaycastHit, bool) {
+	radius := math.Abs(c.Radius)
+	half := math.Abs(c.Height) * 0.5
+	if radius <= 0 || half <= 0 {
+		return RaycastHit{}, false
+	}
+	origin, direction, basis := localRay(c, ray)
+
+	if math.Abs(origin.Y) <= half && origin.X*origin.X+origin.Z*origin.Z <= radius*radius {
+		return insideHit(ray)
+	}
+
+	best := math.Inf(1)
+	var bestNormal Vec3
+
+	a := direction.X*direction.X + direction.Z*direction.Z
+	b := origin.X*direction.X + origin.Z*direction.Z
+	cc := origin.X*origin.X + origin.Z*origin.Z - radius*radius
+	if a > epsilon {
+		discriminant := b*b - a*cc
+		if discriminant >= 0 {
+			root := math.Sqrt(discriminant)
+			for _, t := range [2]float64{(-b - root) / a, (-b + root) / a} {
+				if t < 0 || t > maxDistance || t >= best {
+					continue
+				}
+				y := origin.Y + t*direction.Y
+				if math.Abs(y) > half {
+					continue
+				}
+				best = t
+				bestNormal = Vec3{X: origin.X + t*direction.X, Z: origin.Z + t*direction.Z}.Normalize()
+			}
+		}
+	}
+
+	if math.Abs(direction.Y) > epsilon {
+		for _, capY := range [2]float64{-half, half} {
+			t := (capY - origin.Y) / direction.Y
+			if t < 0 || t > maxDistance || t >= best {
+				continue
+			}
+			x := origin.X + t*direction.X
+			z := origin.Z + t*direction.Z
+			if x*x+z*z > radius*radius {
+				continue
+			}
+			best = t
+			bestNormal = Vec3{Y: math.Copysign(1, capY)}
+		}
+	}
+
+	if math.IsInf(best, 1) {
+		return RaycastHit{}, false
+	}
+	return finishLocalHit(c, ray, basis, bestNormal, best)
+}
+
+func raycastCone(c *Collider, ray Ray, maxDistance float64) (RaycastHit, bool) {
+	radius := math.Abs(c.Radius)
+	half := math.Abs(c.Height) * 0.5
+	if radius <= 0 || half <= 0 {
+		return RaycastHit{}, false
+	}
+	origin, direction, basis := localRay(c, ray)
+
+	// slope is the cone radius gained per unit of drop from the apex.
+	slope := radius / (2 * half)
+	slope2 := slope * slope
+
+	if origin.Y >= -half && origin.Y <= half {
+		limit := slope * (half - origin.Y)
+		if origin.X*origin.X+origin.Z*origin.Z <= limit*limit {
+			return insideHit(ray)
+		}
+	}
+
+	best := math.Inf(1)
+	var bestNormal Vec3
+
+	drop := half - origin.Y
+	a := direction.X*direction.X + direction.Z*direction.Z - slope2*direction.Y*direction.Y
+	b := origin.X*direction.X + origin.Z*direction.Z + slope2*drop*direction.Y
+	cc := origin.X*origin.X + origin.Z*origin.Z - slope2*drop*drop
+
+	accept := func(t float64) {
+		if t < 0 || t > maxDistance || t >= best {
+			return
+		}
+		y := origin.Y + t*direction.Y
+		if y < -half || y > half {
+			return
+		}
+		x := origin.X + t*direction.X
+		z := origin.Z + t*direction.Z
+		normal := Vec3{X: x, Y: slope2 * (half - y), Z: z}.Normalize()
+		if normal.Len2() <= epsilon {
+			// The ray landed on the apex, where the surface has no single
+			// normal. Report the cone axis, which is the usual convention.
+			normal = Vec3{Y: 1}
+		}
+		best = t
+		bestNormal = normal
+	}
+
+	if math.Abs(a) > epsilon {
+		discriminant := b*b - a*cc
+		if discriminant >= 0 {
+			root := math.Sqrt(discriminant)
+			accept((-b - root) / a)
+			accept((-b + root) / a)
+		}
+	} else if math.Abs(b) > epsilon {
+		accept(-cc / (2 * b))
+	}
+
+	if math.Abs(direction.Y) > epsilon {
+		t := (-half - origin.Y) / direction.Y
+		if t >= 0 && t <= maxDistance && t < best {
+			x := origin.X + t*direction.X
+			z := origin.Z + t*direction.Z
+			if x*x+z*z <= radius*radius {
+				best = t
+				bestNormal = Vec3{Y: -1}
+			}
+		}
+	}
+
+	if math.IsInf(best, 1) {
+		return RaycastHit{}, false
+	}
+	return finishLocalHit(c, ray, basis, bestNormal, best)
+}
+
+func raycastMesh(c *Collider, ray Ray, maxDistance float64) (RaycastHit, bool) {
+	if c.mesh == nil {
+		return RaycastHit{}, false
+	}
+	origin, direction, basis := localRay(c, ray)
+
+	best := math.Inf(1)
+	var bestNormal Vec3
+	c.mesh.queryRay(origin, direction, maxDistance, func(index int, limit float64) float64 {
+		tri := c.mesh.tris[index]
+		t, normal, ok := rayTriangle(origin, direction, tri, limit)
+		if !ok || t >= best {
+			return limit
+		}
+		best = t
+		bestNormal = normal
+		return t
+	})
+	if math.IsInf(best, 1) {
+		return RaycastHit{}, false
+	}
+	if bestNormal.Dot(direction) > 0 {
+		bestNormal = bestNormal.Neg()
+	}
+	return finishLocalHit(c, ray, basis, bestNormal, best)
+}
+
+// rayTriangle runs the Moller-Trumbore intersection test and returns the
+// distance plus the geometric normal.
+func rayTriangle(origin, direction Vec3, tri meshTriangle, maxDistance float64) (float64, Vec3, bool) {
+	edge1 := tri.b.Sub(tri.a)
+	edge2 := tri.c.Sub(tri.a)
+	pvec := direction.Cross(edge2)
+	det := edge1.Dot(pvec)
+	if math.Abs(det) <= 1e-15 {
+		return 0, Vec3{}, false
+	}
+	invDet := 1 / det
+	tvec := origin.Sub(tri.a)
+	u := tvec.Dot(pvec) * invDet
+	if u < 0 || u > 1 {
+		return 0, Vec3{}, false
+	}
+	qvec := tvec.Cross(edge1)
+	v := direction.Dot(qvec) * invDet
+	if v < 0 || u+v > 1 {
+		return 0, Vec3{}, false
+	}
+	t := edge2.Dot(qvec) * invDet
+	if t < 0 || t > maxDistance {
+		return 0, Vec3{}, false
+	}
+	return t, edge1.Cross(edge2).Normalize(), true
+}
+
+// finishLocalHit turns a local-space normal plus distance into a world hit.
+func finishLocalHit(c *Collider, ray Ray, basis mat3, localNormal Vec3, distance float64) (RaycastHit, bool) {
+	normal := basis.mul(localNormal).Normalize()
+	if normal.Len2() <= epsilon {
+		normal = ray.Direction.Neg()
+	}
+	return RaycastHit{
+		Point:    ray.At(distance),
+		Normal:   normal,
+		Distance: distance,
+	}, true
+}

--- a/physics/raycast_shapes_test.go
+++ b/physics/raycast_shapes_test.go
@@ -1,0 +1,191 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+func TestRaycastCapsuleTubeAndCaps(t *testing.T) {
+	// Capsule along Y: segment from y=-1 to y=1, radius 0.5.
+	capsule := NewCollider(ColliderConfig{Shape: ShapeCapsule, Radius: 0.5, Height: 2})
+
+	hit, ok := capsule.Raycast(Ray{Origin: Vec3{X: -4}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the capsule tube")
+	}
+	if math.Abs(hit.Distance-3.5) > 1e-9 {
+		t.Fatalf("tube distance = %v, want 3.5", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{X: -1}) < 0.999 {
+		t.Fatalf("tube normal = %+v, want -X", hit.Normal)
+	}
+
+	// Straight down the axis hits the top cap at y=1.5.
+	hit, ok = capsule.Raycast(Ray{Origin: Vec3{Y: 5}, Direction: Vec3{Y: -1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the top cap")
+	}
+	if math.Abs(hit.Distance-3.5) > 1e-9 {
+		t.Fatalf("cap distance = %v, want 3.5", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{Y: 1}) < 0.999 {
+		t.Fatalf("cap normal = %+v, want +Y", hit.Normal)
+	}
+
+	// A ray level with the cap centre but outside the radius must miss.
+	if _, ok := capsule.Raycast(Ray{Origin: Vec3{X: -4, Y: 0.9}, Direction: Vec3{X: 1}}, 0); !ok {
+		t.Fatal("a ray inside the tube radius must hit")
+	}
+	if _, ok := capsule.Raycast(Ray{Origin: Vec3{X: -4, Y: 1.6}, Direction: Vec3{X: 1}}, 0); ok {
+		t.Fatal("a ray above the top cap must miss")
+	}
+}
+
+func TestRaycastCapsuleFromInsideReportsZeroDistance(t *testing.T) {
+	capsule := NewCollider(ColliderConfig{Shape: ShapeCapsule, Radius: 0.5, Height: 2})
+	hit, ok := capsule.Raycast(Ray{Origin: Vec3{}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("a ray starting inside must report a hit")
+	}
+	if hit.Distance != 0 {
+		t.Fatalf("distance = %v, want 0", hit.Distance)
+	}
+}
+
+func TestRaycastCylinderSideAndCaps(t *testing.T) {
+	cylinder := NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 1, Height: 2})
+
+	hit, ok := cylinder.Raycast(Ray{Origin: Vec3{X: -5}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the cylinder wall")
+	}
+	if math.Abs(hit.Distance-4) > 1e-9 {
+		t.Fatalf("wall distance = %v, want 4", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{X: -1}) < 0.999 {
+		t.Fatalf("wall normal = %+v, want -X", hit.Normal)
+	}
+
+	hit, ok = cylinder.Raycast(Ray{Origin: Vec3{X: 0.5, Y: 4}, Direction: Vec3{Y: -1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the top cap")
+	}
+	if math.Abs(hit.Distance-3) > 1e-9 {
+		t.Fatalf("cap distance = %v, want 3", hit.Distance)
+	}
+	if !hit.Normal.Near(Vec3{Y: 1}, 1e-9) {
+		t.Fatalf("cap normal = %+v, want +Y", hit.Normal)
+	}
+
+	// Above the cap plane but outside the wall: must miss.
+	if _, ok := cylinder.Raycast(Ray{Origin: Vec3{X: -5, Y: 1.2}, Direction: Vec3{X: 1}}, 0); ok {
+		t.Fatal("a ray above the cylinder must miss")
+	}
+	// Rotated cylinder: lay it along X and shoot down the new axis.
+	rotated := NewCollider(ColliderConfig{
+		Shape: ShapeCylinder, Radius: 1, Height: 2,
+		Rotation: QuatFromAxisAngle(Vec3{Z: 1}, math.Pi/2),
+	})
+	hit, ok = rotated.Raycast(Ray{Origin: Vec3{X: -5}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the rotated cylinder cap")
+	}
+	if math.Abs(hit.Distance-4) > 1e-9 {
+		t.Fatalf("rotated cap distance = %v, want 4", hit.Distance)
+	}
+	if hit.Normal.Dot(Vec3{X: -1}) < 0.999 {
+		t.Fatalf("rotated cap normal = %+v, want -X", hit.Normal)
+	}
+}
+
+func TestRaycastConeApexBaseAndSide(t *testing.T) {
+	// Radius 1, height 2: apex at y=1, base disc radius 1 at y=-1.
+	cone := NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 1, Height: 2})
+
+	// Straight down the axis hits the apex.
+	hit, ok := cone.Raycast(Ray{Origin: Vec3{Y: 5}, Direction: Vec3{Y: -1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit at the cone apex")
+	}
+	if math.Abs(hit.Distance-4) > 1e-6 {
+		t.Fatalf("apex distance = %v, want 4", hit.Distance)
+	}
+
+	// Straight up the axis hits the base disc.
+	hit, ok = cone.Raycast(Ray{Origin: Vec3{Y: -5}, Direction: Vec3{Y: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the cone base")
+	}
+	if math.Abs(hit.Distance-4) > 1e-9 {
+		t.Fatalf("base distance = %v, want 4", hit.Distance)
+	}
+	if !hit.Normal.Near(Vec3{Y: -1}, 1e-9) {
+		t.Fatalf("base normal = %+v, want -Y", hit.Normal)
+	}
+
+	// Level with the base rim: the wall is at radius 1 there.
+	hit, ok = cone.Raycast(Ray{Origin: Vec3{X: -5, Y: -1 + 1e-6}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit on the cone wall near the base rim")
+	}
+	if math.Abs(hit.Distance-4) > 1e-3 {
+		t.Fatalf("rim distance = %v, want 4", hit.Distance)
+	}
+
+	// Half way up, the cone radius is 0.5, so the wall sits at x=-0.5.
+	hit, ok = cone.Raycast(Ray{Origin: Vec3{X: -5, Y: 0}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit half way up the cone wall")
+	}
+	if math.Abs(hit.Distance-4.5) > 1e-9 {
+		t.Fatalf("mid-wall distance = %v, want 4.5", hit.Distance)
+	}
+	if hit.Normal.X >= 0 || hit.Normal.Y <= 0 {
+		t.Fatalf("wall normal = %+v, want it pointing out and up", hit.Normal)
+	}
+
+	// Above the apex: must miss.
+	if _, ok := cone.Raycast(Ray{Origin: Vec3{X: -5, Y: 1.1}, Direction: Vec3{X: 1}}, 0); ok {
+		t.Fatal("a ray above the apex must miss")
+	}
+	// Below the base: must miss.
+	if _, ok := cone.Raycast(Ray{Origin: Vec3{X: -5, Y: -1.1}, Direction: Vec3{X: 1}}, 0); ok {
+		t.Fatal("a ray below the base must miss")
+	}
+}
+
+func TestRaycastHonoursMaxDistanceForNewShapes(t *testing.T) {
+	shapes := map[string]*Collider{
+		"capsule":  NewCollider(ColliderConfig{Shape: ShapeCapsule, Radius: 0.5, Height: 2, Offset: Vec3{X: 10}}),
+		"cylinder": NewCollider(ColliderConfig{Shape: ShapeCylinder, Radius: 0.5, Height: 2, Offset: Vec3{X: 10}}),
+		"cone":     NewCollider(ColliderConfig{Shape: ShapeCone, Radius: 0.5, Height: 2, Offset: Vec3{X: 10}}),
+	}
+	for name, collider := range shapes {
+		ray := Ray{Origin: Vec3{}, Direction: Vec3{X: 1}}
+		if _, ok := collider.Raycast(ray, 5); ok {
+			t.Fatalf("%s: a 5 unit ray must not reach a shape 10 units away", name)
+		}
+		if _, ok := collider.Raycast(ray, 20); !ok {
+			t.Fatalf("%s: a 20 unit ray must reach the shape", name)
+		}
+	}
+}
+
+func TestWorldRaycastFindsCylinderAmongMixedShapes(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{}, FixedTimestep: 1.0 / 60.0})
+	world.AddCollider(ColliderConfig{Shape: ShapeBox, Offset: Vec3{X: 8}, Width: 1, Height: 1, Depth: 1})
+	cylinder := world.AddCollider(ColliderConfig{Shape: ShapeCylinder, Offset: Vec3{X: 4}, Radius: 0.5, Height: 2})
+	world.AddCollider(ColliderConfig{Shape: ShapeCone, Offset: Vec3{X: 12}, Radius: 0.5, Height: 2})
+
+	hit, ok := world.Raycast(Ray{Origin: Vec3{}, Direction: Vec3{X: 1}}, 0)
+	if !ok {
+		t.Fatal("expected a hit")
+	}
+	if hit.Collider != cylinder {
+		t.Fatalf("hit collider index %d, want the cylinder at index %d",
+			colliderIndex(hit.Collider), colliderIndex(cylinder))
+	}
+	if math.Abs(hit.Distance-3.5) > 1e-9 {
+		t.Fatalf("distance = %v, want 3.5", hit.Distance)
+	}
+}

--- a/physics/sleep_test.go
+++ b/physics/sleep_test.go
@@ -1,0 +1,180 @@
+package physics
+
+import (
+	"math"
+	"testing"
+)
+
+// Sleeping is opt in through BodyConfig.CanSleep. These tests check the three
+// things a sleep system must get right: it must stop a settled body, it must
+// leave every other body alone, and it must wake a sleeper that is disturbed.
+
+func TestSettledBodySleepsWhenCanSleepIsSet(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2}, Friction: 0.5, CanSleep: true})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 300; i++ {
+		world.StepFixed()
+	}
+
+	if !box.IsSleeping() {
+		t.Fatalf("a settled box with CanSleep must sleep, velocity = %+v", box.Velocity)
+	}
+	resting := box.Position
+	for i := 0; i < 3000; i++ {
+		world.StepFixed()
+	}
+	if box.Position != resting {
+		t.Fatalf("a sleeping body must not move: %+v became %+v", resting, box.Position)
+	}
+}
+
+func TestBodyWithoutCanSleepKeepsSimulating(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2}, Friction: 0.5})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 600; i++ {
+		world.StepFixed()
+	}
+	if box.IsSleeping() {
+		t.Fatal("a body without CanSleep must never sleep")
+	}
+}
+
+// TestSleepingStackStopsDriftingCompletely shows what sleeping buys. A stack
+// that reaches rest freezes exactly, with no residual creep at all, over twenty
+// thousand steps.
+//
+// The stack sleeps only when every box in it is slow. A box that leans on a
+// moving box cannot sleep, because a sleeping body acts as an immovable
+// support and one part of a pile freezing would shake the rest.
+func TestSleepingStackStopsDriftingCompletely(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+
+	boxes := make([]*RigidBody, 2)
+	for i := range boxes {
+		body := world.AddBody(BodyConfig{
+			Mass: 1, Position: Vec3{Y: 0.5 + float64(i)}, Friction: 0.6, CanSleep: true,
+		})
+		body.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+		boxes[i] = body
+	}
+
+	for i := 0; i < 300; i++ {
+		world.StepFixed()
+	}
+	for i, box := range boxes {
+		if !box.IsSleeping() {
+			t.Fatalf("box[%d] never settled, velocity = %+v", i, box.Velocity)
+		}
+	}
+
+	settled := make([]Vec3, len(boxes))
+	for i, box := range boxes {
+		settled[i] = box.Position
+	}
+	for i := 0; i < 20000; i++ {
+		world.StepFixed()
+	}
+	for i, box := range boxes {
+		if box.Position != settled[i] {
+			t.Fatalf("box[%d] drifted from %+v to %+v over 20000 steps", i, settled[i], box.Position)
+		}
+		want := 0.5 + float64(i)
+		if math.Abs(box.Position.Y-want) > 0.02 {
+			t.Fatalf("box[%d] settled at y=%v, want near %v", i, box.Position.Y, want)
+		}
+	}
+}
+
+func TestSleepingBodyWakesWhenStruck(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	target := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 0.5}, Friction: 0.4, CanSleep: true})
+	target.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+	if !target.IsSleeping() {
+		t.Fatal("the target must settle before the test means anything")
+	}
+
+	striker := world.AddBody(BodyConfig{Mass: 2, Position: Vec3{X: -4, Y: 0.5}, Velocity: Vec3{X: 6}})
+	striker.AddCollider(ColliderConfig{Shape: ShapeSphere, Radius: 0.4})
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+		if !target.IsSleeping() {
+			break
+		}
+	}
+
+	if target.IsSleeping() {
+		t.Fatal("a struck body must wake")
+	}
+	if target.Position.X <= 0.01 {
+		t.Fatalf("the woken body should have been pushed, x = %v", target.Position.X)
+	}
+}
+
+func TestWakeAllAndSetGravityWakeSleepers(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 8})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 0.5}, CanSleep: true})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+	if !box.IsSleeping() {
+		t.Fatal("the box must sleep first")
+	}
+	world.WakeAll()
+	if box.IsSleeping() {
+		t.Fatal("WakeAll must wake every body")
+	}
+
+	for i := 0; i < 120; i++ {
+		world.StepFixed()
+	}
+	if !box.IsSleeping() {
+		t.Fatal("the box must settle again")
+	}
+	world.SetGravity(Vec3{X: 10})
+	if box.IsSleeping() {
+		t.Fatal("changing gravity must wake every body")
+	}
+}
+
+func TestRemovingTheSupportWakesTheBodyAbove(t *testing.T) {
+	world := NewWorld(WorldConfig{Gravity: Vec3{Y: -10}, FixedTimestep: 1.0 / 60.0, SolverIterations: 10})
+	world.AddCollider(ColliderConfig{Shape: ShapePlane, Normal: Vec3{Y: 1}})
+	support := world.AddBody(BodyConfig{Mass: 0, Position: Vec3{Y: 1}})
+	support.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 4, Height: 2, Depth: 4})
+	box := world.AddBody(BodyConfig{Mass: 1, Position: Vec3{Y: 2.5}, Friction: 0.5, CanSleep: true})
+	box.AddCollider(ColliderConfig{Shape: ShapeBox, Width: 1, Height: 1, Depth: 1})
+
+	for i := 0; i < 240; i++ {
+		world.StepFixed()
+	}
+	if !box.IsSleeping() {
+		t.Fatalf("the box must settle on the support first, velocity = %+v", box.Velocity)
+	}
+
+	world.RemoveBody(support)
+	if box.IsSleeping() {
+		t.Fatal("removing the support must wake the body it held")
+	}
+	for i := 0; i < 240; i++ {
+		world.StepFixed()
+	}
+	if box.Position.Y > 0.6 {
+		t.Fatalf("the box should have fallen to the plane, y = %v", box.Position.Y)
+	}
+}

--- a/physics/solver.go
+++ b/physics/solver.go
@@ -1,105 +1,336 @@
 package physics
 
+import "math"
+
 const (
-	positionSlop          = 0.001
-	positionCorrection    = 0.8
+	// positionSlop is the overlap the position pass leaves in place. A resting
+	// body settles this far inside the surface it stands on, which keeps the
+	// contact alive from step to step.
+	positionSlop = 0.0005
+	// positionCorrection is the share of the excess overlap that one step
+	// removes. Values near 1 recover fast and jitter; values near 0 sink.
+	positionCorrection = 0.45
+	// maxCorrectionSpeed caps the pseudo velocity of the position pass, in
+	// metres per second. Without the cap a deep overlap throws bodies apart.
+	maxCorrectionSpeed = 3.0
+	// restitutionVelMinimum is the approach speed below which a contact stops
+	// bouncing. It stops a resting stack from buzzing.
 	restitutionVelMinimum = 1.0
+	// positionIterations is the iteration count of the position pass. The pass
+	// carries no friction, so it converges faster than the velocity pass.
+	positionIterations = 4
 )
 
-func solveContactVelocity(manifold *ContactManifold) {
-	if manifold == nil || manifold.IsTrigger() {
+// contactSolvePoint is the per-point scratch of one step. The world rebuilds it
+// in prepareContacts and reuses the backing array across steps.
+type contactSolvePoint struct {
+	// rA and rB are the contact offsets from each body centre of mass.
+	rA Vec3
+	rB Vec3
+	// normalMass and tangentMass are the inverse effective masses along the
+	// contact normal and along the two friction directions.
+	normalMass  float64
+	tangentMass [2]float64
+	// restitutionTarget is the separating speed the velocity pass aims for.
+	restitutionTarget float64
+	// penetration is the overlap the position pass must remove.
+	penetration float64
+	// positionImpulse accumulates the pseudo impulse of the position pass.
+	positionImpulse float64
+}
+
+// contactSolveManifold holds the prepared state of one manifold.
+type contactSolveManifold struct {
+	normal   Vec3
+	tangent  [2]Vec3
+	points   [4]contactSolvePoint
+	count    int
+	friction float64
+	active   bool
+}
+
+// inverseInertiaWorld returns the world inverse inertia tensor the solver may
+// use for a body. A static, kinematic, sleeping or rotation-locked body returns
+// the zero matrix, so it absorbs no angular impulse.
+func inverseInertiaWorld(body *RigidBody) mat3 {
+	if body == nil || !body.IsDynamic() || body.IsSleeping() {
+		return mat3{}
+	}
+	return body.invInertiaWorld
+}
+
+// effectiveMassAlong returns the inverse effective mass of a contact pair along
+// direction dir, including the angular term of both bodies.
+//
+// The scalar is invMassA + invMassB + dir . ((IA * (rA x dir)) x rA) + the same
+// term for B. It is the denominator of every sequential impulse in this file.
+func effectiveMassAlong(dir Vec3, invMassA, invMassB float64, invIA, invIB mat3, rA, rB Vec3) float64 {
+	k := invMassA + invMassB
+	if !invIA.isZero() {
+		ra := rA.Cross(dir)
+		k += invIA.mul(ra).Dot(ra)
+	}
+	if !invIB.isZero() {
+		rb := rB.Cross(dir)
+		k += invIB.mul(rb).Dot(rb)
+	}
+	return k
+}
+
+// applyImpulseAtOffset adds a world impulse acting at offset r from the body
+// centre of mass. It changes both linear and angular velocity.
+func applyImpulseAtOffset(body *RigidBody, impulse, r Vec3) {
+	if body == nil || !body.IsDynamic() || body.IsSleeping() {
 		return
 	}
-	invMassA := inverseMass(manifold.BodyA)
-	invMassB := inverseMass(manifold.BodyB)
-	invMassSum := invMassA + invMassB
-	if invMassSum <= 0 {
-		return
-	}
-
-	normal := manifold.Normal.Normalize()
-	for i := 0; i < manifold.PointCount; i++ {
-		point := manifold.Points[i].Point
-		rv := velocityAt(manifold.BodyB, point).Sub(velocityAt(manifold.BodyA, point))
-		velAlongNormal := rv.Dot(normal)
-
-		restitution := manifold.Restitution
-		if -velAlongNormal < restitutionVelMinimum {
-			restitution = 0
-		}
-
-		// Incremental-impulse form: delta is what this iteration wants to
-		// apply, but the accumulated total is clamped to >= 0 so warm-started
-		// seeds are preserved across iterations and stacking stays stable.
-		oldTotal := manifold.Points[i].NormalImpulse
-		delta := -(1 + restitution) * velAlongNormal / invMassSum
-		newTotal := oldTotal + delta
-		if newTotal < 0 {
-			newTotal = 0
-		}
-		actualDelta := newTotal - oldTotal
-		if actualDelta != 0 {
-			impulse := normal.Mul(actualDelta)
-			applyLinearImpulse(manifold.BodyA, impulse.Neg())
-			applyLinearImpulse(manifold.BodyB, impulse)
-		}
-		manifold.Points[i].NormalImpulse = newTotal
-
-		if manifold.Friction <= 0 || newTotal <= 0 {
-			continue
-		}
-		rv = velocityAt(manifold.BodyB, point).Sub(velocityAt(manifold.BodyA, point))
-		tangent := rv.Sub(normal.Mul(rv.Dot(normal)))
-		if tangent.Len2() <= epsilon {
-			continue
-		}
-		tangent = tangent.Normalize()
-
-		oldTangent := manifold.Points[i].TangentImpulse[0]
-		tangentDelta := -rv.Dot(tangent) / invMassSum
-		newTangent := oldTangent + tangentDelta
-		maxFriction := newTotal * manifold.Friction
-		if newTangent > maxFriction {
-			newTangent = maxFriction
-		} else if newTangent < -maxFriction {
-			newTangent = -maxFriction
-		}
-		tangentActual := newTangent - oldTangent
-		if tangentActual != 0 {
-			frictionImpulse := tangent.Mul(tangentActual)
-			applyLinearImpulse(manifold.BodyA, frictionImpulse.Neg())
-			applyLinearImpulse(manifold.BodyB, frictionImpulse)
-		}
-		manifold.Points[i].TangentImpulse[0] = newTangent
+	body.Velocity = body.Velocity.Add(impulse.Mul(body.InvMass))
+	if !body.invInertiaWorld.isZero() {
+		body.AngularVelocity = body.AngularVelocity.Add(body.invInertiaWorld.mul(r.Cross(impulse)))
 	}
 }
 
-func solveContactPosition(manifold *ContactManifold, dt float64) {
-	if manifold == nil || manifold.IsTrigger() || dt <= 0 {
+// applyPseudoImpulseAtOffset is applyImpulseAtOffset for the position pass. It
+// moves the pseudo velocities, which never reach the reported body velocity.
+//
+// A body that receives its first pseudo impulse of the step is appended to
+// touched, so the caller integrates only the bodies the pass moved.
+func applyPseudoImpulseAtOffset(body *RigidBody, impulse, r Vec3, touched []*RigidBody) []*RigidBody {
+	if body == nil || !body.IsDynamic() || body.IsSleeping() {
+		return touched
+	}
+	if !body.pseudoActive {
+		body.pseudoActive = true
+		body.pseudoVelocity = Vec3{}
+		body.pseudoAngular = Vec3{}
+		touched = append(touched, body)
+	}
+	body.pseudoVelocity = body.pseudoVelocity.Add(impulse.Mul(body.InvMass))
+	if !body.invInertiaWorld.isZero() {
+		body.pseudoAngular = body.pseudoAngular.Add(body.invInertiaWorld.mul(r.Cross(impulse)))
+	}
+	return touched
+}
+
+// relativeVelocityAt returns the velocity of body B's material point minus the
+// velocity of body A's material point at the same world location.
+func relativeVelocityAt(a, b *RigidBody, rA, rB Vec3) Vec3 {
+	return bodyPointVelocity(b, rB).Sub(bodyPointVelocity(a, rA))
+}
+
+func bodyPointVelocity(body *RigidBody, r Vec3) Vec3 {
+	if body == nil || body.IsSleeping() {
+		return Vec3{}
+	}
+	return body.Velocity.Add(body.AngularVelocity.Cross(r))
+}
+
+func relativePseudoVelocityAt(a, b *RigidBody, rA, rB Vec3) Vec3 {
+	return bodyPseudoVelocity(b, rB).Sub(bodyPseudoVelocity(a, rA))
+}
+
+func bodyPseudoVelocity(body *RigidBody, r Vec3) Vec3 {
+	if body == nil || body.IsSleeping() || !body.pseudoActive {
+		return Vec3{}
+	}
+	return body.pseudoVelocity.Add(body.pseudoAngular.Cross(r))
+}
+
+// prepareContacts builds the per-step solver state of every manifold, seeds the
+// accumulated impulses from the warm-start cache, and applies those impulses.
+//
+// The tangent basis comes from the contact normal alone, so it is the same in
+// every step in which the normal is the same. That is what makes a cached
+// friction impulse meaningful across steps.
+func (w *World) prepareContacts() {
+	if cap(w.solveState) < len(w.contacts) {
+		w.solveState = make([]contactSolveManifold, len(w.contacts))
+	}
+	w.solveState = w.solveState[:len(w.contacts)]
+
+	for i := range w.contacts {
+		manifold := &w.contacts[i]
+		state := &w.solveState[i]
+		*state = contactSolveManifold{}
+		if manifold.IsTrigger() || manifold.PointCount == 0 {
+			continue
+		}
+
+		bodyA, bodyB := manifold.BodyA, manifold.BodyB
+		invMassA := inverseMass(bodyA)
+		invMassB := inverseMass(bodyB)
+		invIA := inverseInertiaWorld(bodyA)
+		invIB := inverseInertiaWorld(bodyB)
+		if invMassA+invMassB <= 0 {
+			continue
+		}
+
+		normal := manifold.Normal.Normalize()
+		if normal.Len2() <= epsilon {
+			continue
+		}
+		t0, t1 := orthonormalBasis(normal)
+
+		state.normal = normal
+		state.tangent = [2]Vec3{t0, t1}
+		state.friction = manifold.Friction
+		state.count = manifold.PointCount
+		state.active = true
+
+		for p := 0; p < manifold.PointCount; p++ {
+			point := &manifold.Points[p]
+			slot := &state.points[p]
+
+			slot.rA = contactOffset(bodyA, point.Point)
+			slot.rB = contactOffset(bodyB, point.Point)
+			slot.penetration = point.Penetration
+			slot.positionImpulse = 0
+
+			kn := effectiveMassAlong(normal, invMassA, invMassB, invIA, invIB, slot.rA, slot.rB)
+			if kn > epsilon {
+				slot.normalMass = 1 / kn
+			}
+			for axis := 0; axis < 2; axis++ {
+				kt := effectiveMassAlong(state.tangent[axis], invMassA, invMassB, invIA, invIB, slot.rA, slot.rB)
+				if kt > epsilon {
+					slot.tangentMass[axis] = 1 / kt
+				}
+			}
+
+			// Restitution uses the approach speed measured before any impulse
+			// of this step, which is what makes a bounce reproducible.
+			approach := relativeVelocityAt(bodyA, bodyB, slot.rA, slot.rB).Dot(normal)
+			if manifold.Restitution > 0 && -approach > restitutionVelMinimum {
+				slot.restitutionTarget = -manifold.Restitution * approach
+			}
+		}
+	}
+}
+
+// contactOffset returns the vector from a body centre of mass to a world point.
+func contactOffset(body *RigidBody, point Vec3) Vec3 {
+	if body == nil {
+		return Vec3{}
+	}
+	return point.Sub(body.Position)
+}
+
+// solveContactVelocityState runs one velocity iteration over one manifold.
+//
+// Normal and friction impulses both act at the contact point, so both change
+// angular velocity. Friction is a two axis cone: the pair of tangent impulses
+// is clamped by the length of its own vector, not axis by axis, so a sliding
+// box slows the same way in every direction.
+//
+// Friction runs before the normal impulses, bounded by the normal impulse the
+// previous iteration produced. That is the Box2D ordering, and it converges far
+// better on a stack than solving each point in full one after the other.
+func solveContactVelocityState(manifold *ContactManifold, state *contactSolveManifold) {
+	if state == nil || !state.active {
 		return
 	}
-	invMassA := inverseMass(manifold.BodyA)
-	invMassB := inverseMass(manifold.BodyB)
-	invMassSum := invMassA + invMassB
-	if invMassSum <= 0 {
-		return
+	bodyA, bodyB := manifold.BodyA, manifold.BodyB
+	normal := state.normal
+
+	if state.friction > 0 {
+		for i := 0; i < state.count; i++ {
+			point := &manifold.Points[i]
+			slot := &state.points[i]
+			limit := state.friction * point.NormalImpulse
+			if limit <= 0 {
+				point.TangentImpulse[0] = 0
+				point.TangentImpulse[1] = 0
+				continue
+			}
+
+			relative := relativeVelocityAt(bodyA, bodyB, slot.rA, slot.rB)
+			old0 := point.TangentImpulse[0]
+			old1 := point.TangentImpulse[1]
+			new0 := old0 - relative.Dot(state.tangent[0])*slot.tangentMass[0]
+			new1 := old1 - relative.Dot(state.tangent[1])*slot.tangentMass[1]
+
+			if magnitude := math.Hypot(new0, new1); magnitude > limit && magnitude > epsilon {
+				scale := limit / magnitude
+				new0 *= scale
+				new1 *= scale
+			}
+
+			delta0 := new0 - old0
+			delta1 := new1 - old1
+			if delta0 != 0 || delta1 != 0 {
+				impulse := state.tangent[0].Mul(delta0).Add(state.tangent[1].Mul(delta1))
+				applyImpulseAtOffset(bodyA, impulse.Neg(), slot.rA)
+				applyImpulseAtOffset(bodyB, impulse, slot.rB)
+			}
+			point.TangentImpulse[0] = new0
+			point.TangentImpulse[1] = new1
+		}
 	}
 
-	maxPenetration := 0.0
-	for i := 0; i < manifold.PointCount; i++ {
-		maxPenetration = maxFloat(maxPenetration, manifold.Points[i].Penetration)
+	for i := 0; i < state.count; i++ {
+		point := &manifold.Points[i]
+		slot := &state.points[i]
+		if slot.normalMass <= 0 {
+			continue
+		}
+
+		relative := relativeVelocityAt(bodyA, bodyB, slot.rA, slot.rB)
+		velAlongNormal := relative.Dot(normal)
+
+		oldTotal := point.NormalImpulse
+		newTotal := oldTotal + (slot.restitutionTarget-velAlongNormal)*slot.normalMass
+		if newTotal < 0 {
+			newTotal = 0
+		}
+		if delta := newTotal - oldTotal; delta != 0 {
+			impulse := normal.Mul(delta)
+			applyImpulseAtOffset(bodyA, impulse.Neg(), slot.rA)
+			applyImpulseAtOffset(bodyB, impulse, slot.rB)
+		}
+		point.NormalImpulse = newTotal
 	}
-	correctionMagnitude := maxFloat(maxPenetration-positionSlop, 0) / invMassSum * positionCorrection
-	if correctionMagnitude <= 0 {
-		return
+}
+
+// solveContactPositionState runs one iteration of the position pass over one
+// manifold. The pass moves pseudo velocities only; the caller integrates them
+// into positions and rotations after the last iteration.
+//
+// Working on pseudo velocities keeps the overlap correction out of the reported
+// velocity, so a body pushed out of a wall does not gain kinetic energy.
+func solveContactPositionState(manifold *ContactManifold, state *contactSolveManifold, dt float64, touched []*RigidBody) []*RigidBody {
+	if state == nil || !state.active || dt <= 0 {
+		return touched
 	}
-	correction := manifold.Normal.Normalize().Mul(correctionMagnitude)
-	if manifold.BodyA != nil && manifold.BodyA.IsDynamic() {
-		manifold.BodyA.Position = manifold.BodyA.Position.Sub(correction.Mul(invMassA))
+	bodyA, bodyB := manifold.BodyA, manifold.BodyB
+	normal := state.normal
+
+	for i := 0; i < state.count; i++ {
+		slot := &state.points[i]
+		if slot.normalMass <= 0 {
+			continue
+		}
+		excess := slot.penetration - positionSlop
+		if excess <= 0 {
+			continue
+		}
+		bias := positionCorrection * excess / dt
+		if bias > maxCorrectionSpeed {
+			bias = maxCorrectionSpeed
+		}
+
+		relative := relativePseudoVelocityAt(bodyA, bodyB, slot.rA, slot.rB).Dot(normal)
+		old := slot.positionImpulse
+		next := old + (bias-relative)*slot.normalMass
+		if next < 0 {
+			next = 0
+		}
+		if delta := next - old; delta != 0 {
+			impulse := normal.Mul(delta)
+			touched = applyPseudoImpulseAtOffset(bodyA, impulse.Neg(), slot.rA, touched)
+			touched = applyPseudoImpulseAtOffset(bodyB, impulse, slot.rB, touched)
+		}
+		slot.positionImpulse = next
 	}
-	if manifold.BodyB != nil && manifold.BodyB.IsDynamic() {
-		manifold.BodyB.Position = manifold.BodyB.Position.Add(correction.Mul(invMassB))
-	}
+	return touched
 }
 
 func inverseMass(body *RigidBody) float64 {
@@ -113,8 +344,7 @@ func velocityAt(body *RigidBody, point Vec3) Vec3 {
 	if body == nil || body.IsSleeping() {
 		return Vec3{}
 	}
-	r := point.Sub(body.Position)
-	return body.Velocity.Add(body.AngularVelocity.Cross(r))
+	return bodyPointVelocity(body, point.Sub(body.Position))
 }
 
 func applyLinearImpulse(body *RigidBody, impulse Vec3) {

--- a/physics/spec.go
+++ b/physics/spec.go
@@ -1,6 +1,10 @@
 package physics
 
-import "strings"
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
 
 // WorldSpec is a declarative, purely-data description of a physics world
 // that can be constructed all at once via BuildWorld. It mirrors the shape
@@ -16,6 +20,12 @@ type WorldSpec struct {
 	// plane or fixed obstacles). They participate in collision detection
 	// but are never integrated.
 	Static []ColliderConfig
+
+	// Diagnostics carries problems that the spec producer already found, such
+	// as a collider the author declared with a shape name this engine cannot
+	// build. BuildWorldChecked returns them together with the world's own
+	// diagnostics, so a mistake made upstream still fails loudly.
+	Diagnostics []string
 }
 
 // BodySpec declares one rigid body plus its attached colliders.
@@ -29,9 +39,11 @@ type BodySpec struct {
 	Colliders []ColliderConfig
 }
 
-// ConstraintSpec declares one constraint between two bodies. The first
-// shipped declarative constraint is "distance"; future constraint kinds can
-// extend this struct without changing BuildWorld callers.
+// ConstraintSpec declares one constraint between two bodies.
+//
+// Kind names the joint: "distance", "point" (ball and socket), "hinge"
+// (revolute) or "fixed" (weld). An empty Kind means "distance", which keeps
+// older specs working.
 type ConstraintSpec struct {
 	Kind       string
 	BodyAID    string
@@ -42,6 +54,23 @@ type ConstraintSpec struct {
 	AttachB    Vec3
 	Distance   float64
 	Softness   float64
+
+	// AxisA and AxisB name the hinge axis in each body's local frame. They are
+	// ignored by every other kind. Leave them zero to hinge about local +Y.
+	AxisA Vec3
+	AxisB Vec3
+
+	// MotorEnabled drives a hinge at MotorSpeed radians per second, with at
+	// most MaxMotorTorque newton metres. A zero MaxMotorTorque is unlimited.
+	MotorEnabled   bool
+	MotorSpeed     float64
+	MaxMotorTorque float64
+
+	// LimitEnabled stops a hinge between LowerLimit and UpperLimit radians,
+	// measured from the pose the joint held when it first ran.
+	LimitEnabled bool
+	LowerLimit   float64
+	UpperLimit   float64
 }
 
 // BuildWorld constructs a fully-populated physics.World from a WorldSpec.
@@ -72,17 +101,43 @@ func BuildWorld(spec WorldSpec) *World {
 	return world
 }
 
+// BuildWorldChecked builds the world and returns an error when any declared
+// collider cannot collide. Prefer it over BuildWorld: a shape that the engine
+// silently drops is a bug in the scene, not a shape that simply misses.
+//
+// The world is returned even when the error is non-nil, so a caller may choose
+// to log the problem and keep simulating the rest of the scene.
+func BuildWorldChecked(spec WorldSpec) (*World, error) {
+	world := BuildWorld(spec)
+	var errs []error
+	for _, message := range spec.Diagnostics {
+		message = strings.TrimSpace(message)
+		if message == "" {
+			continue
+		}
+		errs = append(errs, fmt.Errorf("physics: %s", message))
+	}
+	if err := world.Err(); err != nil {
+		errs = append(errs, err)
+	}
+	if len(errs) == 0 {
+		return world, nil
+	}
+	return world, errors.Join(errs...)
+}
+
 func addSpecConstraint(world *World, spec ConstraintSpec, byID map[string]*RigidBody, byIndex map[int]*RigidBody) {
 	if world == nil {
 		return
 	}
+	bodyA := specBody(spec.BodyAID, spec.BodyAIndex, byID, byIndex)
+	bodyB := specBody(spec.BodyBID, spec.BodyBIndex, byID, byIndex)
+	if bodyA == nil || bodyB == nil {
+		return
+	}
+
 	switch strings.ToLower(strings.TrimSpace(spec.Kind)) {
 	case "", "distance":
-		bodyA := specBody(spec.BodyAID, spec.BodyAIndex, byID, byIndex)
-		bodyB := specBody(spec.BodyBID, spec.BodyBIndex, byID, byIndex)
-		if bodyA == nil || bodyB == nil {
-			return
-		}
 		distance := spec.Distance
 		if distance <= 0 {
 			distance = bodyA.Position.Add(bodyA.Rotation.Rotate(spec.AttachA)).
@@ -95,6 +150,43 @@ func addSpecConstraint(world *World, spec ConstraintSpec, byID map[string]*Rigid
 			AttachB:        spec.AttachB,
 			TargetDistance: distance,
 			Softness:       spec.Softness,
+		})
+	case "point", "ballsocket", "ball-socket", "balljoint":
+		world.AddConstraint(&PointConstraint{
+			BodyA:   bodyA,
+			BodyB:   bodyB,
+			AttachA: spec.AttachA,
+			AttachB: spec.AttachB,
+		})
+	case "hinge", "revolute":
+		axisA := spec.AxisA
+		if axisA.Len2() <= epsilon {
+			axisA = Vec3{Y: 1}
+		}
+		axisB := spec.AxisB
+		if axisB.Len2() <= epsilon {
+			axisB = axisA
+		}
+		world.AddConstraint(&HingeConstraint{
+			BodyA:          bodyA,
+			BodyB:          bodyB,
+			AttachA:        spec.AttachA,
+			AttachB:        spec.AttachB,
+			AxisA:          axisA,
+			AxisB:          axisB,
+			MotorEnabled:   spec.MotorEnabled,
+			MotorSpeed:     spec.MotorSpeed,
+			MaxMotorTorque: spec.MaxMotorTorque,
+			LimitEnabled:   spec.LimitEnabled,
+			LowerLimit:     spec.LowerLimit,
+			UpperLimit:     spec.UpperLimit,
+		})
+	case "fixed", "weld", "lock":
+		world.AddConstraint(&FixedConstraint{
+			BodyA:   bodyA,
+			BodyB:   bodyB,
+			AttachA: spec.AttachA,
+			AttachB: spec.AttachB,
 		})
 	}
 }

--- a/physics/support.go
+++ b/physics/support.go
@@ -1,0 +1,214 @@
+package physics
+
+import "math"
+
+// mat3 stores a rotation as three world-space column axes. GJK and EPA call
+// the support function many times per pair, and a matrix multiply costs far
+// less than Quat.Rotate, which normalizes the quaternion on every call.
+type mat3 struct {
+	x Vec3
+	y Vec3
+	z Vec3
+}
+
+func mat3FromQuat(q Quat) mat3 {
+	return mat3{
+		x: q.Rotate(Vec3{X: 1}),
+		y: q.Rotate(Vec3{Y: 1}),
+		z: q.Rotate(Vec3{Z: 1}),
+	}
+}
+
+// mul rotates a local vector into world space.
+func (m mat3) mul(v Vec3) Vec3 {
+	return Vec3{
+		X: m.x.X*v.X + m.y.X*v.Y + m.z.X*v.Z,
+		Y: m.x.Y*v.X + m.y.Y*v.Y + m.z.Y*v.Z,
+		Z: m.x.Z*v.X + m.y.Z*v.Y + m.z.Z*v.Z,
+	}
+}
+
+// mulT rotates a world vector into local space.
+func (m mat3) mulT(v Vec3) Vec3 {
+	return Vec3{X: m.x.Dot(v), Y: m.y.Dot(v), Z: m.z.Dot(v)}
+}
+
+// convexShape is a support-mapped convex volume placed in world space. One
+// description covers boxes, spheres, capsules, cylinders, cones, convex hulls
+// and single triangles, so GJK and EPA need no per-shape code.
+//
+// margin is a rounding radius. A sphere is a point with margin = radius; a
+// capsule is a segment with margin = radius. Cylinder and cone carry their
+// radius in the profile instead, because their rim is a sharp edge.
+type convexShape struct {
+	kind   ColliderShape
+	center Vec3
+	basis  mat3
+	half   Vec3
+	radius float64
+	halfH  float64
+	verts  []Vec3
+	margin float64
+	// bound is the radius of a sphere that encloses the shape. EPA uses it to
+	// pick a convergence tolerance that matches the shape size.
+	bound float64
+	// tri holds a single world-space triangle. Set only by triangleShape.
+	tri    [3]Vec3
+	useTri bool
+}
+
+// newConvexShape builds the support description of one collider. It reports
+// false for shapes that no support function can describe, which today is only
+// the infinite plane and any collider that failed validation.
+func newConvexShape(c *Collider) (convexShape, bool) {
+	if c == nil || c.invalid != nil {
+		return convexShape{}, false
+	}
+	shape := convexShape{
+		kind:   c.Shape,
+		center: c.WorldCenter(),
+		basis:  mat3FromQuat(c.WorldRotation()),
+		bound:  c.BoundingRadius(),
+	}
+	switch c.Shape {
+	case ShapeBox:
+		shape.half = c.halfExtents()
+	case ShapeSphere:
+		shape.margin = math.Abs(c.Radius)
+	case ShapeCapsule:
+		shape.margin = math.Abs(c.Radius)
+		shape.halfH = math.Abs(c.Height) * 0.5
+	case ShapeCylinder, ShapeCone:
+		shape.radius = math.Abs(c.Radius)
+		shape.halfH = math.Abs(c.Height) * 0.5
+	case ShapeConvexHull:
+		shape.verts = c.hull
+	default:
+		return convexShape{}, false
+	}
+	return shape, true
+}
+
+// triangleShape wraps three world-space points as a convex shape so mesh
+// triangles reuse the same narrowphase as every other convex pair.
+func triangleShape(a, b, c Vec3) convexShape {
+	centroid := a.Add(b).Add(c).Div(3)
+	bound := a.Sub(centroid).Len()
+	bound = math.Max(bound, b.Sub(centroid).Len())
+	bound = math.Max(bound, c.Sub(centroid).Len())
+	return convexShape{
+		kind:   ShapeConvexHull,
+		center: centroid,
+		bound:  bound,
+		useTri: true,
+		tri:    [3]Vec3{a, b, c},
+	}
+}
+
+// support returns the point of the shape that is farthest along dir. dir need
+// not be normalized.
+func (s convexShape) support(dir Vec3) Vec3 {
+	if s.useTri {
+		best := s.tri[0]
+		bestDot := dir.Dot(best)
+		for i := 1; i < 3; i++ {
+			if d := dir.Dot(s.tri[i]); d > bestDot {
+				bestDot = d
+				best = s.tri[i]
+			}
+		}
+		return best
+	}
+
+	local := s.basis.mulT(dir)
+	var p Vec3
+	switch s.kind {
+	case ShapeBox:
+		p = Vec3{
+			X: signedExtent(local.X, s.half.X),
+			Y: signedExtent(local.Y, s.half.Y),
+			Z: signedExtent(local.Z, s.half.Z),
+		}
+	case ShapeSphere:
+		// A sphere is the origin plus a margin.
+	case ShapeCapsule:
+		if local.Y > 0 {
+			p.Y = s.halfH
+		} else if local.Y < 0 {
+			p.Y = -s.halfH
+		}
+	case ShapeCylinder:
+		p = cylinderLocalSupport(local, s.radius, s.halfH)
+	case ShapeCone:
+		p = coneLocalSupport(local, s.radius, s.halfH)
+	case ShapeConvexHull:
+		p = hullLocalSupport(s.verts, local)
+	}
+
+	world := s.center.Add(s.basis.mul(p))
+	if s.margin > 0 {
+		length := dir.Len()
+		if length > epsilon {
+			world = world.Add(dir.Mul(s.margin / length))
+		}
+	}
+	return world
+}
+
+func signedExtent(component, half float64) float64 {
+	if component >= 0 {
+		return half
+	}
+	return -half
+}
+
+// cylinderLocalSupport returns the farthest cylinder point along a local
+// direction. The cylinder runs along local Y from -halfH to +halfH.
+func cylinderLocalSupport(dir Vec3, radius, halfH float64) Vec3 {
+	p := Vec3{}
+	if dir.Y > 0 {
+		p.Y = halfH
+	} else if dir.Y < 0 {
+		p.Y = -halfH
+	}
+	radial2 := dir.X*dir.X + dir.Z*dir.Z
+	if radial2 > epsilon {
+		scale := radius / math.Sqrt(radial2)
+		p.X = dir.X * scale
+		p.Z = dir.Z * scale
+	}
+	return p
+}
+
+// coneLocalSupport returns the farthest cone point along a local direction.
+// The apex sits at +halfH on local Y and the base disc at -halfH.
+func coneLocalSupport(dir Vec3, radius, halfH float64) Vec3 {
+	radial := math.Sqrt(dir.X*dir.X + dir.Z*dir.Z)
+	apexDot := dir.Y * halfH
+	baseDot := -dir.Y*halfH + radius*radial
+	if apexDot >= baseDot {
+		return Vec3{Y: halfH}
+	}
+	p := Vec3{Y: -halfH}
+	if radial > epsilon {
+		scale := radius / radial
+		p.X = dir.X * scale
+		p.Z = dir.Z * scale
+	}
+	return p
+}
+
+func hullLocalSupport(verts []Vec3, dir Vec3) Vec3 {
+	if len(verts) == 0 {
+		return Vec3{}
+	}
+	best := verts[0]
+	bestDot := dir.Dot(best)
+	for i := 1; i < len(verts); i++ {
+		if d := dir.Dot(verts[i]); d > bestDot {
+			bestDot = d
+			best = verts[i]
+		}
+	}
+	return best
+}

--- a/physics/world.go
+++ b/physics/world.go
@@ -13,6 +13,16 @@ type WorldConfig struct {
 	// starting is on by default; disabling is only useful for tests or
 	// deterministic replay scenarios that must reproduce a cold solver.
 	DisableWarmStart bool
+
+	// SleepTime is how long a body must stay slow before it sleeps, in seconds.
+	// Sleeping applies only to a body whose BodyConfig sets CanSleep. Leave the
+	// field zero to use half a second.
+	SleepTime float64
+	// SleepLinearSpeed and SleepAngularSpeed are the speeds a sleeping
+	// candidate must stay under, in metres and radians per second. Leave them
+	// zero to use 0.05 and 0.1.
+	SleepLinearSpeed  float64
+	SleepAngularSpeed float64
 }
 
 type contactCacheKey struct {
@@ -21,9 +31,10 @@ type contactCacheKey struct {
 }
 
 type cachedContactPoint struct {
-	LocalA        Vec3
-	LocalB        Vec3
-	NormalImpulse float64
+	LocalA         Vec3
+	LocalB         Vec3
+	NormalImpulse  float64
+	TangentImpulse [2]float64
 }
 
 type cachedManifold struct {
@@ -47,6 +58,24 @@ type World struct {
 	warmStart           bool
 	contactCache        map[contactCacheKey]cachedManifold
 	constraints         []Constraint
+
+	// solveState mirrors contacts one to one and holds the per-step solver
+	// scratch. The backing array is reused, so a step allocates nothing here.
+	solveState []contactSolveManifold
+	// pseudoBodies lists the bodies the position pass moved this step. Both
+	// slices keep their backing array between steps.
+	pseudoBodies []*RigidBody
+
+	sleepTime         float64
+	sleepLinearSpeed  float64
+	sleepAngularSpeed float64
+
+	// steps counts fixed steps. broadphaseStep records the step whose poses
+	// the grid holds, so the swept pass never queries a stale grid.
+	steps          uint64
+	broadphaseStep uint64
+	// sweepTargets is the reused result buffer of the swept broadphase query.
+	sweepTargets []*Collider
 }
 
 func DefaultWorldConfig() WorldConfig {
@@ -75,6 +104,15 @@ func NewWorld(config WorldConfig) *World {
 	if config.BroadPhaseCell <= 0 {
 		config.BroadPhaseCell = 2
 	}
+	if config.SleepTime <= 0 {
+		config.SleepTime = 0.5
+	}
+	if config.SleepLinearSpeed <= 0 {
+		config.SleepLinearSpeed = 0.05
+	}
+	if config.SleepAngularSpeed <= 0 {
+		config.SleepAngularSpeed = 0.1
+	}
 	w := &World{
 		gravity:             config.Gravity,
 		fixedTimestep:       config.FixedTimestep,
@@ -82,6 +120,9 @@ func NewWorld(config WorldConfig) *World {
 		broadphase:          NewSpatialHash(config.BroadPhaseCell),
 		continuousCollision: !config.DisableCCD,
 		warmStart:           !config.DisableWarmStart,
+		sleepTime:           config.SleepTime,
+		sleepLinearSpeed:    config.SleepLinearSpeed,
+		sleepAngularSpeed:   config.SleepAngularSpeed,
 	}
 	if w.warmStart {
 		w.contactCache = make(map[contactCacheKey]cachedManifold)
@@ -135,8 +176,13 @@ func (w *World) Contacts() []ContactManifold {
 	return contacts
 }
 
+// CandidatePairs returns the broadphase pairs for the current collider poses.
+// The result is a fresh slice, so callers may keep it.
 func (w *World) CandidatePairs() []ColliderPair {
-	return w.broadphase.CandidatePairs(w.colliders)
+	internal := w.broadphase.CandidatePairs(w.colliders)
+	pairs := make([]ColliderPair, len(internal))
+	copy(pairs, internal)
+	return pairs
 }
 
 func (w *World) FixedTimestep() float64 {
@@ -151,8 +197,11 @@ func (w *World) Gravity() Vec3 {
 	return w.gravity
 }
 
+// SetGravity replaces the world gravity and wakes every body, because a body
+// asleep under the old gravity may have to fall under the new one.
 func (w *World) SetGravity(gravity Vec3) {
 	w.gravity = gravity
+	w.WakeAll()
 }
 
 func (w *World) Step(elapsed float64) int {
@@ -178,8 +227,12 @@ func (w *World) StepFixed() {
 }
 
 func (w *World) stepFixed(dt float64) {
+	w.steps++
+	w.refreshInertia()
 	w.integrateForces(dt)
 	w.generateContacts()
+	w.wakeTouchedBodies()
+	w.prepareContacts()
 	if w.warmStart {
 		w.warmStartContacts()
 	}
@@ -189,6 +242,120 @@ func (w *World) stepFixed(dt float64) {
 		w.cacheContactImpulses()
 	}
 	w.integrateVelocities(dt)
+	w.updateSleep(dt)
+}
+
+// wakeTouchedBodies wakes a sleeping body that a moving body now touches. A
+// sleeping body takes no impulse, so it would sink through an arriving body
+// without this pass.
+func (w *World) wakeTouchedBodies() {
+	for i := range w.contacts {
+		manifold := &w.contacts[i]
+		if manifold.IsTrigger() {
+			continue
+		}
+		a, b := manifold.BodyA, manifold.BodyB
+		// Wake only a body that is asleep. Calling Wake on a body that is
+		// already awake would restart its countdown, and one restless body in a
+		// tower would then stop the whole tower from ever settling.
+		if b.IsSleeping() && bodyDisturbs(w, a) {
+			b.Wake()
+		}
+		if a.IsSleeping() && bodyDisturbs(w, b) {
+			a.Wake()
+		}
+	}
+}
+
+// bodyDisturbs reports whether a body moves fast enough to wake what it hits.
+func bodyDisturbs(w *World, body *RigidBody) bool {
+	if body == nil || body.IsSleeping() {
+		return false
+	}
+	return body.Velocity.Len2() > w.sleepLinearSpeed*w.sleepLinearSpeed ||
+		body.AngularVelocity.Len2() > w.sleepAngularSpeed*w.sleepAngularSpeed
+}
+
+// updateSleep puts a slow body to sleep once it has stayed slow for long
+// enough. A sleeping body keeps its pose, takes no impulse and costs the solver
+// nothing, which is what stops a settled stack from creeping over thousands of
+// steps.
+//
+// Only a body whose BodyConfig sets CanSleep is eligible. Every other body
+// keeps simulating, which preserves the behaviour callers had before.
+func (w *World) updateSleep(dt float64) {
+	if w.sleepTime <= 0 {
+		return
+	}
+
+	// Mark the bodies that are slow enough to be sleep candidates.
+	for _, body := range w.bodies {
+		if body == nil {
+			continue
+		}
+		body.sleepBlocked = false
+		body.sleepSlow = body.Velocity.Len2() <= w.sleepLinearSpeed*w.sleepLinearSpeed &&
+			body.AngularVelocity.Len2() <= w.sleepAngularSpeed*w.sleepAngularSpeed
+	}
+
+	// A body that leans on a moving body cannot sleep. Letting it sleep anyway
+	// turns it into an immovable support for one step, which shakes the pile it
+	// belongs to and wakes it again. The block travels one contact per step, so
+	// a whole tower goes quiet before any part of it sleeps.
+	for i := range w.contacts {
+		manifold := &w.contacts[i]
+		if manifold.IsTrigger() {
+			continue
+		}
+		a, b := manifold.BodyA, manifold.BodyB
+		if a != nil && a.IsDynamic() && !a.sleepSlow && b != nil {
+			b.sleepBlocked = true
+		}
+		if b != nil && b.IsDynamic() && !b.sleepSlow && a != nil {
+			a.sleepBlocked = true
+		}
+	}
+
+	for _, body := range w.bodies {
+		if body == nil || !body.CanSleep || !body.IsDynamic() || body.sleeping {
+			continue
+		}
+		if !body.sleepSlow || body.sleepBlocked {
+			body.sleepTimer = 0
+			continue
+		}
+		body.sleepTimer += dt
+		if body.sleepTimer < w.sleepTime {
+			continue
+		}
+		body.sleeping = true
+		body.sleepTimer = 0
+		body.Velocity = Vec3{}
+		body.AngularVelocity = Vec3{}
+	}
+}
+
+// WakeAll wakes every sleeping body. Call it after changing the world in a way
+// the contact pass cannot see, such as teleporting geometry.
+func (w *World) WakeAll() {
+	if w == nil {
+		return
+	}
+	for _, body := range w.bodies {
+		body.Wake()
+	}
+}
+
+// refreshInertia rebuilds the world inverse inertia tensor of every dynamic
+// body from its current rotation. Contacts and constraints both read it, so it
+// must run before contact generation.
+func (w *World) refreshInertia() {
+	for _, body := range w.bodies {
+		if body == nil || !body.IsDynamic() {
+			continue
+		}
+		body.refreshWorldInertia()
+	}
 }
 
 func (w *World) prepareConstraints(dt float64) {
@@ -210,7 +377,7 @@ func (w *World) solveContactsAndConstraints(dt float64) {
 	}
 	for iter := 0; iter < iterations; iter++ {
 		for i := range w.contacts {
-			solveContactVelocity(&w.contacts[i])
+			solveContactVelocityState(&w.contacts[i], &w.solveState[i])
 		}
 		for _, c := range w.constraints {
 			if c != nil {
@@ -218,14 +385,45 @@ func (w *World) solveContactsAndConstraints(dt float64) {
 			}
 		}
 	}
-	for i := range w.contacts {
-		solveContactPosition(&w.contacts[i], dt)
-	}
+	w.solveContactPositions(dt)
 	for _, c := range w.constraints {
 		if c != nil {
 			c.SolvePosition()
 		}
 	}
+}
+
+// solveContactPositions removes the remaining overlap with a pseudo velocity
+// pass, then integrates the pseudo velocities into positions and rotations.
+//
+// The pass gives a body an angular correction as well as a linear one, so a box
+// that lands on one corner rotates down onto its face instead of sinking.
+func (w *World) solveContactPositions(dt float64) {
+	if dt <= 0 || len(w.contacts) == 0 {
+		return
+	}
+	w.pseudoBodies = w.pseudoBodies[:0]
+	for iter := 0; iter < positionIterations; iter++ {
+		for i := range w.contacts {
+			w.pseudoBodies = solveContactPositionState(&w.contacts[i], &w.solveState[i], dt, w.pseudoBodies)
+		}
+	}
+	for i, body := range w.pseudoBodies {
+		if body.pseudoVelocity.Len2() > 0 {
+			body.Position = body.Position.Add(body.pseudoVelocity.Mul(dt))
+		}
+		if speed := body.pseudoAngular.Len(); speed > epsilon {
+			delta := QuatFromAxisAngle(body.pseudoAngular.Div(speed), speed*dt)
+			body.Rotation = delta.Mul(body.Rotation).Normalize()
+			body.refreshWorldInertia()
+		}
+		body.pseudoVelocity = Vec3{}
+		body.pseudoAngular = Vec3{}
+		body.pseudoActive = false
+		// Drop the reference so a removed body can be collected.
+		w.pseudoBodies[i] = nil
+	}
+	w.pseudoBodies = w.pseudoBodies[:0]
 }
 
 // warmStartContacts seeds newly-generated contact manifolds with cached
@@ -235,9 +433,11 @@ func (w *World) solveContactsAndConstraints(dt float64) {
 //
 // Matching: for each new contact point, find the cached point with the closest
 // (LocalA, LocalB) pair within a tolerance. Matched points inherit the cached
-// NormalImpulse; unmatched points start from zero. Tangent impulses always
-// start from zero because the tangent basis is recomputed each iteration from
-// the current relative velocity.
+// normal and friction impulses; unmatched points start from zero.
+//
+// The friction basis is derived from the contact normal alone, so a cached
+// friction impulse still names the same direction on the next step. That is
+// what lets a resting stack hold its lateral grip without rebuilding it.
 func (w *World) warmStartContacts() {
 	if w.contactCache == nil {
 		return
@@ -246,7 +446,8 @@ func (w *World) warmStartContacts() {
 
 	for mi := range w.contacts {
 		m := &w.contacts[mi]
-		if m.IsTrigger() || m.PointCount == 0 {
+		state := &w.solveState[mi]
+		if !state.active {
 			continue
 		}
 		key := manifoldCacheKey(m)
@@ -254,9 +455,9 @@ func (w *World) warmStartContacts() {
 		if !ok {
 			continue
 		}
-		normal := m.Normal.Normalize()
-		for pi := 0; pi < m.PointCount; pi++ {
+		for pi := 0; pi < state.count; pi++ {
 			p := &m.Points[pi]
+			slot := &state.points[pi]
 			best := -1
 			bestDist := matchToleranceSq
 			for ci := 0; ci < cached.Count; ci++ {
@@ -270,14 +471,18 @@ func (w *World) warmStartContacts() {
 			if best < 0 {
 				continue
 			}
-			seeded := cached.Points[best].NormalImpulse
-			if seeded <= 0 {
+			seededNormal := cached.Points[best].NormalImpulse
+			seededTangent := cached.Points[best].TangentImpulse
+			if seededNormal <= 0 {
 				continue
 			}
-			p.NormalImpulse = seeded
-			impulse := normal.Mul(seeded)
-			applyLinearImpulse(m.BodyA, impulse.Neg())
-			applyLinearImpulse(m.BodyB, impulse)
+			p.NormalImpulse = seededNormal
+			p.TangentImpulse = seededTangent
+			impulse := state.normal.Mul(seededNormal).
+				Add(state.tangent[0].Mul(seededTangent[0])).
+				Add(state.tangent[1].Mul(seededTangent[1]))
+			applyImpulseAtOffset(m.BodyA, impulse.Neg(), slot.rA)
+			applyImpulseAtOffset(m.BodyB, impulse, slot.rB)
 		}
 	}
 }
@@ -300,9 +505,10 @@ func (w *World) cacheContactImpulses() {
 		var cm cachedManifold
 		for pi := 0; pi < m.PointCount; pi++ {
 			cm.Points[cm.Count] = cachedContactPoint{
-				LocalA:        m.Points[pi].LocalA,
-				LocalB:        m.Points[pi].LocalB,
-				NormalImpulse: m.Points[pi].NormalImpulse,
+				LocalA:         m.Points[pi].LocalA,
+				LocalB:         m.Points[pi].LocalB,
+				NormalImpulse:  m.Points[pi].NormalImpulse,
+				TangentImpulse: m.Points[pi].TangentImpulse,
 			}
 			cm.Count++
 		}
@@ -333,7 +539,12 @@ func (w *World) integrateForces(dt float64) {
 		}
 		acceleration := w.gravity.Add(body.force.Mul(body.InvMass))
 		body.Velocity = body.Velocity.Add(acceleration.Mul(dt))
-		body.AngularVelocity = body.AngularVelocity.Add(body.torque.Mul(body.InvMass * dt))
+		if !body.invInertiaWorld.isZero() && body.torque.Len2() > 0 {
+			// Angular acceleration is the inverse inertia tensor applied to the
+			// torque, not the torque divided by mass.
+			body.AngularVelocity = body.AngularVelocity.
+				Add(body.invInertiaWorld.mul(body.torque).Mul(dt))
+		}
 		body.Velocity = body.Velocity.Mul(dampingFactor(body.LinearDamping, dt))
 		body.AngularVelocity = body.AngularVelocity.Mul(dampingFactor(body.AngularDamping, dt))
 		body.clearForces()
@@ -342,13 +553,22 @@ func (w *World) integrateForces(dt float64) {
 
 func (w *World) generateContacts() {
 	pairs := w.broadphase.CandidatePairs(w.colliders)
+	w.broadphaseStep = w.steps
 	w.contacts = w.contacts[:0]
 	for _, pair := range pairs {
-		contact, ok := Collide(pair.A, pair.B)
-		if ok {
-			w.contacts = append(w.contacts, contact)
-		}
+		w.contacts = CollideAll(pair.A, pair.B, w.contacts)
 	}
+}
+
+// ensureBroadphase rebuilds the grid when the current step has not filled it
+// yet. The swept pass reads the static cell map, and a stale map would let a
+// fast body pass through geometry.
+func (w *World) ensureBroadphase() {
+	if w.broadphaseStep == w.steps && w.broadphase.Built() > 0 {
+		return
+	}
+	w.broadphase.Rebuild(w.colliders)
+	w.broadphaseStep = w.steps
 }
 
 func (w *World) integrateVelocities(dt float64) {
@@ -357,20 +577,23 @@ func (w *World) integrateVelocities(dt float64) {
 			continue
 		}
 		displacement := body.Velocity.Mul(dt)
-		if w.continuousCollision {
+		swept := false
+		if w.continuousCollision && bodyNeedsSweep(body, displacement) {
+			w.ensureBroadphase()
 			if hit, ok := w.sweepBody(body, displacement); ok {
 				body.Position = body.Position.Add(displacement.Normalize().Mul(maxFloat(0, hit.Distance-ccdSlop)))
 				resolveCCDVelocity(body, hit)
-			} else {
-				body.Position = body.Position.Add(displacement)
+				swept = true
 			}
-		} else {
+		}
+		if !swept {
 			body.Position = body.Position.Add(displacement)
 		}
 		angularSpeed := body.AngularVelocity.Len()
 		if angularSpeed > epsilon {
 			delta := QuatFromAxisAngle(body.AngularVelocity.Div(angularSpeed), angularSpeed*dt)
 			body.Rotation = delta.Mul(body.Rotation).Normalize()
+			body.refreshWorldInertia()
 		}
 	}
 }

--- a/route/route.go
+++ b/route/route.go
@@ -563,7 +563,7 @@ func newRouteContext(req *http.Request) *RouteContext {
 	// closure assigns a sized map only when the route declares parameters.
 	return &RouteContext{
 		Request:   req,
-		PageState: *server.NewPageState(),
+		PageState: *server.NewPageStateForRequest(req),
 	}
 }
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -46,6 +46,19 @@ func TestRouterBasic(t *testing.T) {
 	}
 }
 
+func TestRouteContextHeadUsesRequestPathForAutomaticMetadataURLs(t *testing.T) {
+	ctx := newRouteContext(httptest.NewRequest(http.MethodGet, "/blog/example", nil))
+	ctx.SetMetadata(server.Metadata{MetadataBase: "https://example.com"})
+
+	html := gosx.RenderHTML(ctx.Head())
+	if !strings.Contains(html, `rel="canonical" href="https://example.com/blog/example"`) {
+		t.Fatalf("route canonical URL missing from %q", html)
+	}
+	if !strings.Contains(html, `property="og:url" content="https://example.com/blog/example"`) {
+		t.Fatalf("route Open Graph URL missing from %q", html)
+	}
+}
+
 func TestRouterBuildCheckedReturnsRegistrationError(t *testing.T) {
 	router := NewRouter()
 	handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {})

--- a/scene/physics_bridge.go
+++ b/scene/physics_bridge.go
@@ -1,6 +1,7 @@
 package scene
 
 import (
+	"fmt"
 	"math"
 	"strings"
 
@@ -34,12 +35,15 @@ func (ir IR) PhysicsSpec() physics.WorldSpec {
 	}
 
 	spec := physics.WorldSpec{Config: cfg}
+	var diagnostics []string
 
 	for _, body := range p.Bodies {
 		mass := body.Mass
 		if body.Static {
 			mass = 0
 		}
+		colliders, bodyDiagnostics := collidersToPhysics(body.Colliders, "body "+strings.TrimSpace(body.ID))
+		diagnostics = append(diagnostics, bodyDiagnostics...)
 		spec.Bodies = append(spec.Bodies, physics.BodySpec{
 			Body: physics.BodyConfig{
 				ID:              strings.TrimSpace(body.ID),
@@ -53,13 +57,16 @@ func (ir IR) PhysicsSpec() physics.WorldSpec {
 				LinearDamping:   body.LinearDamping,
 				AngularDamping:  body.AngularDamping,
 			},
-			Colliders: collidersToPhysics(body.Colliders),
+			Colliders: colliders,
 		})
 	}
 
 	if len(p.Static) > 0 {
-		spec.Static = collidersToPhysics(p.Static)
+		static, staticDiagnostics := collidersToPhysics(p.Static, "scene static geometry")
+		spec.Static = static
+		diagnostics = append(diagnostics, staticDiagnostics...)
 	}
+	spec.Diagnostics = diagnostics
 	if len(p.Constraints) > 0 {
 		spec.Constraints = make([]physics.ConstraintSpec, 0, len(p.Constraints))
 		for _, constraint := range p.Constraints {
@@ -87,14 +94,22 @@ func (ir IR) PhysicsTopic(programRef string) string {
 	return "scene3d:physics:" + trimmed
 }
 
-func collidersToPhysics(src []IRCollider) []physics.ColliderConfig {
+// collidersToPhysics translates scene colliders. owner names the declaring
+// body or the scene, so a diagnostic points the author at the right place.
+//
+// A shape the engine cannot build is reported, never dropped in silence. A
+// dropped collider makes its body pass through the world, which is far harder
+// to notice than an error.
+func collidersToPhysics(src []IRCollider, owner string) ([]physics.ColliderConfig, []string) {
 	if len(src) == 0 {
-		return nil
+		return nil, nil
 	}
 	out := make([]physics.ColliderConfig, 0, len(src))
-	for _, c := range src {
-		shape, ok := shapeNameToKind(c.Shape)
-		if !ok {
+	var diagnostics []string
+	for index, c := range src {
+		shape, err := shapeNameToKind(c.Shape)
+		if err != nil {
+			diagnostics = append(diagnostics, fmt.Sprintf("%s collider %d: %v", owner, index, err))
 			continue
 		}
 		out = append(out, physics.ColliderConfig{
@@ -110,9 +125,18 @@ func collidersToPhysics(src []IRCollider) []physics.ColliderConfig {
 			Distance:  c.Distance,
 		})
 	}
-	return out
+	return out, diagnostics
 }
 
+// constraintToPhysics translates one scene constraint.
+//
+// The engine builds four joints: "distance", "point", "hinge" and "fixed". A
+// scene names the joint through Kind and gives the two attach points. An empty
+// Kind means "distance", which keeps older scenes working.
+//
+// IRConstraint carries no axis, motor or limit fields, so a scene-declared
+// hinge turns about the body local +Y axis with no motor and no limit. Build
+// the hinge through physics.HingeConstraint to set an axis, a motor or limits.
 func constraintToPhysics(c IRConstraint) physics.ConstraintSpec {
 	kind := strings.ToLower(strings.TrimSpace(c.Kind))
 	if kind == "" {
@@ -129,26 +153,36 @@ func constraintToPhysics(c IRConstraint) physics.ConstraintSpec {
 	}
 }
 
-func shapeNameToKind(name string) (physics.ColliderShape, bool) {
-	switch strings.ToLower(strings.TrimSpace(name)) {
+// shapeNameToKind maps a scene shape name onto a physics collider shape.
+//
+// "convex" and "mesh" are rejected on purpose. The physics engine supports both
+// shapes, but Collider3D carries no vertex or index buffer, so a scene-declared
+// hull or mesh would have no geometry and would pass through every body. Build
+// such colliders through the physics API, where ColliderConfig.Vertices and
+// ColliderConfig.Indices supply the geometry.
+func shapeNameToKind(name string) (physics.ColliderShape, error) {
+	trimmed := strings.ToLower(strings.TrimSpace(name))
+	switch trimmed {
 	case "box":
-		return physics.ShapeBox, true
+		return physics.ShapeBox, nil
 	case "sphere":
-		return physics.ShapeSphere, true
+		return physics.ShapeSphere, nil
 	case "capsule":
-		return physics.ShapeCapsule, true
+		return physics.ShapeCapsule, nil
 	case "plane":
-		return physics.ShapePlane, true
+		return physics.ShapePlane, nil
 	case "cylinder":
-		return physics.ShapeCylinder, true
+		return physics.ShapeCylinder, nil
 	case "cone":
-		return physics.ShapeCone, true
+		return physics.ShapeCone, nil
 	case "convex", "convexhull":
-		return physics.ShapeConvexHull, true
+		return 0, fmt.Errorf("shape %q needs vertex data that Collider3D cannot carry; declare the hull through physics.ColliderConfig.Vertices instead", trimmed)
 	case "mesh", "trianglemesh":
-		return physics.ShapeTriangleMesh, true
+		return 0, fmt.Errorf("shape %q needs vertex and index data that Collider3D cannot carry; declare the mesh through physics.ColliderConfig.Vertices and Indices instead", trimmed)
+	case "":
+		return 0, fmt.Errorf("collider Shape is empty; use box, sphere, capsule, plane, cylinder or cone")
 	}
-	return 0, false
+	return 0, fmt.Errorf("unknown collider shape %q; use box, sphere, capsule, plane, cylinder or cone", trimmed)
 }
 
 // eulerToQuat converts XYZ Euler radians to a unit quaternion using the

--- a/server/page.go
+++ b/server/page.go
@@ -99,7 +99,7 @@ type Context struct {
 func newContext(r *http.Request) *Context {
 	return &Context{
 		Request:   r,
-		PageState: *NewPageState(),
+		PageState: *NewPageStateForRequest(r),
 	}
 }
 

--- a/server/page_state.go
+++ b/server/page_state.go
@@ -12,13 +12,14 @@ import (
 // PageState carries shared request-scoped page response state used by both
 // server.Context and route.RouteContext.
 type PageState struct {
-	headers  http.Header
-	status   int
-	metadata Metadata
-	head     []gosx.Node
-	deferred *DeferredRegistry
-	cache    *CacheState
-	runtime  *PageRuntime
+	requestPath string
+	headers     http.Header
+	status      int
+	metadata    Metadata
+	head        []gosx.Node
+	deferred    *DeferredRegistry
+	cache       *CacheState
+	runtime     *PageRuntime
 }
 
 // NewPageState creates an empty shared page-state container.
@@ -31,6 +32,17 @@ type PageState struct {
 // passthrough.
 func NewPageState() *PageState {
 	return &PageState{}
+}
+
+// NewPageStateForRequest creates page state whose automatic metadata URLs use
+// the request's route path. NewPageState intentionally remains pathless so
+// standalone metadata rendering keeps its root-path default.
+func NewPageStateForRequest(r *http.Request) *PageState {
+	state := NewPageState()
+	if r != nil && r.URL != nil {
+		state.requestPath = r.URL.Path
+	}
+	return state
 }
 
 // Header returns the response headers to apply when the request completes.
@@ -186,7 +198,7 @@ func (s *PageState) Head() gosx.Node {
 		return gosx.Text("")
 	}
 	nodes := []gosx.Node{}
-	if metaHead := s.metadata.Head(); !metaHead.IsZero() {
+	if metaHead := s.metadata.head(SiteMetadata{}, s.requestPath); !metaHead.IsZero() {
 		nodes = append(nodes, metaHead)
 	}
 	nodes = append(nodes, s.head...)

--- a/server/page_test.go
+++ b/server/page_test.go
@@ -52,6 +52,82 @@ func TestDocumentContextUsesRequestURIForPathAndPageID(t *testing.T) {
 	}
 }
 
+func TestContextHeadUsesRequestPathForAutomaticMetadataURLs(t *testing.T) {
+	for _, tc := range []struct {
+		name          string
+		requestPath   string
+		meta          Metadata
+		wantCanonical string
+		wantOpenGraph string
+	}{
+		{
+			name:        "nested route",
+			requestPath: "/blog/example?preview=1",
+			meta: Metadata{
+				MetadataBase: "https://example.com",
+			},
+			wantCanonical: "https://example.com/blog/example",
+			wantOpenGraph: "https://example.com/blog/example",
+		},
+		{
+			name:        "root route",
+			requestPath: "/",
+			meta: Metadata{
+				MetadataBase: "https://example.com",
+			},
+			wantCanonical: "https://example.com/",
+			wantOpenGraph: "https://example.com/",
+		},
+		{
+			name:        "explicit URLs win",
+			requestPath: "/blog/example",
+			meta: Metadata{
+				MetadataBase: "https://example.com",
+				Alternates:   &Alternates{Canonical: "/posts/canonical"},
+				OpenGraph:    &OpenGraph{URL: "https://social.example/override"},
+			},
+			wantCanonical: "https://example.com/posts/canonical",
+			wantOpenGraph: "https://social.example/override",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := newContext(httptest.NewRequest(http.MethodGet, tc.requestPath, nil))
+			ctx.SetMetadata(tc.meta)
+			html := gosx.RenderHTML(ctx.Head())
+			if !strings.Contains(html, `rel="canonical" href="`+tc.wantCanonical+`"`) {
+				t.Fatalf("canonical URL missing from %q", html)
+			}
+			if !strings.Contains(html, `property="og:url" content="`+tc.wantOpenGraph+`"`) {
+				t.Fatalf("Open Graph URL missing from %q", html)
+			}
+		})
+	}
+}
+
+func TestStandalonePageStateAndMetadataHeadDefaultToRoot(t *testing.T) {
+	meta := Metadata{MetadataBase: "https://example.com"}
+	state := NewPageState()
+	state.SetMetadata(meta)
+
+	for _, tc := range []struct {
+		name string
+		node gosx.Node
+	}{
+		{name: "page state", node: state.Head()},
+		{name: "metadata", node: meta.Head()},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			html := gosx.RenderHTML(tc.node)
+			if !strings.Contains(html, `rel="canonical" href="https://example.com/"`) {
+				t.Fatalf("root canonical URL missing from %q", html)
+			}
+			if !strings.Contains(html, `property="og:url" content="https://example.com/"`) {
+				t.Fatalf("root Open Graph URL missing from %q", html)
+			}
+		})
+	}
+}
+
 func TestLinkTagNodeNormalizesRelativeHrefAndKeepsDeterministicOrder(t *testing.T) {
 	html := gosx.RenderHTML(LinkTag{
 		Rel:   "stylesheet",

--- a/test/store_test.go
+++ b/test/store_test.go
@@ -20,8 +20,8 @@ func TestSharedStoreBasic(t *testing.T) {
 	if !ok {
 		t.Fatal("expected shared signal")
 	}
-	if val.Str != "dark" {
-		t.Fatalf("expected 'dark', got %q", val.Str)
+	if val.Text() != "dark" {
+		t.Fatalf("expected 'dark', got %q", val.Text())
 	}
 }
 
@@ -47,8 +47,8 @@ func TestSharedStoreTypedInit(t *testing.T) {
 	if val.Type != program.TypeInt {
 		t.Fatalf("expected TypeInt, got %d", val.Type)
 	}
-	if val.Num != 0 {
-		t.Fatalf("expected init value 0, got %v", val.Num)
+	if val.Number() != 0 {
+		t.Fatalf("expected init value 0, got %v", val.Number())
 	}
 }
 
@@ -102,8 +102,8 @@ func TestCrossIslandReRender(t *testing.T) {
 
 	// Verify the store value
 	val, _ := b.GetStore().Get("$count")
-	if val.Num != 1 {
-		t.Fatalf("expected $count=1, got %v", val.Num)
+	if val.Number() != 1 {
+		t.Fatalf("expected $count=1, got %v", val.Number())
 	}
 
 	// Increment again — B should get another patch
@@ -118,7 +118,7 @@ func TestCrossIslandReRender(t *testing.T) {
 	}
 
 	val2, _ := b.GetStore().Get("$count")
-	t.Logf("After 2 increments: $count=%v, B received %d patch sets", val2.Num, len(bPatches2))
+	t.Logf("After 2 increments: $count=%v, B received %d patch sets", val2.Number(), len(bPatches2))
 }
 
 // TestDisposeUnsubscribes proves that disposing an island unsubscribes


### PR DESCRIPTION
Stack 1/11

Depends on main.

This PR decomposes #103 into eleven focused, reviewable pull requests.

## Stack summary

Narrows the VM Value representation, adds subtree reuse and zero-allocation patch encoding, and establishes the 3D rigid-body physics foundation.

## Validation

- Train-builder validation passed for this isolated car.
- The branch tip and clean worktree state were verified before publication.

---

## Summary

The VM's `Value` struct is narrowed to a 32-byte tagged union that passes in registers, introducing typed accessors and closing direct field exposure. Island reconciliation now skips evaluating unchanged subtrees via a read-set based reuse engine, and patch marshalling replaces `encoding/json` with a hand-rolled zero-alloc encoder. This also introduces a complete 3D rigid body physics subsystem with inertia, collision detection, broadphase, constraints, and solvers.

## Changes

- Shrink `Value` to 32 bytes by replacing exported fields with private ones and typed accessors (`.Map()`, `.List()`, `.SetField()`, `.truth()`). Enables register passing for better VM/WASM performance and enforces safe value access patterns.
- Implement island subtree reuse (`reuse.go`) to compute per-expression read sets on first reconcile. Subsequent reconciles copy unchanged subtrees from the previous tree, cutting eval cost for interactive islands.
- Replace `encoding/json` in `MarshalPatches` with a hand-rolled, byte-identical JSON encoder (`patch_json.go`), cutting serialization overhead by ~60%.
- Standardize opcode evaluators to accept `*program.Expr` directly. Add depth guards to `ToAny` and alias detection to `OpIndexSet` to prevent stack overflows/cycles from self-referential values. Add native `FuzzVMEvalNeverPanics` target.
- Add complete 3D rigid body engine (`physics/`) including mass/inertia tensors, collision detection (GJK + narrowphase), convex shapes, broadphase, CCD, joints, iterative solver with sleep/wake, and raycasting. Wire into engine via `physics_bridge.go`.
- Add extensive fuzz tests for VM eval and reuse, randomized corpus tests for the JSON encoder, and comprehensive physics tests for collision, constraints, and dynamics.

## Testing

- Run `go test ./client/vm/... ./client/bridge/... ./physics/... -v -count=1` to verify all unit tests, benchmarks, and fuzz targets compile and pass.
- Execute the native fuzzer with `go test -fuzz=FuzzVMEvalNeverPanics -fuzztime=30s ./client/vm/` to ensure the panic-free contract holds under random programs.
- Spin up the dev server, trigger island updates, and inspect profiler data to confirm register-passing `Value` and subtree reuse reduce reconcile time. Verify 3D physics bodies simulate and collide correctly through the scene bridge.