### PR TITLE
refactor(ci): Run race tests in a parallel job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,13 @@ jobs:
   # go-tests: every root package except cmd/gosx, plus the editor, fuzz and
   # desktop gates. The production-build CLI suite runs in go-cli-tests beside
   # this job, so its ~6 minute TinyGo integration tests no longer serialize all
-  # other Go checks. This lane needs neither TinyGo nor Node. The pull-request
-  # path runs the focused test-race-pr suite and fits a 15-minute fail-safe.
-  # The push path also runs the full test-race suite (about 11 minutes) on top
-  # of the unit lane (about 6.5 minutes), so it needs a 25-minute fail-safe.
+  # other Go checks. The go-race-tests job now runs the race detector in
+  # parallel, so this lane needs neither TinyGo nor Node. A recent PR-path run
+  # measured 12m01s without its race step (run 31573355088, job 94042534187),
+  # so it keeps a 15-minute fail-safe.
   go-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
 
     steps:
       - name: Check out repository
@@ -88,16 +88,6 @@ jobs:
       - name: Editor module tests
         run: make test-editor
 
-      - name: Focused shared-state race tests
-        if: github.event_name == 'pull_request'
-        run: make test-race-pr
-
-      # Pushes reaching main/master retain the exhaustive race gate, including
-      # the expensive BC7 and vector-search kernels omitted from the PR lane.
-      - name: Full repository race tests
-        if: github.event_name == 'push'
-        run: make test-race
-
       - name: Fuzz smoke tests
         run: make test-fuzz-smoke
 
@@ -108,6 +98,36 @@ jobs:
       # portable tests and links both windows test binaries.
       - name: Desktop tests and Windows cross-compile gate
         run: make test-desktop
+
+  # go-race-tests: the race detector gates split out of go-tests so they run
+  # in parallel instead of serializing after the unit lane. This lane needs
+  # neither TinyGo nor Node. The pull-request path runs the focused
+  # test-race-pr suite within a 15-minute fail-safe. The push path instead
+  # runs the full test-race suite, about 11 minutes over every package,
+  # including the BC7 and vector-search kernels the PR lane omits.
+  go-race-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Focused shared-state race tests
+        if: github.event_name == 'pull_request'
+        run: make test-race-pr
+
+      # Pushes reaching main/master retain the exhaustive race gate, including
+      # the expensive BC7 and vector-search kernels omitted from the PR lane.
+      - name: Full repository race tests
+        if: github.event_name == 'push'
+        run: make test-race
 
   # cmd/gosx/build_test.go runs real production builds and therefore requires
   # TinyGo. Isolating it gives PRs a ~6 minute Go critical path while preserving
@@ -312,6 +332,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - go-tests
+      - go-race-tests
       - go-cli-tests
       - js-tests
       - wasm-tests
@@ -320,7 +341,7 @@ jobs:
 
     steps:
       - name: All test jobs passed
-        run: echo "go-tests, go-cli-tests, js-tests, wasm-tests, and browser-tests all passed"
+        run: echo "go-tests, go-race-tests, go-cli-tests, js-tests, wasm-tests, and browser-tests all passed"
 
   # Opt-in certification for a self-hosted runner with a real GPU. Generic
   # GitHub runners use SwiftShader and cannot produce meaningful WebGPU frame


### PR DESCRIPTION
## Summary

Extract race detector checks into a dedicated `go-race-tests` job so they execute concurrently with other Go tests, reducing CI serialization overhead. The parent `go-tests` job's timeout is trimmed from 25 to 15 minutes to match its actual runtime without the long-running race gate.

## Changes

- Move focused (`test-race-pr`) and full repository (`test-race`) steps from `go-tests` to a new `go-race-tests` job.
- Trim `go-tests` timeout from 25 to 15 minutes, aligning with measured runtimes (~12m) after removing the serialized race step.
- Add `go-race-tests` to the final all-tests success check so merging requires it to pass alongside other lanes.
- Update inline comments and the final status echo message to accurately document the new parallel structure.

## Testing

- Push the branch and observe GitHub Actions: `go-tests` and `go-race-tests` should launch concurrently rather than sequentially.
- Verify that `go-tests` completes comfortably under the 15-minute cap and `go-race-tests` finishes within its own timeout.
- Confirm the final "All test jobs passed" step correctly waits for `go-race-tests` before reporting success.