### PR TITLE
fix(docs): initialize demos on direct load

### DIFF
--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -58,6 +58,32 @@ test("bootstrap preserves navigation and request installed before it", async () 
   assert.equal(env.context.__gosx.islands instanceof Map, true);
 });
 
+test("initial document navigation state replays after parser-built links exist", () => {
+  const env = createContext({ elements: [] });
+  env.document.readyState = "loading";
+  env.context.location.href = "http://localhost:3000/demos/playground";
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const link = new FakeElement("a", env.document);
+  link.setAttribute("href", "/demos/playground");
+  link.setAttribute("data-gosx-link", "true");
+  env.document.body.appendChild(link);
+
+  const bindingSnapshots = [];
+  env.context.__gosx.actions = {
+    refreshBindings() {
+      bindingSnapshots.push(link.getAttribute("aria-current"));
+    },
+  };
+  env.document.dispatchEvent({ type: "DOMContentLoaded" });
+
+  assert.equal(link.getAttribute("aria-current"), "page");
+  assert.equal(link.getAttribute("data-gosx-link-current"), "page");
+  assert.equal(link.getAttribute("data-gosx-link-state"), "idle");
+  assert.deepEqual(bindingSnapshots, ["page"]);
+});
+
 test("bootstrap restores legacy page navigation into the preserved namespace", async () => {
   const env = createContext({ elements: [] });
   const navigation = { navigate() {}, revalidate() {} };

--- a/client/runtime/host/navigation.ts
+++ b/client/runtime/host/navigation.ts
@@ -2288,6 +2288,20 @@
     return currentNavigationSnapshot();
   }
 
+  function refreshInitialDocumentNavigation() {
+    // The navigation host can execute from <head> while the parser is still
+    // building <body>. Replay after DOMContentLoaded so initial-document links
+    // receive the same current/prefetch state as links installed by soft nav.
+    // Bindings depend on that current marker, so refresh them only after the
+    // navigation replay. Both operations are synchronous and idempotent.
+    refreshNavigationState();
+    prefetchManagedLinks("render");
+    const actions = window.__gosx && window.__gosx.actions;
+    if (actions && typeof actions.refreshBindings === "function") {
+      actions.refreshBindings();
+    }
+  }
+
   function currentNavigationFetchEpoch() {
     return {
       started: navigationFetchStarted,
@@ -2353,6 +2367,9 @@
     pendingURL: "",
   }, "init");
   prefetchManagedLinks("render");
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", refreshInitialDocumentNavigation, { once: true });
+  }
 
   const navigationAPI = {
     navigate: navigate,

--- a/e2e/gosx_docs_e2e_test.go
+++ b/e2e/gosx_docs_e2e_test.go
@@ -113,6 +113,136 @@ func TestDocsMobileNavigationWorksWithoutDisclosureRuntime(t *testing.T) {
 	}
 }
 
