### PR TITLE
add: Add island source staleness detection on server startup

### DIFF
--- a/buildmanifest/manifest.go
+++ b/buildmanifest/manifest.go
@@ -16,6 +16,15 @@ type Manifest struct {
 	Islands     []IslandAsset       `json:"islands"`
 	CSS         []CSSAsset          `json:"css"`
 	SceneAssets *SceneAssetManifest `json:"sceneAssets,omitempty"`
+
+	// SourceRoot is the absolute project root `gosx build` ran from when it
+	// wrote this manifest (the directory holding `dist/`, `app/`, and
+	// `go.mod`). A server started later prefers this recorded path — if it
+	// still exists on the host — over guessing the project root from where
+	// it found build.json, since a guess breaks whenever the manifest is
+	// not nested one level under a directory literally named "dist". See
+	// StaleIslands.
+	SourceRoot string `json:"sourceRoot,omitempty"`
 }
 
 type RuntimeAssets struct {
@@ -189,17 +198,25 @@ func (m *Manifest) IslandAssetByName(componentName string) (IslandAsset, bool) {
 	return IslandAsset{}, false
 }
 
-// ContentHash returns the first 8 hex characters of the sha256 digest of
-// data. This is the one hashing scheme every build-time content hash in a
-// manifest uses — asset file hashes (HashedAsset.Hash) and island source
-// hashes (IslandAsset.SourceHash) alike — so a hash comparison never
+// ContentHash returns the first 16 hex characters (8 bytes) of the sha256
+// digest of data. This is the one hashing scheme every build-time content
+// hash in a manifest uses — asset file hashes (HashedAsset.Hash) and island
+// source hashes (IslandAsset.SourceHash) alike — so a hash comparison never
 // silently compares two different algorithms.
 func ContentHash(data []byte) string {
 	sum := sha256.Sum256(data)
 	return hex.EncodeToString(sum[:8])
 }
 
-// StaleIslands returns the Name of every island asset whose recorded
+// StaleIsland names one island asset whose recorded SourceHash no longer
+// matches the current bytes of its SourceFile, together with that
+// SourceFile so a caller can name the changed file in a log message.
+type StaleIsland struct {
+	Name       string
+	SourceFile string
+}
+
+// StaleIslands returns one StaleIsland for every island asset whose recorded
 // SourceHash no longer matches the current bytes of its SourceFile under
 // sourceRoot. It reports nothing, and never returns an error, in any of
 // these cases:
@@ -208,13 +225,16 @@ func ContentHash(data []byte) string {
 //   - The island's SourceFile or SourceHash is empty — the manifest
 //     predates issue #166's staleness fields, so there is nothing to
 //     compare against. Reporting staleness here would be a false positive.
+//   - SourceFile is not local to sourceRoot (it escapes via ".." or is
+//     rooted) — a manifest should never record such a path, so this is
+//     defensive, not an expected case.
 //   - SourceFile cannot be read under sourceRoot — a production image may
 //     ship dist/ without the app's .gsx sources, and that is not an error.
 //
 // Recomputing the build-time program hash would require the full compiler
 // pipeline (parse, lower, encode); SourceHash is the cheap, honest
 // alternative recorded once at build time expressly for this comparison.
-func (m *Manifest) StaleIslands(sourceRoot string) []string {
+func (m *Manifest) StaleIslands(sourceRoot string) []StaleIsland {
 	if m == nil {
 		return nil
 	}
@@ -223,18 +243,22 @@ func (m *Manifest) StaleIslands(sourceRoot string) []string {
 		return nil
 	}
 
-	var stale []string
+	var stale []StaleIsland
 	for _, asset := range m.Islands {
 		if strings.TrimSpace(asset.SourceFile) == "" || strings.TrimSpace(asset.SourceHash) == "" {
 			continue
 		}
-		path := filepath.Join(sourceRoot, filepath.FromSlash(asset.SourceFile))
+		rel := filepath.FromSlash(asset.SourceFile)
+		if !filepath.IsLocal(rel) {
+			continue
+		}
+		path := filepath.Join(sourceRoot, rel)
 		data, err := os.ReadFile(path)
 		if err != nil {
 			continue
 		}
 		if ContentHash(data) != asset.SourceHash {
-			stale = append(stale, asset.Name)
+			stale = append(stale, StaleIsland{Name: asset.Name, SourceFile: asset.SourceFile})
 		}
 	}
 	return stale

--- a/buildmanifest/manifest.go
+++ b/buildmanifest/manifest.go
@@ -1,6 +1,8 @@
 package buildmanifest
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -61,6 +63,22 @@ type IslandAsset struct {
 	Name   string `json:"name"`
 	Format string `json:"format"` // "json" or "bin"
 	HashedAsset
+
+	// SourceFile is the project-relative, slash-separated path to the .gsx
+	// file that declared this island. Empty on manifests written before
+	// issue #166 added source staleness detection.
+	SourceFile string `json:"sourceFile,omitempty"`
+	// SourceHash is ContentHash of SourceFile's raw bytes at the moment
+	// `gosx build` wrote this asset. It is deliberately NOT the same value
+	// as HashedAsset.Hash: Hash covers the compiled program bytes (the
+	// JSON/binary IR shipped to the browser), while SourceHash covers the
+	// .gsx source text the compiler read to produce that program. A server
+	// started later re-hashes SourceFile and compares against SourceHash to
+	// detect that source changed since the dist/ program was built, without
+	// re-running the compiler pipeline. Empty when the manifest predates
+	// this field, or when the build could not resolve a source file for
+	// the island (for example, an island a Go-only test synthesizes).
+	SourceHash string `json:"sourceHash,omitempty"`
 }
 
 type CSSAsset struct {
@@ -169,6 +187,57 @@ func (m *Manifest) IslandAssetByName(componentName string) (IslandAsset, bool) {
 		}
 	}
 	return IslandAsset{}, false
+}
+
+// ContentHash returns the first 8 hex characters of the sha256 digest of
+// data. This is the one hashing scheme every build-time content hash in a
+// manifest uses — asset file hashes (HashedAsset.Hash) and island source
+// hashes (IslandAsset.SourceHash) alike — so a hash comparison never
+// silently compares two different algorithms.
+func ContentHash(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:8])
+}
+
+// StaleIslands returns the Name of every island asset whose recorded
+// SourceHash no longer matches the current bytes of its SourceFile under
+// sourceRoot. It reports nothing, and never returns an error, in any of
+// these cases:
+//
+//   - sourceRoot is empty (no app source directory known).
+//   - The island's SourceFile or SourceHash is empty — the manifest
+//     predates issue #166's staleness fields, so there is nothing to
+//     compare against. Reporting staleness here would be a false positive.
+//   - SourceFile cannot be read under sourceRoot — a production image may
+//     ship dist/ without the app's .gsx sources, and that is not an error.
+//
+// Recomputing the build-time program hash would require the full compiler
+// pipeline (parse, lower, encode); SourceHash is the cheap, honest
+// alternative recorded once at build time expressly for this comparison.
+func (m *Manifest) StaleIslands(sourceRoot string) []string {
+	if m == nil {
+		return nil
+	}
+	sourceRoot = strings.TrimSpace(sourceRoot)
+	if sourceRoot == "" {
+		return nil
+	}
+
+	var stale []string
+	for _, asset := range m.Islands {
+		if strings.TrimSpace(asset.SourceFile) == "" || strings.TrimSpace(asset.SourceHash) == "" {
+			continue
+		}
+		path := filepath.Join(sourceRoot, filepath.FromSlash(asset.SourceFile))
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		if ContentHash(data) != asset.SourceHash {
+			stale = append(stale, asset.Name)
+		}
+	}
+	return stale
 }
 
 // IslandURL returns the public URL for an island program asset.

--- a/buildmanifest/manifest_test.go
+++ b/buildmanifest/manifest_test.go
@@ -110,8 +110,8 @@ func TestManifestStaleIslandsReportsChangedSource(t *testing.T) {
 	}
 
 	stale := manifest.StaleIslands(dir)
-	if len(stale) != 1 || stale[0] != "Counter" {
-		t.Fatalf("changed source stale report = %v, want [Counter]", stale)
+	if len(stale) != 1 || stale[0].Name != "Counter" || stale[0].SourceFile != "counter.gsx" {
+		t.Fatalf("changed source stale report = %+v, want one StaleIsland{Name: Counter, SourceFile: counter.gsx}", stale)
 	}
 }
 
@@ -155,6 +155,46 @@ func TestManifestStaleIslandsSkipsMissingSourceTree(t *testing.T) {
 	// shipping dist/ without app source) — skip silently, not an error.
 	if stale := manifest.StaleIslands(t.TempDir()); len(stale) != 0 {
 		t.Fatalf("missing source file reported stale: %v", stale)
+	}
+}
+
+// TestContentHashLength locks in the documented length: 16 hex characters
+// (8 bytes) of the sha256 digest, not 8 hex characters.
+func TestContentHashLength(t *testing.T) {
+	if got := ContentHash([]byte("gosx")); len(got) != 16 {
+		t.Fatalf("ContentHash length = %d, want 16 (got %q)", len(got), got)
+	}
+}
+
+// TestManifestStaleIslandsRejectsEscapingSourceFile asserts StaleIslands
+// skips any island whose recorded SourceFile is not local to sourceRoot —
+// for example a ".." path that would otherwise let hashing escape the
+// resolved root — instead of reading whatever it points at.
+func TestManifestStaleIslandsRejectsEscapingSourceFile(t *testing.T) {
+	dir := t.TempDir()
+	outsideDir := t.TempDir()
+	outsidePath := filepath.Join(outsideDir, "secret.gsx")
+	if err := os.WriteFile(outsidePath, []byte("package app\n"), 0644); err != nil {
+		t.Fatalf("write outside file: %v", err)
+	}
+
+	rel, err := filepath.Rel(dir, outsidePath)
+	if err != nil {
+		t.Fatalf("relativize: %v", err)
+	}
+
+	manifest := &Manifest{Islands: []IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: HashedAsset{File: "Counter.55555555.gxi", Hash: "55555555", Size: 50},
+			SourceFile:  filepath.ToSlash(rel), // "../<tmp>/secret.gsx" — escapes dir
+			SourceHash:  "deadbeef",            // deliberately wrong; must never be reached
+		},
+	}}
+
+	if stale := manifest.StaleIslands(dir); len(stale) != 0 {
+		t.Fatalf("escaping SourceFile reported stale: %v", stale)
 	}
 }
 

