### PR TITLE
fix(docs): wait for public rollout convergence

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -347,6 +347,7 @@ build-runtime:
 #      operation that broke v0.29.0 so a zip-breaking commit fails fast.
 test-docs-deploy:
 	sh scripts/deploy-gosx-docs-concurrency-test.sh
+	sh scripts/deploy-gosx-docs-public-test.sh
 
 release-gate:
 	@echo "release-gate (1/5): go run ./cmd/gosx release check"

--- a/scripts/deploy-gosx-docs-public-test.sh
+++ b/scripts/deploy-gosx-docs-public-test.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env sh
+set -eu
+
+for command_name in awk dirname jq mktemp true; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "deploy public test: required command is unavailable: ${command_name}" >&2
+		exit 1
+	fi
+done
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+# shellcheck source=deploy-gosx-docs-public.sh
+. "${script_dir}/deploy-gosx-docs-public.sh"
+wait_script="${script_dir}/wait-gosx-docs-release.sh"
+fake_curl="${script_dir}/testdata/fake-gosx-docs-curl.sh"
+
+tmp_dir="$(mktemp -d)"
+cleanup() {
+	find "$tmp_dir" -type f -delete
+	find "$tmp_dir" -depth -type d -empty -delete
+}
+trap cleanup EXIT INT TERM
+counter_file="${tmp_dir}/counter"
+
+framework_version="v0.39.0"
+revision="6c9b990f711705707e8bceac52d6c331fe8857ed"
+built_at="2026-08-13T06:22:15Z"
+public_url="https://gosx.m31labs.dev"
+
+reset_counter() {
+	printf '%s\n' 0 >"$counter_file"
+}
+
+read_counter() {
+	awk 'NR == 1 { print $1 }' "$counter_file"
+}
+
+run_wait() {
+	GOSX_DOCS_FAKE_CURL_MODE="$1" \
+		GOSX_DOCS_FAKE_CURL_STATE="$counter_file" \
+		GOSX_DOCS_FAKE_FRAMEWORK_VERSION="$framework_version" \
+		GOSX_DOCS_FAKE_REVISION="$revision" \
+		GOSX_DOCS_FAKE_BUILT_AT="$built_at" \
+		GOSX_DOCS_FAKE_PUBLIC_URL="$public_url" \
+		GOSX_DOCS_PUBLIC_CONVERGENCE_ATTEMPTS="$2" \
+		GOSX_DOCS_PUBLIC_CONVERGENCE_DELAY_SECONDS=1 \
+		CURL="$fake_curl" SLEEP=true \
+		sh "$wait_script" "$public_url" "$framework_version" \
+			"$revision" "$built_at" "$public_url"
+}
+
+reset_counter
+run_wait release-converges 4
+if [ "$(read_counter)" -ne 3 ]; then
+	echo "deploy public test: release convergence did not retry exactly twice" >&2
+	exit 1
+fi
+
+reset_counter
+if run_wait release-never-matches 3; then
+	echo "deploy public test: incomplete release identity unexpectedly converged" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 3 ]; then
+	echo "deploy public test: release mismatch did not exhaust its bounded attempts" >&2
+	exit 1
+fi
+
+reset_counter
+GOSX_DOCS_FAKE_CURL_MODE=health-recovers \
+	GOSX_DOCS_FAKE_CURL_STATE="$counter_file" CURL="$fake_curl" SLEEP=true \
+	gosx_docs_wait_for_public_health "$fake_curl" "$public_url" 4 1
+if [ "$(read_counter)" -ne 3 ]; then
+	echo "deploy public test: rollback health did not retry transient failures" >&2
+	exit 1
+fi
+
+reset_counter
+if GOSX_DOCS_FAKE_CURL_MODE=health-never-recovers \
+	GOSX_DOCS_FAKE_CURL_STATE="$counter_file" CURL="$fake_curl" SLEEP=true \
+	gosx_docs_wait_for_public_health "$fake_curl" "$public_url" 3 1; then
+	echo "deploy public test: unhealthy rollback unexpectedly passed" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 3 ]; then
+	echo "deploy public test: unhealthy rollback did not exhaust its bounded attempts" >&2
+	exit 1
+fi
+
+if gosx_docs_wait_for_public_health "$fake_curl" "$public_url" 0 0; then
+	echo "deploy public test: zero retry attempts unexpectedly passed" >&2
+	exit 1
+fi
+
+printf '%s\n' "deploy public test: release convergence and rollback health retries passed"

