### PR TITLE
fix(ci): retry pinned TinyGo toolchains

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,12 +158,7 @@ jobs:
       - name: Install TinyGo
         env:
           TINYGO_VERSION: 0.41.1
-        run: |
-          curl -fsSL -o tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
-          sudo dpkg -i tinygo.deb
-          go install golang.org/dl/go1.25.5@latest
-          go1.25.5 download
-          tinygo version
+        run: scripts/install-ci-tinygo.sh
 
       - name: CLI production-build integration tests
         run: make test-cli
@@ -228,12 +223,7 @@ jobs:
       - name: Install TinyGo
         env:
           TINYGO_VERSION: 0.41.1
-        run: |
-          curl -fsSL -o tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
-          sudo dpkg -i tinygo.deb
-          go install golang.org/dl/go1.25.5@latest
-          go1.25.5 download
-          tinygo version
+        run: scripts/install-ci-tinygo.sh
 
       # Guards the zero-CGo portability claim: README states every package
       # compiles to WASM. It had stopped being true and nothing noticed,
@@ -300,12 +290,7 @@ jobs:
       - name: Install TinyGo
         env:
           TINYGO_VERSION: 0.41.1
-        run: |
-          curl -fsSL -o tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
-          sudo dpkg -i tinygo.deb
-          go install golang.org/dl/go1.25.5@latest
-          go1.25.5 download
-          tinygo version
+        run: scripts/install-ci-tinygo.sh
 
       - name: Browser docs E2E gate
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,11 +54,30 @@ jobs:
       - name: Install TinyGo
         env:
           TINYGO_VERSION: 0.41.1
+          TINYGO_GO_VERSION: 1.25.5
+          TINYGO_SHA256: 901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe
+          TINYGO_GO_SHA256: 9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b
         run: |
-          curl -fsSL -o tinygo.deb "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
-          sudo dpkg -i tinygo.deb
-          go install golang.org/dl/go1.25.5@latest
-          go1.25.5 download
+          set -euo pipefail
+          work_dir="$(mktemp -d)"
+          trap 'rm -rf -- "${work_dir}"' EXIT
+          curl --fail --location --silent --show-error \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --output "${work_dir}/tinygo.deb" \
+            "https://github.com/tinygo-org/tinygo/releases/download/v${TINYGO_VERSION}/tinygo_${TINYGO_VERSION}_amd64.deb"
+          printf '%s  %s\n' "${TINYGO_SHA256}" "${work_dir}/tinygo.deb" | sha256sum --check --status
+          sudo dpkg -i "${work_dir}/tinygo.deb"
+          compat_root="${HOME}/sdk/go${TINYGO_GO_VERSION}"
+          curl --fail --location --silent --show-error \
+            --retry 5 --retry-delay 2 --retry-all-errors \
+            --output "${work_dir}/go.tar.gz" \
+            "https://dl.google.com/go/go${TINYGO_GO_VERSION}.linux-amd64.tar.gz"
+          printf '%s  %s\n' "${TINYGO_GO_SHA256}" "${work_dir}/go.tar.gz" | sha256sum --check --status
+          mkdir -p "${HOME}/sdk"
+          tar -C "${work_dir}" -xzf "${work_dir}/go.tar.gz"
+          mv "${work_dir}/go" "${compat_root}"
+          GOTOOLCHAIN=local "${compat_root}/bin/go" version
+          printf 'GOSX_TINYGO_GOROOT=%s\n' "${compat_root}" >>"${GITHUB_ENV}"
           tinygo version
 
       - name: Test, vet, and build

--- a/scripts/install-ci-tinygo.sh
+++ b/scripts/install-ci-tinygo.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+tinygo_version="${TINYGO_VERSION:-0.41.1}"
+compat_go_version="${TINYGO_GO_VERSION:-1.25.5}"
+
+if [[ "${tinygo_version}" != "0.41.1" || "${compat_go_version}" != "1.25.5" ]]; then
+	echo "install-ci-tinygo: unsupported toolchain TinyGo ${tinygo_version} / Go ${compat_go_version}" >&2
+	exit 1
+fi
+
+tinygo_sha256="901fbccffc61adb111656d1f907dfc21b6c499ca841b115866a0d6de2d835fbe"
+compat_go_sha256="9e9b755d63b36acf30c12a9a3fc379243714c1c6d3dd72861da637f336ebb35b"
+work_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf -- "${work_dir}"
+}
+trap cleanup EXIT
+
+curl --fail --location --silent --show-error \
+	--retry 5 --retry-delay 2 --retry-all-errors \
+	--output "${work_dir}/tinygo.deb" \
+	"https://github.com/tinygo-org/tinygo/releases/download/v${tinygo_version}/tinygo_${tinygo_version}_amd64.deb"
+printf '%s  %s\n' "${tinygo_sha256}" "${work_dir}/tinygo.deb" | sha256sum --check --status
+sudo dpkg -i "${work_dir}/tinygo.deb"
+
+compat_root="${HOME}/sdk/go${compat_go_version}"
+if [[ ! -x "${compat_root}/bin/go" ]]; then
+	if [[ -e "${compat_root}" ]]; then
+		echo "install-ci-tinygo: refusing an incomplete compatibility root: ${compat_root}" >&2
+		exit 1
+	fi
+	curl --fail --location --silent --show-error \
+		--retry 5 --retry-delay 2 --retry-all-errors \
+		--output "${work_dir}/go.tar.gz" \
+		"https://dl.google.com/go/go${compat_go_version}.linux-amd64.tar.gz"
+	printf '%s  %s\n' "${compat_go_sha256}" "${work_dir}/go.tar.gz" | sha256sum --check --status
+	mkdir -p "${HOME}/sdk"
+	tar -C "${work_dir}" -xzf "${work_dir}/go.tar.gz"
+	mv "${work_dir}/go" "${compat_root}"
+fi
+
+compat_version_output="$(GOTOOLCHAIN=local "${compat_root}/bin/go" version)"
+if [[ "${compat_version_output}" != "go version go${compat_go_version} linux/amd64" ]]; then
+	echo "install-ci-tinygo: unexpected compatibility toolchain: ${compat_version_output}" >&2
+	exit 1
+fi
+
+tinygo_version_output="$(tinygo version)"
+if [[ "${tinygo_version_output}" != tinygo\ version\ ${tinygo_version}\ * ]]; then
+	echo "install-ci-tinygo: unexpected TinyGo toolchain: ${tinygo_version_output}" >&2
+	exit 1
+fi
+
+if [[ -n "${GITHUB_ENV:-}" ]]; then
+	printf 'GOSX_TINYGO_GOROOT=%s\n' "${compat_root}" >>"${GITHUB_ENV}"
+fi
+
+printf '%s\n' "${tinygo_version_output}"
+printf '%s\n' "compatibility GOROOT: ${compat_root} (${compat_version_output})"


### PR DESCRIPTION
## Summary
- replace the transient-prone golang.org/dl compatibility download with retrying, checksum-verified official artifacts
- share the installer across CI TinyGo jobs and export the exact compatibility GOROOT
- keep the release installer inline so workflow_dispatch can still build historical tags

## Root cause
Exact-main run 31671168057 failed before WASM tests when golang.org/dl briefly reported that the existing go1.25.5 Linux archive had no binary release. The official URL returned 200 immediately afterward.

## Verification
- bash syntax and actionlint
- authoritative TinyGo and Go SHA-256 metadata checked
- mocked runner install/discovery/GITHUB_ENV cases
- make release-gate
- git diff --check

Main remains undeployed until this PR and the resulting exact-main run are green.