### PR TITLE
O5: publish capability-linked WASM variants and select by contract

### DIFF
--- a/buildmanifest/manifest.go
+++ b/buildmanifest/manifest.go
@@ -17,30 +17,44 @@ type Manifest struct {
 }
 
 type RuntimeAssets struct {
-	WASM                              HashedAsset `json:"wasm"`
-	WASMIslands                       HashedAsset `json:"wasmIslands,omitempty"`
-	WASMExec                          HashedAsset `json:"wasmExec"`
-	StandardGoWASMExec                HashedAsset `json:"standardGoWasmExec,omitempty"`
-	Bootstrap                         HashedAsset `json:"bootstrap"`
-	BootstrapLite                     HashedAsset `json:"bootstrapLite,omitempty"`
-	BootstrapRuntime                  HashedAsset `json:"bootstrapRuntime,omitempty"`
-	BootstrapFeatureIslands           HashedAsset `json:"bootstrapFeatureIslands,omitempty"`
-	BootstrapFeatureEngines           HashedAsset `json:"bootstrapFeatureEngines,omitempty"`
-	BootstrapFeatureHubs              HashedAsset `json:"bootstrapFeatureHubs,omitempty"`
-	BootstrapFeatureControllers       HashedAsset `json:"bootstrapFeatureControllers,omitempty"`
-	BootstrapFeatureTextlayout        HashedAsset `json:"bootstrapFeatureTextlayout,omitempty"`
-	BootstrapFeatureScene3D           HashedAsset `json:"bootstrapFeatureScene3d,omitempty"`
-	BootstrapFeatureScene3DCommand    HashedAsset `json:"bootstrapFeatureScene3dCommand,omitempty"`
-	BootstrapFeatureScene3DWebGPU     HashedAsset `json:"bootstrapFeatureScene3dWebgpu,omitempty"`
-	BootstrapFeatureScene3DWebGL      HashedAsset `json:"bootstrapFeatureScene3dWebgl,omitempty"`
-	BootstrapFeatureScene3DGLTF       HashedAsset `json:"bootstrapFeatureScene3dGltf,omitempty"`
-	BootstrapFeatureScene3DAnimation  HashedAsset `json:"bootstrapFeatureScene3dAnimation,omitempty"`
-	BootstrapFeatureScene3DCompute    HashedAsset `json:"bootstrapFeatureScene3dCompute,omitempty"`
-	BootstrapFeatureScene3DDecompress HashedAsset `json:"bootstrapFeatureScene3dDecompress,omitempty"`
-	Patch                             HashedAsset `json:"patch"`
-	VideoHLS                          HashedAsset `json:"videoHLS,omitempty"`
-	StripeBridge                      HashedAsset `json:"stripeBridge,omitempty"`
-	Relay                             HashedAsset `json:"relay,omitempty"`
+	WASM        HashedAsset `json:"wasm"`
+	WASMIslands HashedAsset `json:"wasmIslands,omitempty"`
+	// WASMVariants contains the capability-linked artifacts. WASM remains the
+	// full-runtime compatibility field so older servers and source builds keep
+	// working while new renderers select the smallest compatible entry.
+	WASMVariants                      map[string]RuntimeVariantAsset `json:"wasmVariants,omitempty"`
+	WASMExec                          HashedAsset                    `json:"wasmExec"`
+	StandardGoWASMExec                HashedAsset                    `json:"standardGoWasmExec,omitempty"`
+	Bootstrap                         HashedAsset                    `json:"bootstrap"`
+	BootstrapLite                     HashedAsset                    `json:"bootstrapLite,omitempty"`
+	BootstrapRuntime                  HashedAsset                    `json:"bootstrapRuntime,omitempty"`
+	BootstrapFeatureIslands           HashedAsset                    `json:"bootstrapFeatureIslands,omitempty"`
+	BootstrapFeatureEngines           HashedAsset                    `json:"bootstrapFeatureEngines,omitempty"`
+	BootstrapFeatureHubs              HashedAsset                    `json:"bootstrapFeatureHubs,omitempty"`
+	BootstrapFeatureControllers       HashedAsset                    `json:"bootstrapFeatureControllers,omitempty"`
+	BootstrapFeatureTextlayout        HashedAsset                    `json:"bootstrapFeatureTextlayout,omitempty"`
+	BootstrapFeatureScene3D           HashedAsset                    `json:"bootstrapFeatureScene3d,omitempty"`
+	BootstrapFeatureScene3DCommand    HashedAsset                    `json:"bootstrapFeatureScene3dCommand,omitempty"`
+	BootstrapFeatureScene3DWebGPU     HashedAsset                    `json:"bootstrapFeatureScene3dWebgpu,omitempty"`
+	BootstrapFeatureScene3DWebGL      HashedAsset                    `json:"bootstrapFeatureScene3dWebgl,omitempty"`
+	BootstrapFeatureScene3DGLTF       HashedAsset                    `json:"bootstrapFeatureScene3dGltf,omitempty"`
+	BootstrapFeatureScene3DAnimation  HashedAsset                    `json:"bootstrapFeatureScene3dAnimation,omitempty"`
+	BootstrapFeatureScene3DCompute    HashedAsset                    `json:"bootstrapFeatureScene3dCompute,omitempty"`
+	BootstrapFeatureScene3DDecompress HashedAsset                    `json:"bootstrapFeatureScene3dDecompress,omitempty"`
+	Patch                             HashedAsset                    `json:"patch"`
+	VideoHLS                          HashedAsset                    `json:"videoHLS,omitempty"`
+	StripeBridge                      HashedAsset                    `json:"stripeBridge,omitempty"`
+	Relay                             HashedAsset                    `json:"relay,omitempty"`
+}
+
+// RuntimeVariantAsset identifies one runtime artifact independently of its
+// compatibility filename. FeatureMask is the ABI capability declaration the
+// browser must validate after loading the artifact.
+type RuntimeVariantAsset struct {
+	HashedAsset
+	Variant      string `json:"variant"`
+	FeatureMask  uint32 `json:"featureMask"`
+	ManifestHash string `json:"manifestHash"`
 }
 
 type IslandAsset struct {
@@ -73,6 +87,7 @@ type SceneAssetManifest struct {
 type RuntimePaths struct {
 	WASM                              string
 	WASMIslands                       string
+	WASMVariants                      map[string]string
 	WASMExec                          string
 	StandardGoWASMExec                string
 	Bootstrap                         string
@@ -113,9 +128,14 @@ func Load(path string) (*Manifest, error) {
 
 // RuntimeURLs returns the public URLs for the shared runtime assets.
 func (m *Manifest) RuntimeURLs(assetBaseURL string) RuntimePaths {
+	variants := make(map[string]string, len(m.Runtime.WASMVariants))
+	for id, asset := range m.Runtime.WASMVariants {
+		variants[id] = AssetURL(assetBaseURL, "runtime", asset.File)
+	}
 	return RuntimePaths{
 		WASM:                              AssetURL(assetBaseURL, "runtime", m.Runtime.WASM.File),
 		WASMIslands:                       AssetURL(assetBaseURL, "runtime", m.Runtime.WASMIslands.File),
+		WASMVariants:                      variants,
 		WASMExec:                          AssetURL(assetBaseURL, "runtime", m.Runtime.WASMExec.File),
 		StandardGoWASMExec:                AssetURL(assetBaseURL, "runtime", m.Runtime.StandardGoWASMExec.File),
 		Bootstrap:                         AssetURL(assetBaseURL, "runtime", m.Runtime.Bootstrap.File),

--- a/buildmanifest/manifest_test.go
+++ b/buildmanifest/manifest_test.go
@@ -13,6 +13,10 @@ func TestLoadAndURLs(t *testing.T) {
   "runtime": {
     "wasm": {"file": "gosx-runtime.11111111.wasm", "hash": "11111111", "size": 10},
     "wasmIslands": {"file": "gosx-runtime-islands.99999999.wasm", "hash": "99999999", "size": 9},
+	"wasmVariants": {
+	  "core": {"file": "gosx-runtime-core.aaaaaaa1.wasm", "hash": "aaaaaaa1", "size": 8, "variant": "core", "featureMask": 17},
+	  "engine": {"file": "gosx-runtime-engine.bbbbbbb2.wasm", "hash": "bbbbbbb2", "size": 12, "variant": "engine", "featureMask": 11}
+	},
 	    "wasmExec": {"file": "wasm_exec.22222222.js", "hash": "22222222", "size": 20},
 	    "standardGoWasmExec": {"file": "standard-go-wasm_exec.2a2a2a2a.js", "hash": "2a2a2a2a", "size": 21},
     "bootstrap": {"file": "bootstrap.33333333.js", "hash": "33333333", "size": 30},
@@ -42,6 +46,9 @@ func TestLoadAndURLs(t *testing.T) {
 	}
 	if runtime.WASMIslands != "/gosx/assets/runtime/gosx-runtime-islands.99999999.wasm" {
 		t.Fatalf("unexpected islands wasm url: %s", runtime.WASMIslands)
+	}
+	if runtime.WASMVariants["core"] != "/gosx/assets/runtime/gosx-runtime-core.aaaaaaa1.wasm" {
+		t.Fatalf("unexpected core wasm url: %s", runtime.WASMVariants["core"])
 	}
 	if runtime.Bootstrap != "/gosx/assets/runtime/bootstrap.33333333.js" {
 		t.Fatalf("unexpected bootstrap url: %s", runtime.Bootstrap)

--- a/client/wasm/canvas_board_event_test.go
+++ b/client/wasm/canvas_board_event_test.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/canvas_board_full.go
+++ b/client/wasm/canvas_board_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 // Canvas2D paint-loop JS bridge — the missing wire between a hydrated
 // gosx.CanvasBoard (a <canvas data-gosx-surface-kind="canvas2d"> placeholder

--- a/client/wasm/canvas_board_islands_only.go
+++ b/client/wasm/canvas_board_islands_only.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_islands_only
+//go:build js && wasm && (gosx_tiny_islands_only || gosx_runtime_core || gosx_runtime_collab)
 
 // Canvas2D paint-loop JS bridge — islands-only stub.
 //

--- a/client/wasm/crdt_full.go
+++ b/client/wasm/crdt_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_runtime
+//go:build js && wasm && (!gosx_tiny_runtime || gosx_runtime_collab || gosx_runtime_full)
 
 package main
 

--- a/client/wasm/crdt_tiny.go
+++ b/client/wasm/crdt_tiny.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_runtime
+//go:build js && wasm && gosx_tiny_runtime && !gosx_runtime_collab && !gosx_runtime_full
 
 package main
 

--- a/client/wasm/engine_full.go
+++ b/client/wasm/engine_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/engine_islands_only.go
+++ b/client/wasm/engine_islands_only.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_islands_only
+//go:build js && wasm && (gosx_tiny_islands_only || gosx_runtime_core || gosx_runtime_collab)
 
 package main
 

--- a/client/wasm/engine_surface_full.go
+++ b/client/wasm/engine_surface_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 // Engine-surface JS bridge — the missing wire between the server-side
 // data-gosx-engine-bytecode attribute and the Bridge.HydrateEngineSurface

--- a/client/wasm/engine_surface_islands_only.go
+++ b/client/wasm/engine_surface_islands_only.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_islands_only
+//go:build js && wasm && (gosx_tiny_islands_only || gosx_runtime_core || gosx_runtime_collab)
 
 // Engine-surface JS bridge — islands-only stub.
 //

--- a/client/wasm/highlight_full.go
+++ b/client/wasm/highlight_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_runtime
+//go:build js && wasm && !gosx_tiny_runtime && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/highlight_tiny.go
+++ b/client/wasm/highlight_tiny.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_runtime
+//go:build js && wasm && (gosx_tiny_runtime || gosx_runtime_collab)
 
 package main
 

--- a/client/wasm/main_test.go
+++ b/client/wasm/main_test.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/patch_bridge_bench_test.go
+++ b/client/wasm/patch_bridge_bench_test.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 // Measurements for the patch path across the WASM boundary.
 //

--- a/client/wasm/render_full.go
+++ b/client/wasm/render_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/runtime_variant_collab.go
+++ b/client/wasm/runtime_variant_collab.go
@@ -1,0 +1,9 @@
+//go:build js && wasm && gosx_runtime_collab
+
+package main
+
+import runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
+
+func runtimeVariant() runtimewasm.Variant {
+	return runtimewasm.VariantCollab
+}

--- a/client/wasm/runtime_variant_core.go
+++ b/client/wasm/runtime_variant_core.go
@@ -1,0 +1,9 @@
+//go:build js && wasm && gosx_runtime_core
+
+package main
+
+import runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
+
+func runtimeVariant() runtimewasm.Variant {
+	return runtimewasm.VariantCore
+}

--- a/client/wasm/runtime_variant_engine.go
+++ b/client/wasm/runtime_variant_engine.go
@@ -1,0 +1,9 @@
+//go:build js && wasm && gosx_runtime_engine
+
+package main
+
+import runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
+
+func runtimeVariant() runtimewasm.Variant {
+	return runtimewasm.VariantEngine
+}

--- a/client/wasm/textlayout_full.go
+++ b/client/wasm/textlayout_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_runtime
+//go:build js && wasm && !gosx_tiny_runtime && !gosx_runtime_collab
 
 package main
 

--- a/client/wasm/textlayout_tiny.go
+++ b/client/wasm/textlayout_tiny.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_runtime
+//go:build js && wasm && (gosx_tiny_runtime || gosx_runtime_collab)
 
 package main
 

--- a/client/wasm/video_sync_full.go
+++ b/client/wasm/video_sync_full.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && !gosx_tiny_islands_only
+//go:build js && wasm && !gosx_tiny_islands_only && !gosx_runtime_core && !gosx_runtime_collab
 
 // Video-sync JS bridge — WASM runtime exports.
 //

--- a/client/wasm/video_sync_islands_only.go
+++ b/client/wasm/video_sync_islands_only.go
@@ -1,4 +1,4 @@
-//go:build js && wasm && gosx_tiny_islands_only
+//go:build js && wasm && (gosx_tiny_islands_only || gosx_runtime_core || gosx_runtime_collab)
 
 // Video-sync JS bridge — islands-only stub.
 //

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -19,6 +19,7 @@ import (
 	"github.com/andybalholm/brotli"
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/buildmanifest"
+	runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
 	"m31labs.dev/gosx/island/program"
 	sceneinspect "m31labs.dev/gosx/scene/inspect"
 )
@@ -357,6 +358,9 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	// route-selected Go WASM variant that drops shared engine, CRDT, syntax
 	// highlighting, and text-layout exports for pages that only hydrate islands.
 	var wg sync.WaitGroup
+	coreResult := wasmResult{label: "core"}
+	engineResult := wasmResult{label: "engine"}
+	collabResult := wasmResult{label: "collab"}
 	runtimeResult := wasmResult{label: "runtime"}
 	islandsResult := wasmResult{label: "islands"}
 
@@ -415,9 +419,14 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 		_ = os.Remove(tmpPath)
 	}
 
-	// Shared runtime — always built
-	wg.Add(1)
-	go buildOneWASM(&runtimeResult, compiler, "runtime", "gosx-runtime")
+	// Capability-linked runtimes — all four published variants are built in
+	// parallel. The full artifact keeps the compatibility filename while the
+	// core/engine/collab artifacts are selected from page requirements.
+	wg.Add(4)
+	go buildOneWASM(&coreResult, compiler, "core", "gosx-runtime-core", "gosx_runtime_core")
+	go buildOneWASM(&engineResult, compiler, "engine", "gosx-runtime-engine", "gosx_runtime_engine")
+	go buildOneWASM(&collabResult, compiler, "collab", "gosx-runtime-collab", "gosx_runtime_collab")
+	go buildOneWASM(&runtimeResult, compiler, "full", "gosx-runtime", "gosx_runtime_full")
 
 	// Islands-only runtime — parallel with shared runtime.
 	buildIslands := !tinyGoFullRuntimeEnabled()
@@ -432,9 +441,23 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	if runtimeResult.err != nil {
 		return fmt.Errorf("wasm runtime build with %s: %w", compiler, runtimeResult.err)
 	}
+	for _, result := range []*wasmResult{&coreResult, &engineResult, &collabResult} {
+		if result.err != nil {
+			return fmt.Errorf("wasm %s runtime build with %s: %w", result.label, compiler, result.err)
+		}
+	}
 	manifest.Runtime.WASM = runtimeResult.asset
+	manifest.Runtime.WASMVariants = map[string]buildmanifest.RuntimeVariantAsset{
+		"core":   runtimeVariantAsset(string(runtimewasm.VariantCore), coreResult.asset),
+		"engine": runtimeVariantAsset(string(runtimewasm.VariantEngine), engineResult.asset),
+		"collab": runtimeVariantAsset(string(runtimewasm.VariantCollab), collabResult.asset),
+	}
 	gzEst := gzip_c_len(runtimeResult.data)
 	fmt.Printf("    %s (%d bytes, %dKB gz, built with %s)\n", runtimeResult.asset.File, runtimeResult.asset.Size, gzEst/1024, runtimeResult.compiler)
+	for _, result := range []*wasmResult{&coreResult, &engineResult, &collabResult} {
+		gzEst := gzip_c_len(result.data)
+		fmt.Printf("    %s (%d bytes, %dKB gz, built with %s, %s)\n", result.asset.File, result.asset.Size, gzEst/1024, result.compiler, result.label)
+	}
 
 	// Process islands result
 	if buildIslands {
@@ -442,6 +465,7 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 			return fmt.Errorf("wasm islands-only runtime build with %s: %w", compiler, islandsResult.err)
 		} else {
 			manifest.Runtime.WASMIslands = islandsResult.asset
+			manifest.Runtime.WASMVariants[string(runtimewasm.VariantIslands)] = runtimeVariantAsset(string(runtimewasm.VariantIslands), islandsResult.asset)
 			gzEst := gzip_c_len(islandsResult.data)
 			fmt.Printf("    %s (%d bytes, %dKB gz, built with %s, islands-only)\n", islandsResult.asset.File, islandsResult.asset.Size, gzEst/1024, islandsResult.compiler)
 		}
@@ -647,7 +671,7 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 		manifest.Runtime.BootstrapFeatureTextlayout.File,
 		manifest.Runtime.Patch.File,
 		manifest.Runtime.VideoHLS.File,
-	))
+	)+countRuntimeVariantAssets(manifest.Runtime.WASMVariants))
 	fmt.Printf("  Tier 3 (islands): %d programs + %d CSS, immutable CDN\n",
 		len(manifest.Islands), len(manifest.CSS))
 	fmt.Printf("  Manifest: %s\n", manifestPath)
@@ -675,6 +699,16 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	return nil
 }
 
+func countRuntimeVariantAssets(variants map[string]buildmanifest.RuntimeVariantAsset) int {
+	count := 0
+	for _, asset := range variants {
+		if strings.TrimSpace(asset.File) != "" {
+			count++
+		}
+	}
+	return count
+}
+
 // gzip_c_len returns the best-compression gzip transfer size.
 func gzip_c_len(data []byte) int {
 	return int(gzipLength(data))
@@ -686,6 +720,15 @@ func goWASMBuildArgs(outputPath string, extraTags ...string) []string {
 		args = append(args, "-tags="+strings.Join(tags, " "))
 	}
 	return append(args, gosxModuleImportPath+"/client/wasm")
+}
+
+func runtimeVariantAsset(variant string, asset HashedAsset) buildmanifest.RuntimeVariantAsset {
+	return buildmanifest.RuntimeVariantAsset{
+		HashedAsset:  asset,
+		Variant:      variant,
+		FeatureMask:  uint32(runtimewasm.RequiredFeaturesForVariant(runtimewasm.Variant(variant))),
+		ManifestHash: runtimewasm.ManifestIdentity(),
+	}
 }
 
 func islandOnlyWASMTags(compiler wasmCompiler) []string {
@@ -1006,6 +1049,12 @@ func manifestRuntimeRefSourcePath(distDir string, manifest *BuildManifest, ref s
 		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.WASM.File)
 	case "/gosx/runtime-islands.wasm":
 		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.WASMIslands.File)
+	case "/gosx/runtime-core.wasm":
+		return manifestRuntimeVariantFilePath(runtimeDir, manifest, "core")
+	case "/gosx/runtime-engine.wasm":
+		return manifestRuntimeVariantFilePath(runtimeDir, manifest, "engine")
+	case "/gosx/runtime-collab.wasm":
+		return manifestRuntimeVariantFilePath(runtimeDir, manifest, "collab")
 	case "/gosx/wasm_exec.js":
 		return manifestRuntimeFilePath(runtimeDir, manifest.Runtime.WASMExec.File)
 	case "/gosx/standard-go-wasm_exec.js":
@@ -1079,6 +1128,17 @@ func manifestRuntimeFilePath(runtimeDir, file string) (string, bool) {
 		return "", false
 	}
 	return filepath.Join(runtimeDir, file), true
+}
+
+func manifestRuntimeVariantFilePath(runtimeDir string, manifest *BuildManifest, variant string) (string, bool) {
+	if manifest == nil {
+		return "", false
+	}
+	asset, ok := manifest.Runtime.WASMVariants[strings.TrimSpace(variant)]
+	if !ok {
+		return "", false
+	}
+	return manifestRuntimeFilePath(runtimeDir, asset.File)
 }
 
 func cssCompatFilename(asset CSSAsset) string {

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -8,8 +8,23 @@ import (
 	"strings"
 	"testing"
 
+	runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
 	sceneinspect "m31labs.dev/gosx/scene/inspect"
 )
+
+func TestRuntimeVariantAssetCarriesContractIdentity(t *testing.T) {
+	asset := runtimeVariantAsset(string(runtimewasm.VariantIslands), HashedAsset{
+		File: "gosx-runtime-islands.abc.wasm",
+		Hash: "abcdef0123456789",
+		Size: 42,
+	})
+	if asset.ManifestHash == "" || asset.ManifestHash != runtimewasm.ManifestIdentity() {
+		t.Fatalf("runtime variant manifest identity = %q", asset.ManifestHash)
+	}
+	if asset.FeatureMask != uint32(runtimewasm.FeatureCore|runtimewasm.FeatureIslands) {
+		t.Fatalf("runtime variant feature mask = 0x%x", asset.FeatureMask)
+	}
+}
 
 func TestRuntimeJSAssetDataStripsMissingHLSMapTrailer(t *testing.T) {
 	raw := []byte("window.Hls = function() {};\n//# sourceMappingURL=hls.min.js.map\n")

--- a/cmd/gosx/export.go
+++ b/cmd/gosx/export.go
@@ -99,6 +99,12 @@ func exportRuntimeBuildPath(buildDir, ref string) (string, bool) {
 		return filepath.Join(buildDir, "gosx-runtime.wasm"), true
 	case "/gosx/runtime-islands.wasm":
 		return filepath.Join(buildDir, "gosx-runtime-islands.wasm"), true
+	case "/gosx/runtime-core.wasm":
+		return filepath.Join(buildDir, "gosx-runtime-core.wasm"), true
+	case "/gosx/runtime-engine.wasm":
+		return filepath.Join(buildDir, "gosx-runtime-engine.wasm"), true
+	case "/gosx/runtime-collab.wasm":
+		return filepath.Join(buildDir, "gosx-runtime-collab.wasm"), true
 	case "/gosx/wasm_exec.js":
 		return filepath.Join(buildDir, "wasm_exec.js"), true
 	case "/gosx/standard-go-wasm_exec.js":

--- a/cmd/gosx/tinygo_build.go
+++ b/cmd/gosx/tinygo_build.go
@@ -109,7 +109,7 @@ func tinyGoBuildArgs(outputPath string, extraTags ...string) []string {
 
 func tinyGoWASMTags(extraTags ...string) []string {
 	tags := []string{"tinygo"}
-	if !tinyGoFullRuntimeEnabled() {
+	if !tinyGoFullRuntimeEnabled() && !runtimeVariantNeedsFullRuntime(extraTags...) {
 		tags = append(tags, "gosx_tiny_runtime")
 	}
 	tags = append(tags, extraTags...)
@@ -125,6 +125,16 @@ func tinyGoWASMTags(extraTags ...string) []string {
 		out = append(out, tag)
 	}
 	return out
+}
+
+func runtimeVariantNeedsFullRuntime(tags ...string) bool {
+	for _, tag := range normalizeBuildTags(tags...) {
+		switch tag {
+		case "gosx_runtime_collab", "gosx_runtime_full":
+			return true
+		}
+	}
+	return false
 }
 
 func writeTinyGoWASMExec(tinygoPath, runtimeDir string) (HashedAsset, error) {

--- a/island/island.go
+++ b/island/island.go
@@ -23,6 +23,7 @@ import (
 
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/buildmanifest"
+	runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
 	"m31labs.dev/gosx/client/vm"
 	"m31labs.dev/gosx/controller"
 	"m31labs.dev/gosx/engine"
@@ -77,6 +78,7 @@ type Renderer struct {
 	videoHLSPath                   string
 	relayPath                      string
 	islandRuntime                  hydrate.RuntimeRef
+	runtimeVariants                map[string]hydrate.RuntimeRef
 	runtimeAssets                  buildmanifest.RuntimeAssets
 	bootstrapOnly                  bool
 }
@@ -179,11 +181,12 @@ func NewRenderer(bundleID string) *Renderer {
 		runtimeAssets = manifest.Runtime
 	}
 	renderer := &Renderer{
-		manifest:      hydrate.NewManifest(),
-		bundleID:      bundleID,
-		programFormat: "json", // default to dev mode
-		programAssets: make(map[string]programAsset),
-		runtimeAssets: runtimeAssets,
+		manifest:        hydrate.NewManifest(),
+		bundleID:        bundleID,
+		programFormat:   "json", // default to dev mode
+		programAssets:   make(map[string]programAsset),
+		runtimeVariants: make(map[string]hydrate.RuntimeRef),
+		runtimeAssets:   runtimeAssets,
 	}
 	renderer.wasmExecPath = renderer.versionCompatRuntimePath("/gosx/wasm_exec.js", strings.TrimSpace(runtimeAssets.WASMExec.Hash))
 	renderer.standardGoWASMExecPath = renderer.versionCompatRuntimePath("/gosx/standard-go-wasm_exec.js", strings.TrimSpace(runtimeAssets.StandardGoWASMExec.Hash))
@@ -369,10 +372,14 @@ func (r *Renderer) SetRuntime(path string, hash string, size int64) {
 	}
 	path = r.versionCompatRuntimePath(path, hash)
 	r.manifest.Runtime = hydrate.RuntimeRef{
-		Path: path,
-		Hash: hash,
-		Size: size,
+		Path:         path,
+		Hash:         hash,
+		ManifestHash: runtimewasm.ManifestIdentity(),
+		Size:         size,
+		Variant:      string(runtimewasm.VariantFull),
+		FeatureMask:  uint32(runtimewasm.FeatureMaskForVariant(runtimewasm.VariantFull)),
 	}
+	r.setRuntimeVariant(r.manifest.Runtime)
 }
 
 // SetIslandRuntime registers the smaller shared WASM runtime used by pages
@@ -386,10 +393,28 @@ func (r *Renderer) SetIslandRuntime(path string, hash string, size int64) {
 	}
 	path = r.versionCompatRuntimePath(path, hash)
 	r.islandRuntime = hydrate.RuntimeRef{
-		Path: path,
-		Hash: hash,
-		Size: size,
+		Path:         path,
+		Hash:         hash,
+		ManifestHash: runtimewasm.ManifestIdentity(),
+		Size:         size,
+		Variant:      string(runtimewasm.VariantIslands),
+		FeatureMask:  uint32(runtimewasm.FeatureMaskForVariant(runtimewasm.VariantIslands)),
 	}
+	r.setRuntimeVariant(r.islandRuntime)
+}
+
+func (r *Renderer) setRuntimeVariant(ref hydrate.RuntimeRef) {
+	if r == nil || strings.TrimSpace(ref.Path) == "" {
+		return
+	}
+	if r.runtimeVariants == nil {
+		r.runtimeVariants = make(map[string]hydrate.RuntimeRef)
+	}
+	variant := strings.TrimSpace(ref.Variant)
+	if variant == "" {
+		variant = string(runtimewasm.VariantFull)
+	}
+	r.runtimeVariants[variant] = ref
 }
 
 // SetBundle registers a WASM bundle in the manifest.
@@ -659,12 +684,35 @@ func (r *Renderer) ApplyBuildManifest(manifest *buildmanifest.Manifest, assetBas
 	}
 
 	runtime := manifest.RuntimeURLs(assetBaseURL)
+	r.runtimeAssets = manifest.Runtime
 	if runtime.WASM != "" {
 		r.SetRuntime(runtime.WASM, manifest.Runtime.WASM.Hash, manifest.Runtime.WASM.Size)
 		r.SetBundle(r.bundleID, runtime.WASM)
 	}
 	if runtime.WASMIslands != "" {
 		r.SetIslandRuntime(runtime.WASMIslands, manifest.Runtime.WASMIslands.Hash, manifest.Runtime.WASMIslands.Size)
+	}
+	for id, asset := range manifest.Runtime.WASMVariants {
+		path := runtime.WASMVariants[id]
+		if strings.TrimSpace(path) == "" {
+			continue
+		}
+		variant := strings.TrimSpace(asset.Variant)
+		if variant == "" {
+			variant = strings.TrimSpace(id)
+		}
+		mask := asset.FeatureMask
+		if mask == 0 {
+			mask = uint32(runtimewasm.RequiredFeaturesForVariant(runtimewasm.Variant(variant)))
+		}
+		r.setRuntimeVariant(hydrate.RuntimeRef{
+			Path:         path,
+			Hash:         asset.Hash,
+			ManifestHash: firstNonEmptyRuntimeManifestHash(asset.ManifestHash),
+			Size:         asset.Size,
+			Variant:      variant,
+			FeatureMask:  mask,
+		})
 	}
 	r.SetClientAssetPaths(runtime.WASMExec, runtime.Patch, runtime.Bootstrap)
 	r.SetStandardGoWASMExecPath(runtime.StandardGoWASMExec)
@@ -688,6 +736,13 @@ func (r *Renderer) ApplyBuildManifest(manifest *buildmanifest.Manifest, assetBas
 	}
 
 	return nil
+}
+
+func firstNonEmptyRuntimeManifestHash(value string) string {
+	if value = strings.TrimSpace(value); value != "" {
+		return value
+	}
+	return runtimewasm.ManifestIdentity()
 }
 
 // LoadBuildManifest reads a build manifest from disk and applies its asset URLs.
@@ -1814,10 +1869,71 @@ func (r *Renderer) selectedRuntimeRef() hydrate.RuntimeRef {
 	if r == nil {
 		return hydrate.RuntimeRef{}
 	}
+	if required := r.requiredRuntimeFeatures(); required != 0 {
+		if ref, ok := r.smallestCompatibleRuntimeRef(required); ok {
+			return ref
+		}
+	}
 	if (len(r.manifest.Islands) > 0 || len(r.manifest.ComputeIslands) > 0) && !r.needsSharedRuntimeEngineBridge() && strings.TrimSpace(r.islandRuntime.Path) != "" {
 		return r.islandRuntime
 	}
 	return r.manifest.Runtime
+}
+
+func (r *Renderer) smallestCompatibleRuntimeRef(required runtimewasm.FeatureMask) (hydrate.RuntimeRef, bool) {
+	var best hydrate.RuntimeRef
+	for _, ref := range r.runtimeVariants {
+		if strings.TrimSpace(ref.Path) == "" {
+			continue
+		}
+		features := runtimewasm.FeatureMask(ref.FeatureMask)
+		if features == 0 {
+			features = runtimewasm.FeatureMaskForVariant(runtimewasm.Variant(ref.Variant))
+		}
+		if features&required != required {
+			continue
+		}
+		if strings.TrimSpace(best.Path) == "" || runtimeRefIsSmaller(ref, best) {
+			best = ref
+		}
+	}
+	return best, strings.TrimSpace(best.Path) != ""
+}
+
+func runtimeRefIsSmaller(candidate, current hydrate.RuntimeRef) bool {
+	if candidate.Size > 0 && current.Size <= 0 {
+		return true
+	}
+	if candidate.Size <= 0 {
+		return false
+	}
+	if candidate.Size != current.Size {
+		return candidate.Size < current.Size
+	}
+	return candidate.Path < current.Path
+}
+
+func (r *Renderer) requiredRuntimeFeatures() runtimewasm.FeatureMask {
+	if r == nil || r.manifest == nil || !r.clientRuntimePlan().SharedRuntime {
+		return 0
+	}
+	var required runtimewasm.FeatureMask
+	if len(r.manifest.Islands) > 0 || len(r.manifest.ComputeIslands) > 0 {
+		required |= runtimewasm.FeatureIslands
+	}
+	if r.needsSharedRuntimeEngineBridge() {
+		required |= runtimewasm.FeatureEngine
+		if r.hasSceneEngines() {
+			required |= runtimewasm.FeatureScene3D
+		}
+	}
+	if len(r.manifest.Hubs) > 0 && required != 0 {
+		required |= runtimewasm.FeatureCollab
+	}
+	if required == 0 {
+		required = runtimewasm.FeatureCore
+	}
+	return runtimewasm.FeatureCore | required
 }
 
 func (r *Renderer) selectedWASMExecPath() string {

--- a/island/island_test.go
+++ b/island/island_test.go
@@ -548,6 +548,37 @@ func TestBindHubInputAddsManifestInput(t *testing.T) {
 	}
 }
 
+func TestRendererSelectsSmallestPublishedRuntimeVariant(t *testing.T) {
+	r := NewRenderer("main")
+	manifest := &buildmanifest.Manifest{Runtime: buildmanifest.RuntimeAssets{
+		WASM:        buildmanifest.HashedAsset{File: "gosx-runtime.full.wasm", Hash: "full", Size: 40},
+		WASMIslands: buildmanifest.HashedAsset{File: "gosx-runtime-islands.wasm", Hash: "islands", Size: 5},
+		WASMVariants: map[string]buildmanifest.RuntimeVariantAsset{
+			"core":    {HashedAsset: buildmanifest.HashedAsset{File: "gosx-runtime-core.wasm", Hash: "core", Size: 10}, Variant: "core", FeatureMask: 17},
+			"islands": {HashedAsset: buildmanifest.HashedAsset{File: "gosx-runtime-islands.wasm", Hash: "islands", Size: 5}, Variant: "islands", FeatureMask: 17},
+			"engine":  {HashedAsset: buildmanifest.HashedAsset{File: "gosx-runtime-engine.wasm", Hash: "engine", Size: 25}, Variant: "engine", FeatureMask: 11},
+			"collab":  {HashedAsset: buildmanifest.HashedAsset{File: "gosx-runtime-collab.wasm", Hash: "collab", Size: 28}, Variant: "collab", FeatureMask: 21},
+			"full":    {HashedAsset: buildmanifest.HashedAsset{File: "gosx-runtime-full.wasm", Hash: "full", Size: 40}, Variant: "full", FeatureMask: 31},
+		},
+	}}
+	if err := r.ApplyBuildManifest(manifest, "/gosx/assets"); err != nil {
+		t.Fatal(err)
+	}
+	r.RenderIsland("Counter", nil, gosx.Text("counter"))
+	if got := r.Summary().RuntimePath; got != "/gosx/assets/runtime/gosx-runtime-islands.wasm" {
+		t.Fatalf("island runtime = %q, want islands", got)
+	}
+	if got := r.selectedRuntimeRef().ManifestHash; got == "" {
+		t.Fatal("selected runtime omitted manifest identity")
+	}
+
+	engineNode := r.RenderEngine(engine.Config{Name: "Board", Kind: engine.KindSurface, Runtime: engine.RuntimeShared}, gosx.Node{})
+	_ = engineNode
+	if got := r.Summary().RuntimePath; got != "/gosx/assets/runtime/gosx-runtime-full.wasm" {
+		t.Fatalf("island plus engine runtime = %q, want full", got)
+	}
+}
+
 func TestSetClientIdentityAddsManifestConfig(t *testing.T) {
 	r := NewRenderer("main")
 	r.SetClientIdentity(hydrate.ClientIdentityConfig{

--- a/server/runtime_assets.go
+++ b/server/runtime_assets.go
@@ -271,6 +271,9 @@ func runtimeCompatSourcePath(root, name string) (string, bool) {
 	candidates := map[string]string{
 		"runtime.wasm":                         filepath.Join(buildDir, "gosx-runtime.wasm"),
 		"runtime-islands.wasm":                 filepath.Join(buildDir, "gosx-runtime-islands.wasm"),
+		"runtime-core.wasm":                    filepath.Join(buildDir, "gosx-runtime-core.wasm"),
+		"runtime-engine.wasm":                  filepath.Join(buildDir, "gosx-runtime-engine.wasm"),
+		"runtime-collab.wasm":                  filepath.Join(buildDir, "gosx-runtime-collab.wasm"),
 		"wasm_exec.js":                         filepath.Join(buildDir, "wasm_exec.js"),
 		"standard-go-wasm_exec.js":             filepath.Join(buildDir, "standard-go-wasm_exec.js"),
 		"bootstrap.js":                         filepath.Join(buildDir, "bootstrap.js"),
@@ -345,6 +348,12 @@ func (a *App) runtimeCompatBuiltPath(root, name string) (string, bool) {
 			return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.WASM.File)
 		}
 		return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.WASMIslands.File)
+	case "runtime-core.wasm":
+		return runtimeManifestVariantAssetPath(assetsDir, manifest, "core")
+	case "runtime-engine.wasm":
+		return runtimeManifestVariantAssetPath(assetsDir, manifest, "engine")
+	case "runtime-collab.wasm":
+		return runtimeManifestVariantAssetPath(assetsDir, manifest, "collab")
 	case "wasm_exec.js":
 		return runtimeManifestAssetPath(assetsDir, "runtime", manifest.Runtime.WASMExec.File)
 	case "standard-go-wasm_exec.js":
@@ -412,6 +421,17 @@ func (a *App) runtimeCompatBuiltPath(root, name string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func runtimeManifestVariantAssetPath(assetsDir string, manifest *buildmanifest.Manifest, variant string) (string, bool) {
+	if manifest == nil {
+		return "", false
+	}
+	asset, ok := manifest.Runtime.WASMVariants[strings.TrimSpace(variant)]
+	if !ok {
+		return "", false
+	}
+	return runtimeManifestAssetPath(assetsDir, "runtime", asset.File)
 }
 
 func runtimeManifestAssetPath(assetsDir, bucket, file string) (string, bool) {


### PR DESCRIPTION
This is Stack 06 of the PR #142 replacement series, based on #147.

It publishes capability-linked runtime artifacts and route metadata:
- core, islands, engine, collab, and full build variants;
- deterministic build tags and runtime asset manifest entries;
- feature-mask propagation through build/export/hydration/island metadata;
- variant-specific runtime publication and tests;
- route/runtime selection assertions.

The core mask is now core-only, islands remains core+islands, and selection tests cover the smallest compatible artifact instead of hardcoded ordering. Generated browser bundles remain deferred to Stack 07.

Validation includes buildmanifest/hydrate/island/cmd/gosx tests plus standard/TinyGo runtime build and size/selection matrices where available.