### PR TITLE
Fix live docs demo interactions

### DIFF
--- a/e2e/e2e_shared_test.go
+++ b/e2e/e2e_shared_test.go
@@ -120,6 +120,37 @@ func startDocsApp(t *testing.T, baseURL string) *docsApp {
 	return app
 }
 
+// startProductionDocsApp builds the docs application with the same hashed
+// runtime contract used in production, then starts the generated server on a
+// free local port. Interactive island regressions must use this path: dev-mode
+// compatibility URLs intentionally do not prove immutable runtime metadata.
+func startProductionDocsApp(t *testing.T) *docsApp {
+	t.Helper()
+	root := e2eRepoRoot(t)
+	dist := os.Getenv("GOSX_E2E_DOCS_DIST")
+	if dist == "" {
+		build := exec.Command("go", "run", "./cmd/gosx", "build", "--prod", "./examples/gosx-docs")
+		build.Dir = root
+		build.Env = os.Environ()
+		if output, err := build.CombinedOutput(); err != nil {
+			t.Fatalf("build production docs: %v\n%s", err, output)
+		}
+		dist = filepath.Join(root, "examples", "gosx-docs", "dist")
+	}
+	if !filepath.IsAbs(dist) {
+		dist = filepath.Join(root, dist)
+	}
+
+	port := freeE2EPort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	logs := startBuiltFixture(t, dist, port)
+	app := &docsApp{baseURL: baseURL, logs: logs}
+	if err := waitForHealthy(baseURL+"/readyz", 45*time.Second); err != nil {
+		t.Fatalf("%v\n\nLogs:\n%s", err, logs.String())
+	}
+	return app
+}
+
 func waitForHealthy(url string, timeout time.Duration) error {
 	deadline := time.Now().Add(timeout)
 	lastError := ""

--- a/e2e/go_wasm_mixed_prod_e2e_test.go
+++ b/e2e/go_wasm_mixed_prod_e2e_test.go
@@ -301,7 +301,10 @@ func startBuiltFixture(t *testing.T, dist string, port int) *logBuffer {
 	logs := &logBuffer{}
 	cmd := exec.Command(filepath.Join(dist, "run.sh"))
 	cmd.Dir = dist
-	cmd.Env = append(os.Environ(), fmt.Sprintf("PORT=%d", port))
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("PORT=%d", port),
+		"SESSION_SECRET=gosx-e2e-session-secret",
+	)
 	cmd.Stdout = logs
 	cmd.Stderr = logs
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}

--- a/e2e/gosx_docs_e2e_test.go
+++ b/e2e/gosx_docs_e2e_test.go
@@ -113,6 +113,195 @@ func TestDocsMobileNavigationWorksWithoutDisclosureRuntime(t *testing.T) {
 	}
 }
 
