### PR TITLE
add(cli, route): Add version skew check and stale modules warning

### DIFF
--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -189,6 +189,9 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	}
 	dir = absDir
 
+	if err := checkVersionSkew(dir); err != nil {
+		return err
+	}
 	if err := syncModulesPackage(dir); err != nil {
 		return err
 	}

--- a/cmd/gosx/dev.go
+++ b/cmd/gosx/dev.go
@@ -39,6 +39,9 @@ func RunDevWithOptions(dir string, options DevOptions) error {
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
 	}
+	if err := checkVersionSkew(absDir); err != nil {
+		return err
+	}
 
 	isMain, err := isMainPackage(absDir)
 	if err != nil {

--- a/cmd/gosx/export.go
+++ b/cmd/gosx/export.go
@@ -17,6 +17,9 @@ func RunExport(dir string) error {
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
 	}
+	if err := checkVersionSkew(absDir); err != nil {
+		return err
+	}
 
 	isMain, err := isMainPackage(absDir)
 	if err != nil {

--- a/cmd/gosx/main.go
+++ b/cmd/gosx/main.go
@@ -397,6 +397,9 @@ func cmdCheck() {
 }
 
 func runCheck(file string, stderr io.Writer) error {
+	if err := checkVersionSkew(filepath.Dir(file)); err != nil {
+		return err
+	}
 	source, err := os.ReadFile(file)
 	if err != nil {
 		return fmt.Errorf("read %s: %w", file, err)

--- a/cmd/gosx/versionskew.go
+++ b/cmd/gosx/versionskew.go
@@ -1,134 +1,114 @@
 package main
 
 import (
-	"bufio"
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
-	"strings"
 
 	"m31labs.dev/gosx"
 )
 
-// checkVersionSkew fails fast when a project's go.mod pins a different
-// m31labs.dev/gosx release than this CLI. Left unchecked, resolveGoSXModuleRoot
-// resolves client sources from the module cache path of the pinned release,
-// and a newer CLI fails deep inside that path with an obscure missing-file
-// error instead of a version diagnostic.
+// gosxModulePath is the module path this CLI ships as, and the one
+// checkVersionSkew resolves against every project it inspects.
+const gosxModulePath = "m31labs.dev/gosx"
+
+// skipVersionCheckEnv, set to any non-empty value, bypasses checkVersionSkew
+// entirely. It exists because the check runs a real toolchain command and can
+// be wrong for a setup this package has not anticipated; the escape hatch
+// lets a build proceed instead of blocking on a diagnostic.
+const skipVersionCheckEnv = "GOSX_SKIP_VERSION_CHECK"
+
+// checkVersionSkew fails fast when a project's module graph resolves a
+// different m31labs.dev/gosx release than this CLI. Left unchecked,
+// resolveGoSXModuleRoot resolves client sources from the module cache path of
+// the pinned release, and a newer CLI fails deep inside that path with an
+// obscure missing-file error instead of a version diagnostic.
 func checkVersionSkew(projectDir string) error {
-	goModPath, err := projectGoModPath(projectDir)
-	if err != nil || goModPath == "" {
+	if os.Getenv(skipVersionCheckEnv) != "" {
 		return nil
 	}
-	data, err := os.ReadFile(goModPath)
-	if err != nil {
-		return nil
-	}
-	projectVersion, hasLocalReplace := parseGoSXRequirement(string(data))
-	if projectVersion == "" {
+	projectVersion, hasLocalReplace, ok := resolveProjectGoSXVersion(projectDir)
+	if !ok {
 		return nil
 	}
 	return versionSkewError("v"+gosx.Version, projectVersion, hasLocalReplace)
 }
 
-// projectGoModPath resolves the go.mod that governs projectDir, the same way
-// moduleInfo does for modules.go generation. An empty result means projectDir
-// is not inside a module, which is not this check's problem to report.
-func projectGoModPath(projectDir string) (string, error) {
-	cmd := exec.Command("go", "env", "GOMOD")
+// goListModule mirrors the subset of `go list -m -json` fields this check
+// needs. Replace is nil unless a replace directive governs the module; when
+// set, its own Version and Dir describe the replacement, not the original.
+type goListModule struct {
+	Version string
+	Dir     string
+	Replace *goListModule
+}
+
+// resolveProjectGoSXVersion asks the Go toolchain how projectDir's module
+// graph resolves m31labs.dev/gosx, rather than scanning go.mod text by hand.
+// `go list -m -json` already understands require and replace blocks in every
+// formatting a hand-rolled scanner gets wrong (block form, space-free
+// "require(", trailing comments), and it is the one place that correctly
+// resolves go.work workspaces, where `go env GOMOD` still names a member
+// module's go.mod even though a `use` directive overrides the version.
+//
+// ok is false whenever the check has nothing useful to say: m31labs.dev/gosx
+// is not required, projectDir is not inside a module, or the toolchain
+// invocation itself failed (offline, no go on PATH, malformed output, and so
+// on). None of those are grounds to block a build over a diagnostic.
+func resolveProjectGoSXVersion(projectDir string) (version string, localReplace bool, ok bool) {
+	cmd := exec.Command("go", "list", "-m", "-json", gosxModulePath)
 	cmd.Dir = projectDir
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", false, false
 	}
-	path := strings.TrimSpace(string(out))
-	if path == "" || path == os.DevNull {
-		return "", nil
+	var mod goListModule
+	if err := json.Unmarshal(bytes.TrimSpace(out), &mod); err != nil {
+		return "", false, false
 	}
-	return path, nil
+	return interpretGoListModule(mod)
 }
 
-// parseGoSXRequirement scans go.mod text for the m31labs.dev/gosx require
-// version and whether a local-path replace directive redirects it. It is a
-// minimal scanner rather than golang.org/x/mod/modfile because the module does
-// not otherwise depend on that package.
-func parseGoSXRequirement(goMod string) (version string, hasLocalReplace bool) {
-	scanner := bufio.NewScanner(strings.NewReader(goMod))
-	inRequireBlock := false
-	for scanner.Scan() {
-		line := strings.TrimSpace(scanner.Text())
-		if line == "" || strings.HasPrefix(line, "//") {
-			continue
+// interpretGoListModule is the pure decision behind resolveProjectGoSXVersion:
+// given one `go list -m -json` record for m31labs.dev/gosx, it decides the
+// version to compare against the CLI's own, and whether local disk sources
+// make that comparison moot. Kept separate from process execution so it is
+// testable without shelling out.
+func interpretGoListModule(mod goListModule) (version string, localReplace bool, ok bool) {
+	if mod.Replace != nil {
+		if mod.Replace.Version == "" {
+			// A path replace: the target is a directory on disk, not a
+			// tagged version, so the require line never governs the build.
+			return "", true, true
 		}
-		switch {
-		case line == "require (":
-			inRequireBlock = true
-		case inRequireBlock && line == ")":
-			inRequireBlock = false
-		case inRequireBlock:
-			if v, ok := matchGoSXRequireFields(line); ok {
-				version = v
-			}
-		case strings.HasPrefix(line, "require "):
-			if v, ok := matchGoSXRequireFields(strings.TrimPrefix(line, "require ")); ok {
-				version = v
-			}
-		case strings.HasPrefix(line, "replace "):
-			if matchGoSXLocalReplaceFields(strings.TrimPrefix(line, "replace ")) {
-				hasLocalReplace = true
-			}
+		// A module-version replace: the replaced version is what the build
+		// actually uses, not the original require line.
+		return mod.Replace.Version, false, true
+	}
+	if mod.Version == "" {
+		if mod.Dir != "" {
+			// Workspace mode: m31labs.dev/gosx resolved to a `use`d local
+			// module rather than a required version.
+			return "", true, true
 		}
+		// Neither a version nor a local dir: nothing this check understands.
+		return "", false, false
 	}
-	return version, hasLocalReplace
-}
-
-// matchGoSXRequireFields reads one require-line body ("m31labs.dev/gosx
-// v0.31.4" or "m31labs.dev/gosx v0.31.4 // indirect") and returns the pinned
-// version.
-func matchGoSXRequireFields(rest string) (string, bool) {
-	fields := strings.Fields(rest)
-	if len(fields) < 2 || fields[0] != "m31labs.dev/gosx" {
-		return "", false
-	}
-	return fields[1], true
-}
-
-// matchGoSXLocalReplaceFields reports whether a replace-line body ("m31labs.dev/gosx
-// [oldver] => target [newver]") redirects m31labs.dev/gosx to a local
-// filesystem path rather than another module version.
-func matchGoSXLocalReplaceFields(rest string) bool {
-	fields := strings.Fields(rest)
-	if len(fields) == 0 || fields[0] != "m31labs.dev/gosx" {
-		return false
-	}
-	arrow := -1
-	for i, field := range fields {
-		if field == "=>" {
-			arrow = i
-			break
-		}
-	}
-	if arrow < 0 || arrow+1 >= len(fields) {
-		return false
-	}
-	target := fields[arrow+1]
-	if strings.Contains(target, "@") {
-		return false
-	}
-	return strings.HasPrefix(target, ".") || filepath.IsAbs(target)
+	return mod.Version, false, true
 }
 
 // versionSkewError is the pure decision behind checkVersionSkew: given the
-// CLI's own version and the project's pinned m31labs.dev/gosx version, decide
-// whether to fail and with what message. Kept separate from filesystem and
-// process access so it is testable on its own.
+// CLI's own version and the project's resolved m31labs.dev/gosx version,
+// decide whether to fail and with what message. Kept separate from
+// filesystem and process access so it is testable on its own.
 func versionSkewError(cliVersion, projectVersion string, hasLocalReplace bool) error {
 	if hasLocalReplace || projectVersion == "" || cliVersion == projectVersion {
 		return nil
 	}
 	return fmt.Errorf(
-		"gosx %s cannot operate on a project pinned to m31labs.dev/gosx %s. Run: go install m31labs.dev/gosx/cmd/gosx@%s",
-		cliVersion, projectVersion, projectVersion,
+		"gosx %s cannot operate on a project pinned to m31labs.dev/gosx %s. Run: go install m31labs.dev/gosx/cmd/gosx@%s, or set %s=1 to override",
+		cliVersion, projectVersion, projectVersion, skipVersionCheckEnv,
 	)
 }

--- a/cmd/gosx/versionskew.go
+++ b/cmd/gosx/versionskew.go
@@ -1,0 +1,134 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"m31labs.dev/gosx"
+)
+
+// checkVersionSkew fails fast when a project's go.mod pins a different
+// m31labs.dev/gosx release than this CLI. Left unchecked, resolveGoSXModuleRoot
+// resolves client sources from the module cache path of the pinned release,
+// and a newer CLI fails deep inside that path with an obscure missing-file
+// error instead of a version diagnostic.
+func checkVersionSkew(projectDir string) error {
+	goModPath, err := projectGoModPath(projectDir)
+	if err != nil || goModPath == "" {
+		return nil
+	}
+	data, err := os.ReadFile(goModPath)
+	if err != nil {
+		return nil
+	}
+	projectVersion, hasLocalReplace := parseGoSXRequirement(string(data))
+	if projectVersion == "" {
+		return nil
+	}
+	return versionSkewError("v"+gosx.Version, projectVersion, hasLocalReplace)
+}
+
+// projectGoModPath resolves the go.mod that governs projectDir, the same way
+// moduleInfo does for modules.go generation. An empty result means projectDir
+// is not inside a module, which is not this check's problem to report.
+func projectGoModPath(projectDir string) (string, error) {
+	cmd := exec.Command("go", "env", "GOMOD")
+	cmd.Dir = projectDir
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(string(out))
+	if path == "" || path == os.DevNull {
+		return "", nil
+	}
+	return path, nil
+}
+
+// parseGoSXRequirement scans go.mod text for the m31labs.dev/gosx require
+// version and whether a local-path replace directive redirects it. It is a
+// minimal scanner rather than golang.org/x/mod/modfile because the module does
+// not otherwise depend on that package.
+func parseGoSXRequirement(goMod string) (version string, hasLocalReplace bool) {
+	scanner := bufio.NewScanner(strings.NewReader(goMod))
+	inRequireBlock := false
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "//") {
+			continue
+		}
+		switch {
+		case line == "require (":
+			inRequireBlock = true
+		case inRequireBlock && line == ")":
+			inRequireBlock = false
+		case inRequireBlock:
+			if v, ok := matchGoSXRequireFields(line); ok {
+				version = v
+			}
+		case strings.HasPrefix(line, "require "):
+			if v, ok := matchGoSXRequireFields(strings.TrimPrefix(line, "require ")); ok {
+				version = v
+			}
+		case strings.HasPrefix(line, "replace "):
+			if matchGoSXLocalReplaceFields(strings.TrimPrefix(line, "replace ")) {
+				hasLocalReplace = true
+			}
+		}
+	}
+	return version, hasLocalReplace
+}
+
+// matchGoSXRequireFields reads one require-line body ("m31labs.dev/gosx
+// v0.31.4" or "m31labs.dev/gosx v0.31.4 // indirect") and returns the pinned
+// version.
+func matchGoSXRequireFields(rest string) (string, bool) {
+	fields := strings.Fields(rest)
+	if len(fields) < 2 || fields[0] != "m31labs.dev/gosx" {
+		return "", false
+	}
+	return fields[1], true
+}
+
+// matchGoSXLocalReplaceFields reports whether a replace-line body ("m31labs.dev/gosx
+// [oldver] => target [newver]") redirects m31labs.dev/gosx to a local
+// filesystem path rather than another module version.
+func matchGoSXLocalReplaceFields(rest string) bool {
+	fields := strings.Fields(rest)
+	if len(fields) == 0 || fields[0] != "m31labs.dev/gosx" {
+		return false
+	}
+	arrow := -1
+	for i, field := range fields {
+		if field == "=>" {
+			arrow = i
+			break
+		}
+	}
+	if arrow < 0 || arrow+1 >= len(fields) {
+		return false
+	}
+	target := fields[arrow+1]
+	if strings.Contains(target, "@") {
+		return false
+	}
+	return strings.HasPrefix(target, ".") || filepath.IsAbs(target)
+}
+
+// versionSkewError is the pure decision behind checkVersionSkew: given the
+// CLI's own version and the project's pinned m31labs.dev/gosx version, decide
+// whether to fail and with what message. Kept separate from filesystem and
+// process access so it is testable on its own.
+func versionSkewError(cliVersion, projectVersion string, hasLocalReplace bool) error {
+	if hasLocalReplace || projectVersion == "" || cliVersion == projectVersion {
+		return nil
+	}
+	return fmt.Errorf(
+		"gosx %s cannot operate on a project pinned to m31labs.dev/gosx %s. Run: go install m31labs.dev/gosx/cmd/gosx@%s",
+		cliVersion, projectVersion, projectVersion,
+	)
+}

--- a/cmd/gosx/versionskew_test.go
+++ b/cmd/gosx/versionskew_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -33,13 +35,13 @@ func TestVersionSkewError(t *testing.T) {
 			name:           "older project fails with the install hint",
 			cliVersion:     "v0.38.1",
 			projectVersion: "v0.31.4",
-			wantErr:        "gosx v0.38.1 cannot operate on a project pinned to m31labs.dev/gosx v0.31.4. Run: go install m31labs.dev/gosx/cmd/gosx@v0.31.4",
+			wantErr:        "gosx v0.38.1 cannot operate on a project pinned to m31labs.dev/gosx v0.31.4. Run: go install m31labs.dev/gosx/cmd/gosx@v0.31.4, or set GOSX_SKIP_VERSION_CHECK=1 to override",
 		},
 		{
 			name:           "newer project also fails",
 			cliVersion:     "v0.31.4",
 			projectVersion: "v0.38.1",
-			wantErr:        "gosx v0.31.4 cannot operate on a project pinned to m31labs.dev/gosx v0.38.1. Run: go install m31labs.dev/gosx/cmd/gosx@v0.38.1",
+			wantErr:        "gosx v0.31.4 cannot operate on a project pinned to m31labs.dev/gosx v0.38.1. Run: go install m31labs.dev/gosx/cmd/gosx@v0.38.1, or set GOSX_SKIP_VERSION_CHECK=1 to override",
 		},
 	}
 	for _, tc := range cases {
@@ -58,109 +60,190 @@ func TestVersionSkewError(t *testing.T) {
 	}
 }
 
-func TestParseGoSXRequirement(t *testing.T) {
+// TestVersionSkewInterpretGoListModule exercises the pure decision behind
+// resolveProjectGoSXVersion directly against synthetic `go list -m -json`
+// records, without shelling out to the toolchain.
+func TestVersionSkewInterpretGoListModule(t *testing.T) {
 	cases := []struct {
-		name             string
-		goMod            string
-		wantVersion      string
-		wantLocalReplace bool
+		name        string
+		mod         goListModule
+		wantVersion string
+		wantLocal   bool
+		wantOK      bool
 	}{
 		{
-			name: "single-line require",
-			goMod: `module example.com/app
-
-go 1.26
-
-require m31labs.dev/gosx v0.31.4
-`,
+			name:        "plain required version",
+			mod:         goListModule{Version: "v0.31.4"},
 			wantVersion: "v0.31.4",
+			wantOK:      true,
 		},
 		{
-			name: "require block",
+			name:      "path replace has no replacement version",
+			mod:       goListModule{Version: "v0.31.4", Replace: &goListModule{Dir: "/home/dev/gosx"}},
+			wantLocal: true,
+			wantOK:    true,
+		},
+		{
+			name:        "module-version replace compares the replaced version",
+			mod:         goListModule{Version: "v0.31.4", Replace: &goListModule{Version: "v0.30.7"}},
+			wantVersion: "v0.30.7",
+			wantOK:      true,
+		},
+		{
+			name:      "workspace-local module has a dir but no version",
+			mod:       goListModule{Dir: "/home/dev/gosx"},
+			wantLocal: true,
+			wantOK:    true,
+		},
+		{
+			name: "neither version nor dir is unknown",
+			mod:  goListModule{},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			version, localReplace, ok := interpretGoListModule(tc.mod)
+			if version != tc.wantVersion || localReplace != tc.wantLocal || ok != tc.wantOK {
+				t.Fatalf("interpretGoListModule(%+v) = (%q, %v, %v), want (%q, %v, %v)",
+					tc.mod, version, localReplace, ok, tc.wantVersion, tc.wantLocal, tc.wantOK)
+			}
+		})
+	}
+}
+
+// newGoModProject writes a standalone go.mod (no go.sum, no source files —
+// `go list -m` needs neither) and returns its directory.
+func newGoModProject(t *testing.T, goMod string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0644); err != nil {
+		t.Fatalf("write go.mod: %v", err)
+	}
+	return dir
+}
+
+// TestVersionSkewResolveProjectGoModVariants runs the real go toolchain
+// against go.mod shapes the old hand-rolled scanner mishandled: block-form
+// replace (both a local directory and a module-version target) and a
+// require( block with no space before the paren and a trailing comment on
+// the open line.
+func TestVersionSkewResolveProjectGoModVariants(t *testing.T) {
+	localTarget := newGoModProject(t, "module m31labs.dev/gosx\n\ngo 1.26\n")
+
+	cases := []struct {
+		name        string
+		goMod       string
+		wantVersion string
+		wantLocal   bool
+		wantOK      bool
+	}{
+		{
+			name: "block-form replace to a local directory",
 			goMod: `module example.com/app
 
 go 1.26
 
 require (
 	m31labs.dev/gosx v0.31.4
-	github.com/other/thing v1.0.0
+)
+
+replace (
+	m31labs.dev/gosx => ` + localTarget + `
+)
+`,
+			wantLocal: true,
+			wantOK:    true,
+		},
+		{
+			name: "block-form replace to another module version",
+			goMod: `module example.com/app
+
+go 1.26
+
+require (
+	m31labs.dev/gosx v0.31.4
+)
+
+replace (
+	m31labs.dev/gosx v0.31.4 => m31labs.dev/gosx v0.30.7
+)
+`,
+			wantVersion: "v0.30.7",
+			wantOK:      true,
+		},
+		{
+			name: "require block with no space and a trailing comment",
+			goMod: `module example.com/app
+
+go 1.26
+
+require( // pinned deps
+	m31labs.dev/gosx v0.31.4
 )
 `,
 			wantVersion: "v0.31.4",
+			wantOK:      true,
 		},
 		{
-			name: "no gosx dependency",
+			name: "gosx not required at all",
 			goMod: `module example.com/app
 
 go 1.26
 
 require github.com/other/thing v1.0.0
 `,
-			wantVersion: "",
-		},
-		{
-			name: "relative local replace",
-			goMod: `module example.com/app
-
-go 1.26
-
-require m31labs.dev/gosx v0.31.4
-
-replace m31labs.dev/gosx => ../../gosx
-`,
-			wantVersion:      "v0.31.4",
-			wantLocalReplace: true,
-		},
-		{
-			name: "absolute local replace",
-			goMod: `module example.com/app
-
-go 1.26
-
-require m31labs.dev/gosx v0.31.4
-
-replace m31labs.dev/gosx => /home/dev/gosx
-`,
-			wantVersion:      "v0.31.4",
-			wantLocalReplace: true,
-		},
-		{
-			name: "replace to another module version is not local",
-			goMod: `module example.com/app
-
-go 1.26
-
-require m31labs.dev/gosx v0.31.4
-
-replace m31labs.dev/gosx => example.com/fork v0.31.5
-`,
-			wantVersion:      "v0.31.4",
-			wantLocalReplace: false,
-		},
-		{
-			name: "replace with an old-version constraint stays local",
-			goMod: `module example.com/app
-
-go 1.26
-
-require m31labs.dev/gosx v0.31.4
-
-replace m31labs.dev/gosx v0.31.4 => ../local/gosx
-`,
-			wantVersion:      "v0.31.4",
-			wantLocalReplace: true,
+			wantOK: false,
 		},
 	}
+
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			version, hasLocalReplace := parseGoSXRequirement(tc.goMod)
-			if version != tc.wantVersion {
-				t.Errorf("version = %q, want %q", version, tc.wantVersion)
-			}
-			if hasLocalReplace != tc.wantLocalReplace {
-				t.Errorf("hasLocalReplace = %v, want %v", hasLocalReplace, tc.wantLocalReplace)
+			dir := newGoModProject(t, tc.goMod)
+			version, localReplace, ok := resolveProjectGoSXVersion(dir)
+			if version != tc.wantVersion || localReplace != tc.wantLocal || ok != tc.wantOK {
+				t.Fatalf("resolveProjectGoSXVersion(%q) = (%q, %v, %v), want (%q, %v, %v)",
+					dir, version, localReplace, ok, tc.wantVersion, tc.wantLocal, tc.wantOK)
 			}
 		})
+	}
+}
+
+// TestVersionSkewResolveProjectWorkspace builds a real go.work workspace with
+// two member modules — an app module that requires a tagged m31labs.dev/gosx
+// release, and a second member whose own module path is m31labs.dev/gosx —
+// and confirms resolution follows the workspace override rather than the
+// require line. The old scanner read GOMOD (which still names the app
+// module's go.mod under a workspace) and reported the stale tagged version.
+func TestVersionSkewResolveProjectWorkspace(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	gosxDir := filepath.Join(root, "gosx")
+	for _, dir := range []string{appDir, gosxDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	mustWriteFile(t, filepath.Join(appDir, "go.mod"), `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+`)
+	mustWriteFile(t, filepath.Join(gosxDir, "go.mod"), "module m31labs.dev/gosx\n\ngo 1.26\n")
+	mustWriteFile(t, filepath.Join(root, "go.work"), `go 1.26
+
+use ./app
+use ./gosx
+`)
+
+	version, localReplace, ok := resolveProjectGoSXVersion(appDir)
+	if !ok || !localReplace || version != "" {
+		t.Fatalf("resolveProjectGoSXVersion(%q) = (%q, %v, %v), want (\"\", true, true) for a workspace-local module",
+			appDir, version, localReplace, ok)
+	}
+
+	if err := checkVersionSkew(appDir); err != nil {
+		t.Fatalf("checkVersionSkew(%q) = %v, want nil under a workspace override", appDir, err)
 	}
 }
 
@@ -185,5 +268,36 @@ func TestCheckVersionSkewErrorMentionsInstallCommand(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "go install m31labs.dev/gosx/cmd/gosx@v0.31.4") {
 		t.Fatalf("error %q does not name the install command", err.Error())
+	}
+}
+
+func TestCheckVersionSkewErrorMentionsSkipEnvVar(t *testing.T) {
+	err := versionSkewError("v0.38.1", "v0.31.4", false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "GOSX_SKIP_VERSION_CHECK=1 to override") {
+		t.Fatalf("error %q does not mention the escape hatch", err.Error())
+	}
+}
+
+// TestCheckVersionSkewSkipEnvVar confirms GOSX_SKIP_VERSION_CHECK bypasses
+// the check entirely, even for a project pinned to a version this CLI does
+// not share and with no replace directive to excuse it.
+func TestCheckVersionSkewSkipEnvVar(t *testing.T) {
+	dir := newGoModProject(t, `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.30.7
+`)
+
+	if err := checkVersionSkew(dir); err == nil {
+		t.Fatal("expected checkVersionSkew to fail on a genuine version pin before the escape hatch is set")
+	}
+
+	t.Setenv("GOSX_SKIP_VERSION_CHECK", "1")
+	if err := checkVersionSkew(dir); err != nil {
+		t.Fatalf("checkVersionSkew(%q) = %v, want nil with GOSX_SKIP_VERSION_CHECK set", dir, err)
 	}
 }

--- a/cmd/gosx/versionskew_test.go
+++ b/cmd/gosx/versionskew_test.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestVersionSkewError(t *testing.T) {
+	cases := []struct {
+		name            string
+		cliVersion      string
+		projectVersion  string
+		hasLocalReplace bool
+		wantErr         string
+	}{
+		{
+			name:           "matching versions pass",
+			cliVersion:     "v0.41.0",
+			projectVersion: "v0.41.0",
+		},
+		{
+			name:           "no gosx dependency skips",
+			cliVersion:     "v0.41.0",
+			projectVersion: "",
+		},
+		{
+			name:            "local replace skips even on skew",
+			cliVersion:      "v0.41.0",
+			projectVersion:  "v0.31.4",
+			hasLocalReplace: true,
+		},
+		{
+			name:           "older project fails with the install hint",
+			cliVersion:     "v0.38.1",
+			projectVersion: "v0.31.4",
+			wantErr:        "gosx v0.38.1 cannot operate on a project pinned to m31labs.dev/gosx v0.31.4. Run: go install m31labs.dev/gosx/cmd/gosx@v0.31.4",
+		},
+		{
+			name:           "newer project also fails",
+			cliVersion:     "v0.31.4",
+			projectVersion: "v0.38.1",
+			wantErr:        "gosx v0.31.4 cannot operate on a project pinned to m31labs.dev/gosx v0.38.1. Run: go install m31labs.dev/gosx/cmd/gosx@v0.38.1",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := versionSkewError(tc.cliVersion, tc.projectVersion, tc.hasLocalReplace)
+			if tc.wantErr == "" {
+				if err != nil {
+					t.Fatalf("versionSkewError(%q, %q, %v) = %v, want nil", tc.cliVersion, tc.projectVersion, tc.hasLocalReplace, err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.wantErr {
+				t.Fatalf("versionSkewError(%q, %q, %v) = %v, want %q", tc.cliVersion, tc.projectVersion, tc.hasLocalReplace, err, tc.wantErr)
+			}
+		})
+	}
+}
+
+func TestParseGoSXRequirement(t *testing.T) {
+	cases := []struct {
+		name             string
+		goMod            string
+		wantVersion      string
+		wantLocalReplace bool
+	}{
+		{
+			name: "single-line require",
+			goMod: `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+`,
+			wantVersion: "v0.31.4",
+		},
+		{
+			name: "require block",
+			goMod: `module example.com/app
+
+go 1.26
+
+require (
+	m31labs.dev/gosx v0.31.4
+	github.com/other/thing v1.0.0
+)
+`,
+			wantVersion: "v0.31.4",
+		},
+		{
+			name: "no gosx dependency",
+			goMod: `module example.com/app
+
+go 1.26
+
+require github.com/other/thing v1.0.0
+`,
+			wantVersion: "",
+		},
+		{
+			name: "relative local replace",
+			goMod: `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+
+replace m31labs.dev/gosx => ../../gosx
+`,
+			wantVersion:      "v0.31.4",
+			wantLocalReplace: true,
+		},
+		{
+			name: "absolute local replace",
+			goMod: `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+
+replace m31labs.dev/gosx => /home/dev/gosx
+`,
+			wantVersion:      "v0.31.4",
+			wantLocalReplace: true,
+		},
+		{
+			name: "replace to another module version is not local",
+			goMod: `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+
+replace m31labs.dev/gosx => example.com/fork v0.31.5
+`,
+			wantVersion:      "v0.31.4",
+			wantLocalReplace: false,
+		},
+		{
+			name: "replace with an old-version constraint stays local",
+			goMod: `module example.com/app
+
+go 1.26
+
+require m31labs.dev/gosx v0.31.4
+
+replace m31labs.dev/gosx v0.31.4 => ../local/gosx
+`,
+			wantVersion:      "v0.31.4",
+			wantLocalReplace: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			version, hasLocalReplace := parseGoSXRequirement(tc.goMod)
+			if version != tc.wantVersion {
+				t.Errorf("version = %q, want %q", version, tc.wantVersion)
+			}
+			if hasLocalReplace != tc.wantLocalReplace {
+				t.Errorf("hasLocalReplace = %v, want %v", hasLocalReplace, tc.wantLocalReplace)
+			}
+		})
+	}
+}
+
+func TestCheckVersionSkewSkipsOutsideAModule(t *testing.T) {
+	dir := t.TempDir()
+	if err := checkVersionSkew(dir); err != nil {
+		t.Fatalf("checkVersionSkew(%q) = %v, want nil outside any module", dir, err)
+	}
+}
+
+func TestCheckVersionSkewMatchesCLI(t *testing.T) {
+	dir := newInvalidStrictStarter(t, "version-skew-match")
+	if err := checkVersionSkew(dir); err != nil {
+		t.Fatalf("checkVersionSkew(%q) = %v, want nil for a project on this CLI's own version with a local replace", dir, err)
+	}
+}
+
+func TestCheckVersionSkewErrorMentionsInstallCommand(t *testing.T) {
+	err := versionSkewError("v0.38.1", "v0.31.4", false)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if !strings.Contains(err.Error(), "go install m31labs.dev/gosx/cmd/gosx@v0.31.4") {
+		t.Fatalf("error %q does not name the install command", err.Error())
+	}
+}

--- a/route/filemodule_warnings.go
+++ b/route/filemodule_warnings.go
@@ -31,13 +31,25 @@ func (r *Router) logUnregisteredFileModuleWarnings() {
 	}
 }
 
+// unregisteredFileModuleDirThreshold is the most unregistered directories
+// unregisteredFileModuleWarnings reports one line each for. Past it, a
+// partially regenerated modules.go floods the log with a line per directory
+// under test, so the function collapses the list to one summary line
+// instead.
+const unregisteredFileModuleDirThreshold = 2
+
 // unregisteredFileModuleWarnings finds discovered page directories that ship a
 // page.server.go (or index.server.go) file on disk but never registered a
 // file module — the signature of a stale modules.go. It is the pure decision
 // behind the router-build warning, so a test can assert on it without
 // capturing log output.
+//
+// unregisteredFileModuleDirThreshold or fewer unregistered directories get one
+// line each. More than that collapse to a single summary line, so a stale
+// modules.go covering a whole sub-tree does not flood the log with a line per
+// directory.
 func unregisteredFileModuleWarnings(registry *FileModuleRegistry, root string, pages []FilePage) []string {
-	var warnings []string
+	var dirs []string
 	for _, page := range pages {
 		if _, ok := resolveFileModule(registry, root, page); ok {
 			continue
@@ -45,9 +57,22 @@ func unregisteredFileModuleWarnings(registry *FileModuleRegistry, root string, p
 		if !isFile(fileRoutePageServerGoPath(page)) {
 			continue
 		}
+		dirs = append(dirs, filepath.Dir(page.FilePath))
+	}
+	if len(dirs) == 0 {
+		return nil
+	}
+	if len(dirs) > unregisteredFileModuleDirThreshold {
+		return []string{fmt.Sprintf(
+			"gosx route: %d routed directories have page.server.go files with no registered module (first: %s); regenerate modules.go (gosx build)",
+			len(dirs), dirs[0],
+		)}
+	}
+	warnings := make([]string, 0, len(dirs))
+	for _, dir := range dirs {
 		warnings = append(warnings, fmt.Sprintf(
 			"gosx route: %s has a page.server.go but no registered module; regenerate modules.go (gosx build)",
-			filepath.Dir(page.FilePath),
+			dir,
 		))
 	}
 	return warnings

--- a/route/filemodule_warnings.go
+++ b/route/filemodule_warnings.go
@@ -1,0 +1,68 @@
+package route
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// fileRouteDirSource remembers what AddDir discovered so Build/BuildChecked
+// can re-check the file module registry at build time, when a stale
+// modules.go is otherwise silent: the route serves, the template renders, and
+// only the missing Load/Actions wiring gives it away.
+type fileRouteDirSource struct {
+	root     string
+	registry *FileModuleRegistry
+	pages    []FilePage
+}
+
+// logUnregisteredFileModuleWarnings logs one line per page directory whose
+// *.server.go registrant never made it into the file module registry.
+func (r *Router) logUnregisteredFileModuleWarnings() {
+	if r == nil {
+		return
+	}
+	for _, source := range r.fileRouteDirs {
+		for _, warning := range unregisteredFileModuleWarnings(source.registry, source.root, source.pages) {
+			log.Print(warning)
+		}
+	}
+}
+
+// unregisteredFileModuleWarnings finds discovered page directories that ship a
+// page.server.go (or index.server.go) file on disk but never registered a
+// file module — the signature of a stale modules.go. It is the pure decision
+// behind the router-build warning, so a test can assert on it without
+// capturing log output.
+func unregisteredFileModuleWarnings(registry *FileModuleRegistry, root string, pages []FilePage) []string {
+	var warnings []string
+	for _, page := range pages {
+		if _, ok := resolveFileModule(registry, root, page); ok {
+			continue
+		}
+		if !isFile(fileRoutePageServerGoPath(page)) {
+			continue
+		}
+		warnings = append(warnings, fmt.Sprintf(
+			"gosx route: %s has a page.server.go but no registered module; regenerate modules.go (gosx build)",
+			filepath.Dir(page.FilePath),
+		))
+	}
+	return warnings
+}
+
+// fileRoutePageServerGoPath is the *.server.go sibling a page source expects,
+// following the same base-name convention FileModuleHere infers from the
+// calling file (page.gsx <-> page.server.go, index.html <-> index.server.go).
+func fileRoutePageServerGoPath(page FilePage) string {
+	ext := filepath.Ext(page.FilePath)
+	base := strings.TrimSuffix(page.FilePath, ext)
+	return base + ".server.go"
+}
+
+func isFile(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}

--- a/route/filemodule_warnings_test.go
+++ b/route/filemodule_warnings_test.go
@@ -80,6 +80,121 @@ func Page() Node {
 	}
 }
 
+// TestUnregisteredFileModuleWarningsListsEachDirAtThreshold confirms exactly
+// unregisteredFileModuleDirThreshold unregistered directories still get one
+// line each, rather than collapsing to the summary form.
+func TestUnregisteredFileModuleWarningsListsEachDirAtThreshold(t *testing.T) {
+	root := t.TempDir()
+	var wantDirs []string
+	for _, name := range []string{"board", "roster"} {
+		writeRouteFile(t, root, name+"/page.gsx", `package app
+func Page() Node {
+	return <main>Page</main>
+}
+`)
+		writeRouteFile(t, root, name+"/page.server.go", `package app
+func init() {}
+`)
+		wantDirs = append(wantDirs, filepath.Join(root, name))
+	}
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := unregisteredFileModuleWarnings(NewFileModuleRegistry(), root, bundle.Pages)
+	if len(warnings) != len(wantDirs) {
+		t.Fatalf("warnings = %v, want one line per directory (%d)", warnings, len(wantDirs))
+	}
+	for _, dir := range wantDirs {
+		want := "gosx route: " + dir + " has a page.server.go but no registered module; regenerate modules.go (gosx build)"
+		found := false
+		for _, warning := range warnings {
+			if warning == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("warnings = %v, want a line for %q", warnings, dir)
+		}
+	}
+}
+
+// TestUnregisteredFileModuleWarningsSummarizesAboveThreshold confirms more
+// than unregisteredFileModuleDirThreshold unregistered directories collapse
+// to one summary line instead of flooding the log with a line per directory
+// — the failure a partially regenerated modules.go produced running a docs
+// sub-package test with ten or more routed directories.
+func TestUnregisteredFileModuleWarningsSummarizesAboveThreshold(t *testing.T) {
+	root := t.TempDir()
+	names := []string{"board", "roster", "standings"}
+	for _, name := range names {
+		writeRouteFile(t, root, name+"/page.gsx", `package app
+func Page() Node {
+	return <main>Page</main>
+}
+`)
+		writeRouteFile(t, root, name+"/page.server.go", `package app
+func init() {}
+`)
+	}
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := unregisteredFileModuleWarnings(NewFileModuleRegistry(), root, bundle.Pages)
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one summary line for %d unregistered directories", warnings, len(names))
+	}
+	if !strings.Contains(warnings[0], "3 routed directories have page.server.go files with no registered module") {
+		t.Fatalf("warning = %q, want the summary count and phrasing", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "regenerate modules.go (gosx build)") {
+		t.Fatalf("warning = %q, want the regenerate hint", warnings[0])
+	}
+	if !strings.Contains(warnings[0], "(first: "+filepath.Join(root, "board")+")") {
+		t.Fatalf("warning = %q, want the first unregistered directory named", warnings[0])
+	}
+}
+
+// TestUnregisteredFileModuleWarningsWarnsRegardlessOfBuildTag documents
+// current behavior for a page.server.go guarded by a build tag that excludes
+// it from the default build: the warning still fires. This is a plain
+// filesystem check (isFile on the *.server.go path) with no build-constraint
+// parsing, so it cannot tell a genuinely stale modules.go from a
+// build-tag-gated file the developer excluded on purpose. That is acceptable
+// here — the check is a cheap diagnostic hint, not a build gate, and warning
+// on a legitimately excluded file is a false positive a developer can read
+// past, whereas staying silent on a genuinely stale modules.go is the failure
+// this warning exists to catch.
+func TestUnregisteredFileModuleWarningsWarnsRegardlessOfBuildTag(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "board/page.gsx", `package app
+func Page() Node {
+	return <main>Board</main>
+}
+`)
+	writeRouteFile(t, root, "board/page.server.go", `//go:build ignore
+
+package app
+func init() {}
+`)
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := unregisteredFileModuleWarnings(NewFileModuleRegistry(), root, bundle.Pages)
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want one warning even though the build tag excludes page.server.go from compilation", warnings)
+	}
+}
+
 // TestRouterBuildChecketLogsUnregisteredFileModuleWarning exercises the wiring
 // through AddDir and BuildChecked end to end: a routed directory with a
 // page.server.go on disk but no registration must warn at build time, not

--- a/route/filemodule_warnings_test.go
+++ b/route/filemodule_warnings_test.go
@@ -1,0 +1,120 @@
+package route
+
+import (
+	"bytes"
+	"log"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestUnregisteredFileModuleWarningsFiresForUnregisteredServerGo(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "board/page.gsx", `package app
+func Page() Node {
+	return <main>Board</main>
+}
+`)
+	writeRouteFile(t, root, "board/page.server.go", `package app
+func init() {}
+`)
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	warnings := unregisteredFileModuleWarnings(NewFileModuleRegistry(), root, bundle.Pages)
+	if len(warnings) != 1 {
+		t.Fatalf("warnings = %v, want exactly one", warnings)
+	}
+
+	wantDir := filepath.Join(root, "board")
+	want := "gosx route: " + wantDir + " has a page.server.go but no registered module; regenerate modules.go (gosx build)"
+	if warnings[0] != want {
+		t.Fatalf("warning = %q, want %q", warnings[0], want)
+	}
+}
+
+func TestUnregisteredFileModuleWarningsSkipsRegisteredModule(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "board/page.gsx", `package app
+func Page() Node {
+	return <main>Board</main>
+}
+`)
+	writeRouteFile(t, root, "board/page.server.go", `package app
+func init() {}
+`)
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	modules := NewFileModuleRegistry()
+	if err := modules.Register(FileModuleFor(bundle.Pages[0].Source, FileModuleOptions{})); err != nil {
+		t.Fatal(err)
+	}
+
+	if warnings := unregisteredFileModuleWarnings(modules, root, bundle.Pages); len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none for a registered module", warnings)
+	}
+}
+
+func TestUnregisteredFileModuleWarningsSkipsPagesWithoutServerGo(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "board/page.gsx", `package app
+func Page() Node {
+	return <main>Board</main>
+}
+`)
+
+	bundle, err := ScanDir(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if warnings := unregisteredFileModuleWarnings(NewFileModuleRegistry(), root, bundle.Pages); len(warnings) != 0 {
+		t.Fatalf("warnings = %v, want none when there is no page.server.go to register", warnings)
+	}
+}
+
+// TestRouterBuildChecketLogsUnregisteredFileModuleWarning exercises the wiring
+// through AddDir and BuildChecked end to end: a routed directory with a
+// page.server.go on disk but no registration must warn at build time, not
+// render silently with empty data.
+func TestRouterBuildCheckedLogsUnregisteredFileModuleWarning(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "board/page.gsx", `package app
+func Page() Node {
+	return <main>Board</main>
+}
+`)
+	writeRouteFile(t, root, "board/page.server.go", `package app
+func init() {}
+`)
+
+	var logs bytes.Buffer
+	prevOutput, prevFlags := log.Writer(), log.Flags()
+	log.SetOutput(&logs)
+	log.SetFlags(0)
+	defer func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	}()
+
+	router := NewRouter()
+	if err := router.AddDir(root, FileRoutesOptions{Modules: NewFileModuleRegistry()}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := router.BuildChecked(); err != nil {
+		t.Fatal(err)
+	}
+
+	wantDir := filepath.Join(root, "board")
+	want := "gosx route: " + wantDir + " has a page.server.go but no registered module; regenerate modules.go (gosx build)"
+	if !strings.Contains(logs.String(), want) {
+		t.Fatalf("log output = %q, want it to contain %q", logs.String(), want)
+	}
+}

--- a/route/filesystem.go
+++ b/route/filesystem.go
@@ -290,6 +290,16 @@ func (r *Router) AddDir(root string, opts FileRoutesOptions) error {
 		return err
 	}
 	r.Add(routes...)
+	// Remembered for Build/BuildChecked, which re-checks the registry at build
+	// time rather than here: registration in the shared registry usually runs
+	// from package init() blocks that execute before AddDir either way, but
+	// checking at build time keeps the diagnostic tied to where a developer
+	// actually observes the empty-data symptom.
+	r.fileRouteDirs = append(r.fileRouteDirs, fileRouteDirSource{
+		root:     root,
+		registry: registrar.moduleRegistry,
+		pages:    bundle.Pages,
+	})
 	return nil
 }
 

