### PR TITLE
fix(docs): require stable edge rollout

### DIFF
--- a/deploy/gosx-docs.yaml
+++ b/deploy/gosx-docs.yaml
@@ -11,6 +11,10 @@ metadata:
     kubernetes.io/change-cause: "Deploy gosx-docs __GIT_REVISION__ at __BUILT_AT__ (sha256:__IMAGE_DIGEST__)"
 spec:
   replicas: 1
+  # Keep the prior ready pod serving while ingress controllers observe the
+  # candidate endpoint. A single successful readiness probe is not enough to
+  # declare a one-replica public rollout stable.
+  minReadySeconds: 10
   # Keep enough rollout history for an immediate operator rollback without
   # retaining an unbounded set of old ReplicaSets.
   revisionHistoryLimit: 5

--- a/scripts/deploy-gosx-docs-public-test.sh
+++ b/scripts/deploy-gosx-docs-public-test.sh
@@ -44,15 +44,63 @@ run_wait() {
 		GOSX_DOCS_FAKE_PUBLIC_URL="$public_url" \
 		GOSX_DOCS_PUBLIC_CONVERGENCE_ATTEMPTS="$2" \
 		GOSX_DOCS_PUBLIC_CONVERGENCE_DELAY_SECONDS=1 \
+		GOSX_DOCS_PUBLIC_CONVERGENCE_SUCCESSES="${3:-3}" \
 		CURL="$fake_curl" SLEEP=true \
 		sh "$wait_script" "$public_url" "$framework_version" \
 			"$revision" "$built_at" "$public_url"
 }
 
 reset_counter
-run_wait release-converges 4
-if [ "$(read_counter)" -ne 3 ]; then
-	echo "deploy public test: release convergence did not retry exactly twice" >&2
+run_wait release-converges 5
+if [ "$(read_counter)" -ne 15 ]; then
+	echo "deploy public test: release convergence did not require three stable checks" >&2
+	exit 1
+fi
+
+reset_counter
+run_wait release-flaps 6
+if [ "$(read_counter)" -ne 18 ]; then
+	echo "deploy public test: an unhealthy edge response did not reset the stability streak" >&2
+	exit 1
+fi
+
+reset_counter
+if run_wait release-health-fails 3; then
+	echo "deploy public test: persistently unhealthy release unexpectedly converged" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 9 ]; then
+	echo "deploy public test: unhealthy release did not exhaust its bounded checks" >&2
+	exit 1
+fi
+
+reset_counter
+if run_wait release-ready-fails 3; then
+	echo "deploy public test: persistently unready release unexpectedly converged" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 9 ]; then
+	echo "deploy public test: unready release did not exhaust its bounded checks" >&2
+	exit 1
+fi
+
+reset_counter
+if run_wait release-converges 5 2; then
+	echo "deploy public test: fewer than three required successes unexpectedly passed validation" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 0 ]; then
+	echo "deploy public test: invalid stability configuration made a public request" >&2
+	exit 1
+fi
+
+reset_counter
+if run_wait release-converges 2 3; then
+	echo "deploy public test: successes greater than attempts unexpectedly passed validation" >&2
+	exit 1
+fi
+if [ "$(read_counter)" -ne 0 ]; then
+	echo "deploy public test: impossible stability configuration made a public request" >&2
 	exit 1
 fi
 
@@ -61,7 +109,7 @@ if run_wait release-never-matches 3; then
 	echo "deploy public test: incomplete release identity unexpectedly converged" >&2
 	exit 1
 fi
-if [ "$(read_counter)" -ne 3 ]; then
+if [ "$(read_counter)" -ne 9 ]; then
 	echo "deploy public test: release mismatch did not exhaust its bounded attempts" >&2
 	exit 1
 fi

