### PR TITLE
CI: bound exhaustive CLI suite at fifteen minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,10 +131,13 @@ jobs:
 
   # cmd/gosx/build_test.go runs real production builds and therefore requires
   # TinyGo. Isolating it gives PRs a ~6 minute Go critical path while preserving
-  # every production-build assertion and the standalone CLI build gate.
+  # every production-build assertion and the standalone CLI build gate. A cold
+  # merged-main run reached Go's default 10-minute package timeout in the final
+  # generated-docs fixture, so the suite has a 15-minute Go timeout inside this
+  # 20-minute job ceiling.
   go-cli-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ test-unit:
 	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest test unit
 
 test-cli:
-	$(GO) test ./cmd/gosx
+	$(GO) test -timeout 15m ./cmd/gosx
 
 test-ci-partitions:
 	$(GO) test ./internal/citest


### PR DESCRIPTION
The merged O-series main run reached the Go package default 10-minute timeout in the final generated-docs fixture; no test assertion failed. This gives make test-cli an explicit 15-minute Go timeout and raises the enclosing job ceiling to 20 minutes, preserving a bounded failure while allowing cold-cache production-build coverage to finish.

Evidence:
- failing main run 31587288226, go-cli job 94083949027
- make -n test-cli resolves to go test -timeout 15m ./cmd/gosx
- git diff --check passes