### PR TITLE
fix(ci): bound exhaustive race packages explicitly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,11 +105,13 @@ jobs:
   # test-race-pr suite within the shared job ceiling. The push path instead
   # runs the full test-race suite over every package, including the BC7 and
   # vector-search kernels the PR lane omits. Main has exceeded 15 minutes on
-  # a cold runner, so the job ceiling leaves explicit headroom for that wider
-  # protected-branch gate.
+  # a cold runner, and perf/ouroboros exceeds Go's default 10-minute
+  # per-package timeout under race instrumentation. The Make target carries a
+  # 40-minute package timeout inside this 50-minute job ceiling, leaving room
+  # for race-instrumented compilation and the remaining packages.
   go-race-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 50
 
     steps:
       - name: Check out repository

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ test-ci-partitions:
 	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest verify
 
 test-race:
-	$(GO) test -race ./...
+	$(GO) test -race -timeout 40m ./...
 
 # Pull requests exercise the reviewed shared-state surfaces without rerunning
 # CPU-heavy codec and vector kernels under the race detector. Protected-branch


### PR DESCRIPTION
## Summary

- give `make test-race` an explicit 40-minute Go package timeout
- give the main-only exhaustive race job a 50-minute outer ceiling for compilation and cleanup

## Why

The exact v0.39 merge SHA run executed the full repository race suite and reported no data race, but `perf/ouroboros` hit Go's implicit 10-minute per-package alarm during active Brotli/parser evidence work. The Actions job itself failed after ~14 minutes, well inside its prior 25-minute ceiling.

A slower local stress run also remained actively CPU-bound beyond 30 minutes, so the final limits use measured headroom rather than another 10/20/30-minute cliff. Typical GitHub wall time should remain near the observed ~15 minutes; these values are failure ceilings, not delays.

## Verification

- `actionlint .github/workflows/ci.yml`
- `make test-ci-partitions`
- exact-main run 31648526352: every non-race lane green; race log contains no race detector finding and fails only on `panic: test timed out after 10m0s`
- local race-instrumented Ouroboros stress: active beyond the former 10, 20, and 30-minute package bounds with no race finding (wide-limit completion run in progress)

This PR intentionally does not split or reduce race coverage before v0.39.0.