--- a/scripts/smoke-gosx-docs.sh
+++ b/scripts/smoke-gosx-docs.sh
@@ -52,8 +52,10 @@ assert_status() {
 fetch_exact() {
 	path="$1"
 	output="$2"
+	retries="${3:-3}"
 	headers="${output}.headers"
 	if ! "$curl_cmd" --fail --silent --show-error --max-redirs 0 \
+		--retry "$retries" --retry-delay 1 --retry-max-time 15 \
 		--connect-timeout 10 --max-time 45 --dump-header "$headers" \
 		"${base_url}${path}" -o "$output"; then
 		return 1
@@ -231,7 +233,10 @@ image_attempt=0
 image_ok=0
 while [ "$image_attempt" -lt 5 ]; do
 	image_attempt=$((image_attempt + 1))
-	if fetch_exact "/_gosx/image?src=%2Fcheckers-native-preview.png&w=320&format=png" "$tmp_dir/checkers-320.png"; then
+	# This endpoint has its own bounded loop because an initial cache miss may
+	# return a non-retriable HTTP status. Disable curl's inner retry here so the
+	# two bounds cannot multiply into twenty requests.
+	if fetch_exact "/_gosx/image?src=%2Fcheckers-native-preview.png&w=320&format=png" "$tmp_dir/checkers-320.png" 0; then
 		image_ok=1
 		break
 	fi

--- a/scripts/testdata/fake-gosx-docs-curl.sh
+++ b/scripts/testdata/fake-gosx-docs-curl.sh
@@ -11,25 +11,63 @@ public_url="${GOSX_DOCS_FAKE_PUBLIC_URL:-https://gosx.m31labs.dev}"
 count="$(awk 'NR == 1 { print $1 }' "$state_file")"
 count=$((count + 1))
 printf '%s\n' "$count" >"$state_file"
+request_url=""
+for request_arg in "$@"; do
+	request_url="$request_arg"
+done
+
+write_current_release() {
+	printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"%s","publicURL":"%s/"}\n' \
+		"$framework_version" "$revision" "$built_at" "$public_url"
+}
+
+write_endpoint_success() {
+	case "$request_url" in
+		*/api/site) write_current_release ;;
+		*/healthz|*/readyz) printf '%s\n' '{"ok":true}' ;;
+		*) echo "fake curl: unexpected URL ${request_url}" >&2; exit 2 ;;
+	esac
+}
 
 case "$mode" in
 	release-converges)
 		case "$count" in
 			1) exit 28 ;;
-			2)
+			4)
 				printf '%s\n' '{"site":"gosx-docs","status":"ok","frameworkVersion":"v0.32.0","revision":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","builtAt":"2026-07-19T00:00:00Z","publicURL":"https://gosx.m31labs.dev"}'
 				;;
-			*)
-				printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"%s","publicURL":"%s/"}\n' \
-					"$framework_version" "$revision" "$built_at" "$public_url"
-				;;
+			*) write_endpoint_success ;;
+		esac
+		;;
+	release-flaps)
+		case "$count" in
+			2|8) exit 22 ;;
+			*) write_endpoint_success ;;
+		esac
+		;;
+	release-health-fails)
+		case "$request_url" in
+			*/healthz) exit 22 ;;
+			*) write_endpoint_success ;;
+		esac
+		;;
+	release-ready-fails)
+		case "$request_url" in
+			*/readyz) printf '%s\n' '{"ok":false}' ;;
+			*) write_endpoint_success ;;
 		esac
 		;;
 	release-never-matches)
-		# Matching framework and revision are insufficient: builtAt belongs to
-		# the immutable deployment identity too.
-		printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"2026-08-13T00:00:00Z","publicURL":"%s"}\n' \
-			"$framework_version" "$revision" "$public_url"
+		case "$request_url" in
+			*/api/site)
+				# Matching framework and revision are insufficient: builtAt
+				# belongs to the immutable deployment identity too.
+				printf '{"site":"gosx-docs","status":"ok","frameworkVersion":"%s","revision":"%s","builtAt":"2026-08-13T00:00:00Z","publicURL":"%s"}\n' \
+					"$framework_version" "$revision" "$public_url"
+				;;
+			*/healthz|*/readyz) printf '%s\n' '{"ok":true}' ;;
+			*) echo "fake curl: unexpected URL ${request_url}" >&2; exit 2 ;;
+		esac
 		;;
 	health-recovers)
 		case "$count" in

--- a/scripts/wait-gosx-docs-release.sh
+++ b/scripts/wait-gosx-docs-release.sh
@@ -10,6 +10,7 @@ base_url="${base_url%/}"
 expected_public_url="${expected_public_url%/}"
 attempts="${GOSX_DOCS_PUBLIC_CONVERGENCE_ATTEMPTS:-12}"
 delay_seconds="${GOSX_DOCS_PUBLIC_CONVERGENCE_DELAY_SECONDS:-5}"
+required_successes="${GOSX_DOCS_PUBLIC_CONVERGENCE_SUCCESSES:-3}"
 curl_cmd="${CURL:-curl}"
 sleep_cmd="${SLEEP:-sleep}"
 
@@ -26,11 +27,25 @@ case "$attempts" in
 		;;
 esac
 case "$delay_seconds" in
-	''|*[!0-9]*)
-		echo "gosx docs deploy: public convergence delay must be a non-negative integer" >&2
+	''|0|*[!0-9]*)
+		echo "gosx docs deploy: public convergence delay must be a positive integer" >&2
 		exit 2
 		;;
 esac
