### PR TITLE
fix(editor): Fix blank area click mutation and add textarea accessible name

### DIFF
--- a/editor/assets/native-editor.js
+++ b/editor/assets/native-editor.js
@@ -532,13 +532,10 @@
         return true;
       }
 
-      const missingRows = visualRow - visualRowToLine.length + 1;
-      if (missingRows <= 0) return false;
+      if (visualRow < visualRowToLine.length) return false;
       event.preventDefault();
       textarea.focus();
-      textarea.value += "\n".repeat(missingRows);
       textarea.setSelectionRange(textarea.value.length, textarea.value.length);
-      textarea.dispatchEvent(new Event("input", { bubbles: true }));
       return true;
     };
 

--- a/editor/code_surface_test.go
+++ b/editor/code_surface_test.go
@@ -103,6 +103,67 @@ func TestNativeEditorAssetProvidesMultiCursorEditing(t *testing.T) {
 	}
 }
 
+func TestNativeEditorAssetKeepsBlankAreaClicksInputFree(t *testing.T) {
+	asset, err := embeddedAssets.ReadFile("assets/native-editor.js")
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(asset)
+	start := strings.Index(source, "const focusBlankVisualRow =")
+	if start < 0 {
+		t.Fatal("native editor asset is missing blank-area click handling")
+	}
+	end := strings.Index(source[start:], "    const syncScroll =")
+	if end < 0 {
+		t.Fatal("native editor asset is missing the end of blank-area click handling")
+	}
+	handler := source[start : start+end]
+	for _, forbidden := range []string{
+		`textarea.value +=`,
+		`textarea.dispatchEvent(new Event("input"`,
+	} {
+		if strings.Contains(handler, forbidden) {
+			t.Fatalf("blank-area click handling must not mutate editor content or emit input: found %q", forbidden)
+		}
+	}
+	for _, want := range []string{
+		`textarea.focus()`,
+		`textarea.setSelectionRange(textarea.value.length, textarea.value.length)`,
+	} {
+		if !strings.Contains(handler, want) {
+			t.Fatalf("blank-area click handling missing %q", want)
+		}
+	}
+}
+
+func TestNativeSourceTextareaUsesConfigurableAccessibleName(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		opts Options
+		want string
+	}{
+		{name: "label", opts: Options{Label: "Source code"}, want: "Source code"},
+		{name: "title fallback", opts: Options{Title: "main.go"}, want: "main.go"},
+		{name: "default", opts: Options{}, want: "Editor"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			html := gosx.RenderHTML(New("editor", tc.opts).Render())
+			textareaStart := strings.Index(html, `<textarea id="editor-content"`)
+			if textareaStart < 0 {
+				t.Fatalf("source textarea missing from %s", html)
+			}
+			tagEnd := strings.Index(html[textareaStart:], ">")
+			if tagEnd < 0 {
+				t.Fatalf("source textarea tag is unterminated in %s", html)
+			}
+			sourceTextarea := html[textareaStart : textareaStart+tagEnd+1]
+			if !strings.Contains(sourceTextarea, `aria-label="`+tc.want+`"`) {
+				t.Fatalf("source textarea accessible name = %q, want %q", sourceTextarea, tc.want)
+			}
+		})
+	}
+}
+
 func TestNativeEditorAssetProvidesCodeEditingChecklist(t *testing.T) {
 	asset, err := embeddedAssets.ReadFile("assets/native-editor.js")
 	if err != nil {

--- a/editor/native.go
+++ b/editor/native.go
@@ -258,6 +258,9 @@ func (e *Editor) renderNativePanelSegments() []gosx.Node {
 }
 
 func (e *Editor) renderNativeBody() gosx.Node {
+	sourceAttrs := e.nativeTextareaAttrs("editor-content", "content", "editor-source", e.Options.Placeholder, 0)
+	sourceAttrs = append(sourceAttrs, gosx.Attr("aria-label", e.ariaLabel()))
+
 	return gosx.El(
 		"section",
 		gosx.Attrs(
@@ -286,7 +289,7 @@ func (e *Editor) renderNativeBody() gosx.Node {
 				),
 				gosx.El(
 					"textarea",
-					e.nativeTextareaAttrs("editor-content", "content", "editor-source", e.Options.Placeholder, 0),
+					sourceAttrs,
 					gosx.Text(e.doc.Content()),
 				),
 			),


### PR DESCRIPTION
## Summary

Stop the native editor from injecting newlines when users click in the blank area below their code, which previously caused unwanted input events and content mutation. Additionally, wire up a configurable aria-label on the source textarea using the editor's options for improved screen reader support.

## Changes

- Update native-editor.js blank-area click handler to remove newline mutation and event dispatching, retaining only focus and cursor-positioning logic to prevent accidental content changes.
- Attach a dynamic aria-label to the source textarea derived from Options.Label, falling back to Options.Title or a default "Editor" string, enhancing accessibility compliance.
- Add unit tests verifying that blank-area clicks remain input-free while correctly focusing the editor, and validate the accessible name fallback chain in Go.

## Testing

- Run `go test ./editor/... -v -run "TestNativeEditorAssetKeepsBlankAreaClicksInputFree|TestNativeSourceTextareaUsesConfigurableAccessibleName"`
- Manually verify that clicking below the last line of code focuses the textarea and moves the cursor to the end without inserting characters.
- Inspect the rendered HTML via browser devtools to confirm the textarea includes the correct aria-label attribute based on the editor configuration.