### PR TITLE
Split deterministic evidence scans from race suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,12 +103,14 @@ jobs:
   # in parallel instead of serializing after the unit lane. This lane needs
   # neither TinyGo nor Node. The pull-request path runs the focused
   # test-race-pr suite within the shared job ceiling. The push path instead
-  # runs the full test-race suite over every package, including the BC7 and
-  # vector-search kernels the PR lane omits. Main has exceeded 15 minutes on
-  # a cold runner, and perf/ouroboros exceeds Go's default 10-minute
-  # per-package timeout under race instrumentation. The Make target carries a
-  # 40-minute package timeout inside this 50-minute job ceiling, leaving room
-  # for race-instrumented compilation and the remaining packages.
+  # race-builds every package and runs the full package set except nine named,
+  # validated perf/ouroboros tests whose real-repository evidence scans spend
+  # tens of minutes in deterministic parsing/Brotli work under instrumentation.
+  # Ordinary tests still gate all nine. A second scoped perf/ouroboros race run
+  # retains every fixture-sized test plus direct concurrent coverage of its
+  # mutex-protected network capture. The broad lane includes the expensive BC7
+  # and vector-search kernels omitted from pull requests and keeps a 40-minute
+  # per-package alarm inside this 50-minute job ceiling.
   go-race-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 50
@@ -127,8 +129,8 @@ jobs:
         if: github.event_name == 'pull_request'
         run: make test-race-pr
 
-      # Pushes reaching main/master retain the exhaustive race gate, including
-      # the expensive BC7 and vector-search kernels omitted from the PR lane.
+      # Pushes reaching main/master retain exhaustive package coverage, with
+      # only the validated deterministic evidence recomputations split out.
       - name: Full repository race tests
         if: github.event_name == 'push'
         run: make test-race

--- a/Makefile
+++ b/Makefile
@@ -112,11 +112,15 @@ test-ci-partitions:
 	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest verify
 
 test-race:
-	$(GO) test -race -timeout 40m ./...
+	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest test full-race
+	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest test ouroboros-race
 
 # Pull requests exercise the reviewed shared-state surfaces without rerunning
 # CPU-heavy codec and vector kernels under the race detector. Protected-branch
-# pushes still run test-race across every package.
+# pushes race-build every package and run every test except nine explicitly
+# validated real-repository evidence recomputations in perf/ouroboros. The unit
+# lane runs those deterministic tests; the scoped race lane retains a direct
+# concurrent network-capture mutation/snapshot test.
 test-race-pr:
 	GOSX_CI_GO="$(GO)" $(GO) run ./internal/citest test race
 

--- a/internal/citest/main.go
+++ b/internal/citest/main.go
@@ -18,16 +18,27 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
 )
 
-const cliRelativePath = "cmd/gosx"
+const (
+	cliRelativePath                   = "cmd/gosx"
+	ouroborosRaceRelativePath         = "perf/ouroboros"
+	exhaustiveRacePackageTimeout      = "40m"
+	ouroborosScopedRacePackageTimeout = "10m"
+)
 
 type raceTarget struct {
 	relativePath string
 	reason       string
+}
+
+type raceSkipTarget struct {
+	testName string
+	reason   string
 }
 
 // prRaceTargets covers shared framework state and the server-authoritative 3D