--- a/route/route.go
+++ b/route/route.go
@@ -187,6 +187,7 @@ type Router struct {
 	errorLayout    LayoutFunc
 	revalidator    *server.Revalidator
 	observers      []server.RequestObserver
+	fileRouteDirs  []fileRouteDirSource
 }
 
 type handlerRoute struct {
@@ -290,6 +291,7 @@ func (r *Router) BuildChecked() (http.Handler, error) {
 	if r == nil {
 		return nil, fmt.Errorf("route router is nil")
 	}
+	r.logUnregisteredFileModuleWarnings()
 	mux := http.NewServeMux()
 	for _, extra := range r.handlers {
 		var h http.Handler = extra.handler


### PR DESCRIPTION
## Summary

Introduces a pre-flight version skew check that fails fast when the CLI detects a different m31labs.dev/gosx version pinned in the project's go.mod, providing a direct upgrade instruction. Additionally, adds a build-time warning when routed directories contain *.server.go files that weren't registered in the generated modules.go, preventing silent rendering failures due to stale code generation.

## Changes

- New `checkVersionSkew` function scans project go.mod for `m31labs.dev/gosx` requirement and replace directives; fails early on version mismatches with a clear `go install` hint.
- Integrated `checkVersionSkew` into all main CLI entry points (`build`, `dev`, `export`, `check`) before proceeding with operations.
- Extended `Router.AddDir` to record tracked file route directories and their registries for later validation.
- Added `logUnregisteredFileModuleWarnings` to `Router.BuildChecked` to log diagnostics when `*.server.go` pages are discovered on disk but missing from the file module registry.
- Added comprehensive unit tests for version skew parsing, matching logic, and file module warning detection across isolated and integrated scenarios.

## Testing

- Run `go test ./cmd/gosx/... ./route/...` to verify new unit tests pass.
- Create a dummy project with an older `m31labs.dev/gosx` version pinned in `go.mod` and run `gosx build`; confirm it exits immediately with the version mismatch error and install command hint.
- Generate a route directory with a `page.server.go` file but skip `gosx build` so `modules.go` remains empty; run `gosx dev` or `gosx build` and verify the build step logs the unregistered module warning.