+func TestPlaygroundDirectLoadMetadataAndMobileHeader(t *testing.T) {
+	chrome := e2eChromePath(t)
+	app := startProductionDocsApp(t)
+	page := newBrowserPage(t, chrome, nil, 390, 844, "", 90*time.Second)
+	if err := chromedp.Run(page.ctx, chromedp.EmulateViewport(390, 844)); err != nil {
+		t.Fatalf("emulate 390x844 mobile viewport: %v", err)
+	}
+	if status := page.navigate(t, app.baseURL+"/demos/playground"); status < 200 || status > 299 {
+		t.Fatalf("/demos/playground returned %d\n\nLogs:\n%s", status, app.logs.String())
+	}
+
+	type mobileContract struct {
+		ViewportWidth       int      `json:"viewportWidth"`
+		CurrentHrefs        []string `json:"currentHrefs"`
+		ShellSlug           string   `json:"shellSlug"`
+		DetailsTitle        string   `json:"detailsTitle"`
+		DetailsLesson       string   `json:"detailsLesson"`
+		Facts               []string `json:"facts"`
+		SourceHref          string   `json:"sourceHref"`
+		SourcePath          string   `json:"sourcePath"`
+		HeaderDirection     string   `json:"headerDirection"`
+		HeaderAlign         string   `json:"headerAlign"`
+		TitleWidth          float64  `json:"titleWidth"`
+		TitleHeight         float64  `json:"titleHeight"`
+		HasHorizontalScroll bool     `json:"hasHorizontalScroll"`
+	}
+	var got mobileContract
+	page.eval(t, `(() => {
+	const current = [...document.querySelectorAll('.demo-dock__link[aria-current="page"]')];
+	const header = document.querySelector('.play__header');
+	const title = document.querySelector('.play__title');
+	const headerStyle = getComputedStyle(header);
+	const titleRect = title.getBoundingClientRect();
+	return {
+	  viewportWidth: window.innerWidth,
+	  currentHrefs: current.map((link) => new URL(link.href, location.href).pathname),
+	  shellSlug: document.querySelector('.demos-shell')?.dataset.demoSlug || '',
+	  detailsTitle: document.querySelector('#demo-details-title')?.textContent.trim() || '',
+	  detailsLesson: document.querySelector('.demo-details__lesson')?.textContent.trim() || '',
+	  facts: [...document.querySelectorAll('.demo-details__facts dd')].map((fact) => fact.textContent.trim()),
+	  sourceHref: document.querySelector('.demo-details__source')?.getAttribute('href') || '',
+	  sourcePath: document.querySelector('.demo-details__path')?.textContent.trim() || '',
+	  headerDirection: headerStyle.flexDirection,
+	  headerAlign: headerStyle.alignItems,
+	  titleWidth: titleRect.width,
+	  titleHeight: titleRect.height,
+	  hasHorizontalScroll: document.documentElement.scrollWidth > document.documentElement.clientWidth,
+	};
+	})()`, &got)
+
+	if got.ViewportWidth != 390 {
+		t.Fatalf("mobile viewport width = %d, want 390", got.ViewportWidth)
+	}
+	if len(got.CurrentHrefs) != 1 || got.CurrentHrefs[0] != "/demos/playground" {
+		t.Errorf("current demo links = %#v, want only /demos/playground", got.CurrentHrefs)
+	}
+	if got.ShellSlug != "playground" || got.DetailsTitle != "GoSX Playground" {
+		t.Errorf("direct-load metadata = slug %q, title %q", got.ShellSlug, got.DetailsTitle)
+	}
+	if got.DetailsLesson == "" || strings.Contains(got.DetailsLesson, "Choose a demo") {
+		t.Errorf("direct-load lesson was not initialized: %q", got.DetailsLesson)
+	}
+	if len(got.Facts) != 4 {
+		t.Errorf("direct-load facts = %#v, want four facts", got.Facts)
+	} else {
+		for index, fact := range got.Facts {
+			if fact == "" || fact == "—" {
+				t.Errorf("direct-load fact %d was not initialized: %q", index, fact)
+			}
+		}
+	}
+	if !strings.Contains(got.SourceHref, "/examples/gosx-docs/app/demos/playground/page.gsx") || got.SourcePath != "examples/gosx-docs/app/demos/playground/page.gsx" {
+		t.Errorf("direct-load source = (%q, %q)", got.SourceHref, got.SourcePath)
+	}
+	if got.HeaderDirection != "column" || got.HeaderAlign != "flex-start" {
+		t.Errorf("mobile playground header layout = direction %q, align %q", got.HeaderDirection, got.HeaderAlign)
+	}
+	if got.TitleWidth < 250 || got.TitleHeight > 40 {
+		t.Errorf("mobile playground title bounds = %.2fx%.2f; title is still squeezed or wrapped", got.TitleWidth, got.TitleHeight)
+	}
+	if got.HasHorizontalScroll {
+		t.Error("mobile playground introduced horizontal document scrolling")
+	}
+
+	if err := chromedp.Run(page.ctx, chromedp.Click(`.demos-topbar__menu`, chromedp.ByQuery)); err != nil {
+		t.Fatalf("open mobile demos dock: %v", err)
+	}
+	page.waitFor(t,
+		`document.querySelector('.demos-body')?.hasAttribute('data-dock-open') &&
+		document.querySelector('.demos-topbar__menu')?.getAttribute('aria-expanded') === 'true' &&
+		document.querySelector('#demo-dock')?.getBoundingClientRect().left >= -0.5`,
+		5*time.Second,
+		"settled mobile demos dock",
+	)
+	if err := chromedp.Run(page.ctx,
+		chromedp.ScrollIntoView(`.demo-dock__link[href="/demos/cms"]`, chromedp.ByQuery),
+		chromedp.Click(`.demo-dock__link[href="/demos/cms"]`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("soft-navigate from playground to CMS demo: %v", err)
+	}
+	softNavigationReady := page.pollFor(`location.pathname === "/demos/cms" &&
+	  document.querySelectorAll('.demo-dock__link[aria-current="page"]').length === 1 &&
+	  new URL(document.querySelector('.demo-dock__link[aria-current="page"]')?.href || '', location.href).pathname === "/demos/cms" &&
+	  document.querySelector('.demos-shell')?.dataset.demoSlug === "cms" &&
+	  document.querySelector('#demo-details-title')?.textContent.trim() === "CMS Editor" &&
+	  document.querySelector('.demo-details__source')?.getAttribute('href')?.includes('/examples/gosx-docs/app/demos/cms/page.gsx')`,
+		10*time.Second)
+	if !softNavigationReady {
+		var snapshot map[string]any
+		page.eval(t, `({
+		  path: location.pathname,
+		  currentHrefs: [...document.querySelectorAll('.demo-dock__link[aria-current="page"]')].map((link) => new URL(link.href, location.href).pathname),
+		  shellSlug: document.querySelector('.demos-shell')?.dataset.demoSlug || '',
+		  detailsTitle: document.querySelector('#demo-details-title')?.textContent.trim() || '',
+		  sourceHref: document.querySelector('.demo-details__source')?.getAttribute('href') || '',
+		  dockOpen: document.querySelector('.demos-body')?.hasAttribute('data-dock-open') || false,
+		})`, &snapshot)
+		t.Fatalf("timed out waiting for soft-navigation current demo metadata: %#v\nconsole:\n%s", snapshot, page.Console())
+	}
+	var stalePlaygroundCurrent bool
+	page.eval(t, `[...document.querySelectorAll('.demo-dock__link')].some((link) =>
+	  new URL(link.href, location.href).pathname === '/demos/playground' && link.hasAttribute('aria-current'))`, &stalePlaygroundCurrent)
+	if stalePlaygroundCurrent {
+		t.Error("soft navigation left the server-rendered playground link current")
+	}
+	if len(page.PageErrors()) > 0 {
+		t.Fatalf("mobile playground raised page errors: %v\nconsole:\n%s", page.PageErrors(), page.Console())
+	}
+}
+
 func TestPlaygroundCounterHydratesAndUpdates(t *testing.T) {
 	chrome := e2eChromePath(t)
 	var app *docsApp

--- a/examples/gosx-docs/app/demos/catalog_test.go
+++ b/examples/gosx-docs/app/demos/catalog_test.go
@@ -197,6 +197,105 @@ func TestDemoLayoutRendersMobileDockWithCompleteCatalog(t *testing.T) {
 	}
 }
 
+func TestDemoLayoutDirectLoadsRenderCurrentProofMetadata(t *testing.T) {
+	layoutPath := repoPath(t, "examples/gosx-docs/app/demos/layout.gsx")
+	layout, err := route.FileLayout(layoutPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range Demos() {
+		want := want
+		t.Run(want.Slug, func(t *testing.T) {
+			ctx := &route.RouteContext{Request: httptest.NewRequest(http.MethodGet, "/demos/"+want.Slug, nil)}
+			rendered := gosx.RenderHTML(layout(ctx, gosx.El("main", gosx.Text(want.Title))))
+			if status := ctx.StatusCode(); status != 0 && status != http.StatusOK {
+				t.Fatalf("layout render status = %d; body=%s", status, rendered)
+			}
+
+			doc, parseErr := html.Parse(strings.NewReader(rendered))
+			if parseErr != nil {
+				t.Fatalf("parse rendered layout: %v", parseErr)
+			}
+
+			currentHrefs := []string{}
+			currentManaged := []string{}
+			facts := map[string]string{}
+			var shellSlug, title, lesson, sourceHref, sourcePath string
+			var visit func(*html.Node)
+			visit = func(node *html.Node) {
+				if node.Type == html.ElementNode {
+					attrs := htmlAttributes(node)
+					classes := strings.Fields(attrs["class"])
+					switch {
+					case contains(classes, "demos-shell"):
+						shellSlug = attrs["data-demo-slug"]
+					case node.Data == "a" && contains(classes, "demo-dock__link") && attrs["aria-current"] == "page":
+						currentHrefs = append(currentHrefs, attrs["href"])
+						currentManaged = append(currentManaged, attrs["data-gosx-aria-current-managed"])
+					case node.Data == "h2" && attrs["id"] == "demo-details-title":
+						title = normalizedNodeText(node)
+					case node.Data == "p" && contains(classes, "demo-details__lesson"):
+						lesson = normalizedNodeText(node)
+					case node.Data == "dd" && attrs["data-gosx-bind-text"] != "":
+						facts[attrs["data-gosx-bind-text"]] = normalizedNodeText(node)
+					case node.Data == "a" && contains(classes, "demo-details__source"):
+						sourceHref = attrs["href"]
+					case node.Data == "code" && contains(classes, "demo-details__path"):
+						sourcePath = normalizedNodeText(node)
+					}
+				}
+				for child := node.FirstChild; child != nil; child = child.NextSibling {
+					visit(child)
+				}
+			}
+			visit(doc)
+
+			if len(currentHrefs) != 1 || currentHrefs[0] != "/demos/"+want.Slug {
+				t.Fatalf("server-rendered current links = %#v, want only /demos/%s", currentHrefs, want.Slug)
+			}
+			if len(currentManaged) != 1 || currentManaged[0] != "true" {
+				t.Fatalf("server-rendered current link ownership = %#v, want managed current state", currentManaged)
+			}
+			if shellSlug != want.Slug {
+				t.Errorf("server-rendered shell slug = %q, want %q", shellSlug, want.Slug)
+			}
+			if title != want.Title || lesson != want.Lesson {
+				t.Errorf("server-rendered details = title %q, lesson %q", title, lesson)
+			}
+			wantFacts := map[string]string{
+				"data-demo-facets":      demoValues(want.Facets),
+				"data-demo-packages":    demoValues(want.Packages),
+				"data-demo-render-mode": want.RenderMode,
+				"data-demo-limitations": want.Limitations,
+			}
+			for binding, wantValue := range wantFacts {
+				if facts[binding] != wantValue {
+					t.Errorf("server-rendered %s = %q, want %q", binding, facts[binding], wantValue)
+				}
+			}
+			if sourceHref != demoSourceURL(want.SourcePath) || sourcePath != want.SourcePath {
+				t.Errorf("server-rendered source = (%q, %q), want (%q, %q)", sourceHref, sourcePath, demoSourceURL(want.SourcePath), want.SourcePath)
+			}
+		})
+	}
+}
+
+func normalizedNodeText(node *html.Node) string {
+	parts := []string{}
+	var visit func(*html.Node)
+	visit = func(current *html.Node) {
+		if current.Type == html.TextNode {
+			parts = append(parts, current.Data)
+		}
+		for child := current.FirstChild; child != nil; child = child.NextSibling {
+			visit(child)
+		}
+	}
+	visit(node)
+	return strings.Join(strings.Fields(strings.Join(parts, " ")), " ")
+}
+
 func htmlAttributes(node *html.Node) map[string]string {
 	attrs := make(map[string]string, len(node.Attr))
 	for _, attr := range node.Attr {

--- a/examples/gosx-docs/app/demos/layout.gsx
+++ b/examples/gosx-docs/app/demos/layout.gsx
@@ -5,131 +5,135 @@ package docs
 // toggles and accessible disclosure behavior are runtime capabilities too.
 
 func Layout() Node {
-    return <div
-    	class="demos-shell"
-    	data-gosx-bind-source=".demo-dock__link[aria-current='page']"
-    	data-gosx-bind-attr="data-demo-slug:data-demo"
-    >
-    	<header class="demos-topbar">
-    		<span class="demos-topbar__crumb">
-    			<a href="/" class="demos-topbar__home" data-gosx-link="true">GoSX</a>
-    			<span class="demos-topbar__sep" aria-hidden="true">/</span>
-    			<a href="/demos" class="demos-topbar__section" data-gosx-link="true">Demos</a>
-    		</span>
-    		<button
-    			class="demos-topbar__menu"
-    			type="button"
-    			aria-label="Toggle demos menu"
-    			aria-controls="demo-dock"
-    			aria-expanded="false"
-    			data-gosx-toggle-target=".demos-body"
-    			data-gosx-toggle-attribute="data-dock-open"
-    		>
-    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-    			<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
-    		</button>
-    	</header>
-    	<div class="demos-body">
-    		<nav id="demo-dock" class="demo-dock" aria-label="Demos">
-    			<ul class="demo-dock__list" role="list">
-    				<Each of={Demos()} as="demo">
-    					<li class="demo-dock__item" role="listitem">
-    						<a
-    							href={"/demos/" + demo.Slug}
-    							class="demo-dock__link"
-    							data-gosx-link="true"
-    							data-demo={demo.Slug}
-    							data-demo-title={demo.Title}
-    							data-demo-lesson={demo.Lesson}
-    							data-demo-facets={demoValues(demo.Facets)}
-    							data-demo-source={demoSourceURL(demo.SourcePath)}
-    							data-demo-source-path={demo.SourcePath}
-    							data-demo-packages={demoValues(demo.Packages)}
-    							data-demo-render-mode={demo.RenderMode}
-    							data-demo-limitations={demo.Limitations}
-    							data-gosx-toggle-close=".demos-body"
-    							data-gosx-toggle-attribute="data-dock-open"
-    						>
-    							<span class="demo-dock__dot" aria-hidden="true"></span>
-    							<span class="demo-dock__body">
-    								<span class="demo-dock__title">{demo.Title}</span>
-    								<span class="demo-dock__tag">{demo.Tag}</span>
-    							</span>
-    							<span class={"demo-dock__chip demo-dock__chip--" + demo.Status}>{demo.Status}</span>
-    						</a>
-    					</li>
-    				</Each>
-    			</ul>
-    		</nav>
-    		<div class="demo-viewport">
-    			<Slot />
-    			<footer class="demo-meta" role="contentinfo" aria-label="Demo metadata">
-    				<button
-    					type="button"
-    					class="demo-meta__pill"
-    					data-gosx-disclosure-target="#demo-details"
-    					aria-controls="demo-details"
-    					aria-expanded="false"
-    				>How this is GoSX</button>
-    			</footer>
-    		</div>
-    	</div>
-    	<div class="demo-details-backdrop" data-gosx-disclosure-backdrop="#demo-details" hidden></div>
-    	<aside
-    		id="demo-details"
-    		class="demo-details"
-    		data-gosx-disclosure
-    		data-gosx-bind-source=".demo-dock__link[aria-current='page']"
-    		role="dialog"
-    		aria-modal="true"
-    		aria-labelledby="demo-details-title"
-    		hidden
-    	>
-    		<header class="demo-details__header">
-    			<div>
-    				<p class="demo-details__eyebrow">How this is GoSX</p>
-    				<h2 id="demo-details-title" class="demo-details__title" data-gosx-bind-text="data-demo-title">Demo details</h2>
-    			</div>
-    			<button
-    				type="button"
-    				class="demo-details__close"
-    				data-gosx-disclosure-close="#demo-details"
-    				data-gosx-disclosure-initial-focus
-    				aria-label="Close demo details"
-    			>×</button>
-    		</header>
-    		<p class="demo-details__lesson" data-gosx-bind-text="data-demo-lesson">
-    			Choose a demo to inspect how it is built.
-    		</p>
-    		<dl class="demo-details__facts">
-    			<div>
-    				<dt>Built with</dt>
-    				<dd data-gosx-bind-text="data-demo-facets">—</dd>
-    			</div>
-    			<div>
-    				<dt>Packages</dt>
-    				<dd data-gosx-bind-text="data-demo-packages">—</dd>
-    			</div>
-    			<div>
-    				<dt>Rendering</dt>
-    				<dd data-gosx-bind-text="data-demo-render-mode">—</dd>
-    			</div>
-    			<div>
-    				<dt>Honest limits</dt>
-    				<dd data-gosx-bind-text="data-demo-limitations">—</dd>
-    			</div>
-    		</dl>
-    		<a
-    			class="demo-details__source"
-    			data-gosx-bind-attr="href:data-demo-source"
-    			target="_blank"
-    			rel="noopener noreferrer"
-    		>
-    			View GoSX source
-    			<span aria-hidden="true">↗</span>
-    		</a>
-    		<code class="demo-details__path" data-gosx-bind-text="data-demo-source-path"></code>
-    	</aside>
-    </div>
+	return <div
+		class="demos-shell"
+		data-gosx-bind-source=".demo-dock__link[aria-current='page']"
+		data-gosx-bind-attr="data-demo-slug:data-demo"
+		data-demo-slug={currentDemoSlug}
+	>
+		<header class="demos-topbar">
+			<span class="demos-topbar__crumb">
+				<a href="/" class="demos-topbar__home" data-gosx-link="true">GoSX</a>
+				<span class="demos-topbar__sep" aria-hidden="true">/</span>
+				<a href="/demos" class="demos-topbar__section" data-gosx-link="true">Demos</a>
+			</span>
+			<button
+				class="demos-topbar__menu"
+				type="button"
+				aria-label="Toggle demos menu"
+				aria-controls="demo-dock"
+				aria-expanded="false"
+				data-gosx-toggle-target=".demos-body"
+				data-gosx-toggle-attribute="data-dock-open"
+			>
+				<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+				<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+				<span class="demos-topbar__menu-bar" aria-hidden="true"></span>
+			</button>
+		</header>
+		<div class="demos-body">
+			<nav id="demo-dock" class="demo-dock" aria-label="Demos">
+				<ul class="demo-dock__list" role="list">
+					<Each of={Demos()} as="demo">
+						<li class="demo-dock__item" role="listitem">
+							<a
+								href={"/demos/" + demo.Slug}
+								class="demo-dock__link"
+								data-gosx-link="true"
+								data-demo={demo.Slug}
+								data-demo-title={demo.Title}
+								data-demo-lesson={demo.Lesson}
+								data-demo-facets={demoValues(demo.Facets)}
+								data-demo-source={demoSourceURL(demo.SourcePath)}
+								data-demo-source-path={demo.SourcePath}
+								data-demo-packages={demoValues(demo.Packages)}
+								data-demo-render-mode={demo.RenderMode}
+								data-demo-limitations={demo.Limitations}
+								data-gosx-toggle-close=".demos-body"
+								data-gosx-toggle-attribute="data-dock-open"
+								aria-current={demoAriaCurrent(demo.Slug)}
+								data-gosx-aria-current-managed={demoCurrentManaged(demo.Slug)}
+							>
+								<span class="demo-dock__dot" aria-hidden="true"></span>
+								<span class="demo-dock__body">
+									<span class="demo-dock__title">{demo.Title}</span>
+									<span class="demo-dock__tag">{demo.Tag}</span>
+								</span>
+								<span class={"demo-dock__chip demo-dock__chip--" + demo.Status}>{demo.Status}</span>
+							</a>
+						</li>
+					</Each>
+				</ul>
+			</nav>
+			<div class="demo-viewport">
+				<Slot />
+				<footer class="demo-meta" role="contentinfo" aria-label="Demo metadata">
+					<button
+						type="button"
+						class="demo-meta__pill"
+						data-gosx-disclosure-target="#demo-details"
+						aria-controls="demo-details"
+						aria-expanded="false"
+					>How this is GoSX</button>
+				</footer>
+			</div>
+		</div>
+		<div class="demo-details-backdrop" data-gosx-disclosure-backdrop="#demo-details" hidden></div>
+		<aside
+			id="demo-details"
+			class="demo-details"
+			data-gosx-disclosure
+			data-gosx-bind-source=".demo-dock__link[aria-current='page']"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="demo-details-title"
+			hidden
+		>
+			<header class="demo-details__header">
+				<div>
+					<p class="demo-details__eyebrow">How this is GoSX</p>
+					<h2 id="demo-details-title" class="demo-details__title" data-gosx-bind-text="data-demo-title">{currentDemoTitle}</h2>
+				</div>
+				<button
+					type="button"
+					class="demo-details__close"
+					data-gosx-disclosure-close="#demo-details"
+					data-gosx-disclosure-initial-focus
+					aria-label="Close demo details"
+				>×</button>
+			</header>
+			<p class="demo-details__lesson" data-gosx-bind-text="data-demo-lesson">
+				{currentDemoLesson}
+			</p>
+			<dl class="demo-details__facts">
+				<div>
+					<dt>Built with</dt>
+					<dd data-gosx-bind-text="data-demo-facets">{currentDemoFacets}</dd>
+				</div>
+				<div>
+					<dt>Packages</dt>
+					<dd data-gosx-bind-text="data-demo-packages">{currentDemoPackages}</dd>
+				</div>
+				<div>
+					<dt>Rendering</dt>
+					<dd data-gosx-bind-text="data-demo-render-mode">{currentDemoRenderMode}</dd>
+				</div>
+				<div>
+					<dt>Honest limits</dt>
+					<dd data-gosx-bind-text="data-demo-limitations">{currentDemoLimitations}</dd>
+				</div>
+			</dl>
+			<a
+				class="demo-details__source"
+				data-gosx-bind-attr="href:data-demo-source"
+				href={currentDemoSourceURL}
+				target="_blank"
+				rel="noopener noreferrer"
+			>
+				View GoSX source
+				<span aria-hidden="true">↗</span>
+			</a>
+			<code class="demo-details__path" data-gosx-bind-text="data-demo-source-path">{currentDemoSourcePath}</code>
+		</aside>
+	</div>
 }

--- a/examples/gosx-docs/app/demos/layout.server.go
+++ b/examples/gosx-docs/app/demos/layout.server.go
@@ -2,6 +2,7 @@ package docs
 
 import (
 	"log"
+	"strings"
 
 	"m31labs.dev/gosx/route"
 )
@@ -14,10 +15,65 @@ func init() {
 	}
 }
 
-func demoLayoutBindings(*route.RouteContext, route.FilePage, any) route.FileTemplateBindings {
-	return route.FileTemplateBindings{Funcs: map[string]any{
-		"Demos":         Demos,
-		"demoValues":    demoValues,
-		"demoSourceURL": demoSourceURL,
-	}}
+func demoLayoutBindings(ctx *route.RouteContext, page route.FilePage, _ any) route.FileTemplateBindings {
+	current, hasCurrent := currentDemoForLayout(ctx, page)
+	values := map[string]any{
+		"currentDemoSlug":        "",
+		"currentDemoTitle":       "Demo details",
+		"currentDemoLesson":      "Choose a demo to inspect how it is built.",
+		"currentDemoFacets":      "—",
+		"currentDemoPackages":    "—",
+		"currentDemoRenderMode":  "—",
+		"currentDemoLimitations": "—",
+		"currentDemoSourceURL":   nil,
+		"currentDemoSourcePath":  "",
+	}
+	if hasCurrent {
+		values["currentDemoSlug"] = current.Slug
+		values["currentDemoTitle"] = current.Title
+		values["currentDemoLesson"] = current.Lesson
+		values["currentDemoFacets"] = demoValues(current.Facets)
+		values["currentDemoPackages"] = demoValues(current.Packages)
+		values["currentDemoRenderMode"] = current.RenderMode
+		values["currentDemoLimitations"] = current.Limitations
+		values["currentDemoSourceURL"] = demoSourceURL(current.SourcePath)
+		values["currentDemoSourcePath"] = current.SourcePath
+	}
+
+	return route.FileTemplateBindings{
+		Values: values,
+		Funcs: map[string]any{
+			"Demos":         Demos,
+			"demoValues":    demoValues,
+			"demoSourceURL": demoSourceURL,
+			"demoAriaCurrent": func(slug string) any {
+				if hasCurrent && slug == current.Slug {
+					return "page"
+				}
+				return nil
+			},
+			"demoCurrentManaged": func(slug string) any {
+				if hasCurrent && slug == current.Slug {
+					return "true"
+				}
+				return nil
+			},
+		},
+	}
+}
+
+func currentDemoForLayout(ctx *route.RouteContext, page route.FilePage) (DemoDefinition, bool) {
+	currentPath := page.RoutePath
+	if ctx != nil && ctx.Request != nil && ctx.Request.URL != nil && ctx.Request.URL.Path != "" {
+		currentPath = ctx.Request.URL.Path
+	}
+	const prefix = "/demos/"
+	if !strings.HasPrefix(currentPath, prefix) {
+		return DemoDefinition{}, false
+	}
+	slug := strings.Trim(strings.TrimPrefix(currentPath, prefix), "/")
+	if slug == "" || strings.Contains(slug, "/") {
+		return DemoDefinition{}, false
+	}
+	return FindDemo(slug)
 }

--- a/examples/gosx-docs/app/demos/playground/page.css
+++ b/examples/gosx-docs/app/demos/playground/page.css
@@ -25,21 +25,22 @@
   flex-shrink: 0;
   display: flex;
   align-items: baseline;
-  gap: 1rem;
-  padding-bottom: 0.75rem;
+  gap: var(--space-sm);
+  padding-bottom: var(--space-xs);
   border-bottom: 1px solid var(--demo-hair);
 }
 
 .play__title {
-  font-size: 1rem;
+  flex-shrink: 0;
+  font-size: var(--type-base);
   font-weight: 600;
-  color: #9fffa5;
+  color: var(--demo-accent);
   margin: 0;
   letter-spacing: 0.01em;
 }
 
 .play__subtitle {
-  font-size: 0.8rem;
+  font-size: var(--type-xs);
   color: var(--demo-muted);
   margin: 0;
 }
@@ -467,6 +468,16 @@
   .play {
     padding: 1rem;
     overflow: auto;
+  }
+
+  .play__header {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-xs);
+  }
+
+  .play__title {
+    width: 100%;
   }
 
   .play__body {


### PR DESCRIPTION
## Summary
- replay initial navigation state after the parser-built body exists so direct-loaded links receive current/form/prefetch state before explanatory bindings run
- render a fully managed current-demo marker as an SSR fallback and prove soft navigation clears it
- make the playground header readable and overflow-free at true 390px mobile width

## Verification
- Node navigation runtime tests: 76/76
- `go test ./examples/gosx-docs/... -count=1`
- focused race + vet + GoSX fmt/check
- clean pinned production build
- production Chrome at 390×844: direct-load metadata, one current item, readable title/no overflow, settled drawer, and Playground → CMS soft navigation