--- a/scripts/deploy-gosx-docs-public.sh
+++ b/scripts/deploy-gosx-docs-public.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+
+# Public-path rollback verification for the docs deployment. This helper is
+# sourced by deploy-gosx-docs.sh and intentionally does not set shell options.
+
+gosx_docs_wait_for_public_health() {
+	gosx_public_curl="$1"
+	gosx_public_base_url="${2%/}"
+	gosx_public_attempts="${3:-6}"
+	gosx_public_delay="${4:-2}"
+	gosx_public_sleep="${SLEEP:-sleep}"
+
+	case "$gosx_public_attempts" in
+		''|0|*[!0-9]*)
+			echo "gosx docs deploy: rollback health attempts must be a positive integer" >&2
+			return 1
+			;;
+	esac
+	case "$gosx_public_delay" in
+		''|*[!0-9]*)
+			echo "gosx docs deploy: rollback health delay must be a non-negative integer" >&2
+			return 1
+			;;
+	esac
+	if ! command -v "$gosx_public_curl" >/dev/null 2>&1; then
+		echo "gosx docs deploy: rollback health curl command is unavailable: ${gosx_public_curl}" >&2
+		return 1
+	fi
+	if ! command -v "$gosx_public_sleep" >/dev/null 2>&1; then
+		echo "gosx docs deploy: rollback health sleep command is unavailable: ${gosx_public_sleep}" >&2
+		return 1
+	fi
+
+	gosx_public_attempt=1
+	while [ "$gosx_public_attempt" -le "$gosx_public_attempts" ]; do
+		gosx_public_body=""
+		if gosx_public_body="$($gosx_public_curl \
+			--fail --silent --show-error --connect-timeout 5 --max-time 10 \
+			"${gosx_public_base_url}/healthz" 2>/dev/null)" && \
+			printf '%s\n' "$gosx_public_body" | jq -e '.ok == true' >/dev/null 2>&1; then
+			echo "gosx docs deploy: rolled-back public health recovered after ${gosx_public_attempt}/${gosx_public_attempts} checks" >&2
+			return 0
+		fi
+		echo "gosx docs deploy: waiting for rolled-back public health (${gosx_public_attempt}/${gosx_public_attempts})" >&2
+		if [ "$gosx_public_attempt" -lt "$gosx_public_attempts" ] && [ "$gosx_public_delay" -gt 0 ]; then
+			"$gosx_public_sleep" "$gosx_public_delay"
+		fi
+		gosx_public_attempt=$((gosx_public_attempt + 1))
+	done
+
+	echo "gosx docs deploy: captured Deployment was restored, but public health did not recover" >&2
+	return 1
+}

--- a/scripts/deploy-gosx-docs.sh
+++ b/scripts/deploy-gosx-docs.sh
@@ -43,6 +43,13 @@ if [ ! -f "$transaction_lib" ]; then
 fi
 # shellcheck source=deploy-gosx-docs-transaction.sh
 . "$transaction_lib"
+public_lib="${repo_root}/scripts/deploy-gosx-docs-public.sh"
+if [ ! -f "$public_lib" ]; then
+	echo "gosx docs deploy: public verification helper is missing: ${public_lib}" >&2
+	exit 1
+fi
+# shellcheck source=deploy-gosx-docs-public.sh
+. "$public_lib"
 
 host_goos="$($go_cmd env GOHOSTOS)"
 host_goarch="$($go_cmd env GOHOSTARCH)"