+case "$required_successes" in
+	''|0|*[!0-9]*)
+		echo "gosx docs deploy: public convergence successes must be an integer of at least 3" >&2
+		exit 2
+		;;
+esac
+if [ "$required_successes" -lt 3 ]; then
+	echo "gosx docs deploy: public convergence successes must be an integer of at least 3" >&2
+	exit 2
+fi
+if [ "$required_successes" -gt "$attempts" ]; then
+	echo "gosx docs deploy: public convergence successes cannot exceed attempts" >&2
+	exit 2
+fi
 for command_name in "$curl_cmd" "$sleep_cmd" jq; do
 	if ! command -v "$command_name" >/dev/null 2>&1; then
 		echo "gosx docs deploy: public convergence command is unavailable: ${command_name}" >&2
@@ -40,8 +55,14 @@ done
 
 attempt=1
 observed="unavailable"
+successes=0
 while [ "$attempt" -le "$attempts" ]; do
 	body=""
+	health_body=""
+	ready_body=""
+	identity_ok=0
+	health_ok=0
+	ready_ok=0
 	if body="$($curl_cmd \
 		--fail --silent --show-error --connect-timeout 5 --max-time 15 \
 		--header 'cache-control: no-cache' \
@@ -55,8 +76,34 @@ while [ "$attempt" -le "$attempts" ]; do
 			 .frameworkVersion == $frameworkVersion and
 			 .revision == $revision and .builtAt == $builtAt and
 			 (.publicURL | rtrimstr("/")) == $publicURL' >/dev/null 2>&1; then
-		echo "gosx docs deploy: public release converged after ${attempt}/${attempts} checks" >&2
-		exit 0
+		identity_ok=1
+	fi
+	if health_body="$($curl_cmd \
+			--fail --silent --show-error --connect-timeout 5 --max-time 15 \
+			--header 'cache-control: no-cache' \
+			"${base_url}/healthz" 2>/dev/null)" && \
+		printf '%s\n' "$health_body" | jq -e '.ok == true' >/dev/null 2>&1; then
+		health_ok=1
+	fi
+	if ready_body="$($curl_cmd \
+			--fail --silent --show-error --connect-timeout 5 --max-time 15 \
+			--header 'cache-control: no-cache' \
+			"${base_url}/readyz" 2>/dev/null)" && \
+		printf '%s\n' "$ready_body" | jq -e '.ok == true' >/dev/null 2>&1; then
+		ready_ok=1
+	fi
+	if [ "$identity_ok" -eq 1 ] && [ "$health_ok" -eq 1 ] && [ "$ready_ok" -eq 1 ]; then
+		successes=$((successes + 1))
+		echo "gosx docs deploy: public release stable (${successes}/${required_successes}) after check ${attempt}/${attempts}" >&2
+		if [ "$successes" -ge "$required_successes" ]; then
+			echo "gosx docs deploy: public release converged after ${attempt}/${attempts} checks" >&2
+			exit 0
+		fi
+	else
+		if [ "$successes" -gt 0 ]; then
+			echo "gosx docs deploy: public stability streak reset after ${successes}/${required_successes} successes" >&2
+		fi
+		successes=0
 	fi
 
 	if observed_value="$(printf '%s\n' "$body" | jq -er \
@@ -65,8 +112,10 @@ while [ "$attempt" -le "$attempts" ]; do
 	else
 		observed="unavailable"
 	fi
-	echo "gosx docs deploy: waiting for public release (${attempt}/${attempts}); observed ${observed}" >&2
-	if [ "$attempt" -lt "$attempts" ] && [ "$delay_seconds" -gt 0 ]; then
+	if [ "$successes" -eq 0 ]; then
+		echo "gosx docs deploy: waiting for public release (${attempt}/${attempts}); identity=${identity_ok} health=${health_ok} ready=${ready_ok}; observed ${observed}" >&2
+	fi
+	if [ "$attempt" -lt "$attempts" ]; then
 		"$sleep_cmd" "$delay_seconds"
 	fi
 	attempt=$((attempt + 1))


### PR DESCRIPTION
## Summary
- hold the prior pod ready for ten seconds before scale-down
- require three consecutive public cycles of exact release identity, health, and readiness before smoke
- reset the stability streak on any transport, proxy, identity, health, or readiness failure
- retry only safe GET smoke requests; state-changing POSTs are never replayed

## Incident evidence
The second exact-main rollout reached the candidate `/api/site`, then the immediately following `/healthz` received a transient Traefik 502 during the single-replica endpoint handoff. The guarded rollback restored v0.32 and its new retrying health verification passed.

## Verification
- `make release-gate`
- `make test-docs-deploy`
- `sh -n` and `dash -n` on changed scripts
- Kubernetes server-side dry-run of the rendered manifest
- independent edge-stability blocker review: clean