@@ -52,6 +63,23 @@ var prRaceTargets = []raceTarget{
 	{"signal", "concurrent subscriptions, tracking, and batching"},
 	{"sim", "server-authoritative simulation loop"},
 	{"scene", "parallel scene geometry work"},
+}
+
+// ouroborosRaceSkips is intentionally an exact-name allowlist, not a file or
+// prefix exclusion. These tests build source identity from the real repository,
+// repeatedly parsing and Brotli-compressing the complete browser-source corpus.
+// The ordinary unit lane executes every one. The scoped race lane retains all
+// fixture-sized evidence tests and the package's shared-state tests.
+var ouroborosRaceSkips = []raceSkipTarget{
+	{"TestBuildSizeEvidenceAttributesRouteAssetsAndDedupesTotals", "recomputes the real-repository source inventory before checking route attribution"},
+	{"TestBuildSizeEvidenceResolvesHashedURLsWithQuery", "recomputes the real-repository source inventory before checking hashed URL resolution"},
+	{"TestBuildSizeEvidenceResolvesCapabilityRuntimeVariants", "recomputes the real-repository source inventory before checking runtime variants"},
+	{"TestBuildSizeEvidenceRecordsNoncanonicalUnresolvedRefs", "recomputes the real-repository source inventory before checking unresolved refs"},
+	{"TestBuildSizeEvidenceRecordsNoncanonicalUnsafeManifestPaths", "recomputes the real-repository source inventory before checking unsafe paths"},
+	{"TestBuildSizeEvidenceRecordsNoncanonicalSymlinkEscapedAsset", "recomputes the real-repository source inventory before checking symlink escapes"},
+	{"TestBuildSizeEvidenceRejectsInventoryOverlayMismatch", "recomputes the real-repository source inventory to construct and reject a stale receipt"},
+	{"TestCompatibilityAuditReceiptAndReconciliation", "recomputes and parses the real-repository compatibility inventory"},
+	{"TestRunBrowserBaselineRemoteDialErrorRedactedInArtifacts", "recomputes real-repository source identity before exercising the remote dial boundary"},
 }
 
 type listedModule struct {
@@ -80,12 +108,20 @@ type racePackage struct {
 	evidence concurrencyEvidence
 }
 
+type scopedRacePackage struct {
+	listedPackage
+	testCount int
+	skips     []raceSkipTarget
+}
+
 type testPlan struct {
-	modulePath string
-	all        []listedPackage
-	unit       []listedPackage
-	cli        []listedPackage
-	race       []racePackage
+	modulePath    string
+	all           []listedPackage
+	unit          []listedPackage
+	cli           []listedPackage
+	race          []racePackage
+	fullRace      []listedPackage
+	ouroborosRace scopedRacePackage
 }
 
 func main() {
@@ -97,7 +133,7 @@ func main() {
 
 func run(args []string, stdout, stderr io.Writer) error {
 	if len(args) == 0 {
-		return errors.New("usage: citest verify | list <unit|cli|race> | test <unit|race>")
+		return errors.New("usage: citest verify | list <unit|cli|race|full-race> | test <unit|race|full-race|ouroboros-race>")
 	}
 
 	goBinary := os.Getenv("GOSX_CI_GO")
@@ -118,7 +154,7 @@ func run(args []string, stdout, stderr io.Writer) error {
 		return nil
 	case "list":
 		if len(args) != 2 {
-			return errors.New("usage: citest list <unit|cli|race>")
+			return errors.New("usage: citest list <unit|cli|race|full-race>")
 		}
 		packages, err := selectPackages(plan, args[1])
 		if err != nil {
@@ -129,17 +165,29 @@ func run(args []string, stdout, stderr io.Writer) error {
 		}
 		return nil
 	case "test":
-		if len(args) != 2 || (args[1] != "unit" && args[1] != "race") {
-			return errors.New("usage: citest test <unit|race>")
+		if len(args) != 2 || (args[1] != "unit" && args[1] != "race" && args[1] != "full-race" && args[1] != "ouroboros-race") {
+			return errors.New("usage: citest test <unit|race|full-race|ouroboros-race>")
 		}
 		printPlan(stderr, plan)
-		packages, err := selectPackages(plan, args[1])
-		if err != nil {
-			return err
-		}
 		commandArgs := []string{"test"}
-		if args[1] == "race" {
+		if args[1] != "unit" {
 			commandArgs = append(commandArgs, "-race")
+		}
+		if args[1] == "full-race" {
+			commandArgs = append(commandArgs, "-timeout", exhaustiveRacePackageTimeout)
+		}
+		var packages []string
+		if args[1] == "ouroboros-race" {
+			commandArgs = append(commandArgs,
+				"-timeout", ouroborosScopedRacePackageTimeout,
+				"-skip", raceSkipPattern(plan.ouroborosRace.skips),
+			)
+			packages = []string{plan.ouroborosRace.ImportPath}
+		} else {
+			packages, err = selectPackages(plan, args[1])
+			if err != nil {
+				return err
+			}
 		}
 		commandArgs = append(commandArgs, packages...)
 		fmt.Fprintf(stderr, "citest: running %s tests across %d packages\n", args[1], len(packages))
@@ -189,12 +237,18 @@ func buildTestPlan(goBinary string) (testPlan, error) {
 	if err != nil {
 		return testPlan{}, err
 	}
+	fullRace, ouroborosRace, err := resolveExhaustiveRacePackages(modulePath, packages)
+	if err != nil {
+		return testPlan{}, err
+	}
 	return testPlan{
-		modulePath: modulePath,
-		all:        packages,
-		unit:       unit,
-		cli:        cli,
-		race:       race,
+		modulePath:    modulePath,
+		all:           packages,
+		unit:          unit,
+		cli:           cli,
+		race:          race,
+		fullRace:      fullRace,
+		ouroborosRace: ouroborosRace,
 	}, nil
 }
 
@@ -367,6 +421,85 @@ func inspectConcurrencySource(filename string, source []byte) (int, int, error) 
 	return goStatements, syncImports, nil
 }
 
+func resolveExhaustiveRacePackages(modulePath string, all []listedPackage) ([]listedPackage, scopedRacePackage, error) {
+	ouroborosImportPath := modulePath + "/" + ouroborosRaceRelativePath
+	fullRace := make([]listedPackage, 0, len(all)-1)
+	var ouroboros listedPackage
+	for _, pkg := range all {
+		if pkg.ImportPath == ouroborosImportPath {
+			if ouroboros.ImportPath != "" {
+				return nil, scopedRacePackage{}, fmt.Errorf("exhaustive race package %s is listed more than once", ouroborosImportPath)
+			}
+			ouroboros = pkg
+			continue
+		}
+		fullRace = append(fullRace, pkg)
+	}
+	if ouroboros.ImportPath == "" {
+		return nil, scopedRacePackage{}, fmt.Errorf("exhaustive race package %s is missing", ouroborosImportPath)
+	}
+	if err := validateCoverage(all, map[string][]listedPackage{
+		"full-race":      fullRace,
+		"ouroboros-race": {ouroboros},
+	}); err != nil {
+		return nil, scopedRacePackage{}, err
+	}
+
+	testNames, err := inspectTestNames(ouroboros)
+	if err != nil {
+		return nil, scopedRacePackage{}, err
+	}
+	seen := make(map[string]struct{}, len(ouroborosRaceSkips))
+	for _, skip := range ouroborosRaceSkips {
+		if strings.TrimSpace(skip.reason) == "" {
+			return nil, scopedRacePackage{}, fmt.Errorf("Ouroboros race skip %s has no review reason", skip.testName)
+		}
+		if _, duplicate := seen[skip.testName]; duplicate {
+			return nil, scopedRacePackage{}, fmt.Errorf("Ouroboros race skip %s is listed more than once", skip.testName)
+		}
+		seen[skip.testName] = struct{}{}
+		if _, exists := testNames[skip.testName]; !exists {
+			return nil, scopedRacePackage{}, fmt.Errorf("Ouroboros race skip %s does not name a current test", skip.testName)
+		}
+	}
+	if len(testNames) <= len(ouroborosRaceSkips) {
+		return nil, scopedRacePackage{}, fmt.Errorf("Ouroboros scoped race lane would run no tests: discovered=%d skipped=%d", len(testNames), len(ouroborosRaceSkips))
+	}
+	return fullRace, scopedRacePackage{
+		listedPackage: ouroboros,
+		testCount:     len(testNames),
+		skips:         append([]raceSkipTarget(nil), ouroborosRaceSkips...),
+	}, nil
+}
+
+func inspectTestNames(pkg listedPackage) (map[string]struct{}, error) {
+	names := make(map[string]struct{})
+	files := append(append([]string{}, pkg.TestGoFiles...), pkg.XTestGoFiles...)
+	for _, name := range files {
+		path := filepath.Join(pkg.Dir, name)
+		file, err := parser.ParseFile(token.NewFileSet(), path, nil, 0)
+		if err != nil {
+			return nil, fmt.Errorf("parse %s: %w", path, err)
+		}
+		for _, decl := range file.Decls {
+			fn, ok := decl.(*ast.FuncDecl)
+			if !ok || fn.Recv != nil || !strings.HasPrefix(fn.Name.Name, "Test") {
+				continue
+			}
+			names[fn.Name.Name] = struct{}{}
+		}
+	}
+	return names, nil
+}
+
+func raceSkipPattern(skips []raceSkipTarget) string {
+	names := make([]string, 0, len(skips))
+	for _, skip := range skips {
+		names = append(names, regexp.QuoteMeta(skip.testName))
+	}
+	return "^(" + strings.Join(names, "|") + ")$"
+}
+
 func selectPackages(plan testPlan, partition string) ([]string, error) {
 	var packages []string
 	switch partition {
@@ -385,6 +518,11 @@ func selectPackages(plan testPlan, partition string) ([]string, error) {
 		for _, pkg := range plan.race {
 			packages = append(packages, pkg.ImportPath)
 		}
+	case "full-race":
+		packages = make([]string, 0, len(plan.fullRace))
+		for _, pkg := range plan.fullRace {
+			packages = append(packages, pkg.ImportPath)
+		}
 	default:
 		return nil, fmt.Errorf("unknown package partition %q", partition)
 	}
@@ -394,12 +532,15 @@ func selectPackages(plan testPlan, partition string) ([]string, error) {
 func printPlan(w io.Writer, plan testPlan) {
 	fmt.Fprintf(
 		w,
-		"citest: partition verified module=%s total=%d unit=%d cli=%d pr-race=%d\n",
+		"citest: partition verified module=%s total=%d unit=%d cli=%d pr-race=%d full-race=%d ouroboros-race-tests=%d ouroboros-race-skips=%d\n",
 		plan.modulePath,
 		len(plan.all),
 		len(plan.unit),
 		len(plan.cli),
 		len(plan.race),
+		len(plan.fullRace),
+		plan.ouroborosRace.testCount,
+		len(plan.ouroborosRace.skips),
 	)
 	fmt.Fprintf(w, "citest: cli %s\n", plan.cli[0].ImportPath)
 	for _, pkg := range plan.race {
@@ -412,5 +553,9 @@ func printPlan(w io.Writer, plan testPlan) {
 			pkg.evidence.syncImports,
 			pkg.target.reason,
 		)
+	}
+	fmt.Fprintf(w, "citest: scoped race %s runs=%d skips=%d\n", plan.ouroborosRace.ImportPath, plan.ouroborosRace.testCount-len(plan.ouroborosRace.skips), len(plan.ouroborosRace.skips))
+	for _, skip := range plan.ouroborosRace.skips {
+		fmt.Fprintf(w, "citest: scoped race skip %s reason=%q\n", skip.testName, skip.reason)
 	}
 }

--- a/internal/citest/main_test.go
+++ b/internal/citest/main_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 )
@@ -78,6 +81,68 @@ func TestInspectConcurrencySourceRejectsInvalidGo(t *testing.T) {
 	_, _, err := inspectConcurrencySource("broken.go", []byte("package broken\nfunc"))
 	if err == nil {
 		t.Fatal("inspectConcurrencySource() accepted invalid Go")
+	}
+}
+
+func TestResolveExhaustiveRacePackagesValidatesExactOuroborosSkips(t *testing.T) {
+	ouroboros := writeOuroborosRaceFixture(t, len(ouroborosRaceSkips))
+	all := []listedPackage{
+		{ImportPath: "example.dev/gosx/action"},
+		ouroboros,
+		{ImportPath: "example.dev/gosx/server"},
+	}
+	fullRace, scoped, err := resolveExhaustiveRacePackages("example.dev/gosx", all)
+	if err != nil {
+		t.Fatalf("resolveExhaustiveRacePackages() error = %v", err)
+	}
+	if len(fullRace) != 2 || scoped.ImportPath != ouroboros.ImportPath {
+		t.Fatalf("race split = full %#v scoped %#v", fullRace, scoped)
+	}
+	if scoped.testCount != len(ouroborosRaceSkips)+1 || len(scoped.skips) != len(ouroborosRaceSkips) {
+		t.Fatalf("scoped test accounting = tests %d skips %d", scoped.testCount, len(scoped.skips))
+	}
+	pattern, err := regexp.Compile(raceSkipPattern(scoped.skips))
+	if err != nil {
+		t.Fatalf("race skip pattern does not compile: %v", err)
+	}
+	for _, skip := range ouroborosRaceSkips {
+		if !pattern.MatchString(skip.testName) {
+			t.Fatalf("race skip pattern does not match %s", skip.testName)
+		}
+		if pattern.MatchString(skip.testName + "Suffix") {
+			t.Fatalf("race skip pattern is not exact for %s", skip.testName)
+		}
+	}
+	if pattern.MatchString("TestRetainedRaceCoverage") {
+		t.Fatal("race skip pattern matched the retained coverage test")
+	}
+}
+
+func TestResolveExhaustiveRacePackagesRejectsStaleSkipName(t *testing.T) {
+	ouroboros := writeOuroborosRaceFixture(t, len(ouroborosRaceSkips)-1)
+	_, _, err := resolveExhaustiveRacePackages("example.dev/gosx", []listedPackage{ouroboros})
+	if err == nil || !strings.Contains(err.Error(), "does not name a current test") {
+		t.Fatalf("resolveExhaustiveRacePackages() error = %v, want stale skip", err)
+	}
+}
+
+func writeOuroborosRaceFixture(t *testing.T, skipCount int) listedPackage {
+	t.Helper()
+	dir := t.TempDir()
+	var source strings.Builder
+	source.WriteString("package ouroboros\n\nimport \"testing\"\n\n")
+	for _, skip := range ouroborosRaceSkips[:skipCount] {
+		source.WriteString("func " + skip.testName + "(t *testing.T) {}\n")
+	}
+	source.WriteString("func TestRetainedRaceCoverage(t *testing.T) {}\n")
+	name := "race_test.go"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(source.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return listedPackage{
+		Dir:         dir,
+		ImportPath:  "example.dev/gosx/" + ouroborosRaceRelativePath,
+		TestGoFiles: []string{name},
 	}
 }
 

--- a/perf/ouroboros/browser.go
+++ b/perf/ouroboros/browser.go
@@ -3084,62 +3084,64 @@ type networkCapture struct {
 func startNetworkCapture(d *perf.Driver) (*networkCapture, error) {
 	ctx, cancel := context.WithCancel(d.Context())
 	c := &networkCapture{records: map[network.RequestID]*NetworkRecord{}, cancel: cancel, d: d}
-	chromedp.ListenTarget(ctx, func(ev any) {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		switch e := ev.(type) {
-		case *network.EventRequestWillBeSent:
-			rec := c.records[e.RequestID]
-			if rec == nil {
-				rec = &NetworkRecord{RequestID: string(e.RequestID)}
-				c.records[e.RequestID] = rec
-			}
-			rec.DocumentURL = e.DocumentURL
-			rec.Role = string(e.Type)
-			if e.Request != nil {
-				rec.URL = e.Request.URL
-				rec.Method = e.Request.Method
-			}
-		case *network.EventResponseReceived:
-			rec := c.records[e.RequestID]
-			if rec == nil {
-				rec = &NetworkRecord{RequestID: string(e.RequestID)}
-				c.records[e.RequestID] = rec
-			}
-			rec.Role = string(e.Type)
-			if e.Response != nil {
-				rec.URL = e.Response.URL
-				rec.Status = e.Response.Status
-				rec.MimeType = e.Response.MimeType
-				rec.Protocol = e.Response.Protocol
-				rec.EncodedDataLength = e.Response.EncodedDataLength
-				rec.TransferredBytes = e.Response.EncodedDataLength
-				rec.FromDiskCache = e.Response.FromDiskCache
-				rec.FromServiceWorker = e.Response.FromServiceWorker
-				rec.FromPrefetchCache = e.Response.FromPrefetchCache
-				rec.CacheControl = headerValue(e.Response.Headers, "cache-control")
-				rec.Immutable = strings.Contains(strings.ToLower(rec.CacheControl), "immutable")
-				rec.HeaderBytes = approximateHeaderBytes(e.Response.Headers)
-				rec.Headers = headersToStrings(e.Response.Headers)
-				rec.RuntimeAssetRole, rec.UnresolvedAssetRole = classifyRuntimeAsset(rec.URL)
-			}
-		case *network.EventLoadingFinished:
-			rec := c.records[e.RequestID]
-			if rec == nil {
-				rec = &NetworkRecord{RequestID: string(e.RequestID)}
-				c.records[e.RequestID] = rec
-			}
-			rec.TransferredBytes = e.EncodedDataLength
-			if rec.EncodedDataLength == 0 {
-				rec.EncodedDataLength = e.EncodedDataLength
-			}
-		}
-	})
+	chromedp.ListenTarget(ctx, c.record)
 	if err := chromedp.Run(d.Context(), network.Enable()); err != nil {
 		cancel()
 		return nil, err
 	}
 	return c, nil
+}
+
+func (c *networkCapture) record(ev any) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	switch e := ev.(type) {
+	case *network.EventRequestWillBeSent:
+		rec := c.records[e.RequestID]
+		if rec == nil {
+			rec = &NetworkRecord{RequestID: string(e.RequestID)}
+			c.records[e.RequestID] = rec
+		}
+		rec.DocumentURL = e.DocumentURL
+		rec.Role = string(e.Type)
+		if e.Request != nil {
+			rec.URL = e.Request.URL
+			rec.Method = e.Request.Method
+		}
+	case *network.EventResponseReceived:
+		rec := c.records[e.RequestID]
+		if rec == nil {
+			rec = &NetworkRecord{RequestID: string(e.RequestID)}
+			c.records[e.RequestID] = rec
+		}
+		rec.Role = string(e.Type)
+		if e.Response != nil {
+			rec.URL = e.Response.URL
+			rec.Status = e.Response.Status
+			rec.MimeType = e.Response.MimeType
+			rec.Protocol = e.Response.Protocol
+			rec.EncodedDataLength = e.Response.EncodedDataLength
+			rec.TransferredBytes = e.Response.EncodedDataLength
+			rec.FromDiskCache = e.Response.FromDiskCache
+			rec.FromServiceWorker = e.Response.FromServiceWorker
+			rec.FromPrefetchCache = e.Response.FromPrefetchCache
+			rec.CacheControl = headerValue(e.Response.Headers, "cache-control")
+			rec.Immutable = strings.Contains(strings.ToLower(rec.CacheControl), "immutable")
+			rec.HeaderBytes = approximateHeaderBytes(e.Response.Headers)
+			rec.Headers = headersToStrings(e.Response.Headers)
+			rec.RuntimeAssetRole, rec.UnresolvedAssetRole = classifyRuntimeAsset(rec.URL)
+		}
+	case *network.EventLoadingFinished:
+		rec := c.records[e.RequestID]
+		if rec == nil {
+			rec = &NetworkRecord{RequestID: string(e.RequestID)}
+			c.records[e.RequestID] = rec
+		}
+		rec.TransferredBytes = e.EncodedDataLength
+		if rec.EncodedDataLength == 0 {
+			rec.EncodedDataLength = e.EncodedDataLength
+		}
+	}
 }
 
 func (c *networkCapture) Stop() {

--- a/perf/ouroboros/browser_test.go
+++ b/perf/ouroboros/browser_test.go
@@ -13,9 +13,11 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/chromedp/cdproto/network"
 	"m31labs.dev/gosx/perf"
 	"m31labs.dev/gosx/visual"
 )
@@ -437,6 +439,81 @@ func TestSampleMetricsPreservesRawTransferAndMemoryValues(t *testing.T) {
 	metrics := sampleMetrics(page, mem)
 	if metrics["transferBytes"] != 789 || metrics["jsHeapUsedMb"] != 1.5 || metrics["domNodeCount"] != 42 {
 		t.Fatalf("metrics = %#v", metrics)
+	}
+}
+
+func TestNetworkCaptureConcurrentRecordAndSnapshot(t *testing.T) {
+	const (
+		requestCount = 8
+		iterations   = 250
+		readers      = 4
+	)
+	capture := &networkCapture{records: make(map[network.RequestID]*NetworkRecord)}
+	for i := 0; i < requestCount; i++ {
+		id := network.RequestID(fmt.Sprintf("request-%d", i))
+		capture.record(&network.EventRequestWillBeSent{
+			RequestID:   id,
+			DocumentURL: "https://example.test/",
+			Type:        network.ResourceTypeScript,
+			Request: &network.Request{
+				URL:     fmt.Sprintf("https://example.test/runtime-%d.js", i),
+				Method:  http.MethodGet,
+				Headers: network.Headers{},
+			},
+		})
+	}
+
+	start := make(chan struct{})
+	var workers sync.WaitGroup
+	for i := 0; i < requestCount; i++ {
+		i := i
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			id := network.RequestID(fmt.Sprintf("request-%d", i))
+			url := fmt.Sprintf("https://example.test/runtime-%d.js", i)
+			for n := 1; n <= iterations; n++ {
+				capture.record(&network.EventResponseReceived{
+					RequestID: id,
+					Type:      network.ResourceTypeScript,
+					Response: &network.Response{
+						URL:               url,
+						Status:            http.StatusOK,
+						MimeType:          "text/javascript",
+						Protocol:          "h2",
+						EncodedDataLength: float64(n),
+						Headers:           network.Headers{"cache-control": "public, max-age=31536000, immutable"},
+					},
+				})
+				capture.record(&network.EventLoadingFinished{RequestID: id, EncodedDataLength: float64(n * 2)})
+			}
+		}()
+	}
+	for i := 0; i < readers; i++ {
+		workers.Add(1)
+		go func() {
+			defer workers.Done()
+			<-start
+			for n := 0; n < iterations; n++ {
+				_ = capture.Records()
+			}
+		}()
+	}
+	close(start)
+	workers.Wait()
+
+	records := capture.Records()
+	if len(records) != requestCount {
+		t.Fatalf("network records = %d, want %d", len(records), requestCount)
+	}
+	for _, record := range records {
+		if record.Status != http.StatusOK || record.TransferredBytes != iterations*2 {
+			t.Fatalf("incomplete network record: %+v", record)
+		}
+		if !record.Immutable || record.CacheControl == "" {
+			t.Fatalf("cache metadata was lost: %+v", record)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- keep exhaustive race coverage as a complete, validated 177-package partition
- run 176 packages in the broad race lane and `perf/ouroboros` in a scoped lane
- exclude exactly nine named real-repository evidence recomputations from race instrumentation; ordinary unit CI still runs all nine
- add a direct concurrent mutation/snapshot regression for Ouroboros's mutex-protected CDP network capture

## Why

Exact-main CI run [31653534434](https://github.com/odvcencio/gosx/actions/runs/31653534434) hit the explicit 40-minute `perf/ouroboros` package timeout while actively running deterministic Brotli `BestCompression`. The log contained no race finding. Raising the alarm again would spend more than 40 minutes in single-threaded compression without increasing shared-state coverage.

The split is enforced by `internal/citest`: the package partition must be complete and disjoint, every skip is an anchored exact current test name with a nonempty reason, stale/duplicate names fail validation, and 174 Ouroboros tests remain in the race lane.

## Verification

- scoped Ouroboros race: 174/174 passed in 91.750s, zero races/timeouts
- ordinary Ouroboros suite: 183/183 passed in 337.756s, including all nine excluded-from-race evidence scans
- direct concurrent network capture test passed repeatedly under `-race`
- CI partition tests and verification passed
- actionlint passed
- diff/format checks passed
- independent blocker-only review: zero findings