@@ -176,7 +183,7 @@ on_exit() {
 	trap - EXIT INT TERM
 	if [ "$exit_status" -ne 0 ] && [ "${rollback_armed:-0}" -eq 1 ]; then
 		if ! rollback; then
-			echo "gosx docs deploy: automatic rollback did not restore the captured template" >&2
+			echo "gosx docs deploy: automatic rollback could not be fully verified" >&2
 		fi
 	fi
 	cleanup
@@ -374,7 +381,9 @@ rollback() {
 		echo "gosx docs deploy: rollback state is not the captured release; image is ${rolled_back_image:-unavailable}, expected ${previous_image}" >&2
 		return 1
 	fi
-	if ! "$curl_cmd" --fail --silent --show-error --connect-timeout 10 --max-time 30 "${public_url}/healthz" >/dev/null; then
+	if ! gosx_docs_wait_for_public_health "$curl_cmd" "$public_url" \
+		"${GOSX_DOCS_ROLLBACK_HEALTH_ATTEMPTS:-6}" \
+		"${GOSX_DOCS_ROLLBACK_HEALTH_DELAY_SECONDS:-2}"; then
 		return 1
 	fi
 	return 0
@@ -572,6 +581,9 @@ if [ "$identity_ok" -ne 1 ]; then
 	fi
 	exit 1
 fi
+
+CURL="$curl_cmd" scripts/wait-gosx-docs-release.sh "$public_url" \
+	"$framework_version" "$revision" "$built_at" "$public_url"
 
 GOSX_DOCS_EXPECT_FRAMEWORK_VERSION="$framework_version" \
 	GOSX_DOCS_EXPECT_REVISION="$revision" \

--- a/scripts/testdata/fake-gosx-docs-curl.sh
+++ b/scripts/testdata/fake-gosx-docs-curl.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+set -eu
+
+mode="${GOSX_DOCS_FAKE_CURL_MODE:?}"
+state_file="${GOSX_DOCS_FAKE_CURL_STATE:?}"
+framework_version="${GOSX_DOCS_FAKE_FRAMEWORK_VERSION:-v0.39.0}"
+revision="${GOSX_DOCS_FAKE_REVISION:-6c9b990f711705707e8bceac52d6c331fe8857ed}"
+built_at="${GOSX_DOCS_FAKE_BUILT_AT:-2026-08-13T06:22:15Z}"
+public_url="${GOSX_DOCS_FAKE_PUBLIC_URL:-https://gosx.m31labs.dev}"
+
+count="$(awk 'NR == 1 { print $1 }' "$state_file")"
+count=$((count + 1))
+printf '%s\n' "$count" >"$state_file"
+
+case "$mode" in
+	release-converges)
+		case "$count" in
+			1) exit 28 ;;
+			2)
+				printf '%s\n' '{"site":"gosx-docs","status":"ok","frameworkVersion":"v0.32.0","revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","builtAt":"2026-07-19T00:00:00Z","publicURL":"https://gosx.m31labs.dev"}'
+				;;
+			*)
+				printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"%s","publicURL":"%s/"}\n' \
+					"$framework_version" "$revision" "$built_at" "$public_url"
+				;;
+		esac
+		;;
+	release-never-matches)
+		# Matching framework and revision are insufficient: builtAt belongs to
+		# the immutable deployment identity too.
+		printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"2026-08-13T00:00:00Z","publicURL":"%s"}\n' \
+			"$framework_version" "$revision" "$public_url"
+		;;
+	health-recovers)
+		case "$count" in
+			1) exit 28 ;;
+			2) printf '%s\n' '{"ok":false}' ;;
+			*) printf '%s\n' '{"ok":true}' ;;
+		esac
+		;;
+	health-never-recovers)
+		printf '%s\n' '{"ok":false}'
+		;;
+	*)
+		echo "fake curl: unknown mode ${mode}" >&2
+		exit 2
+		;;
+esac