+func TestPlaygroundCounterHydratesAndUpdates(t *testing.T) {
+	chrome := e2eChromePath(t)
+	var app *docsApp
+	if existing := strings.TrimRight(os.Getenv("GOSX_E2E_EXISTING_BASE_URL"), "/"); existing != "" {
+		app = &docsApp{baseURL: existing, logs: &logBuffer{}}
+	} else {
+		app = startProductionDocsApp(t)
+	}
+	page := newBrowserPage(t, chrome, nil, 1440, 960, "", 90*time.Second)
+
+	if status := page.navigate(t, app.baseURL+"/demos/playground"); status < 200 || status > 299 {
+		t.Fatalf("/demos/playground returned %d\n\nLogs:\n%s", status, app.logs.String())
+	}
+	page.waitFor(t,
+		`document.querySelector(".play")?.dataset.playgroundState === "hydrated"`,
+		20*time.Second,
+		"playground hydration",
+	)
+
+	if err := chromedp.Run(page.ctx,
+		chromedp.Click(`.play__preview-frame [data-gosx-island] button:last-child`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("click playground +1: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play__preview-frame [data-gosx-island] span")?.textContent.trim() === "1"`,
+		10*time.Second,
+		"counter increment",
+	)
+
+	// Recompile the same preset and exercise it again. This proves the editor
+	// disposed the old VM/listeners, restored the compiled initial DOM, and
+	// registered the replacement under the wrapper id.
+	page.eval(t, `document.querySelector(".play").dataset.playgroundState = "reset-requested"`, nil)
+	if err := chromedp.Run(page.ctx, chromedp.Click(`.play__reset-btn`, chromedp.ByQuery)); err != nil {
+		t.Fatalf("reset playground counter: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play")?.dataset.playgroundState === "hydrated" &&
+document.querySelector(".play__preview-frame [data-gosx-island] span")?.textContent.trim() === "0"`,
+		10*time.Second,
+		"counter recompilation",
+	)
+	if err := chromedp.Run(page.ctx,
+		chromedp.Click(`.play__preview-frame [data-gosx-island] button:last-child`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("click recompiled playground +1: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play__preview-frame [data-gosx-island] span")?.textContent.trim() === "1"`,
+		10*time.Second,
+		"recompiled counter increment",
+	)
+	var registeredByDOMID bool
+	page.eval(t, `(() => {
+const root = document.querySelector(".play__preview-frame [data-gosx-island]");
+return !!root?.id && window.__gosx?.islands?.has(root.id) && !window.__gosx.islands.has(root.dataset.gosxIsland);
+})()`, &registeredByDOMID)
+	if !registeredByDOMID {
+		t.Fatal("playground replacement island was not registered by its DOM id")
+	}
+	var counterListenersSelective bool
+	page.eval(t, `(() => {
+const root = document.querySelector(".play__preview-frame [data-gosx-island]");
+const record = window.__gosx.islands.get(root.id);
+if (!record || record.listeners.length !== 1 || record.listeners[0].type !== "click") return false;
+const oldListeners = record.listeners.slice();
+const originalRemove = root.removeEventListener.bind(root);
+window.__playgroundListenerAudit = { oldListeners, removed: 0, originalRemove };
+root.removeEventListener = function(type, listener, capture) {
+  if (oldListeners.some((entry) => entry.type === type && entry.listener === listener && entry.capture === capture)) {
+    window.__playgroundListenerAudit.removed++;
+  }
+  return originalRemove(type, listener, capture);
+};
+return true;
+})()`, &counterListenersSelective)
+	if !counterListenersSelective {
+		t.Fatal("compiled Counter did not register only its declared click listener")
+	}
+
+	// Change component shape and event family. Counter only needs click;
+	// Greeter needs input. A real browser input after the switch proves the
+	// replacement listener set is attached to the stable wrapper rather than
+	// inherited accidentally from the original manifest entry.
+	page.eval(t, `(() => {
+const picker = document.querySelector(".play__preset-select");
+picker.value = "greeter";
+picker.dispatchEvent(new Event("change", { bubbles: true }));
+})()`, nil)
+	page.waitFor(t,
+		`document.querySelector(".play")?.dataset.playgroundState === "hydrated" &&
+document.querySelector('.play__preview-frame [data-gosx-island="Greeter"]')?.dataset.component === "Greeter" &&
+document.querySelector(".play__preview-frame h1")?.textContent.trim() === "Hello, world" &&
+(() => {
+  const root = document.querySelector('.play__preview-frame [data-gosx-island="Greeter"]');
+  const record = window.__gosx.islands.get(root.id);
+  const audit = window.__playgroundListenerAudit;
+  return audit?.removed === audit?.oldListeners?.length &&
+    record?.listeners?.length === 1 && record.listeners[0].type === "input" &&
+    !audit.oldListeners.some((old) => old.listener === record.listeners[0].listener);
+})()`,
+		10*time.Second,
+		"greeter preset hydration",
+	)
+	page.eval(t, `(() => {
+const root = document.querySelector('.play__preview-frame [data-gosx-island="Greeter"]');
+if (root && window.__playgroundListenerAudit?.originalRemove) {
+  root.removeEventListener = window.__playgroundListenerAudit.originalRemove;
+}
+})()`, nil)
+	if err := chromedp.Run(page.ctx,
+		chromedp.Click(`.play__preview-frame input`, chromedp.ByQuery),
+		chromedp.SendKeys(`.play__preview-frame input`, "Ada", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("type in playground greeter: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play__preview-frame h1")?.textContent.trim() === "Hello, Ada"`,
+		10*time.Second,
+		"greeter input update",
+	)
+
+	// Reset recompiles the selected Greeter preset. Exercise input once more so
+	// the regression also covers disposal and rebinding within the new family.
+	if err := chromedp.Run(page.ctx, chromedp.Click(`.play__reset-btn`, chromedp.ByQuery)); err != nil {
+		t.Fatalf("reset playground greeter: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play")?.dataset.playgroundState === "hydrated" &&
+document.querySelector('.play__preview-frame [data-gosx-island="Greeter"]')?.dataset.component === "Greeter" &&
+document.querySelector(".play__preview-frame h1")?.textContent.trim() === "Hello, world"`,
+		10*time.Second,
+		"greeter recompilation",
+	)
+	if err := chromedp.Run(page.ctx,
+		chromedp.Click(`.play__preview-frame input`, chromedp.ByQuery),
+		chromedp.SendKeys(`.play__preview-frame input`, "Grace", chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("type in recompiled playground greeter: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector(".play__preview-frame h1")?.textContent.trim() === "Hello, Grace"`,
+		10*time.Second,
+		"recompiled greeter input update",
+	)
+
+	// Active markup must be rejected before program encoding. Keep the live
+	// Greeter DOM and global scope as sentinels: each probe must produce a
+	// diagnostic without replacing the last good preview or executing content.
+	page.eval(t, `window.__gosxPlaygroundPwned = 0`, nil)
+	attackBodies := []string{
+		`<img src="/definitely-missing.png" onerror="window.__gosxPlaygroundPwned++" />`,
+		`<script>window.__gosxPlaygroundPwned++</script>`,
+		`<svg onload="window.__gosxPlaygroundPwned++"></svg>`,
+	}
+	for index, body := range attackBodies {
+		source := `package playground
+
+//gosx:island
+func Attack() Node {
+	return ` + body + `
+}
+`
+		sourceJSON, err := json.Marshal(source)
+		if err != nil {
+			t.Fatalf("encode unsafe playground source: %v", err)
+		}
+		page.eval(t, `(() => {
+const editor = document.querySelector(".play__source");
+editor.value = `+string(sourceJSON)+`;
+editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", ctrlKey: true, bubbles: true }));
+})()`, nil)
+		page.waitFor(t,
+			`document.querySelector(".play")?.dataset.playgroundState === "diagnostic" &&
+document.querySelector(".play__errors")?.textContent.includes("not allowed") &&
+document.querySelector('.play__preview-frame [data-gosx-island="Greeter"]')?.dataset.component === "Greeter" &&
+document.querySelector(".play__preview-frame h1")?.textContent.trim() === "Hello, Grace" &&
+window.__gosxPlaygroundPwned === 0`,
+			10*time.Second,
+			"unsafe playground source rejection "+string(rune('1'+index)),
+		)
+	}
+
+	if len(page.PageErrors()) > 0 {
+		t.Fatalf("playground raised page errors: %v\nconsole:\n%s", page.PageErrors(), page.Console())
+	}
+}
+
 type accessibilityReport struct {
 	HasMain            bool     `json:"hasMain"`
 	HasContentInfo     bool     `json:"hasContentInfo"`

--- a/examples/gosx-docs/app/demos/catalog_test.go
+++ b/examples/gosx-docs/app/demos/catalog_test.go
@@ -1,11 +1,17 @@
 package docs
 
 import (
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"golang.org/x/net/html"
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
 )
 
 func TestDemoCatalogContracts(t *testing.T) {
@@ -123,6 +129,80 @@ func TestDemoShellUsesGoSXManagedInteractions(t *testing.T) {
 	if strings.Contains(source, `<script`) {
 		t.Error("demo layout must not ship bespoke script elements")
 	}
+}
+
+func TestDemoLayoutRendersMobileDockWithCompleteCatalog(t *testing.T) {
+	layoutPath := repoPath(t, "examples/gosx-docs/app/demos/layout.gsx")
+	layout, err := route.FileLayout(layoutPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := &route.RouteContext{Request: httptest.NewRequest(http.MethodGet, "/demos/playground", nil)}
+	rendered := gosx.RenderHTML(layout(ctx, gosx.El("main", gosx.Attrs(gosx.Attr("data-test-slot", "playground")))))
+	if status := ctx.StatusCode(); status != 0 && status != http.StatusOK {
+		t.Fatalf("layout render status = %d; body=%s", status, rendered)
+	}
+
+	doc, err := html.Parse(strings.NewReader(rendered))
+	if err != nil {
+		t.Fatalf("parse rendered layout: %v", err)
+	}
+
+	links := make(map[string]map[string]string, len(Demos()))
+	var hasDock, hasMobileMenu, hasSlot bool
+	var visit func(*html.Node)
+	visit = func(node *html.Node) {
+		if node.Type == html.ElementNode {
+			attrs := htmlAttributes(node)
+			classes := strings.Fields(attrs["class"])
+			switch {
+			case node.Data == "nav" && attrs["id"] == "demo-dock":
+				hasDock = attrs["aria-label"] == "Demos"
+			case node.Data == "button" && contains(classes, "demos-topbar__menu"):
+				hasMobileMenu = attrs["aria-controls"] == "demo-dock" &&
+					attrs["data-gosx-toggle-target"] == ".demos-body" &&
+					attrs["data-gosx-toggle-attribute"] == "data-dock-open"
+			case node.Data == "a" && contains(classes, "demo-dock__link"):
+				links[attrs["href"]] = attrs
+			case node.Data == "main" && attrs["data-test-slot"] == "playground":
+				hasSlot = true
+			}
+		}
+		for child := node.FirstChild; child != nil; child = child.NextSibling {
+			visit(child)
+		}
+	}
+	visit(doc)
+
+	if !hasDock || !hasMobileMenu {
+		t.Fatalf("rendered demo shell is missing its accessible mobile dock controls: %s", rendered)
+	}
+	if !hasSlot {
+		t.Fatalf("rendered demo layout dropped its page slot: %s", rendered)
+	}
+	if len(links) != len(Demos()) {
+		t.Fatalf("rendered dock links = %d, want %d; body=%s", len(links), len(Demos()), rendered)
+	}
+	for _, demo := range Demos() {
+		href := "/demos/" + demo.Slug
+		attrs, ok := links[href]
+		if !ok {
+			t.Errorf("rendered dock missing %s", href)
+			continue
+		}
+		if attrs["data-demo"] != demo.Slug || attrs["data-demo-title"] != demo.Title || attrs["data-demo-source-path"] != demo.SourcePath {
+			t.Errorf("rendered dock metadata for %s = %#v", href, attrs)
+		}
+	}
+}
+
+func htmlAttributes(node *html.Node) map[string]string {
+	attrs := make(map[string]string, len(node.Attr))
+	for _, attr := range node.Attr {
+		attrs[attr.Key] = attr.Val
+	}
+	return attrs
 }
 
 func TestBespokeDemoScriptDebtDoesNotGrow(t *testing.T) {

--- a/examples/gosx-docs/app/demos/layout.server.go
+++ b/examples/gosx-docs/app/demos/layout.server.go
@@ -1,0 +1,23 @@
+package docs
+
+import (
+	"log"
+
+	"m31labs.dev/gosx/route"
+)
+
+func init() {
+	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
+		Bindings: demoLayoutBindings,
+	}); err != nil {
+		log.Fatal(err)
+	}
+}
+
+func demoLayoutBindings(*route.RouteContext, route.FilePage, any) route.FileTemplateBindings {
+	return route.FileTemplateBindings{Funcs: map[string]any{
+		"Demos":         Demos,
+		"demoValues":    demoValues,
+		"demoSourceURL": demoSourceURL,
+	}}
+}

--- a/examples/gosx-docs/app/demos/playground/compile_handler.go
+++ b/examples/gosx-docs/app/demos/playground/compile_handler.go
@@ -11,6 +11,7 @@ import (
 
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/action"
+	clientvm "m31labs.dev/gosx/client/vm"
 	"m31labs.dev/gosx/examples/gosx-docs/app/demos/democtl"
 	"m31labs.dev/gosx/ir"
 	"m31labs.dev/gosx/island/program"
@@ -50,9 +51,14 @@ type CompileResult struct {
 	// "Page".
 	Component string `json:"component"`
 
-	// HTML is the SSR placeholder the client runtime hydrates. In this task
-	// it is a static hydration target; future tasks may enrich it.
+	// HTML is a static hydration target kept for API compatibility. Authored
+	// markup never enters this string; Preview carries the initial DOM as data.
 	HTML string `json:"html"`
+
+	// Preview is the program's resolved initial tree. The browser materializes
+	// it with createElement/createTextNode after enforcing the same constrained
+	// tag and attribute policy used before program encoding.
+	Preview PlaygroundPreviewTree `json:"preview"`
 
 	// Program is the binary-encoded island VM program. Callers are expected
 	// to base64 the bytes when they travel over JSON.
@@ -148,15 +154,24 @@ func compileSourceWithCountsImpl(source []byte) (CompileResult, int, int, error)
 
 	nNodes := len(island.Nodes)
 	nExprs := len(island.Exprs)
+	if err := validatePlaygroundProgram(island); err != nil {
+		return CompileResult{
+			Diagnostics: []Diagnostic{{Message: err.Error()}},
+			NodeCount:   nNodes,
+			ExprCount:   nExprs,
+		}, nNodes, nExprs, nil
+	}
 
 	bin, err := program.EncodeBinary(island)
 	if err != nil {
 		return CompileResult{}, nNodes, nExprs, fmt.Errorf("encode island program: %w", err)
 	}
 
+	preview := makePlaygroundPreview(clientvm.ResolveInitialTree(island, `{}`))
 	return CompileResult{
 		Component: prog.Components[0].Name,
 		HTML:      renderPlaygroundSSR(prog.Components[0].Name),
+		Preview:   preview,
 		Program:   bin,
 		NodeCount: nNodes,
 		ExprCount: nExprs,
@@ -172,9 +187,8 @@ func CompileSource(source []byte) (CompileResult, error) {
 	return result, err
 }
 
-// renderPlaygroundSSR emits the minimal hydration target element. The client
-// replaces its children when the new program is hydrated. We keep the element
-// slot stable across recompiles so the hydrator can find it.
+// renderPlaygroundSSR emits only a static hydration target. Authored markup is
+// transported in Preview as structured data and never parsed as HTML.
 func renderPlaygroundSSR(componentName string) string {
 	return `<div data-gosx-island="playground-preview" data-component="` + componentName + `"></div>`
 }
@@ -377,6 +391,7 @@ func NewCompileAction(compiler *Compiler) func(*action.Context) error {
 		return ctx.Success("", map[string]any{
 			"component":   result.Component,
 			"html":        result.HTML,
+			"preview":     result.Preview,
 			"program":     base64.StdEncoding.EncodeToString(result.Program),
 			"diagnostics": result.Diagnostics,
 			"nodeCount":   result.NodeCount,
@@ -417,6 +432,7 @@ func CompileAction(ctx *action.Context) error {
 	return ctx.Success("", map[string]any{
 		"component":   result.Component,
 		"html":        result.HTML,
+		"preview":     result.Preview,
 		"program":     base64.StdEncoding.EncodeToString(result.Program),
 		"diagnostics": result.Diagnostics,
 		"nodeCount":   result.NodeCount,

--- a/examples/gosx-docs/app/demos/playground/compile_handler_test.go
+++ b/examples/gosx-docs/app/demos/playground/compile_handler_test.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"errors"
 	"net/http"
+	"os"
+	"path/filepath"
+	"regexp"
+	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"time"
 
 	"m31labs.dev/gosx/examples/gosx-docs/app/demos/democtl"
+	"m31labs.dev/gosx/island/program"
 )
 
 // ---------------------------------------------------------------------------
@@ -31,6 +37,12 @@ func TestCompileSourceDefaultPresetRoundTrip(t *testing.T) {
 	}
 	if result.Component != "Counter" {
 		t.Fatalf("Component = %q; want Counter", result.Component)
+	}
+	if strings.Contains(result.HTML, "<button") {
+		t.Fatalf("HTML must not contain authored preview markup: %s", result.HTML)
+	}
+	if !previewHasAttr(result.Preview, "data-gosx-on-click") || !previewHasAttr(result.Preview, "data-gosx-handler") || !previewHasText(result.Preview, "0") {
+		t.Fatalf("structured preview does not contain an interactive counter baseline: %#v", result.Preview)
 	}
 	if len(result.Diagnostics) != 0 {
 		t.Fatalf("expected zero diagnostics, got: %v", result.Diagnostics)
@@ -63,7 +75,152 @@ func TestCompileSourceAllPresets(t *testing.T) {
 			if result.NodeCount <= 0 {
 				t.Fatalf("preset %q: expected NodeCount > 0, got %d", p.Slug, result.NodeCount)
 			}
+			decoded, err := program.DecodeBinary(result.Program)
+			if err != nil {
+				t.Fatalf("preset %q: decode program: %v", p.Slug, err)
+			}
+			if len(decoded.Handlers) == 0 {
+				t.Fatalf("preset %q: compiled without event handlers", p.Slug)
+			}
+			if p.Slug == "greeter" && !previewHasAttr(result.Preview, "data-gosx-on-input") {
+				t.Fatalf("preset %q: structured preview is missing its input marker", p.Slug)
+			}
 		})
+	}
+}
+
+func TestCompileSourceRejectsActivePlaygroundMarkup(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{"static img onerror", `<img src="/missing.png" onerror="alert(1)" />`},
+		{"dynamic img onerror", `<img src="/missing.png" onerror={payload.Get()} />`},
+		{"dynamic onerror", `<div onerror={payload.Get()}>unsafe</div>`},
+		{"mixed case onerror", `<div OnErRoR="alert(1)">unsafe</div>`},
+		{"javascript href", `<a href="javascript:alert(1)">unsafe</a>`},
+		{"mixed case javascript href", `<a HREF="JaVaScRiPt:alert(1)">unsafe</a>`},
+		{"iframe srcdoc", `<iframe srcdoc="unsafe"></iframe>`},
+		{"srcdoc attribute", `<div srcdoc="unsafe">unsafe</div>`},
+		{"svg onload", `<svg onload="alert(1)"></svg>`},
+		{"dynamic href", `<a href={payload.Get()}>unsafe</a>`},
+		{"srcset", `<div srcset="/safe.png 1x">unsafe</div>`},
+		{"custom element is", `<div is="script-widget">unsafe</div>`},
+		{"reserved runtime attribute", `<div data-gosx-path="0">unsafe</div>`},
+		{"unsupported mouseover", `<button data-on-mouseover="payload.Set(value)">unsafe</button>`},
+		{"script element", `<script>window.__gosxPlaygroundPwned = true</script>`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			source := `package playground
+
+//gosx:island
+func Attack() Node {
+	payload := signal.New("safe")
+	return ` + tt.body + `
+}
+`
+			result, err := CompileSource([]byte(source))
+			if err != nil {
+				t.Fatalf("CompileSource: %v", err)
+			}
+			if len(result.Diagnostics) == 0 {
+				t.Fatalf("unsafe source compiled without a diagnostic: %s", tt.body)
+			}
+			if len(result.Program) != 0 || result.HTML != "" || len(result.Preview.Nodes) != 0 {
+				t.Fatalf("unsafe source returned runnable output: %#v", result)
+			}
+		})
+	}
+}
+
+func TestCompileSourceRejectsFragmentRoot(t *testing.T) {
+	source := `package playground
+
+//gosx:island
+func FragmentRoot() Node {
+	return <><span>one</span><span>two</span></>
+}
+`
+	result, err := CompileSource([]byte(source))
+	if err != nil {
+		t.Fatalf("CompileSource: %v", err)
+	}
+	if len(result.Diagnostics) == 0 || !strings.Contains(result.Diagnostics[0].Message, "root must be one HTML element") {
+		t.Fatalf("fragment root diagnostic = %#v", result.Diagnostics)
+	}
+	if len(result.Program) != 0 || result.HTML != "" || len(result.Preview.Nodes) != 0 {
+		t.Fatalf("fragment root returned runnable output: %#v", result)
+	}
+}
+
+func previewHasAttr(tree PlaygroundPreviewTree, name string) bool {
+	for _, node := range tree.Nodes {
+		for _, attr := range node.Attrs {
+			if attr.Name == name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func previewHasText(tree PlaygroundPreviewTree, text string) bool {
+	for _, node := range tree.Nodes {
+		if node.Text == text {
+			return true
+		}
+	}
+	return false
+}
+
+func TestPlaygroundEditorSafeDOMPolicyMatchesServer(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve test source path")
+	}
+	editorPath := filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "public", "playground-editor.js")
+	source, err := os.ReadFile(editorPath)
+	if err != nil {
+		t.Fatalf("read playground editor: %v", err)
+	}
+	if bytes.Contains(source, []byte("innerHTML")) || bytes.Contains(source, []byte("outerHTML")) || bytes.Contains(source, []byte("insertAdjacentHTML")) {
+		t.Fatal("playground editor must not parse compiled source as HTML")
+	}
+
+	assertClientSetMatches(t, source, "allowedTags", playgroundAllowedTags)
+	assertClientSetMatches(t, source, "allowedAttrs", playgroundAllowedAttrs)
+	assertClientSetMatches(t, source, "urlAttrs", playgroundURLAttrs)
+	assertClientSetMatches(t, source, "eventMarkers", playgroundAllowedEvents)
+}
+
+func assertClientSetMatches(t *testing.T, source []byte, name string, server map[string]struct{}) {
+	t.Helper()
+	pattern := `(?s)var ` + regexp.QuoteMeta(name) + ` = new Set\(\[(.*?)\]\);`
+	block := regexp.MustCompile(pattern).FindSubmatch(source)
+	if len(block) != 2 {
+		t.Fatalf("playground editor %s set was not found", name)
+	}
+	client := make(map[string]struct{})
+	for _, match := range regexp.MustCompile(`"([a-z0-9:_-]+)"`).FindAllSubmatch(block[1], -1) {
+		client[string(match[1])] = struct{}{}
+	}
+
+	var missing, extra []string
+	for value := range server {
+		if _, ok := client[value]; !ok {
+			missing = append(missing, value)
+		}
+	}
+	for value := range client {
+		if _, ok := server[value]; !ok {
+			extra = append(extra, value)
+		}
+	}
+	sort.Strings(missing)
+	sort.Strings(extra)
+	if len(missing) != 0 || len(extra) != 0 {
+		t.Fatalf("client/server %s policy differs; missing=%v extra=%v", name, missing, extra)
 	}
 }
 

--- a/examples/gosx-docs/app/demos/playground/preview_policy.go
+++ b/examples/gosx-docs/app/demos/playground/preview_policy.go
@@ -1,0 +1,243 @@
+package playground
+
+import (
+	"fmt"
+	"strings"
+
+	clientvm "m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/island/program"
+)
+
+// PlaygroundPreviewTree is an inert, structured initial DOM snapshot. The
+// editor builds it with DOM construction APIs; it is never parsed as HTML.
+type PlaygroundPreviewTree struct {
+	Nodes []PlaygroundPreviewNode `json:"nodes"`
+}
+
+type PlaygroundPreviewNode struct {
+	Tag      string                  `json:"tag,omitempty"`
+	Text     string                  `json:"text,omitempty"`
+	Attrs    []PlaygroundPreviewAttr `json:"attrs,omitempty"`
+	Children []int                   `json:"children,omitempty"`
+}
+
+type PlaygroundPreviewAttr struct {
+	Name  string `json:"name"`
+	Value string `json:"value,omitempty"`
+	Bool  bool   `json:"bool,omitempty"`
+}
+
+// The public playground intentionally supports a conservative HTML subset.
+// Excluding active/resource-bearing elements means both the initial snapshot
+// and later VM create/replace operations remain inert even without a page CSP.
+var playgroundAllowedTags = map[string]struct{}{
+	"a": {}, "article": {}, "aside": {}, "b": {}, "blockquote": {}, "br": {},
+	"button": {}, "caption": {}, "code": {}, "dd": {}, "details": {},
+	"div": {}, "dl": {}, "dt": {}, "em": {}, "fieldset": {},
+	"figcaption": {}, "figure": {}, "footer": {}, "form": {},
+	"h1": {}, "h2": {}, "h3": {}, "h4": {}, "h5": {}, "h6": {},
+	"header": {}, "hr": {}, "i": {}, "input": {}, "label": {},
+	"legend": {}, "li": {}, "main": {}, "mark": {}, "meter": {},
+	"nav": {}, "ol": {}, "option": {}, "output": {}, "p": {},
+	"pre": {}, "progress": {}, "s": {}, "section": {}, "select": {},
+	"small": {}, "span": {}, "strong": {}, "sub": {}, "summary": {},
+	"sup": {}, "table": {}, "tbody": {}, "td": {}, "textarea": {},
+	"tfoot": {}, "th": {}, "thead": {}, "tr": {}, "u": {}, "ul": {},
+}
+
+var playgroundAllowedAttrs = map[string]struct{}{
+	"aria-atomic": {}, "aria-busy": {}, "aria-controls": {},
+	"aria-current": {}, "aria-describedby": {}, "aria-details": {},
+	"aria-disabled": {}, "aria-expanded": {}, "aria-haspopup": {},
+	"aria-hidden": {}, "aria-label": {}, "aria-labelledby": {},
+	"aria-live": {}, "aria-pressed": {}, "aria-selected": {},
+	"aria-valuemax": {}, "aria-valuemin": {}, "aria-valuenow": {},
+	"aria-valuetext": {}, "autocomplete": {}, "checked": {},
+	"class": {}, "cols": {}, "colspan": {}, "dir": {}, "disabled": {},
+	"for": {}, "hidden": {}, "inputmode": {}, "lang": {}, "max": {},
+	"maxlength": {}, "min": {}, "minlength": {}, "multiple": {},
+	"name": {}, "open": {}, "pattern": {}, "placeholder": {},
+	"readonly": {}, "required": {}, "role": {}, "rows": {},
+	"rowspan": {}, "selected": {}, "size": {}, "step": {}, "style": {},
+	"tabindex": {}, "title": {}, "type": {}, "value": {}, "wrap": {},
+}
+
+var playgroundURLAttrs = map[string]struct{}{
+	"action": {}, "cite": {}, "formaction": {}, "href": {}, "poster": {},
+	"src": {}, "xlink:href": {},
+}
+
+var playgroundAllowedEvents = map[string]struct{}{
+	"blur": {}, "change": {}, "click": {}, "dragend": {},
+	"dragleave": {}, "dragover": {}, "dragstart": {}, "drop": {},
+	"document-keydown": {}, "document-keyup": {}, "focus": {},
+	"input": {}, "keydown": {}, "keyup": {},
+	"pointercancel": {}, "pointerdown": {}, "pointermove": {},
+	"pointerup": {}, "submit": {}, "window-resize": {},
+}
+
+// validatePlaygroundProgram is the authority for every DOM mutation the VM can
+// later request. Tags and attribute names are static program metadata even
+// when their values are reactive, so checking the encoded program once covers
+// initial construction plus create/replace/set-attribute patches.
+func validatePlaygroundProgram(prog *program.Program) error {
+	if prog == nil {
+		return fmt.Errorf("playground: missing island program")
+	}
+	if int(prog.Root) >= len(prog.Nodes) || prog.Nodes[prog.Root].Kind != program.NodeElement {
+		return fmt.Errorf("playground: island root must be one HTML element")
+	}
+	for _, node := range prog.Nodes {
+		if node.Kind != program.NodeElement {
+			continue
+		}
+		tag := strings.ToLower(strings.TrimSpace(node.Tag))
+		if _, ok := playgroundAllowedTags[tag]; !ok {
+			return fmt.Errorf("playground: element <%s> is not allowed", node.Tag)
+		}
+		for _, attr := range node.Attrs {
+			if attr.Kind == program.AttrEvent {
+				eventType := playgroundEventType(attr.Name)
+				if _, ok := playgroundAllowedEvents[eventType]; !ok {
+					return fmt.Errorf("playground: event %q is not allowed on <%s>", attr.Name, node.Tag)
+				}
+				continue
+			}
+			name := strings.ToLower(strings.TrimSpace(attr.Name))
+			if strings.HasPrefix(name, "on") || name == "srcdoc" || name == "is" {
+				return fmt.Errorf("playground: attribute %q is not allowed on <%s>", attr.Name, node.Tag)
+			}
+			if _, isURL := playgroundURLAttrs[name]; isURL {
+				if attr.Kind != program.AttrStatic || !playgroundStaticURLAllowed(attr.Value) {
+					return fmt.Errorf("playground: attribute %q requires a safe static URL", attr.Name)
+				}
+				continue
+			}
+			if !playgroundAttributeAllowed(name) {
+				return fmt.Errorf("playground: attribute %q is not allowed on <%s>", attr.Name, node.Tag)
+			}
+		}
+	}
+	return nil
+}
+
+func playgroundStaticURLAllowed(value string) bool {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || strings.HasPrefix(trimmed, "#") || strings.HasPrefix(trimmed, "/") || strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") || strings.HasPrefix(trimmed, "?") {
+		return true
+	}
+	lower := strings.ToLower(trimmed)
+	return strings.HasPrefix(lower, "https://") || strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "mailto:") || strings.HasPrefix(lower, "tel:")
+}
+
+func playgroundAttributeAllowed(name string) bool {
+	if _, ok := playgroundAllowedAttrs[name]; ok {
+		return true
+	}
+	// Application data is inert and is forwarded in event payloads. Framework
+	// data-gosx-* metadata is reserved so authored nodes cannot create nested
+	// island boundaries or forge handler/path markers.
+	return strings.HasPrefix(name, "data-") && !strings.HasPrefix(name, "data-gosx-")
+}
+
+func playgroundEventType(name string) string {
+	switch name {
+	case "onClick":
+		return "click"
+	case "onInput":
+		return "input"
+	case "onChange":
+		return "change"
+	case "onSubmit":
+		return "submit"
+	case "onKeyDown":
+		return "keydown"
+	case "onKeyUp":
+		return "keyup"
+	case "onFocus":
+		return "focus"
+	case "onBlur":
+		return "blur"
+	case "onDragStart":
+		return "dragstart"
+	case "onDragEnd":
+		return "dragend"
+	case "onDragOver":
+		return "dragover"
+	case "onDragLeave":
+		return "dragleave"
+	case "onDrop":
+		return "drop"
+	case "onPointerDown":
+		return "pointerdown"
+	case "onPointerMove":
+		return "pointermove"
+	case "onPointerUp":
+		return "pointerup"
+	case "onPointerCancel":
+		return "pointercancel"
+	case "onDocumentKeyDown":
+		return "document-keydown"
+	case "onDocumentKeyUp":
+		return "document-keyup"
+	case "onWindowResize":
+		return "window-resize"
+	default:
+		return strings.ToLower(strings.TrimSpace(name))
+	}
+}
+
+func makePlaygroundPreview(resolved *clientvm.ResolvedTree) PlaygroundPreviewTree {
+	if resolved == nil || len(resolved.Nodes) == 0 {
+		return PlaygroundPreviewTree{}
+	}
+	preview := PlaygroundPreviewTree{Nodes: make([]PlaygroundPreviewNode, len(resolved.Nodes))}
+	visited := make(map[int]struct{}, len(resolved.Nodes))
+	var copyNode func(int, string)
+	copyNode = func(index int, path string) {
+		if index < 0 || index >= len(resolved.Nodes) {
+			return
+		}
+		if _, ok := visited[index]; ok {
+			return
+		}
+		visited[index] = struct{}{}
+		source := &resolved.Nodes[index]
+		target := &preview.Nodes[index]
+		target.Tag = source.Tag
+		target.Text = source.Text
+		target.Children = append(target.Children, source.Children...)
+
+		for _, attr := range source.Attrs {
+			target.Attrs = append(target.Attrs, PlaygroundPreviewAttr{
+				Name:  attr.Name,
+				Value: attr.Value,
+				Bool:  attr.Bool,
+			})
+		}
+		if len(source.Events) > 0 {
+			for _, event := range source.Events {
+				eventType := playgroundEventType(event.Name)
+				target.Attrs = append(target.Attrs, PlaygroundPreviewAttr{
+					Name:  "data-gosx-on-" + eventType,
+					Value: event.Handler,
+				})
+				if eventType == "click" {
+					target.Attrs = append(target.Attrs, PlaygroundPreviewAttr{
+						Name:  "data-gosx-handler",
+						Value: event.Handler,
+					})
+				}
+			}
+			target.Attrs = append(target.Attrs, PlaygroundPreviewAttr{
+				Name:  "data-gosx-path",
+				Value: path,
+			})
+		}
+		for childIndex, child := range source.Children {
+			copyNode(child, path+"/"+fmt.Sprint(childIndex))
+		}
+	}
+	copyNode(0, "0")
+	return preview
+}

--- a/examples/gosx-docs/public/playground-editor.js
+++ b/examples/gosx-docs/public/playground-editor.js
@@ -15,11 +15,15 @@
 
   function waitForRuntime() {
     return new Promise(function (resolve, reject) {
-      if (typeof window.__gosx_hydrate === "function") {
+      function isReady() {
+        return typeof window.__gosx_hydrate === "function" &&
+          window.__gosx && window.__gosx.ready === true;
+      }
+      if (isReady()) {
         return resolve();
       }
       var interval = setInterval(function () {
-        if (typeof window.__gosx_hydrate === "function") {
+        if (isReady()) {
           clearInterval(interval);
           resolve();
         }
@@ -72,7 +76,13 @@
     if (!compileURL || !textarea || !preview) {
       return;
     }
-    var islandID = preview.getAttribute("data-gosx-island");
+    // __gosx_hydrate and the patch runtime key islands by the wrapper's DOM
+    // id. data-gosx-island is the component name (for example "Counter"),
+    // not the runtime identity.
+    var islandID = preview.id;
+    if (!islandID) {
+      return;
+    }
 
     var timer = null;
     var requestGeneration = 0;
@@ -147,6 +157,155 @@
       }
     }
 
+    function runtimeHost() {
+      return window.__gosx && window.__gosx.host;
+    }
+
+    function disposePreviewIsland() {
+      var host = runtimeHost();
+      var registry = window.__gosx && window.__gosx.islands;
+      if (host && host.islands && typeof host.islands.dispose === "function" &&
+          registry && typeof registry.has === "function" && registry.has(islandID)) {
+        host.islands.dispose(islandID);
+        return;
+      }
+      if (typeof window.__gosx_dispose === "function") {
+        window.__gosx_dispose(islandID);
+      }
+    }
+
+    function safePreviewURL(value) {
+      var trimmed = String(value || "").trim();
+      if (trimmed === "" || trimmed.charAt(0) === "#" ||
+          trimmed.charAt(0) === "?" ||
+          trimmed.indexOf("/") === 0 || trimmed.indexOf("./") === 0 ||
+          trimmed.indexOf("../") === 0) {
+        return true;
+      }
+      return /^(https?:|mailto:|tel:)/i.test(trimmed);
+    }
+
+    function buildPreviewContent(tree) {
+      if (!tree || !Array.isArray(tree.nodes) || tree.nodes.length === 0) {
+        throw new Error("compiler did not return a structured island preview");
+      }
+      var allowedTags = new Set([
+        "a", "article", "aside", "b", "blockquote", "br", "button",
+        "caption", "code", "dd", "details", "div", "dl", "dt", "em",
+        "fieldset", "figcaption", "figure", "footer", "form", "h1", "h2",
+        "h3", "h4", "h5", "h6", "header", "hr", "i", "input", "label",
+        "legend", "li", "main", "mark", "meter", "nav", "ol", "option",
+        "output", "p", "pre", "progress", "s", "section", "select", "small",
+        "span", "strong", "sub", "summary", "sup", "table", "tbody", "td",
+        "textarea", "tfoot", "th", "thead", "tr", "u", "ul"
+      ]);
+      var allowedAttrs = new Set([
+        "aria-atomic", "aria-busy", "aria-controls", "aria-current",
+        "aria-describedby", "aria-details", "aria-disabled", "aria-expanded",
+        "aria-haspopup", "aria-hidden", "aria-label", "aria-labelledby",
+        "aria-live", "aria-pressed", "aria-selected", "aria-valuemax",
+        "aria-valuemin", "aria-valuenow", "aria-valuetext", "autocomplete",
+        "checked", "class", "cols", "colspan", "dir", "disabled", "for",
+        "hidden", "inputmode", "lang", "max", "maxlength", "min", "minlength",
+        "multiple", "name", "open", "pattern", "placeholder", "readonly",
+        "required", "role", "rows", "rowspan", "selected", "size", "step",
+        "style", "tabindex", "title", "type", "value", "wrap"
+      ]);
+      var urlAttrs = new Set([
+        "action", "cite", "formaction", "href", "poster", "src", "xlink:href"
+      ]);
+      var eventMarkers = new Set([
+        "blur", "change", "click", "document-keydown", "document-keyup",
+        "dragend", "dragleave", "dragover", "dragstart", "drop", "focus",
+        "input", "keydown", "keyup", "pointercancel", "pointerdown",
+        "pointermove", "pointerup", "submit", "window-resize"
+      ]);
+      var active = new Set();
+
+      function materialize(index) {
+        if (!Number.isInteger(index) || index < 0 || index >= tree.nodes.length) {
+          throw new Error("compiler returned an invalid preview node reference");
+        }
+        if (active.has(index)) {
+          throw new Error("compiler returned a cyclic preview tree");
+        }
+        active.add(index);
+        var spec = tree.nodes[index] || {};
+        var tag = String(spec.tag || "").toLowerCase();
+        var node;
+        if (tag === "") {
+          node = document.createTextNode(String(spec.text || ""));
+        } else {
+          if (!allowedTags.has(tag)) {
+            throw new Error("compiler returned a disallowed preview element");
+          }
+          node = document.createElement(tag);
+          var attrs = Array.isArray(spec.attrs) ? spec.attrs : [];
+          attrs.forEach(function (attr) {
+            var name = String((attr && attr.name) || "").toLowerCase();
+            var eventMarkerPrefix = "data-gosx-on-";
+            var generatedMarker = name === "data-gosx-handler" || name === "data-gosx-path" ||
+              (name.indexOf(eventMarkerPrefix) === 0 && eventMarkers.has(name.slice(eventMarkerPrefix.length)));
+            var applicationData = name.indexOf("data-") === 0 && name.indexOf("data-gosx-") !== 0;
+            if (!name || name.indexOf("on") === 0 || name === "srcdoc" || name === "is" ||
+                (!allowedAttrs.has(name) && !urlAttrs.has(name) && !applicationData && !generatedMarker)) {
+              throw new Error("compiler returned a disallowed preview attribute");
+            }
+            if (urlAttrs.has(name) && !safePreviewURL(attr.value)) {
+              throw new Error("compiler returned an unsafe preview URL");
+            }
+            node.setAttribute(name, attr && attr.bool ? "" : String((attr && attr.value) || ""));
+          });
+          if (spec.text) node.appendChild(document.createTextNode(String(spec.text)));
+          var children = Array.isArray(spec.children) ? spec.children : [];
+          children.forEach(function (child) { node.appendChild(materialize(child)); });
+        }
+        active.delete(index);
+        return node;
+      }
+
+      return materialize(0);
+    }
+
+    function replacePreviewContent(content) {
+      preview.replaceChildren(content);
+    }
+
+    function previewEventSlots() {
+      var prefix = "data-gosx-on-";
+      var seen = new Set();
+      var slots = [];
+      var elements = [preview].concat(Array.from(preview.querySelectorAll("*")));
+      elements.forEach(function (element) {
+        Array.from(element.attributes || []).forEach(function (attr) {
+          if (attr.name.indexOf(prefix) !== 0) return;
+          var eventType = attr.name.slice(prefix.length);
+          if (!eventType || seen.has(eventType)) return;
+          seen.add(eventType);
+          slots.push({ eventType: eventType });
+        });
+      });
+      return slots;
+    }
+
+    function registerPreviewEvents(component) {
+      var host = runtimeHost();
+      var registry = window.__gosx && window.__gosx.islands;
+      if (!host || !host.events || typeof host.events.setup !== "function" ||
+          !registry || typeof registry.set !== "function") {
+        throw new Error("GoSX island event host is unavailable");
+      }
+      // The playground accepts freshly compiled programs, so derive the same
+      // selective listener slots a normal build manifest would carry from the
+      // validated, generated data-gosx-on-* markers.
+      var listeners = host.events.setup(preview, islandID, previewEventSlots());
+      registry.set(islandID, {
+        component: component,
+        root: preview,
+        listeners: listeners,
+      });
+    }
+
     function compile(source) {
       var generation = ++requestGeneration;
       if (activeController) activeController.abort();
@@ -208,15 +367,17 @@
             return;
           }
           var bytes = base64ToBytes(data.program);
+          // Build the detached replacement from structured nodes first. No
+          // authored source is ever passed to an HTML-string parser.
+          var previewContent = buildPreviewContent(data.preview);
           // Dispose the previous island instance before mounting the new one
           // to avoid leaking signal subscriptions and DOM event listeners.
           try {
-            if (typeof window.__gosx_dispose === "function") {
-              window.__gosx_dispose(islandID);
-            }
+            disposePreviewIsland();
           } catch (e) {
             // Ignore dispose errors — a missing island is fine on first run.
           }
+          replacePreviewContent(previewContent);
           var ret = window.__gosx_hydrate(
             islandID,
             data.component,
@@ -235,6 +396,8 @@
             setStatus("diagnostic", "Hydration failed");
             return;
           }
+          registerPreviewEvents(data.component);
+          preview.setAttribute("data-gosx-island", data.component);
           preview.setAttribute("data-component", data.component);
           setStatus("hydrated", data.component + " hydrated from GoSX island bytecode");
         })

--- a/ir/island.go
+++ b/ir/island.go
@@ -139,11 +139,12 @@ func cloneExprScope(scope *ExprScope) *ExprScope {
 }
 
 type islandLowerer struct {
-	src     *Program
-	dst     *program.Program
-	nodeMap map[NodeID]program.NodeID
-	srcIDs  []NodeID // tracks source node ID for each dst node
-	scope   *ExprScope
+	src                *Program
+	dst                *program.Program
+	nodeMap            map[NodeID]program.NodeID
+	srcIDs             []NodeID // tracks source node ID for each dst node
+	scope              *ExprScope
+	inlineHandlerIndex int
 }
 
 func newIslandLowerer(src *Program, name string, scope *ExprScope) *islandLowerer {
@@ -471,6 +472,13 @@ func (l *islandLowerer) scopeForEach(node program.Node) *ExprScope {
 func (l *islandLowerer) lowerAttr(attr Attr) (program.Attr, error) {
 	switch attr.Kind {
 	case AttrStatic:
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(attr.Name)), "data-on-") {
+			eventType, ok := legacyInlineEventType(attr.Name)
+			if !ok {
+				return program.Attr{}, fmt.Errorf("island event attribute %q is not supported", attr.Name)
+			}
+			return l.lowerInlineEvent(eventType, attr.Value)
+		}
 		return program.Attr{
 			Kind:  program.AttrStatic,
 			Name:  attr.Name,
@@ -500,6 +508,77 @@ func (l *islandLowerer) lowerAttr(attr Attr) (program.Attr, error) {
 		return program.Attr{}, fmt.Errorf("spread attributes are not allowed in island components")
 	default:
 		return program.Attr{}, fmt.Errorf("unknown attr kind: %d", attr.Kind)
+	}
+}
+
+// legacyInlineEventType recognizes the original island event spelling:
+//
+//	<button data-on-click="count.Set(count.Get() + 1)">+1</button>
+//
+// TSX-style onClick={increment} remains the preferred typed form. Keeping this
+// spelling in the island lowerer preserves existing components and playground
+// snippets without treating data-on-* as executable on server components.
+func legacyInlineEventType(name string) (string, bool) {
+	const prefix = "data-on-"
+	if !strings.HasPrefix(name, prefix) {
+		return "", false
+	}
+	eventType := strings.TrimSpace(strings.ToLower(strings.TrimPrefix(name, prefix)))
+	if eventType == "" {
+		return "", false
+	}
+	return eventType, legacyInlineEventSupported(eventType)
+}
+
+func legacyInlineEventSupported(eventType string) bool {
+	switch eventType {
+	case "click", "input", "change", "submit", "keydown", "keyup", "focus", "blur",
+		"dragstart", "dragend", "dragover", "dragleave", "drop",
+		"pointerdown", "pointermove", "pointerup", "pointercancel",
+		"document-keydown", "document-keyup", "window-resize":
+		return true
+	default:
+		return false
+	}
+}
+
+func (l *islandLowerer) lowerInlineEvent(eventType, source string) (program.Attr, error) {
+	expression := strings.TrimSpace(source)
+	// JSX string literals retain Go-style escapes in the IR so ordinary static
+	// attributes round-trip exactly. Inline event source is code, however, and
+	// must turn \"light\" back into "light" before expression parsing.
+	if unquoted, err := strconv.Unquote(`"` + expression + `"`); err == nil {
+		expression = unquoted
+	}
+	if expression == "" {
+		return program.Attr{}, fmt.Errorf("data-on-%s requires a handler expression", eventType)
+	}
+
+	handlerName := l.nextInlineHandlerName()
+	exprs, rootID, err := ParseExpr(expression, handlerExprScope(l.scope))
+	if err != nil {
+		return program.Attr{}, fmt.Errorf("parse data-on-%s expression %q: %w", eventType, expression, err)
+	}
+	bodyID := l.appendExprs(exprs, rootID)
+	l.dst.Handlers = append(l.dst.Handlers, program.Handler{
+		Name: handlerName,
+		Body: []program.ExprID{bodyID},
+	})
+
+	return program.Attr{
+		Kind:  program.AttrEvent,
+		Name:  eventType,
+		Event: handlerName,
+	}, nil
+}
+
+func (l *islandLowerer) nextInlineHandlerName() string {
+	for {
+		name := "__gosx_inline_event_" + strconv.Itoa(l.inlineHandlerIndex)
+		l.inlineHandlerIndex++
+		if l.scope == nil || !l.scope.Handlers[name] {
+			return name
+		}
 	}
 }
 

--- a/ir/island_test.go
+++ b/ir/island_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	clientvm "m31labs.dev/gosx/client/vm"
 	"m31labs.dev/gosx/island/program"
 )
 
@@ -111,6 +112,57 @@ func TestLowerIslandEventAttr(t *testing.T) {
 	}
 	if attr.Event != "handleClick" {
 		t.Fatalf("expected handleClick, got %s", attr.Event)
+	}
+}
+
+func TestLowerIslandLegacyInlineEventDispatches(t *testing.T) {
+	prog := &Program{
+		Nodes: []Node{
+			{Kind: NodeElement, Tag: "div", Children: []NodeID{1, 2}},
+			{
+				Kind: NodeElement,
+				Tag:  "button",
+				Attrs: []Attr{{
+					Kind:  AttrStatic,
+					Name:  "data-on-click",
+					Value: "count.Set(count.Get() + 1)",
+				}},
+				Children: []NodeID{3},
+			},
+			{Kind: NodeExpr, Text: "count.Get()"},
+			{Kind: NodeText, Text: "+1", IsStatic: true},
+		},
+		Components: []Component{{
+			Name:     "Counter",
+			Root:     0,
+			IsIsland: true,
+			Scope: &ComponentScope{Signals: []SignalInfo{{
+				Name:     "count",
+				Local:    "count",
+				InitExpr: "0",
+			}}},
+		}},
+	}
+
+	island, err := LowerIsland(prog, 0)
+	if err != nil {
+		t.Fatalf("LowerIsland: %v", err)
+	}
+	if len(island.Nodes[1].Attrs) != 1 {
+		t.Fatalf("button attrs = %#v, want one event", island.Nodes[1].Attrs)
+	}
+	event := island.Nodes[1].Attrs[0]
+	if event.Kind != program.AttrEvent || event.Name != "click" || event.Event == "" {
+		t.Fatalf("legacy event attr = %#v, want a named click event", event)
+	}
+	if len(island.Handlers) != 1 || island.Handlers[0].Name != event.Event || len(island.Handlers[0].Body) != 1 {
+		t.Fatalf("handlers = %#v, want one synthesized inline handler", island.Handlers)
+	}
+
+	runtime := clientvm.NewIsland(island, `{}`)
+	patches := runtime.Dispatch(event.Event, `{"type":"click"}`)
+	if len(patches) != 1 || patches[0].Kind != clientvm.PatchSetText || patches[0].Text != "1" {
+		t.Fatalf("dispatch patches = %#v, want one SetText(1)", patches)
 	}
 }
 


### PR DESCRIPTION
## What changed

- bind the demos catalog into the file-layout renderer so the dock renders all 11 demos
- lower legacy `data-on-*` island expressions into real VM event handlers
- make playground recompiles replace the resolved DOM baseline, dispose old listeners/VM state, and rebind selective event families by DOM island ID
- constrain playground markup with parity-pinned server/browser tag, attribute, URL, and event policies; build preview DOM from structured nodes only
- add production Chrome coverage for Counter → Greeter hot recompilation and active-markup rejection

## Verification

- `go test ./ir ./client/vm ./client/bridge ./island ./examples/gosx-docs/... -count=1`
- `go test -race ./ir ./examples/gosx-docs/app/demos/... -count=1`
- `go vet ./ir ./examples/gosx-docs/app/demos/...`
- `go vet -tags e2e ./e2e`
- `make release-gate`
- fresh production TinyGo/Chrome `TestPlaygroundCounterHydratesAndUpdates` (130.22s)

The browser regression verifies listener disposal/rebinding, click→input event-family switching, reset/recompile, and rejection of img/script/SVG attack probes without replacing the last good preview.