--- a/buildmanifest/manifest_test.go
+++ b/buildmanifest/manifest_test.go
@@ -82,6 +82,82 @@ func TestLoadAndURLs(t *testing.T) {
 	}
 }
 
+func TestManifestStaleIslandsReportsChangedSource(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "counter.gsx")
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node {\n\treturn <div>0</div>\n}\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := &Manifest{Islands: []IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: HashedAsset{File: "Counter.55555555.gxi", Hash: "55555555", Size: 50},
+			SourceFile:  "counter.gsx",
+			SourceHash:  ContentHash(original),
+		},
+	}}
+
+	if stale := manifest.StaleIslands(dir); len(stale) != 0 {
+		t.Fatalf("unchanged source reported stale: %v", stale)
+	}
+
+	changed := []byte("package app\n\n//gosx:island\nfunc Counter() Node {\n\treturn <div>1</div>\n}\n")
+	if err := os.WriteFile(sourcePath, changed, 0644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+
+	stale := manifest.StaleIslands(dir)
+	if len(stale) != 1 || stale[0] != "Counter" {
+		t.Fatalf("changed source stale report = %v, want [Counter]", stale)
+	}
+}
+
+func TestManifestStaleIslandsSkipsBackCompatManifest(t *testing.T) {
+	dir := t.TempDir()
+	sourcePath := filepath.Join(dir, "counter.gsx")
+	if err := os.WriteFile(sourcePath, []byte("package app\n"), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	// A manifest written before issue #166 has no SourceFile/SourceHash on
+	// its island assets. StaleIslands must not report anything for it —
+	// there is nothing recorded to compare the current source against, and
+	// reporting staleness here would be a false positive on every startup.
+	manifest := &Manifest{Islands: []IslandAsset{
+		{Name: "Counter", Format: "bin", HashedAsset: HashedAsset{File: "Counter.55555555.gxi", Hash: "55555555", Size: 50}},
+	}}
+
+	if stale := manifest.StaleIslands(dir); len(stale) != 0 {
+		t.Fatalf("back-compat manifest (no SourceFile/SourceHash) reported stale: %v", stale)
+	}
+}
+
+func TestManifestStaleIslandsSkipsMissingSourceTree(t *testing.T) {
+	manifest := &Manifest{Islands: []IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: HashedAsset{File: "Counter.55555555.gxi", Hash: "55555555", Size: 50},
+			SourceFile:  "counter.gsx",
+			SourceHash:  "deadbeef",
+		},
+	}}
+
+	// No sourceRoot: nothing to compare against.
+	if stale := manifest.StaleIslands(""); len(stale) != 0 {
+		t.Fatalf("empty sourceRoot reported stale: %v", stale)
+	}
+
+	// sourceRoot given, but the .gsx file is not there (production image
+	// shipping dist/ without app source) — skip silently, not an error.
+	if stale := manifest.StaleIslands(t.TempDir()); len(stale) != 0 {
+		t.Fatalf("missing source file reported stale: %v", stale)
+	}
+}
+
 func TestExportFilePath(t *testing.T) {
 	cases := map[string]string{
 		"/":              "index.html",

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -54,7 +53,7 @@ type hashedWriteOptions struct {
 	CompressedSidecars bool
 }
 
-// contentHash returns the first 8 hex chars of sha256. Delegates to
+// contentHash returns the first 16 hex chars (8 bytes) of sha256. Delegates to
 // buildmanifest.ContentHash so every content hash the build writes —
 // hashed asset filenames and island SourceHash entries alike — comes from
 // one algorithm; a server comparing them later must never see two schemes.
@@ -157,6 +156,68 @@ func removeFileIfExists(path string) error {
 	return nil
 }
 
+// writeIslandManifestAssets serializes and content-hash-writes each already-
+// discovered island program under islandDir, and returns the IslandAsset
+// manifest entries for them — including SourceFile/SourceHash, which let a
+// server started later (issue #166) detect that an island's .gsx source
+// changed since this build without re-running the compiler pipeline: it
+// re-hashes the file at SourceFile and compares against SourceHash. Store
+// the path project-relative so it stays stable across machines and matches
+// the manifest.SourceRoot / effectiveRuntimeRoot a server resolves it
+// against. Best-effort: an island whose source lives outside the project
+// tree (an imported package elsewhere on disk) still gets a "../"-relative
+// path.
+//
+// RunBuildWithOptions calls this as its real island+manifest stage.
+// Factored out so a test can exercise the real manifest-writing and
+// SourceFile-recording code without paying for the wasm runtime compile
+// RunBuildWithOptions also performs — see
+// TestWarnStaleIslandsEndToEndAfterRealBuildPipeline.
+func writeIslandManifestAssets(dir, islandDir string, dev bool, islandProgs []*IslandProgramSource) ([]IslandAsset, error) {
+	fmt.Println("\n  Islands:")
+	islandExt := ".gxi" // GoSX Island — binary prod format
+	if dev {
+		islandExt = ".json"
+	}
+
+	islands := make([]IslandAsset, 0, len(islandProgs))
+	for _, prog := range islandProgs {
+		var data []byte
+		var err error
+		format := "bin"
+		if dev {
+			data, err = program.EncodeJSON(prog.Program)
+			format = "json"
+		} else {
+			data, err = program.EncodeBinary(prog.Program)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("serialize %s: %w", prog.Name, err)
+		}
+
+		asset, err := writeHashed(islandDir, prog.Name, islandExt, data)
+		if err != nil {
+			return nil, fmt.Errorf("write island %s: %w", prog.Name, err)
+		}
+
+		sourceFile := ""
+		if rel, relErr := filepath.Rel(dir, prog.SourceFile); relErr == nil {
+			sourceFile = filepath.ToSlash(rel)
+		}
+
+		islands = append(islands, IslandAsset{
+			Name:        prog.Name,
+			Format:      format,
+			HashedAsset: asset,
+			SourceFile:  sourceFile,
+			SourceHash:  prog.SourceHash,
+		})
+
+		fmt.Printf("    %s → %s (%d bytes)\n", prog.Name, asset.File, asset.Size)
+	}
+	return islands, nil
+}
+
 // RunBuild orchestrates the full GoSX build pipeline.
 //
 // Output structure (prod):
@@ -218,6 +279,12 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	}
 
 	manifest := BuildManifest{}
+	// SourceRoot records this build's project root so a server started later
+	// on the same host can resolve IslandAsset.SourceFile against it
+	// directly, instead of guessing the project root from wherever it found
+	// build.json — see buildmanifest.Manifest.SourceRoot and
+	// server.resolveIslandSourceRoot (issue #166).
+	manifest.SourceRoot = dir
 	mode := "prod"
 	if opts.Dev {
 		mode = "dev"
@@ -262,55 +329,11 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 
 	// ── Tier 3: Island programs (content-hashed) ────────────────────────
 
-	fmt.Println("\n  Islands:")
-	islandFormat := "json"
-	islandExt := ".gxi" // GoSX Island — binary prod format
-	if opts.Dev {
-		islandExt = ".json"
+	islandAssets, err := writeIslandManifestAssets(dir, islandDir, opts.Dev, islandProgs)
+	if err != nil {
+		return err
 	}
-
-	for _, prog := range islandProgs {
-		var data []byte
-		var err error
-		if opts.Dev {
-			data, err = program.EncodeJSON(prog.Program)
-			islandFormat = "json"
-		} else {
-			data, err = program.EncodeBinary(prog.Program)
-			islandFormat = "bin"
-		}
-		if err != nil {
-			return fmt.Errorf("serialize %s: %w", prog.Name, err)
-		}
-
-		asset, err := writeHashed(islandDir, prog.Name, islandExt, data)
-		if err != nil {
-			return fmt.Errorf("write island %s: %w", prog.Name, err)
-		}
-
-		// SourceFile/SourceHash let a server started later (issue #166)
-		// detect that this island's .gsx source changed since this build,
-		// without re-running the compiler pipeline: it re-hashes the file
-		// at SourceFile and compares against SourceHash. Store the path
-		// project-relative so it stays stable across machines and matches
-		// the root a server passes to SetRuntimeRoot. Best-effort: an
-		// island whose source lives outside the project tree (an imported
-		// package elsewhere on disk) still gets a "../"-relative path.
-		sourceFile := ""
-		if rel, relErr := filepath.Rel(dir, prog.SourceFile); relErr == nil {
-			sourceFile = filepath.ToSlash(rel)
-		}
-
-		manifest.Islands = append(manifest.Islands, IslandAsset{
-			Name:        prog.Name,
-			Format:      islandFormat,
-			HashedAsset: asset,
-			SourceFile:  sourceFile,
-			SourceHash:  prog.SourceHash,
-		})
-
-		fmt.Printf("    %s → %s (%d bytes)\n", prog.Name, asset.File, asset.Size)
-	}
+	manifest.Islands = append(manifest.Islands, islandAssets...)
 
 	// ── Tier 3: Sidecar CSS (content-hashed) ────────────────────────────
 
@@ -609,13 +632,9 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 
 	// ── Build manifest ──────────────────────────────────────────────────
 
-	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	manifestPath, err := writeBuildManifest(distDir, &manifest)
 	if err != nil {
-		return fmt.Errorf("marshal manifest: %w", err)
-	}
-	manifestPath := filepath.Join(distDir, "build.json")
-	if err := os.WriteFile(manifestPath, manifestJSON, 0644); err != nil {
-		return fmt.Errorf("write manifest: %w", err)
+		return err
 	}
 
 	// Build the application binary when the target directory is a runnable app.

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -4,8 +4,6 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -56,10 +54,12 @@ type hashedWriteOptions struct {
 	CompressedSidecars bool
 }
 
-// contentHash returns the first 8 hex chars of sha256.
+// contentHash returns the first 8 hex chars of sha256. Delegates to
+// buildmanifest.ContentHash so every content hash the build writes —
+// hashed asset filenames and island SourceHash entries alike — comes from
+// one algorithm; a server comparing them later must never see two schemes.
 func contentHash(data []byte) string {
-	h := sha256.Sum256(data)
-	return hex.EncodeToString(h[:8])
+	return buildmanifest.ContentHash(data)
 }
 
 // writeHashed writes data to dir/name.hash.ext and returns the asset info.
@@ -273,10 +273,10 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 		var data []byte
 		var err error
 		if opts.Dev {
-			data, err = program.EncodeJSON(prog)
+			data, err = program.EncodeJSON(prog.Program)
 			islandFormat = "json"
 		} else {
-			data, err = program.EncodeBinary(prog)
+			data, err = program.EncodeBinary(prog.Program)
 			islandFormat = "bin"
 		}
 		if err != nil {
@@ -288,10 +288,25 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 			return fmt.Errorf("write island %s: %w", prog.Name, err)
 		}
 
+		// SourceFile/SourceHash let a server started later (issue #166)
+		// detect that this island's .gsx source changed since this build,
+		// without re-running the compiler pipeline: it re-hashes the file
+		// at SourceFile and compares against SourceHash. Store the path
+		// project-relative so it stays stable across machines and matches
+		// the root a server passes to SetRuntimeRoot. Best-effort: an
+		// island whose source lives outside the project tree (an imported
+		// package elsewhere on disk) still gets a "../"-relative path.
+		sourceFile := ""
+		if rel, relErr := filepath.Rel(dir, prog.SourceFile); relErr == nil {
+			sourceFile = filepath.ToSlash(rel)
+		}
+
 		manifest.Islands = append(manifest.Islands, IslandAsset{
 			Name:        prog.Name,
 			Format:      islandFormat,
 			HashedAsset: asset,
+			SourceFile:  sourceFile,
+			SourceHash:  prog.SourceHash,
 		})
 
 		fmt.Printf("    %s → %s (%d bytes)\n", prog.Name, asset.File, asset.Size)

--- a/cmd/gosx/dev.go
+++ b/cmd/gosx/dev.go
@@ -293,7 +293,7 @@ func compileDevIslands(dir, islandDir string) error {
 	}
 
 	for _, isl := range islands {
-		data, err := program.EncodeJSON(isl)
+		data, err := program.EncodeJSON(isl.Program)
 		if err != nil {
 			return fmt.Errorf("encode island %s: %w", isl.Name, err)
 		}

--- a/cmd/gosx/island_discovery.go
+++ b/cmd/gosx/island_discovery.go
@@ -13,11 +13,24 @@ import (
 	"strings"
 
 	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/buildmanifest"
 	"m31labs.dev/gosx/ir"
 	islandprogram "m31labs.dev/gosx/island/program"
 )
 
-func collectProjectIslandPrograms(projectDir string) ([]*islandprogram.Program, []string, error) {
+// IslandProgramSource pairs a compiled island program with the absolute path
+// to the .gsx file that declared it and a content hash (buildmanifest.
+// ContentHash) of that file's raw source bytes as read for this compile.
+// RunBuildWithOptions stores SourceHash in the build manifest so a server
+// started later can detect that source changed since `gosx build` without
+// re-running the compiler pipeline — see buildmanifest.Manifest.StaleIslands.
+type IslandProgramSource struct {
+	*islandprogram.Program
+	SourceFile string
+	SourceHash string
+}
+
+func collectProjectIslandPrograms(projectDir string) ([]*IslandProgramSource, []string, error) {
 	absProjectDir, err := filepath.Abs(projectDir)
 	if err != nil {
 		return nil, nil, fmt.Errorf("resolve project dir: %w", err)
@@ -88,8 +101,8 @@ func discoverProjectGSXFiles(projectDir string) ([]string, error) {
 	return files, nil
 }
 
-func collectIslandProgramsFromFiles(files []string) ([]*islandprogram.Program, []string, []string, error) {
-	var programs []*islandprogram.Program
+func collectIslandProgramsFromFiles(files []string) ([]*IslandProgramSource, []string, []string, error) {
+	var programs []*IslandProgramSource
 	importSet := map[string]struct{}{}
 	qualifiedAliasSet := map[string]struct{}{}
 
@@ -121,7 +134,11 @@ func collectIslandProgramsFromFiles(files []string) ([]*islandprogram.Program, [
 			if err != nil {
 				return nil, nil, nil, fmt.Errorf("lower island %s in %s: %w", comp.Name, file, err)
 			}
-			programs = append(programs, island)
+			programs = append(programs, &IslandProgramSource{
+				Program:    island,
+				SourceFile: file,
+				SourceHash: buildmanifest.ContentHash(source),
+			})
 		}
 	}
 

--- a/cmd/gosx/island_discovery_test.go
+++ b/cmd/gosx/island_discovery_test.go
@@ -80,7 +80,7 @@ func Counter() Node {
 `)
 
 	stale := manifest.StaleIslands(dir)
-	if len(stale) != 1 || stale[0] != "Counter" {
-		t.Fatalf("changed island stale report = %v, want [Counter]", stale)
+	if len(stale) != 1 || stale[0].Name != "Counter" {
+		t.Fatalf("changed island stale report = %+v, want [Counter]", stale)
 	}
 }

--- a/cmd/gosx/island_discovery_test.go
+++ b/cmd/gosx/island_discovery_test.go
@@ -1,0 +1,86 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	"m31labs.dev/gosx/buildmanifest"
+)
+
+// TestCollectProjectIslandProgramsSourceHashDetectsSourceChange exercises the
+// same discovery function RunBuildWithOptions calls to populate
+// IslandAsset.SourceFile/SourceHash (issue #166). It builds a manifest from
+// the real compiler pipeline, confirms the staleness check reports nothing
+// for unchanged source, mutates the island's .gsx file, and confirms the
+// staleness check now reports it — plus a back-compat manifest entry that
+// predates the field, which must never be reported.
+func TestCollectProjectIslandProgramsSourceHashDetectsSourceChange(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "counter.gsx", `package main
+
+//gosx:island
+func Counter() Node {
+	count := signal.New(0)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <div><span>{count.Get()}</span><button onClick={increment}>+</button></div>
+}
+`)
+
+	programs, _, err := collectProjectIslandPrograms(dir)
+	if err != nil {
+		t.Fatalf("collectProjectIslandPrograms: %v", err)
+	}
+	if len(programs) != 1 || programs[0].Name != "Counter" {
+		t.Fatalf("collectProjectIslandPrograms = %v, want one Counter island", programs)
+	}
+	prog := programs[0]
+	if prog.SourceFile != filepath.Join(dir, "counter.gsx") {
+		t.Fatalf("SourceFile = %q, want %q", prog.SourceFile, filepath.Join(dir, "counter.gsx"))
+	}
+	if prog.SourceHash == "" {
+		t.Fatal("SourceHash is empty")
+	}
+
+	rel, err := filepath.Rel(dir, prog.SourceFile)
+	if err != nil {
+		t.Fatalf("relativize source path: %v", err)
+	}
+	manifest := &buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        prog.Name,
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+			SourceFile:  filepath.ToSlash(rel),
+			SourceHash:  prog.SourceHash,
+		},
+		// A pre-#166 manifest entry: no SourceFile/SourceHash. Must never be
+		// reported, regardless of what its dist program hash claims.
+		{
+			Name:        "LegacyIsland",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "LegacyIsland.bbbbbbbb.gxi", Hash: "bbbbbbbb", Size: 1},
+		},
+	}}
+
+	if stale := manifest.StaleIslands(dir); len(stale) != 0 {
+		t.Fatalf("unchanged island reported stale: %v", stale)
+	}
+
+	// Re-run the pipeline after the source changes, mirroring what happens
+	// between `gosx build` and a later `go run`: only the .gsx source
+	// mutates, the manifest on disk (and thus SourceHash) does not.
+	writeTempFile(t, dir, "counter.gsx", `package main
+
+//gosx:island
+func Counter() Node {
+	count := signal.New(0)
+	increment := func() { count.Set(count.Get() + 2) }
+	return <div><span>{count.Get()}</span><button onClick={increment}>+</button></div>
+}
+`)
+
+	stale := manifest.StaleIslands(dir)
+	if len(stale) != 1 || stale[0] != "Counter" {
+		t.Fatalf("changed island stale report = %v, want [Counter]", stale)
+	}
+}

--- a/cmd/gosx/island_manifest_stage.go
+++ b/cmd/gosx/island_manifest_stage.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// islandManifestStage runs the real per-island discovery, encode, and
+// content-hash-write pipeline RunBuildWithOptions uses to populate
+// build.json's Islands and SourceRoot fields, and writes the result to
+// dir/dist/build.json.
+//
+// It is RunBuildWithOptions' island+manifest stage, factored out so a test
+// can exercise the real manifest-writing, SourceFile-recording, and
+// SourceRoot-recording code (issue #166) without paying for the wasm
+// runtime compile RunBuildWithOptions also performs. See
+// TestWarnStaleIslandsEndToEndAfterRealBuildPipeline.
+func islandManifestStage(dir string, dev bool) (*BuildManifest, string, error) {
+	distDir := filepath.Join(dir, "dist")
+	islandDir := filepath.Join(distDir, "assets", "islands")
+	if err := os.MkdirAll(islandDir, 0755); err != nil {
+		return nil, "", fmt.Errorf("create island output directory %s: %w", islandDir, err)
+	}
+
+	islandProgs, _, err := collectProjectIslandPrograms(dir)
+	if err != nil {
+		return nil, "", err
+	}
+	islandAssets, err := writeIslandManifestAssets(dir, islandDir, dev, islandProgs)
+	if err != nil {
+		return nil, "", err
+	}
+
+	manifest := &BuildManifest{SourceRoot: dir, Islands: islandAssets}
+	manifestPath, err := writeBuildManifest(distDir, manifest)
+	if err != nil {
+		return nil, "", err
+	}
+	return manifest, manifestPath, nil
+}
+
+// writeBuildManifest marshals manifest and writes it to distDir/build.json —
+// the same write RunBuildWithOptions performs for the full manifest.
+func writeBuildManifest(distDir string, manifest *BuildManifest) (string, error) {
+	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal manifest: %w", err)
+	}
+	manifestPath := filepath.Join(distDir, "build.json")
+	if err := os.WriteFile(manifestPath, manifestJSON, 0644); err != nil {
+		return "", fmt.Errorf("write manifest: %w", err)
+	}
+	return manifestPath, nil
+}

--- a/cmd/gosx/island_staleness_e2e_test.go
+++ b/cmd/gosx/island_staleness_e2e_test.go
@@ -1,0 +1,112 @@
+package main
+
+import (
+	"bytes"
+	"log"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/server"
+)
+
+// TestWarnStaleIslandsEndToEndAfterRealBuildPipeline runs GoSX's real
+// island-discovery and manifest-writing pipeline (islandManifestStage —
+// RunBuildWithOptions' own island+manifest stage, minus the wasm runtime
+// compile) against a temp project, mutates the island's .gsx source at the
+// project root after the build (mirroring issue #166: editing an island and
+// rebuilding only the Go binary, never `gosx build` again), points a
+// server.App at the project root exactly as issue #166's repro does (server
+// root == project root, with dist/build.json nested underneath — not a
+// synthetic layout where build.json and sources sit in the same directory),
+// and asserts the staleness warning fires through the server's public
+// Build() entry point.
+func TestWarnStaleIslandsEndToEndAfterRealBuildPipeline(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "counter.gsx", `package main
+
+//gosx:island
+func Counter() Node {
+	count := signal.New(0)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <div><span>{count.Get()}</span><button onClick={increment}>+</button></div>
+}
+`)
+
+	if _, _, err := islandManifestStage(dir, false); err != nil {
+		t.Fatalf("islandManifestStage: %v", err)
+	}
+
+	// Mirror issue #166: edit the island and rebuild only the Go binary —
+	// never run `gosx build` again — so dist/build.json's SourceHash still
+	// reflects the original source.
+	writeTempFile(t, dir, "counter.gsx", `package main
+
+//gosx:island
+func Counter() Node {
+	count := signal.New(0)
+	increment := func() { count.Set(count.Get() + 2) }
+	return <div><span>{count.Get()}</span><button onClick={increment}>+</button></div>
+}
+`)
+
+	app := server.New()
+	app.SetRuntimeRoot(dir) // project root, not dist — issue #166's layout
+
+	buf := captureBuildLogOutput(t)
+	app.Build()
+
+	want := "gosx islands: Counter's source file changed since gosx build (counter.gsx); run gosx build"
+	if got := buf.String(); strings.Count(got, want) != 1 {
+		t.Fatalf("warnStaleIslands log output = %q, want exactly one occurrence of %q", got, want)
+	}
+}
+
+// TestWarnStaleIslandsEndToEndSilentWhenUnchanged is the inverse of
+// TestWarnStaleIslandsEndToEndAfterRealBuildPipeline: the same real build
+// pipeline and project-root/dist/build.json layout, but the island source
+// never changed after the build, so nothing should log.
+func TestWarnStaleIslandsEndToEndSilentWhenUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	writeTempFile(t, dir, "counter.gsx", `package main
+
+//gosx:island
+func Counter() Node {
+	count := signal.New(0)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <div><span>{count.Get()}</span><button onClick={increment}>+</button></div>
+}
+`)
+
+	if _, _, err := islandManifestStage(dir, false); err != nil {
+		t.Fatalf("islandManifestStage: %v", err)
+	}
+
+	app := server.New()
+	app.SetRuntimeRoot(dir)
+
+	buf := captureBuildLogOutput(t)
+	app.Build()
+
+	if buf.Len() != 0 {
+		t.Fatalf("unchanged island logged unexpectedly: %q", buf.String())
+	}
+}
+
+// captureBuildLogOutput redirects the standard library log package to a
+// buffer for the duration of the test and restores the previous output and
+// flags on cleanup. warnStaleIslands (invoked indirectly through the
+// exported server.App.Build(), since it is unexported to package server)
+// reports through the standard log package.
+func captureBuildLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOutput := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}

--- a/server/island_staleness.go
+++ b/server/island_staleness.go
@@ -1,0 +1,36 @@
+package server
+
+import "log"
+
+// warnStaleIslands logs one warning per island whose dist/ program is stale
+// relative to its current .gsx source (issue #166: editing an island and
+// rebuilding only the Go binary — not `gosx build` — leaves dist/ serving an
+// old program while SSR markup reflects the new source).
+//
+// Runs at most once per App (guarded by staleIslandsOnce) and costs nothing
+// beyond the sync.Once check when no build manifest is loaded: it reuses the
+// same cached manifest read (runtimeBuildManifest) the runtime asset server
+// already performs, and buildmanifest.Manifest.StaleIslands skips any island
+// whose manifest entry predates the SourceFile/SourceHash fields or whose
+// source file cannot be read (a production image may ship dist/ without the
+// app's .gsx sources — that is not an error).
+//
+// Never fails startup: every branch here only logs or returns.
+func (a *App) warnStaleIslands() {
+	if a == nil {
+		return
+	}
+	a.staleIslandsOnce.Do(func() {
+		root := a.effectiveRuntimeRoot()
+		if root == "" {
+			return
+		}
+		manifest, ok := a.runtimeBuildManifest(root)
+		if !ok || manifest == nil {
+			return
+		}
+		for _, name := range manifest.StaleIslands(root) {
+			log.Printf("gosx islands: %s program in dist is stale (source changed since gosx build); run gosx build", name)
+		}
+	})
+}

--- a/server/island_staleness.go
+++ b/server/island_staleness.go
@@ -1,6 +1,12 @@
 package server
 
-import "log"
+import (
+	"log"
+	"path/filepath"
+	"strings"
+
+	"m31labs.dev/gosx/buildmanifest"
+)
 
 // warnStaleIslands logs one warning per island whose dist/ program is stale
 // relative to its current .gsx source (issue #166: editing an island and
@@ -8,12 +14,12 @@ import "log"
 // old program while SSR markup reflects the new source).
 //
 // Runs at most once per App (guarded by staleIslandsOnce) and costs nothing
-// beyond the sync.Once check when no build manifest is loaded: it reuses the
-// same cached manifest read (runtimeBuildManifest) the runtime asset server
-// already performs, and buildmanifest.Manifest.StaleIslands skips any island
-// whose manifest entry predates the SourceFile/SourceHash fields or whose
-// source file cannot be read (a production image may ship dist/ without the
-// app's .gsx sources — that is not an error).
+// beyond the sync.Once check when no build manifest is loaded.
+//
+// Two things have to line up for this check to fire on real staleness and
+// stay silent everywhere else: finding build.json at all, and resolving
+// IslandAsset.SourceFile against the right directory. See
+// loadStaleCheckManifest and resolveIslandSourceRoot.
 //
 // Never fails startup: every branch here only logs or returns.
 func (a *App) warnStaleIslands() {
@@ -21,16 +27,84 @@ func (a *App) warnStaleIslands() {
 		return
 	}
 	a.staleIslandsOnce.Do(func() {
-		root := a.effectiveRuntimeRoot()
-		if root == "" {
+		runtimeRoot := a.effectiveRuntimeRoot()
+		if runtimeRoot == "" {
 			return
 		}
-		manifest, ok := a.runtimeBuildManifest(root)
+		manifest, manifestDir, ok := a.loadStaleCheckManifest(runtimeRoot)
 		if !ok || manifest == nil {
 			return
 		}
-		for _, name := range manifest.StaleIslands(root) {
-			log.Printf("gosx islands: %s program in dist is stale (source changed since gosx build); run gosx build", name)
+		sourceRoot := resolveIslandSourceRoot(manifest, manifestDir, runtimeRoot)
+		if sourceRoot == "" {
+			return
+		}
+		for _, stale := range manifest.StaleIslands(sourceRoot) {
+			log.Printf("gosx islands: %s's source file changed since gosx build (%s); run gosx build", stale.Name, stale.SourceFile)
 		}
 	})
+}
+
+// loadStaleCheckManifest finds build.json under runtimeRoot, trying the two
+// locations a GoSX deployment may load it from — the same two candidates
+// island.loadDefaultBuildManifest tries for the runtime asset renderer:
+//
+//  1. runtimeRoot/build.json — production, where SetRuntimeRoot (or its
+//     ResolveAppRoot("") fallback via GOSX_APP_ROOT) points straight at the
+//     dist/ output that run.sh stages GOSX_APP_ROOT to.
+//  2. runtimeRoot/dist/build.json — runtimeRoot is a project root (a
+//     dev/example server's SetRuntimeRoot(root), or `go build` executed and
+//     run from the project root after `gosx build` populated dist/ —
+//     issue #166's exact repro).
+//
+// Returns the manifest and the directory it was actually found in, so the
+// caller can tell which of the two layouts matched.
+func (a *App) loadStaleCheckManifest(runtimeRoot string) (*buildmanifest.Manifest, string, bool) {
+	if manifest, ok := a.runtimeBuildManifest(runtimeRoot); ok {
+		return manifest, runtimeRoot, true
+	}
+	distRoot := filepath.Join(runtimeRoot, "dist")
+	if manifest, ok := a.runtimeBuildManifest(distRoot); ok {
+		return manifest, distRoot, true
+	}
+	return nil, "", false
+}
+
+// resolveIslandSourceRoot picks the directory to resolve IslandAsset.
+// SourceFile paths against, in precedence order:
+//
+//  1. manifest.SourceRoot — the project root `gosx build` recorded at build
+//     time — if that directory still exists on this host. Most direct: a
+//     dev machine (or CI job) running the server from the same checkout
+//     that produced the build doesn't need any layout guessing.
+//  2. manifestDir's parent ("dist/.."), only when build.json was actually
+//     found nested under runtimeRoot/dist (manifestDir != runtimeRoot).
+//     That parent is the project root — issue #166's project-root-as-
+//     server-root layout, where live .gsx sources sit beside dist/, not
+//     inside it. When build.json was found directly at runtimeRoot instead,
+//     there is no "dist" nesting to walk up out of, so this tier does not
+//     apply — using it anyway would walk one directory too far.
+//  3. runtimeRoot itself. The production fallback: dist/app is only ever
+//     the build-time snapshot `gosx build` staged there (stageDeployment
+//     Bundle copies app/ into dist/app), so hashing that snapshot against
+//     itself always matches and the check stays silent — correctly, since
+//     a production image commonly ships dist/ without the app's live
+//     sources to compare against.
+//
+// A candidate that turns out to be wrong for a given island (its SourceFile
+// doesn't resolve to a readable file there) still resolves safely: Manifest.
+// StaleIslands skips any island whose SourceFile can't be read under the
+// chosen root instead of reporting it stale.
+func resolveIslandSourceRoot(manifest *buildmanifest.Manifest, manifestDir, runtimeRoot string) string {
+	if manifest != nil {
+		if root := strings.TrimSpace(manifest.SourceRoot); root != "" && isDir(root) {
+			return root
+		}
+	}
+	if manifestDir != runtimeRoot {
+		if parent := filepath.Dir(manifestDir); parent != "" && parent != manifestDir && isDir(parent) {
+			return parent
+		}
+	}
+	return runtimeRoot
 }

--- a/server/island_staleness_test.go
+++ b/server/island_staleness_test.go
@@ -55,7 +55,7 @@ func TestWarnStaleIslandsLogsMismatchOnce(t *testing.T) {
 	app.warnStaleIslands()
 	app.warnStaleIslands() // second call must not log again
 
-	want := "gosx islands: Counter program in dist is stale (source changed since gosx build); run gosx build"
+	want := "gosx islands: Counter's source file changed since gosx build (app/counter.gsx); run gosx build"
 	got := buf.String()
 	if strings.Count(got, want) != 1 {
 		t.Fatalf("warnStaleIslands log output = %q, want exactly one occurrence of %q", got, want)
@@ -131,6 +131,158 @@ func TestWarnStaleIslandsNoOpWithoutManifest(t *testing.T) {
 
 	if buf.Len() != 0 {
 		t.Fatalf("no manifest present but warnStaleIslands logged: %q", buf.String())
+	}
+}
+
+// TestWarnStaleIslandsFindsManifestNestedUnderDist reproduces issue #166's
+// exact layout: SetRuntimeRoot points at the project root (a server built
+// with `go build` and run from there after `gosx build` populated dist/),
+// so build.json sits at runtimeRoot/dist/build.json, not runtimeRoot/
+// build.json directly. Before this fix, runtimeBuildManifest only ever
+// checked runtimeRoot/build.json and warnStaleIslands stayed silent —
+// finding no manifest at all, not merely resolving SourceFile wrong.
+func TestWarnStaleIslandsFindsManifestNestedUnderDist(t *testing.T) {
+	root := t.TempDir()
+	sourceRel := "app/counter.gsx"
+	sourcePath := filepath.Join(root, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>0</div> }\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+			SourceFile:  sourceRel,
+			SourceHash:  buildmanifest.ContentHash(original),
+		},
+	}}
+	distDir := filepath.Join(root, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	writeManifest(t, distDir, manifest)
+
+	changed := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>1</div> }\n")
+	if err := os.WriteFile(sourcePath, changed, 0644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+
+	app := New()
+	app.SetRuntimeRoot(root) // project root, not dist — issue #166's layout
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	want := "gosx islands: Counter's source file changed since gosx build (app/counter.gsx); run gosx build"
+	if got := buf.String(); strings.Count(got, want) != 1 {
+		t.Fatalf("warnStaleIslands log output = %q, want exactly one occurrence of %q", got, want)
+	}
+}
+
+// TestWarnStaleIslandsFindsManifestNestedUnderDistSilentWhenUnchanged is the
+// inverse of TestWarnStaleIslandsFindsManifestNestedUnderDist: the same
+// project-root/dist/build.json layout, but the source never changed after
+// the build, so nothing should log.
+func TestWarnStaleIslandsFindsManifestNestedUnderDistSilentWhenUnchanged(t *testing.T) {
+	root := t.TempDir()
+	sourceRel := "app/counter.gsx"
+	sourcePath := filepath.Join(root, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>0</div> }\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+			SourceFile:  sourceRel,
+			SourceHash:  buildmanifest.ContentHash(original),
+		},
+	}}
+	distDir := filepath.Join(root, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	writeManifest(t, distDir, manifest)
+
+	app := New()
+	app.SetRuntimeRoot(root)
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	if buf.Len() != 0 {
+		t.Fatalf("unchanged island under nested dist/build.json logged unexpectedly: %q", buf.String())
+	}
+}
+
+// TestWarnStaleIslandsPrefersRecordedSourceRootOverGuess asserts precedence
+// tier 1: when the manifest recorded SourceRoot (the project root `gosx
+// build` actually ran from) and that directory still exists on this host,
+// the check uses it instead of guessing the project root from where
+// build.json was found. The manifest here lives under a directory that has
+// no live sources of its own at all — only the recorded SourceRoot does —
+// so a correct implementation can only find the mutated source, and thus
+// only fire, by honoring SourceRoot.
+func TestWarnStaleIslandsPrefersRecordedSourceRootOverGuess(t *testing.T) {
+	liveProjectRoot := t.TempDir()
+	sourceRel := "app/counter.gsx"
+	sourcePath := filepath.Join(liveProjectRoot, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>0</div> }\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	// runtimeRoot is unrelated to liveProjectRoot: it has no app/ directory
+	// of its own, so a guess based on where build.json was found (dist/..)
+	// resolves to an empty directory with nothing at "app/counter.gsx".
+	runtimeRoot := t.TempDir()
+	manifest := buildmanifest.Manifest{
+		SourceRoot: liveProjectRoot,
+		Islands: []buildmanifest.IslandAsset{
+			{
+				Name:        "Counter",
+				Format:      "bin",
+				HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+				SourceFile:  sourceRel,
+				SourceHash:  buildmanifest.ContentHash(original),
+			},
+		},
+	}
+	distDir := filepath.Join(runtimeRoot, "dist")
+	if err := os.MkdirAll(distDir, 0755); err != nil {
+		t.Fatalf("mkdir dist: %v", err)
+	}
+	writeManifest(t, distDir, manifest)
+
+	changed := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>1</div> }\n")
+	if err := os.WriteFile(sourcePath, changed, 0644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+
+	app := New()
+	app.SetRuntimeRoot(runtimeRoot)
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	want := "gosx islands: Counter's source file changed since gosx build (app/counter.gsx); run gosx build"
+	if got := buf.String(); strings.Count(got, want) != 1 {
+		t.Fatalf("warnStaleIslands log output = %q, want exactly one occurrence of %q (recorded SourceRoot ignored)", got, want)
 	}
 }
 

--- a/server/island_staleness_test.go
+++ b/server/island_staleness_test.go
@@ -1,0 +1,163 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/buildmanifest"
+)
+
+// TestWarnStaleIslandsLogsMismatchOnce reproduces issue #166: a build.json
+// entry recorded SourceHash against the island's .gsx source, the source
+// then changed (island edited, only the Go binary rebuilt), and
+// warnStaleIslands must log exactly one warning naming the island — even
+// across repeated calls, since staleIslandsOnce guards the check.
+func TestWarnStaleIslandsLogsMismatchOnce(t *testing.T) {
+	root := t.TempDir()
+	sourceRel := "app/counter.gsx"
+	sourcePath := filepath.Join(root, filepath.FromSlash(sourceRel))
+	if err := os.MkdirAll(filepath.Dir(sourcePath), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>0</div> }\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+			SourceFile:  sourceRel,
+			SourceHash:  buildmanifest.ContentHash(original),
+		},
+	}}
+	writeManifest(t, root, manifest)
+
+	// Mutate the source AFTER the manifest recorded its hash, mirroring
+	// editing an island and rebuilding only the Go binary.
+	changed := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>1</div> }\n")
+	if err := os.WriteFile(sourcePath, changed, 0644); err != nil {
+		t.Fatalf("rewrite source: %v", err)
+	}
+
+	app := New()
+	app.SetRuntimeRoot(root)
+
+	buf := captureLogOutput(t)
+
+	app.warnStaleIslands()
+	app.warnStaleIslands() // second call must not log again
+
+	want := "gosx islands: Counter program in dist is stale (source changed since gosx build); run gosx build"
+	got := buf.String()
+	if strings.Count(got, want) != 1 {
+		t.Fatalf("warnStaleIslands log output = %q, want exactly one occurrence of %q", got, want)
+	}
+}
+
+// TestWarnStaleIslandsSilentWhenSourceUnchanged asserts the happy path: a
+// manifest whose SourceHash still matches the source on disk logs nothing.
+func TestWarnStaleIslandsSilentWhenSourceUnchanged(t *testing.T) {
+	root := t.TempDir()
+	sourcePath := filepath.Join(root, "counter.gsx")
+	original := []byte("package app\n\n//gosx:island\nfunc Counter() Node { return <div>0</div> }\n")
+	if err := os.WriteFile(sourcePath, original, 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+			SourceFile:  "counter.gsx",
+			SourceHash:  buildmanifest.ContentHash(original),
+		},
+	}}
+	writeManifest(t, root, manifest)
+
+	app := New()
+	app.SetRuntimeRoot(root)
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	if buf.Len() != 0 {
+		t.Fatalf("unchanged island logged unexpectedly: %q", buf.String())
+	}
+}
+
+// TestWarnStaleIslandsSilentOnBackCompatManifest asserts a manifest written
+// before issue #166 (no SourceFile/SourceHash on its island assets) never
+// logs — there is nothing recorded to compare the current source against.
+func TestWarnStaleIslandsSilentOnBackCompatManifest(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "counter.gsx"), []byte("package app\n"), 0644); err != nil {
+		t.Fatalf("write source: %v", err)
+	}
+
+	manifest := buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{Name: "Counter", Format: "bin", HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1}},
+	}}
+	writeManifest(t, root, manifest)
+
+	app := New()
+	app.SetRuntimeRoot(root)
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	if buf.Len() != 0 {
+		t.Fatalf("back-compat manifest logged unexpectedly: %q", buf.String())
+	}
+}
+
+// TestWarnStaleIslandsNoOpWithoutManifest asserts the zero-manifest case
+// (e.g. `go run` in dev before the first `gosx build`) never logs and never
+// panics.
+func TestWarnStaleIslandsNoOpWithoutManifest(t *testing.T) {
+	app := New()
+	app.SetRuntimeRoot(t.TempDir())
+
+	buf := captureLogOutput(t)
+	app.warnStaleIslands()
+
+	if buf.Len() != 0 {
+		t.Fatalf("no manifest present but warnStaleIslands logged: %q", buf.String())
+	}
+}
+
+func writeManifest(t *testing.T, root string, manifest buildmanifest.Manifest) {
+	t.Helper()
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "build.json"), data, 0644); err != nil {
+		t.Fatalf("write build.json: %v", err)
+	}
+}
+
+// captureLogOutput redirects the standard library log package to a buffer
+// for the duration of the test and restores the previous output/flags on
+// cleanup.
+func captureLogOutput(t *testing.T) *bytes.Buffer {
+	t.Helper()
+	var buf bytes.Buffer
+	prevOutput := log.Writer()
+	prevFlags := log.Flags()
+	log.SetOutput(&buf)
+	log.SetFlags(0)
+	t.Cleanup(func() {
+		log.SetOutput(prevOutput)
+		log.SetFlags(prevFlags)
+	})
+	return &buf
+}

