### PR TITLE
fix(ci): raise the go-tests push timeout to 25 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
   # go-tests: every root package except cmd/gosx, plus the editor, fuzz and
   # desktop gates. The production-build CLI suite runs in go-cli-tests beside
   # this job, so its ~6 minute TinyGo integration tests no longer serialize all
-  # other Go checks. PR117 measured the superseded serial lane at 6m31s for
-  # unit tests plus 10m48s for race tests (BC7 alone took 504.697s), which is
-  # why it temporarily needed 30 minutes. This lane needs neither TinyGo nor
-  # Node and returns to a 15-minute fail-safe.
+  # other Go checks. This lane needs neither TinyGo nor Node. The pull-request
+  # path runs the focused test-race-pr suite and fits a 15-minute fail-safe.
+  # The push path also runs the full test-race suite (about 11 minutes) on top
+  # of the unit lane (about 6.5 minutes), so it needs a 25-minute fail-safe.
   go-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 25
 
     steps:
       - name: Check out repository


### PR DESCRIPTION
## Summary

Adjusts the `go-tests` job timeout from 15 to 25 minutes to accommodate the combined duration of unit tests (~6.5 min) and the full race suite (~11 min) executed during push pipelines.

## Changes

- Increase `timeout-minutes` in `.github/workflows/ci.yml` from 15 to 25 for the `go-tests` job.
- Update inline documentation to clarify that PR runs remain within 15 minutes while push runs combine unit + race suites and require 25 minutes.

## Testing

- Check post-merge CI logs to confirm the `go-tests` job completes successfully under the new 25-minute threshold on push events.