--- a/scripts/wait-gosx-docs-release.sh
+++ b/scripts/wait-gosx-docs-release.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env sh
+set -eu
+
+base_url="${1:-}"
+expected_framework_version="${2:-}"
+expected_revision="${3:-}"
+expected_built_at="${4:-}"
+expected_public_url="${5:-$base_url}"
+base_url="${base_url%/}"
+expected_public_url="${expected_public_url%/}"
+attempts="${GOSX_DOCS_PUBLIC_CONVERGENCE_ATTEMPTS:-12}"
+delay_seconds="${GOSX_DOCS_PUBLIC_CONVERGENCE_DELAY_SECONDS:-5}"
+curl_cmd="${CURL:-curl}"
+sleep_cmd="${SLEEP:-sleep}"
+
+if [ -z "$base_url" ] || [ -z "$expected_framework_version" ] || \
+	[ -z "$expected_revision" ] || [ -z "$expected_built_at" ] || \
+	[ -z "$expected_public_url" ]; then
+	echo "usage: $0 BASE_URL FRAMEWORK_VERSION REVISION BUILT_AT [PUBLIC_URL]" >&2
+	exit 2
+fi
+case "$attempts" in
+	''|0|*[!0-9]*)
+		echo "gosx docs deploy: public convergence attempts must be a positive integer" >&2
+		exit 2
+		;;
+esac
+case "$delay_seconds" in
+	''|*[!0-9]*)
+		echo "gosx docs deploy: public convergence delay must be a non-negative integer" >&2
+		exit 2
+		;;
+esac
+for command_name in "$curl_cmd" "$sleep_cmd" jq; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "gosx docs deploy: public convergence command is unavailable: ${command_name}" >&2
+		exit 2
+	fi
+done
+
+attempt=1
+observed="unavailable"
+while [ "$attempt" -le "$attempts" ]; do
+	body=""
+	if body="$($curl_cmd \
+		--fail --silent --show-error --connect-timeout 5 --max-time 15 \
+		--header 'cache-control: no-cache' \
+		"${base_url}/api/site" 2>/dev/null)" && \
+		printf '%s\n' "$body" | jq -e \
+			--arg frameworkVersion "$expected_framework_version" \
+			--arg revision "$expected_revision" \
+			--arg builtAt "$expected_built_at" \
+			--arg publicURL "$expected_public_url" \
+			'.site == "gosx-docs" and .status == "ok" and
+			 .frameworkVersion == $frameworkVersion and
+			 .revision == $revision and .builtAt == $builtAt and
+			 (.publicURL | rtrimstr("/")) == $publicURL' >/dev/null 2>&1; then
+		echo "gosx docs deploy: public release converged after ${attempt}/${attempts} checks" >&2
+		exit 0
+	fi
+
+	if observed_value="$(printf '%s\n' "$body" | jq -er \
+		'[.frameworkVersion, .revision, .builtAt, .publicURL] | map(tostring) | join(" ")' 2>/dev/null)"; then
+		observed="$observed_value"
+	else
+		observed="unavailable"
+	fi
+	echo "gosx docs deploy: waiting for public release (${attempt}/${attempts}); observed ${observed}" >&2
+	if [ "$attempt" -lt "$attempts" ] && [ "$delay_seconds" -gt 0 ]; then
+		"$sleep_cmd" "$delay_seconds"
+	fi
+	attempt=$((attempt + 1))
+done
+
+echo "gosx docs deploy: public release did not converge to ${expected_framework_version} ${expected_revision} (${expected_built_at})" >&2
+exit 1


### PR DESCRIPTION
## Summary
- wait for the public `/api/site` identity to match the exact immutable release before running the full smoke suite
- retry rollback health verification across the ingress endpoint propagation window
- add hermetic POSIX-shell regressions and bind them into `release-gate`

## Incident evidence
The first v0.39 docs rollout produced a healthy, ready candidate pod, but the public smoke began before Traefik stopped routing early requests to the old v0.32 pod. The guarded transaction rolled back successfully; its one-shot public health request then timed out during the reverse endpoint handoff and emitted a misleading restoration error. The old site remained healthy throughout recovery.

## Verification
- `make test-docs-deploy`
- `make release-gate`
- `sh -n` / `dash -n` on all changed scripts
- `dash scripts/deploy-gosx-docs-public-test.sh`
- independent blocker review: clean