--- a/server/server.go
+++ b/server/server.go
@@ -106,6 +106,12 @@ type App struct {
 	schedulerOnce sync.Once
 	scheduler     *scheduled.Scheduler
 	srv           *http.Server
+
+	// staleIslandsOnce guards warnStaleIslands, so hashing every island's
+	// source runs at most once per App even if Build() runs more than once
+	// (a test harness may call it directly, more than once, without ever
+	// calling ListenAndServe).
+	staleIslandsOnce sync.Once
 }
 
 // New creates a new GoSX server app.
@@ -469,6 +475,7 @@ func (a *App) preloadGrammarBlob() {
 
 func (a *App) Build() http.Handler {
 	a.preloadGrammarBlob()
+	a.warnStaleIslands()
 	mux := http.NewServeMux()
 	redirectMux := http.NewServeMux()
 	rewriteMux := http.NewServeMux()


### PR DESCRIPTION
## Summary

Detects when an island's compiled dist/ program is out of date relative to its current .gsx source. At server startup, the runtime compares recorded source hashes against live files and logs a warning if they mismatch, preventing silent execution of stale SSR markup while avoiding compiler overhead.

## Changes

- Add `SourceFile` and `SourceHash` fields to `IslandAsset` in the build manifest to track project-relative source paths and their content hashes at build time.
- Introduce `ContentHash` utility in `buildmanifest` to guarantee a single hashing algorithm across build-time asset generation and runtime comparisons.
- Implement `Manifest.StaleIslands` to efficiently detect mismatches between recorded source hashes and current file contents without re-running the compiler.
- Update the `gosx build` and island discovery pipelines to capture and store `SourceFile`/`SourceHash` for every compiled island program.
- Wire `warnStaleIslands` into `server.App.Build()` to trigger the check once per app instance, logging precise warnings for any outdated islands.
- Gracefully handle back-compatible manifests (missing hash fields), missing source trees (production deployments), and nil apps to prevent false positives or panics.

## Testing

- Run `go test ./buildmanifest/... ./cmd/gosx/... ./server/... -v` to verify staleness detection, back-compat skipping, and log output behavior.
- Manually edit a `.gsx` island file after running `gosx build`, then start the Go server binary to confirm the expected `gosx islands: <name> program in dist is stale` warning prints exactly once.

## Related Issues

- Refs #166