### PR TITLE
improve(runtime): Stabilize engine IDs and add page cache TTL

### DIFF
--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -27,6 +27,7 @@ const {
   flushAsyncWork,
   appendManagedHead,
   buildNavigatedDocument,
+  installManualClock,
 } = require("./runtime-test-harness.js");
 
 test("bootstrap exposes page lifecycle hooks and can re-bootstrap after disposal", async () => {
@@ -1669,6 +1670,102 @@ test("navigation runtime prefetches marked links and reuses cached HTML", async 
 
   assert.equal(env.fetchCalls.length, 1);
   assert.equal(env.document.title, "Prefetched");
+});
+
+test("navigation runtime page cache entries expire after their TTL", async () => {
+  const link = new FakeElement("a", null);
+  link.setAttribute("href", "/ttl-page");
+  link.setAttribute("data-gosx-link", "");
+  link.textContent = "TTL page";
+
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [link],
+    fetchRoutes: {
+      "http://localhost:3000/ttl-page": {
+        text: "__TTL_DOC__",
+        url: "http://localhost:3000/ttl-page",
+      },
+    },
+    parseHTML(html) {
+      return parsedDocs.get(html);
+    },
+  });
+
+  parsedDocs.set("__TTL_DOC__", buildNavigatedDocument({
+    title: "TTL",
+    bodyNodes: [new FakeElement("div", null)],
+  }));
+
+  const clock = installManualClock(env.context, 0);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const overListener = env.document.eventListeners.get("mouseover")[0];
+
+  overListener({ type: "mouseover", target: link });
+  await flushAsyncWork();
+  assert.equal(env.fetchCalls.length, 1);
+  assert.equal(link.getAttribute("data-gosx-prefetch-state"), "ready");
+
+  // Well inside the 5-minute TTL: the cached entry still answers a re-hover.
+  clock.advance(60 * 1000);
+  overListener({ type: "mouseover", target: link });
+  await flushAsyncWork();
+  assert.equal(env.fetchCalls.length, 1);
+
+  // Past the 5-minute TTL: the entry is a miss, so the runtime refetches.
+  clock.advance(5 * 60 * 1000);
+  overListener({ type: "mouseover", target: link });
+  await flushAsyncWork();
+  assert.equal(env.fetchCalls.length, 2);
+  assert.equal(env.fetchCalls[1].url, env.fetchCalls[0].url);
+});
+
+test("navigation runtime never caches HTML for a page that opts out via meta", async () => {
+  const link = new FakeElement("a", null);
+  link.setAttribute("href", "/no-store-page");
+  link.setAttribute("data-gosx-link", "");
+  link.textContent = "No-store page";
+
+  const optOutMeta = new FakeElement("meta", null);
+  optOutMeta.setAttribute("name", "gosx-page-cache");
+  optOutMeta.setAttribute("content", "no-store");
+
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [link],
+    fetchRoutes: {
+      "http://localhost:3000/no-store-page": {
+        text: "__NO_STORE_DOC__",
+        url: "http://localhost:3000/no-store-page",
+      },
+    },
+    parseHTML(html) {
+      return parsedDocs.get(html);
+    },
+  });
+
+  parsedDocs.set("__NO_STORE_DOC__", buildNavigatedDocument({
+    title: "No store",
+    headNodes: [optOutMeta],
+    bodyNodes: [new FakeElement("div", null)],
+  }));
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const overListener = env.document.eventListeners.get("mouseover")[0];
+
+  overListener({ type: "mouseover", target: link });
+  await flushAsyncWork();
+  assert.equal(env.fetchCalls.length, 1);
+  assert.equal(link.getAttribute("data-gosx-prefetch-state"), "ready");
+  assert.equal(env.context.__gosx_page_cache.size, 0);
+
+  // A second hover has nothing cached to reuse, so it fetches again.
+  overListener({ type: "mouseover", target: link });
+  await flushAsyncWork();
+  assert.equal(env.fetchCalls.length, 2);
+  assert.equal(env.context.__gosx_page_cache.size, 0);
 });
 
 test("navigation runtime eagerly prefetches render-marked links", async () => {

--- a/client/js/runtime-test-harness.js
+++ b/client/js/runtime-test-harness.js
@@ -2550,6 +2550,28 @@ function installManualTimers(context) {
   };
 }
 
+// installManualClock replaces context.Date with a minimal double exposing
+// only Date.now() — the one clock entry point server/navigation_runtime.js
+// reads (see PAGE_CACHE_TTL_MS). A test advances it explicitly instead of
+// waiting on the real clock.
+function installManualClock(context, startAt) {
+  let current = typeof startAt === "number" ? startAt : Date.now();
+  context.Date = {
+    now() {
+      return current;
+    },
+  };
+  return {
+    now() {
+      return current;
+    },
+    advance(ms) {
+      current += Number(ms) || 0;
+      return current;
+    },
+  };
+}
+
 function runScript(source, context, filename) {
   vm.runInContext(source, context, { filename });
 }
@@ -5371,6 +5393,7 @@ module.exports = {
   installManualRAF,
   flushSceneInitialFrameBoundary,
   installManualTimers,
+  installManualClock,
   runScript,
   flushAsyncWork,
   sharedSignalValue,

--- a/hydrate/manifest.go
+++ b/hydrate/manifest.go
@@ -422,7 +422,7 @@ func (m *Manifest) AddEngineWithRuntimeRequirements(component, kind, programRef,
 	if err != nil {
 		return "", err
 	}
-	id := engineID(len(m.Engines))
+	id := engineID(len(m.Engines), mountID)
 	entry := EngineEntry{
 		ID:                   id,
 		Component:            component,
@@ -522,7 +522,23 @@ func controllerID(n int) string {
 	return "gosx-controller-" + itoa(n)
 }
 
-func engineID(n int) string {
+// autoMountIDPrefix is island.Renderer.RenderEngine's own placeholder mount
+// id ("gosx-engine-mount-<n>") for a mount-needing engine whose caller left
+// Config.MountID empty. It carries no author identity, so it is still
+// positional and engineID must not treat it as one — that pairing must stay
+// in sync with island/island.go's fallback.
+const autoMountIDPrefix = "gosx-engine-mount-"
+
+// engineID assigns a stable engine id. An authored mount id derives the id
+// directly (two engines never share a mount id, since it is also the DOM
+// element the engine attaches to), so two engines on different routes with
+// different mount ids never collide on a shared positional id. An engine
+// with no mount id, or only the auto-generated placeholder mount id, falls
+// back to the positional id.
+func engineID(n int, mountID string) string {
+	if mountID != "" && !strings.HasPrefix(mountID, autoMountIDPrefix) {
+		return "gosx-engine-" + mountID
+	}
 	return "gosx-engine-" + itoa(n)
 }
 

--- a/hydrate/manifest_test.go
+++ b/hydrate/manifest_test.go
@@ -403,8 +403,8 @@ func TestManifestAddEngineWithPixelSurface(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddEngineWithRuntime failed: %v", err)
 	}
-	if id != "gosx-engine-0" {
-		t.Fatalf("expected gosx-engine-0, got %s", id)
+	if id != "gosx-engine-retro-root" {
+		t.Fatalf("expected gosx-engine-retro-root, got %s", id)
 	}
 
 	data, err := m.Marshal()
@@ -453,8 +453,8 @@ func TestManifestAddEngineWithRequiredCapabilities(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddEngineWithRuntimeRequirements failed: %v", err)
 	}
-	if id != "gosx-engine-0" {
-		t.Fatalf("expected gosx-engine-0, got %s", id)
+	if id != "gosx-engine-strict-root" {
+		t.Fatalf("expected gosx-engine-strict-root, got %s", id)
 	}
 
 	data, err := m.Marshal()
@@ -468,6 +468,71 @@ func TestManifestAddEngineWithRequiredCapabilities(t *testing.T) {
 	if got := decoded.Engines[0].RequiredCapabilities; len(got) != 2 || got[0] != "wasm" || got[1] != "webgl" {
 		t.Fatalf("unexpected required capabilities: %#v", got)
 	}
+}
+
+// TestManifestEngineIDDerivesFromMountID pins the id engineID(...) assigns
+// for every mount id shape it must tell apart: none, an authored id, and
+// island.Renderer.RenderEngine's own positional placeholder
+// ("gosx-engine-mount-<n>") for a mount-needing engine the caller left
+// unnamed. Two different routes whose first engine is a different authored
+// surface (the bug this pins: m31labs.dev's galaxy and starfield engines
+// both landed on "gosx-engine-0") must not collide on a shared positional id.
+func TestManifestEngineIDDerivesFromMountID(t *testing.T) {
+	t.Run("no mount id falls back to the positional id", func(t *testing.T) {
+		m := NewManifest()
+		first, err := m.AddEngineWithRuntime("First", "surface", "", "", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		second, err := m.AddEngineWithRuntime("Second", "surface", "", "", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		if first != "gosx-engine-0" {
+			t.Fatalf("expected gosx-engine-0, got %s", first)
+		}
+		if second != "gosx-engine-1" {
+			t.Fatalf("expected gosx-engine-1, got %s", second)
+		}
+	})
+
+	t.Run("an authored mount id derives the engine id directly", func(t *testing.T) {
+		m := NewManifest()
+		id, err := m.AddEngineWithRuntime("GalaxyScene", "surface", "", "galaxy-scene-primary", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		if id != "gosx-engine-galaxy-scene-primary" {
+			t.Fatalf("expected gosx-engine-galaxy-scene-primary, got %s", id)
+		}
+	})
+
+	t.Run("two routes' first engine no longer collide on a shared positional id", func(t *testing.T) {
+		galaxyRoute := NewManifest()
+		galaxyID, err := galaxyRoute.AddEngineWithRuntime("GoSXScene3D", "surface", "", "galaxy-scene-primary", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		starfieldRoute := NewManifest()
+		starfieldID, err := starfieldRoute.AddEngineWithRuntime("GoSXScene3D", "surface", "", "starfield-background", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		if galaxyID == starfieldID {
+			t.Fatalf("expected distinct engine ids for distinct mount ids, both got %s", galaxyID)
+		}
+	})
+
+	t.Run("island.Renderer's own auto-generated placeholder mount id still falls back to the positional id", func(t *testing.T) {
+		m := NewManifest()
+		id, err := m.AddEngineWithRuntime("Unnamed", "surface", "", "gosx-engine-mount-0", "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("AddEngineWithRuntime: %v", err)
+		}
+		if id != "gosx-engine-0" {
+			t.Fatalf("expected the placeholder mount id to fall back to gosx-engine-0, got %s", id)
+		}
+	})
 }
 
 func TestManifestAddEngineRejectsMalformedGoWASMRuntime(t *testing.T) {

--- a/server/navigation_runtime.js
+++ b/server/navigation_runtime.js
@@ -35,6 +35,13 @@
     formMethod: "formmethod",
     formTarget: "formtarget",
   };
+  // A prefetched page never revalidates on its own, so a stale entry can
+  // outlive the session that time-boxed its content (rotating tokens,
+  // bucketed data). PAGE_CACHE_TTL_MS bounds how long a cached page answers
+  // before the next lookup treats it as a miss and refetches.
+  const PAGE_CACHE_TTL_MS = 5 * 60 * 1000;
+  const PAGE_CACHE_OPT_OUT_META = "gosx-page-cache";
+  const PAGE_CACHE_OPT_OUT_VALUE = "no-store";
   const scriptCache = window.__gosx_loaded_scripts || new Map();
   const pageCache = window.__gosx_page_cache || new Map();
   let navigationState = {
@@ -1694,10 +1701,43 @@
     return new DOMParser().parseFromString(html, "text/html");
   }
 
+  // pageCacheOptsOut reads the FETCHED page's own head, not the live
+  // document's — a page opts its own HTML out of pageCache with <meta
+  // name="gosx-page-cache" content="no-store">, the same meta/attribute
+  // lookup shape as csrfTokenFromMeta above.
+  function pageCacheOptsOut(html) {
+    let doc;
+    try {
+      doc = parseDocument(html);
+    } catch (_e) {
+      return false;
+    }
+    const meta = findElement(doc && doc.head, function(node) {
+      return isElement(node, "META")
+        && node.getAttribute
+        && node.getAttribute("name") === PAGE_CACHE_OPT_OUT_META;
+    });
+    return !!meta && String(meta.getAttribute("content") || "").toLowerCase() === PAGE_CACHE_OPT_OUT_VALUE;
+  }
+
+  // A pageCache entry is a Promise, decorated with its own insertion time
+  // (__gosxCachedAt) rather than wrapped in a {value, insertedAt} record, so
+  // the map keeps its original Map<string, Promise<{html,url}>> shape for
+  // any code outside this module that already reads window.__gosx_page_cache.
+  function pageCacheEntryExpired(entry) {
+    return typeof entry.__gosxCachedAt === "number"
+      && (Date.now() - entry.__gosxCachedAt) > PAGE_CACHE_TTL_MS;
+  }
+
   async function fetchPage(url, signal) {
     const key = String(url);
-    if (pageCache.has(key)) {
-      return pageCache.get(key);
+    const cached = pageCache.get(key);
+    if (cached) {
+      if (pageCacheEntryExpired(cached)) {
+        pageCache.delete(key);
+      } else {
+        return cached;
+      }
     }
 
     const request = (async function() {
@@ -1719,8 +1759,13 @@
     })();
 
     pageCache.set(key, request);
+    request.__gosxCachedAt = Date.now();
     try {
-      return await request;
+      const page = await request;
+      if (pageCacheOptsOut(page.html)) {
+        pageCache.delete(key);
+      }
+      return page;
     } catch (err) {
       pageCache.delete(key);
       throw err;


### PR DESCRIPTION
## Summary

Stabilizes engine ID assignment in the hydration manifest to prevent positional collisions across routes. Enforces a 5-minute TTL on the server-side page prefetch cache and honors `<meta name="gosx-page-cache" content="no-store">` opt-out directives.

## Changes

- Derive engine IDs directly from authored mount IDs in hydrate/manifest.go to prevent collisions when engines with different mounts share the same route index
- Fall back to positional IDs for unnamed engines or platform-generated mount-id placeholders to preserve existing behavior
- Enforce a 5-minute cache TTL on the client navigation runtime, removing expired entries on lookup and skipping cache population for opted-out pages
- Tag cached promises with __gosxCachedAt instead of wrapping them in objects to maintain the original Map<string, Promise> shape for downstream consumers
- Add installManualClock to runtime-test-harness.js to mock Date.now() deterministically for cache expiration scenarios
- Update hydration manifest tests for the new engine ID signature and add coverage for TTL expiration and meta-based cache opt-out

## Testing

- go test ./hydrate -run TestManifestEngineIDDerivesFromMountID
- node client/js/runtime-14-navigation.test.js

## Review Focus

Verify that the mount ID prefix fallback logic aligns with island/island.go's placeholder generation, and check that the TTL expiration doesn't break long-running navigation tests.
## Task 3 (investigation only, no code change): bounded design for the force-WebGL session latch

### Problem

`window.__gosx_scene3d_force_webgl` and its sessionStorage marker
(`gosx:scene3d:force-webgl-next`, set by `requestWebGLRecovery()` in
`client/js/bootstrap-src/09-scene3d-command-bridge.js`) never expire.
`requestWebGLRecovery({reload:true})` sets the marker and reloads. The
reloaded page consumes the one-shot sessionStorage key, but keeps the
in-memory flag for the rest of that page's life. Every later mount and
soft navigation reads that flag through `sceneForcesWebGL()`
(`20a-scene-mount-backend.js`). `clearWebGLRecovery()` exists and has
test coverage, but no framework code calls it. After one WebGPU
failure, the tab never asks for WebGPU again.

### Proposed bounded design

1. Store an expiring record instead of a boolean: `{until, attempts}`.
   Treat the marker as active only while `Date.now() < until`.
2. Reuse the rolling-window-and-backoff shape
   `16z-scene-webgpu-probe.js` already uses for its own WebGPU
   reprobe (`WEBGPU_LOST_REPROBE_WINDOW_MS`, `_MAX_PER_WINDOW`,
   `_BACKOFF_MS`). Cap attempts at a small number per session (for
   example 2) and extend `until` on each new recovery call.
3. Never trigger a reload from marker expiry. Expiry should only let a
   reload the app already triggers for its own reasons re-probe
   WebGPU. `requestWebGLRecovery` keeps its existing reload; nothing
   new reloads on its own.
4. Call `clearWebGLRecovery()` from `recoverSceneWebGPUFromWebGLFallback`
   (`20-scene-mount.js`) once it confirms a live WebGPU device. A
   confirmed-good device clears the latch immediately, instead of
   waiting out the timer.

### Risks

- **Reload loops.** A design that retries WebGPU on marker expiry and
  reloads again on failure can cycle: reload, fail, reload, fail. The
  proposal avoids this because expiry never reloads on its own. A
  later change that adds an eager retry-on-expiry reload would
  reintroduce the loop — this needs an explicit code comment, not just
  correct runtime behavior today.
- **Persistently broken GPUs.** A time-based expiry retries a
  permanently broken driver on every window. Each retry wastes a probe
  and may briefly show the failure WebGL was forced to hide. The
  attempt cap bounds this cost; it does not remove it.
- **Per-tab semantics.** sessionStorage is per tab. A duplicated tab
  inherits the marker. Carrying the same `until` and `attempts`
  values forward, instead of resetting them, ties the bound to the
  last real failure's clock time, not to tab count.
- **Two recovery paths.** `recoverSceneWebGPUFromWebGLFallback`
  already climbs back onto WebGPU per mount, without touching the
  session latch. Wiring it to also clear the latch needs a
  "confirmed good" signal — a rendered frame, not just a successful
  `getContext("webgpu")` call, since a raw context can still fail
  immediately after.
