### PR TITLE
fix(core): Fix file-router nav injection and flag .length in legacy templates

### DIFF
--- a/cmd/gosx/check_test.go
+++ b/cmd/gosx/check_test.go
@@ -177,6 +177,59 @@ func Page() Node {
 	}
 }
 
+// TestRunCheckRejectsLengthMemberInCond covers gosx#164: `gosx check` used to
+// report ok for a legacy `<If cond={data.picks.length == 0}>`, and the page
+// then silently rendered neither branch (a slice has no .length; the
+// reflective renderer resolves it to nil, and nil never equals 0). check must
+// now fail closed and name the offending expression.
+func TestRunCheckRejectsLengthMemberInCond(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.gsx")
+	writeTempFile(t, dir, "page.gsx", `package main
+
+func Page(data any) Node {
+	return <div>
+		<If cond={data.picks.length == 0}>
+			<b>empty</b>
+		</If>
+	</div>
+}
+`)
+
+	err := runCheck(path, &bytes.Buffer{})
+	if err == nil {
+		t.Fatal("expected runCheck to reject .length in a cond expression")
+	}
+	if !strings.Contains(err.Error(), ".length") {
+		t.Fatalf("expected error naming .length, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "data.picks.length == 0") {
+		t.Fatalf("expected error naming the offending expression, got: %v", err)
+	}
+}
+
+// TestRunCheckAcceptsValidCondWorkaround proves the documented workaround —
+// passing a precomputed boolean from a DataLoader instead of reading .length
+// in the template — still passes check.
+func TestRunCheckAcceptsValidCondWorkaround(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.gsx")
+	writeTempFile(t, dir, "page.gsx", `package main
+
+func Page(data any) Node {
+	return <div>
+		<If cond={data.picksEmpty}>
+			<b>empty</b>
+		</If>
+	</div>
+}
+`)
+
+	if err := runCheck(path, &bytes.Buffer{}); err != nil {
+		t.Fatalf("runCheck failed on a valid cond: %v", err)
+	}
+}
+
 func TestRunCheckAcceptsDocsAppPages(t *testing.T) {
 	root, err := filepath.Abs(filepath.Join("..", "..", "examples", "gosx-docs", "app"))
 	if err != nil {

--- a/cmd/gosx/export_test.go
+++ b/cmd/gosx/export_test.go
@@ -70,8 +70,17 @@ func TestRunExportWritesStaticBundleForStarterApp(t *testing.T) {
 	if manifest.Routes[0].Path != "/" || manifest.Routes[0].File != "index.html" {
 		t.Fatalf("unexpected root export route %#v", manifest.Routes[0])
 	}
-	if manifest.Routes[0].Capabilities.Navigation || manifest.Routes[0].Capabilities.Bootstrap || manifest.Routes[0].Capabilities.WASM {
-		t.Fatalf("expected exported starter route to stay zero-runtime, got %#v", manifest.Routes[0].Capabilities)
+	// The starter template calls app.EnableNavigation() (see cmd/gosx/init.go),
+	// so the exported route carries the inline navigation script and reports
+	// Navigation: true (gosx#169 — App.Mount now wires that flag through to a
+	// file-routed app instead of silently dropping it). Navigation adds no
+	// WASM or bootstrap asset: it is one inline <script>, so Bootstrap and WASM
+	// stay false and dist/static/gosx stays absent (checked above).
+	if !manifest.Routes[0].Capabilities.Navigation {
+		t.Fatalf("expected exported starter route to report navigation, got %#v", manifest.Routes[0].Capabilities)
+	}
+	if manifest.Routes[0].Capabilities.Bootstrap || manifest.Routes[0].Capabilities.WASM {
+		t.Fatalf("expected exported starter route to stay zero-runtime aside from navigation, got %#v", manifest.Routes[0].Capabilities)
 	}
 }
 

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -2,6 +2,8 @@ package ir
 
 import (
 	"fmt"
+	"go/ast"
+	"go/parser"
 	"strings"
 )
 
@@ -84,6 +86,18 @@ func (v *validator) validateComponent(comp *Component) {
 	if comp.IsEngine && comp.EngineKind == "surface" {
 		v.diags = append(v.diags, validateEngineSurface(v.prog, comp)...)
 	}
+
+	// Legacy (non-strict, non-island) components render through the
+	// file-router's reflective interpreter (route/fileeval.go), which has no
+	// static types for `any` data params. gosx#164: `.length` there resolves
+	// to nil on every target — a slice has no such field or method — so
+	// `cond={data.picks.length == 0}` compares nil to 0 and silently renders
+	// neither branch. Strict and island components carry their own
+	// type-checked or type-restricted expression paths and do not need this
+	// rule.
+	if comp.Syntax != ComponentSyntaxStrict && !comp.IsIsland {
+		v.diags = append(v.diags, validateLegacyTemplateExprs(v.prog, comp)...)
+	}
 }
 
 func (v *validator) validateNode(node *Node) {
@@ -145,6 +159,73 @@ func (v *validator) validateAttr(node *Node, attr *Attr) {
 			v.errorf(node.Span, "spread attribute has empty expression")
 		}
 	}
+}
+
+// validateLegacyTemplateExprs flags the well-known JS mistake of reading
+// .length on a slice-valued expression (see gosx#164). The legacy file-router
+// renderer resolves member access reflectively with no static types, so a
+// slice's .length silently evaluates to nil instead of failing to compile —
+// and nil compared to 0 is always false, so `<If cond={x.length == 0}>`
+// renders neither branch with no error anywhere.
+//
+// gosx has no type information for legacy `any` data at check time, so this
+// cannot distinguish a slice's .length from a map value legitimately keyed
+// "length" (m[string]any{"length": n} resolves that reflectively too, and
+// correctly). It flags every ".length" selector in the component's
+// expression holes rather than staying silent — the honest trade a checker
+// with no types can make: a rare, working `data["length"]`-shaped access is
+// rejected alongside the far more common accidental one, and check-time
+// failure with a diagnosis beats silent divergence between check and render.
+func validateLegacyTemplateExprs(prog *Program, comp *Component) []Diagnostic {
+	if int(comp.Root) >= len(prog.Nodes) {
+		return nil
+	}
+
+	var diags []Diagnostic
+	for _, id := range collectComponentNodeIDs(prog, comp.Root) {
+		node := &prog.Nodes[id]
+		if node.Kind == NodeExpr {
+			diags = append(diags, lengthSelectorDiagnostics(node.Span, node.Text)...)
+		}
+		for _, attr := range node.Attrs {
+			switch attr.Kind {
+			case AttrExpr, AttrSpread:
+				diags = append(diags, lengthSelectorDiagnostics(node.Span, attr.Expr)...)
+			}
+		}
+	}
+	return diags
+}
+
+// lengthSelectorDiagnostics parses one Go expression hole and reports every
+// ".length" member access it contains. A source that fails to parse here is
+// not this check's job — the render path already tolerates unparseable
+// expressions by evaluating them to nil, and normal validation elsewhere
+// covers empty/malformed expressions.
+func lengthSelectorDiagnostics(span Span, source string) []Diagnostic {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return nil
+	}
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return nil
+	}
+
+	var diags []Diagnostic
+	ast.Inspect(expr, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "length" {
+			return true
+		}
+		diags = append(diags, Diagnostic{
+			Span:    span,
+			Message: fmt.Sprintf("unsupported member \".length\" in expression %q", source),
+			Hint:    "Go has no automatic .length; pass a precomputed count from a DataLoader (e.g. \"picksEmpty\": len(picks) == 0), or add a typed component that calls len(...) directly",
+		})
+		return true
+	})
+	return diags
 }
 
 // validateIslandExprs validates that all expressions in an island component

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -171,11 +171,26 @@ func (v *validator) validateAttr(node *Node, attr *Attr) {
 // gosx has no type information for legacy `any` data at check time, so this
 // cannot distinguish a slice's .length from a map value legitimately keyed
 // "length" (m[string]any{"length": n} resolves that reflectively too, and
-// correctly). It flags every ".length" selector in the component's
-// expression holes rather than staying silent — the honest trade a checker
-// with no types can make: a rare, working `data["length"]`-shaped access is
-// rejected alongside the far more common accidental one, and check-time
-// failure with a diagnosis beats silent divergence between check and render.
+// correctly). It flags ".length" selectors rooted at the identifier "data"
+// rather than staying silent — the honest trade a checker with no types can
+// make: a rare, working `data["length"]`-shaped access is rejected alongside
+// the far more common accidental one, and check-time failure with a
+// diagnosis beats silent divergence between check and render.
+//
+// gosx#174: the rule used to flag ".length" anywhere in a legacy component's
+// expression holes, regardless of which identifier it was read from. That
+// rejected valid Go: a legacy component can declare a typed parameter other
+// than "data" (e.g. `func Page(r *ruler) Node` where `type ruler struct{
+// length int }`), and `r.length` there is an ordinary, statically-checked
+// struct field read — real Go code that compiles fine. It is "data" alone
+// that route/fileeval.go binds to the reflective, untyped route payload
+// (see fileRenderEnv / newFileRenderEnv: `env.values["data"] = ctx.Data`) —
+// that binding exists under the literal name "data" no matter what the
+// component's own function-parameter is named, because the file router
+// never reads the source parameter name back. Only a selector chain whose
+// root identifier is that literal "data" binding (`data.picks.length`,
+// `data.picks[0].length`, ...) can hit the reflective-nil gotcha this rule
+// exists for, so only those are flagged now.
 func validateLegacyTemplateExprs(prog *Program, comp *Component) []Diagnostic {
 	if int(comp.Root) >= len(prog.Nodes) {
 		return nil
@@ -198,10 +213,10 @@ func validateLegacyTemplateExprs(prog *Program, comp *Component) []Diagnostic {
 }
 
 // lengthSelectorDiagnostics parses one Go expression hole and reports every
-// ".length" member access it contains. A source that fails to parse here is
-// not this check's job — the render path already tolerates unparseable
-// expressions by evaluating them to nil, and normal validation elsewhere
-// covers empty/malformed expressions.
+// ".length" member access rooted at the "data" identifier it contains. A
+// source that fails to parse here is not this check's job — the render path
+// already tolerates unparseable expressions by evaluating them to nil, and
+// normal validation elsewhere covers empty/malformed expressions.
 func lengthSelectorDiagnostics(span Span, source string) []Diagnostic {
 	source = strings.TrimSpace(source)
 	if source == "" {
@@ -218,6 +233,16 @@ func lengthSelectorDiagnostics(span Span, source string) []Diagnostic {
 		if !ok || sel.Sel == nil || sel.Sel.Name != "length" {
 			return true
 		}
+		// Only the reflective "data" binding resolves .length to a silent nil
+		// (see the comment above validateLegacyTemplateExprs). A selector
+		// rooted at any other identifier — including a legacy component's own
+		// typed, non-"data" parameter — is either a real Go struct/map access
+		// the compiler already checks, or a value the file router never binds
+		// reflectively, so it is out of scope for this rule.
+		root, ok := selectorRootIdent(sel.X)
+		if !ok || root != "data" {
+			return true
+		}
 		diags = append(diags, Diagnostic{
 			Span:    span,
 			Message: fmt.Sprintf("unsupported member \".length\" in expression %q", source),
@@ -226,6 +251,30 @@ func lengthSelectorDiagnostics(span Span, source string) []Diagnostic {
 		return true
 	})
 	return diags
+}
+
+// selectorRootIdent walks down the left-hand side of a selector/index/paren
+// chain (data.picks[0].length -> data.picks[0] -> data.picks -> data) to find
+// the identifier the chain is rooted at. It reports ok=false for a chain
+// rooted at anything other than a bare identifier (a call result, a
+// composite literal, and so on), since those can never be the "data" binding.
+func selectorRootIdent(expr ast.Expr) (string, bool) {
+	for {
+		switch e := expr.(type) {
+		case *ast.Ident:
+			return e.Name, true
+		case *ast.SelectorExpr:
+			expr = e.X
+		case *ast.IndexExpr:
+			expr = e.X
+		case *ast.ParenExpr:
+			expr = e.X
+		case *ast.StarExpr:
+			expr = e.X
+		default:
+			return "", false
+		}
+	}
 }
 
 // validateIslandExprs validates that all expressions in an island component

--- a/ir/validate_test.go
+++ b/ir/validate_test.go
@@ -120,3 +120,119 @@ component Page(props: PageProps) {
 		t.Fatalf("expected no diagnostics for a strict component, got: %+v", diags)
 	}
 }
+
+// TestValidateSkipsLengthRuleForTypedNonDataParam covers gosx#174 (PR #174
+// review, M1): the reviewer's failing fixture. A legacy component can declare
+// a typed parameter that is not named "data" and whose type genuinely has a
+// "length" field — real, statically-checked Go that compiles fine. Before the
+// fix, the rule flagged any ".length" selector anywhere in a legacy
+// component's expression holes, so `r.length` here was rejected even though
+// it never goes through the file router's reflective "data" binding (see
+// route/fileeval.go: newFileRenderEnv binds ctx.Data to the literal
+// identifier "data", never to a component's own parameter name).
+func TestValidateSkipsLengthRuleForTypedNonDataParam(t *testing.T) {
+	source := []byte(`package main
+
+type ruler struct {
+	length int
+}
+
+func Page(r *ruler) Node {
+	return <div>{r.length}</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for a typed non-data parameter's .length field, got: %+v", diags)
+	}
+}
+
+// TestValidateStillFlagsDataLengthAlongsideTypedParam proves the M1 fix does
+// not overcorrect: in the same file, a genuine "data" selector's .length
+// still fails, even though the typed r.length sibling above it does not.
+func TestValidateStillFlagsDataLengthAlongsideTypedParam(t *testing.T) {
+	source := []byte(`package main
+
+type ruler struct {
+	length int
+}
+
+func Page(data any, r *ruler) Node {
+	return <div>
+		<span>{r.length}</span>
+		<span>{data.picks.length}</span>
+	</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) == 0 {
+		t.Fatal("expected a diagnostic for data.picks.length, got none")
+	}
+	for _, d := range diags {
+		if strings.Contains(d.Message, "r.length") {
+			t.Fatalf("did not expect r.length (typed, non-data) to be flagged, got: %+v", diags)
+		}
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "data.picks.length") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a diagnostic naming data.picks.length, got: %+v", diags)
+	}
+}
+
+// TestValidateSkipsLengthInsideHandlersAndComputeds asserts current behavior
+// (unchanged by gosx#174): validateLegacyTemplateExprs only walks a
+// component's rendered node tree (collectComponentNodeIDs from comp.Root). It
+// does not walk ComponentScope.Handlers or ComponentScope.Computeds, which
+// hold source text captured separately by analyzeBody for island lowering.
+// A ".length" read inside a handler or computed body is therefore never
+// scanned by this rule, whatever it is called on.
+func TestValidateSkipsLengthInsideHandlersAndComputeds(t *testing.T) {
+	source := []byte(`package main
+
+func Page(data any) Node {
+	isEmpty := func() bool {
+		return data.length == 0
+	}
+	doubled := signal.Derive(func() int {
+		return data.length * 2
+	})
+	_ = isEmpty
+	_ = doubled
+	return <div>{data.picks}</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	comp := prog.Components[0]
+	if comp.Scope == nil {
+		t.Fatal("expected a populated component scope")
+	}
+	if len(comp.Scope.Handlers) == 0 {
+		t.Fatalf("expected the handler pattern to be recognized, got Handlers=%+v", comp.Scope.Handlers)
+	}
+	if len(comp.Scope.Computeds) == 0 {
+		t.Fatalf("expected the computed pattern to be recognized, got Computeds=%+v", comp.Scope.Computeds)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics — .length only appears in Handlers/Computeds source text, which this rule does not scan, got: %+v", diags)
+	}
+}

--- a/ir/validate_test.go
+++ b/ir/validate_test.go
@@ -1,0 +1,122 @@
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+// TestValidateFlagsLengthMemberInLegacyCond covers gosx#164: a legacy
+// component's <If cond={...}> reading .length on a slice used to render
+// neither branch with no diagnostic anywhere. Validate must now fail closed.
+func TestValidateFlagsLengthMemberInLegacyCond(t *testing.T) {
+	source := []byte(`package main
+
+func Page(data any) Node {
+	return <div>
+		<If cond={data.picks.length == 0}>
+			<b>empty</b>
+		</If>
+	</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) == 0 {
+		t.Fatal("expected a diagnostic for .length in cond, got none")
+	}
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, ".length") && strings.Contains(d.Message, "data.picks.length == 0") {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected a diagnostic naming the .length expression, got: %+v", diags)
+	}
+}
+
+// TestValidateFlagsLengthMemberInTextExpr proves the rule covers any
+// expression hole, not only <If cond={...}>: {data.picks.length} silently
+// prints nothing today for the same reason a cond silently renders neither
+// branch — there's no static type to tell a slice's .length from a resolvable
+// member.
+func TestValidateFlagsLengthMemberInTextExpr(t *testing.T) {
+	source := []byte(`package main
+
+func Page(data any) Node {
+	return <span>{data.picks.length}</span>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) == 0 {
+		t.Fatal("expected a diagnostic for .length in a text expression, got none")
+	}
+}
+
+// TestValidateAllowsValidCondsInLegacyComponents proves the rule does not
+// false-positive on ordinary legacy conditions, including the documented
+// workaround of passing a precomputed boolean from a DataLoader.
+func TestValidateAllowsValidCondsInLegacyComponents(t *testing.T) {
+	source := []byte(`package main
+
+func Page(data any, ok bool) Node {
+	return <div>
+		<If cond={data.picksEmpty}>
+			<b>empty</b>
+		</If>
+		<If when={ok}>
+			<b>ready</b>
+		</If>
+		<If cond={len(data.picks) == 0}>
+			<b>also empty</b>
+		</If>
+	</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics, got: %+v", diags)
+	}
+}
+
+// TestValidateSkipsLengthRuleForStrictComponents proves the rule stays scoped
+// to legacy syntax: a strict component's props are Go-typed and checked by
+// strictcheck (the real Go type checker), so Validate must not duplicate or
+// second-guess that here.
+func TestValidateSkipsLengthRuleForStrictComponents(t *testing.T) {
+	source := []byte(`package main
+
+type PageProps struct {
+	Length int
+}
+
+component Page(props: PageProps) {
+	return <div>{props.Length}</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	diags := ir.Validate(prog)
+	if len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for a strict component, got: %+v", diags)
+	}
+}

--- a/route/navigation_test.go
+++ b/route/navigation_test.go
@@ -80,3 +80,36 @@ func TestFileRoutedAppManualNavigationScriptNotDuplicated(t *testing.T) {
 		t.Fatalf("expected exactly one navigation script tag, got %d\n%s", count, html)
 	}
 }
+
+// TestFileRoutedAppMountBeforeEnableNavigationStillInjectsScript covers PR
+// #174 review N3: Mount used to read app.navigation eagerly, so calling
+// app.Mount before app.EnableNavigation silently dropped the wiring. The
+// wiring now resolves at Build() time (see server.App.registerMountRoutes),
+// so app.EnableNavigation() may run before or after app.Mount() as long as
+// both run before app.Build().
+func TestFileRoutedAppMountBeforeEnableNavigationStillInjectsScript(t *testing.T) {
+	router := NewRouter()
+	router.SetLayout(func(ctx *RouteContext, body gosx.Node) gosx.Node {
+		return server.HTMLDocumentWithLanguage(ctx.Title("Test"), "en", ctx.Head(), body)
+	})
+	router.Add(Route{
+		Pattern: "/",
+		Handler: func(ctx *RouteContext) gosx.Node {
+			return gosx.El("p", gosx.Text("home"))
+		},
+	})
+	rootHandler, err := router.BuildChecked()
+	if err != nil {
+		t.Fatalf("BuildChecked: %v", err)
+	}
+
+	app := server.New()
+	app.Mount("/", rootHandler) // Mount before EnableNavigation, deliberately.
+	app.EnableNavigation()
+	handler := app.Build()
+
+	html := getBody(t, handler)
+	if count := strings.Count(html, navScriptOpenTag); count != 1 {
+		t.Fatalf("expected exactly one navigation script tag when Mount runs before EnableNavigation, got %d\n%s", count, html)
+	}
+}

--- a/route/navigation_test.go
+++ b/route/navigation_test.go
@@ -1,0 +1,82 @@
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/server"
+)
+
+// navScriptOpenTag is the literal opening-tag fragment NavigationScript
+// renders. Counting it in the response body distinguishes "the runtime
+// script is present" from any other data-gosx-navigation-* attribute a
+// future feature might add.
+const navScriptOpenTag = `<script ` + server.NavigationScriptAttr + `="true"`
+
+func buildFileRoutedApp(t *testing.T, layout LayoutFunc) (*server.App, http.Handler) {
+	t.Helper()
+	router := NewRouter()
+	router.SetLayout(layout)
+	router.Add(Route{
+		Pattern: "/",
+		Handler: func(ctx *RouteContext) gosx.Node {
+			return gosx.El("p", gosx.Text("home"))
+		},
+	})
+
+	rootHandler, err := router.BuildChecked()
+	if err != nil {
+		t.Fatalf("BuildChecked: %v", err)
+	}
+
+	app := server.New()
+	app.EnableNavigation()
+	app.Mount("/", rootHandler)
+	return app, app.Build()
+}
+
+func getBody(t *testing.T, handler http.Handler) string {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", w.Code, w.Body.String())
+	}
+	return w.Body.String()
+}
+
+// TestFileRoutedAppEnableNavigationInjectsScript covers issue #169: an app
+// built with route.NewRouter + router.SetLayout + app.Mount("/", handler)
+// bypasses App.decoratePageContext, so app.EnableNavigation() alone used to
+// be a silent no-op. The navigation runtime must now reach the page head
+// through app.EnableNavigation() with no manual AddHead call in the layout.
+func TestFileRoutedAppEnableNavigationInjectsScript(t *testing.T) {
+	_, handler := buildFileRoutedApp(t, func(ctx *RouteContext, body gosx.Node) gosx.Node {
+		return server.HTMLDocumentWithLanguage(ctx.Title("Test"), "en", ctx.Head(), body)
+	})
+
+	html := getBody(t, handler)
+	if count := strings.Count(html, navScriptOpenTag); count != 1 {
+		t.Fatalf("expected exactly one navigation script tag, got %d\n%s", count, html)
+	}
+}
+
+// TestFileRoutedAppManualNavigationScriptNotDuplicated covers the existing
+// workaround (ctx.AddHead(server.NavigationScript()) in SetLayout) alongside
+// app.EnableNavigation(): the automatic injection must defer to the
+// already-present script instead of adding a second one.
+func TestFileRoutedAppManualNavigationScriptNotDuplicated(t *testing.T) {
+	_, handler := buildFileRoutedApp(t, func(ctx *RouteContext, body gosx.Node) gosx.Node {
+		ctx.AddHead(server.NavigationScript())
+		return server.HTMLDocumentWithLanguage(ctx.Title("Test"), "en", ctx.Head(), body)
+	})
+
+	html := getBody(t, handler)
+	if count := strings.Count(html, navScriptOpenTag); count != 1 {
+		t.Fatalf("expected exactly one navigation script tag, got %d\n%s", count, html)
+	}
+}

--- a/route/route.go
+++ b/route/route.go
@@ -187,6 +187,7 @@ type Router struct {
 	errorLayout    LayoutFunc
 	revalidator    *server.Revalidator
 	observers      []server.RequestObserver
+	navigationHead func(nonce string) gosx.Node
 }
 
 type handlerRoute struct {
@@ -244,6 +245,17 @@ func (r *Router) UseObserver(observer server.RequestObserver) {
 // SetLayout sets the default layout for all routes.
 func (r *Router) SetLayout(layout LayoutFunc) {
 	r.defaultLayout = layout
+}
+
+// SetNavigationHead registers the navigation-runtime head builder RouteContext
+// carries into PageState.Head. server.App.Mount calls this automatically (via
+// server.NavigationConfigurable) when the owning App has EnableNavigation set,
+// so a file-routed app needs only app.EnableNavigation() to get the runtime —
+// no manual ctx.AddHead(server.NavigationScript()) in the layout. A manual
+// AddHead call keeps working too: Head only injects when the script isn't
+// already present (see server.NavigationScriptAttr).
+func (r *Router) SetNavigationHead(fn func(nonce string) gosx.Node) {
+	r.navigationHead = fn
 }
 
 // SetNotFound sets the 404 handler.
@@ -332,10 +344,30 @@ func (r *Router) BuildChecked() (http.Handler, error) {
 
 		r.renderNotFound(w, req)
 	})
+	var handler http.Handler = root
 	if len(r.observers) > 0 {
-		return server.ObserveHandler(root, append([]server.RequestObserver(nil), r.observers...)), nil
+		handler = server.ObserveHandler(root, append([]server.RequestObserver(nil), r.observers...))
 	}
-	return root, nil
+	return &builtRouter{router: r, handler: handler}, nil
+}
+
+// builtRouter is what Build/BuildChecked return. It serves exactly like the
+// compiled mux handler, but keeps a live pointer back to the Router so
+// server.App.Mount can still reach Router.SetNavigationHead after Build has
+// erased the concrete *Router type into an http.Handler.
+type builtRouter struct {
+	router  *Router
+	handler http.Handler
+}
+
+func (b *builtRouter) ServeHTTP(w http.ResponseWriter, req *http.Request) {
+	b.handler.ServeHTTP(w, req)
+}
+
+// SetNavigationHead implements server.NavigationConfigurable by forwarding to
+// the wrapped Router.
+func (b *builtRouter) SetNavigationHead(fn func(nonce string) gosx.Node) {
+	b.router.SetNavigationHead(fn)
 }
 
 func buildErrorHandler(err error) http.Handler {
@@ -395,7 +427,7 @@ func (r *Router) buildHandler(pattern string, route Route, layouts []LayoutFunc,
 
 	return func(w http.ResponseWriter, req *http.Request) {
 		server.MarkObservedRequest(req, "page", pattern)
-		ctx := newRouteContext(req)
+		ctx := r.newRouteContext(req)
 		ctx.Params = extractParamsByNames(req, paramNames)
 
 		defer func() {
@@ -469,7 +501,7 @@ func (r *Router) renderPage(w http.ResponseWriter, ctx *RouteContext, layouts []
 
 func (r *Router) renderNotFound(w http.ResponseWriter, req *http.Request) {
 	server.MarkObservedRequest(req, "not_found", "")
-	ctx := newRouteContext(req)
+	ctx := r.newRouteContext(req)
 	ctx.SetStatus(http.StatusNotFound)
 
 	layouts := []LayoutFunc{}
@@ -507,7 +539,7 @@ func (r *Router) renderNotFound(w http.ResponseWriter, req *http.Request) {
 
 func (r *Router) renderError(w http.ResponseWriter, ctx *RouteContext, layouts []LayoutFunc, errorHandler ErrorHandler, errorLayout LayoutFunc, err error, pattern string) {
 	if ctx == nil {
-		ctx = newRouteContext(nil)
+		ctx = r.newRouteContext(nil)
 	}
 	server.MarkObservedRequest(ctx.Request, "error", pattern)
 	if ctx.StatusCode() == 0 {
@@ -572,7 +604,7 @@ func extractPatternParams(pattern string, requestPath string) map[string]string 
 	return params
 }
 
-func newRouteContext(req *http.Request) *RouteContext {
+func (r *Router) newRouteContext(req *http.Request) *RouteContext {
 	// Params is left nil; reads from a nil map are valid and the build-time
 	// closure assigns a sized map only when the route declares parameters.
 	ctx := &RouteContext{
@@ -582,6 +614,9 @@ func newRouteContext(req *http.Request) *RouteContext {
 	// Carry the generated Content-Security-Policy nonce, so the document shell
 	// and the streamed chunks attach the same value the header names.
 	ctx.SetNonce(server.RequestNonce(req))
+	if r != nil && r.navigationHead != nil {
+		ctx.SetNavigationHead(r.navigationHead)
+	}
 	return ctx
 }
 

--- a/route/route_test.go
+++ b/route/route_test.go
@@ -47,7 +47,7 @@ func TestRouterBasic(t *testing.T) {
 }
 
 func TestRouteContextHeadUsesRequestPathForAutomaticMetadataURLs(t *testing.T) {
-	ctx := newRouteContext(httptest.NewRequest(http.MethodGet, "/blog/example", nil))
+	ctx := (&Router{}).newRouteContext(httptest.NewRequest(http.MethodGet, "/blog/example", nil))
 	ctx.SetMetadata(server.Metadata{MetadataBase: "https://example.com"})
 
 	html := gosx.RenderHTML(ctx.Head())

--- a/server/navigation.go
+++ b/server/navigation.go
@@ -7,6 +7,12 @@ import (
 	runtimehost "m31labs.dev/gosx/client/runtime/host"
 )
 
+// NavigationScriptAttr marks the inline script tag NavigationScript renders.
+// PageState.Head uses it to detect that the navigation runtime is already in
+// the head — from either App.EnableNavigation or a manual AddHead call — so
+// it never injects the script twice.
+const NavigationScriptAttr = "data-gosx-navigation"
+
 // NavigationScript returns the inline GoSX page-navigation runtime. Its public
 // navigate method soft-fetches only same-origin HTTP(S), hard-navigates safe
 // cross-origin HTTP(S), and rejects other schemes.
@@ -18,7 +24,7 @@ func NavigationScript() gosx.Node {
 // with a CSP nonce attribute attached. Passing an empty nonce is equivalent to
 // NavigationScript.
 func NavigationScriptWithNonce(nonce string) gosx.Node {
-	return gosx.RawHTML(`<script data-gosx-navigation="true"` + nonceAttr(nonce) + `>` + runtimehost.NavigationRuntime + `</script>`)
+	return gosx.RawHTML(`<script ` + NavigationScriptAttr + `="true"` + nonceAttr(nonce) + `>` + runtimehost.NavigationRuntime + `</script>`)
 }
 
 func nonceAttr(nonce string) string {

--- a/server/page_state.go
+++ b/server/page_state.go
@@ -24,6 +24,11 @@ type PageState struct {
 	runtime        *PageRuntime
 	nonce          string
 	navigationHead func(nonce string) gosx.Node
+	// hasNavigationScript records whether an AddHead call has already added a
+	// node carrying the navigation script marker. AddHead sets it once, at
+	// add time; Head reads it instead of re-rendering every head node on
+	// every call. See headContainsNavigationScriptMarker.
+	hasNavigationScript bool
 }
 
 // NewPageState creates an empty shared page-state container.
@@ -210,6 +215,10 @@ func (s *PageState) SetNavigationHead(fn func(nonce string) gosx.Node) {
 }
 
 // AddHead appends arbitrary head nodes to the response document.
+//
+// Each added node is checked for the navigation script marker here, once,
+// instead of at every later Head() call. See headContainsNavigationScriptMarker
+// and hasNavigationScript.
 func (s *PageState) AddHead(nodes ...gosx.Node) {
 	if s == nil {
 		return
@@ -219,6 +228,9 @@ func (s *PageState) AddHead(nodes ...gosx.Node) {
 			continue
 		}
 		s.head = append(s.head, node)
+		if !s.hasNavigationScript && headContainsNavigationScriptMarker(node) {
+			s.hasNavigationScript = true
+		}
 	}
 }
 
@@ -229,6 +241,14 @@ func (s *PageState) AddHead(nodes ...gosx.Node) {
 // page pipeline. The document shell calls Head() after every inner layout
 // has rendered, so engines registered by layouts (not just pages) make it
 // into the manifest — the manifest is marshaled when Head() runs.
+//
+// gosx#174 (PR #174 review, M3): Head() used to call a headContainsNavigationScript
+// helper against the whole assembled node slice on every call, which serialized every
+// head node (metadata, every AddHead node) to HTML with gosx.RenderHTML just
+// to substring-search it — full-head rendering on every request, and again on
+// every Head() call within a request when nested layouts each call it. That
+// scan now happens once per node, in AddHead, and Head() only reads the
+// resulting flag.
 func (s *PageState) Head() gosx.Node {
 	if s == nil {
 		return gosx.Text("")
@@ -238,7 +258,7 @@ func (s *PageState) Head() gosx.Node {
 		nodes = append(nodes, metaHead)
 	}
 	nodes = append(nodes, s.head...)
-	if s.navigationHead != nil && !headContainsNavigationScript(nodes) {
+	if s.navigationHead != nil && !s.hasNavigationScript {
 		if nav := s.navigationHead(s.nonce); !nav.IsZero() {
 			nodes = append(nodes, nav)
 		}
@@ -386,21 +406,25 @@ func (s *PageState) CacheState() *CacheState {
 	return s.cache
 }
 
-// navigationScriptAttrMarker matches the attribute *assignment* NavigationScript
-// renders (`data-gosx-navigation="true"`), not just the attribute name. A plain
-// NavigationScriptAttr substring match would also fire on unrelated attributes
-// that merely start with the same name, such as data-gosx-navigation-state.
-const navigationScriptAttrMarker = NavigationScriptAttr + `="`
+// navigationScriptAttrMarker matches the literal opening tag NavigationScript
+// and NavigationScriptWithNonce render (`<script data-gosx-navigation="true"`),
+// not just the attribute assignment. gosx#174 (PR #174 review, N1): a plain
+// `data-gosx-navigation="true"` substring match also fired on a head script
+// that only *queries* the attribute, e.g.
+// `document.querySelector('[data-gosx-navigation="true"]')` inside an
+// unrelated inline script — that string appears nowhere near a `<script
+// data-gosx-navigation="true"` opening tag, so anchoring the match to the tag
+// itself distinguishes "the navigation runtime is present" from "some script
+// happens to mention the attribute value."
+const navigationScriptAttrMarker = `<script ` + NavigationScriptAttr + `="true"`
 
-// headContainsNavigationScript reports whether the already-assembled head
-// nodes carry a script tagged with NavigationScriptAttr. Head calls this
-// before invoking navigationHead, so a manual AddHead(NavigationScript(...))
-// call in a layout suppresses the automatic injection instead of duplicating it.
-func headContainsNavigationScript(nodes []gosx.Node) bool {
-	for _, node := range nodes {
-		if strings.Contains(gosx.RenderHTML(node), navigationScriptAttrMarker) {
-			return true
-		}
-	}
-	return false
+// headContainsNavigationScriptMarker reports whether one head node carries a
+// script tagged with the navigation marker. AddHead calls this once per node,
+// at add time, and caches the result in PageState.hasNavigationScript so Head
+// never re-renders the accumulated head nodes to check for it — see gosx#174
+// (PR #174 review, M3). A manual AddHead(NavigationScript(...)) call in a
+// layout is what this detects; it makes Head skip the automatic injection
+// instead of duplicating it.
+func headContainsNavigationScriptMarker(node gosx.Node) bool {
+	return strings.Contains(gosx.RenderHTML(node), navigationScriptAttrMarker)
 }

--- a/server/page_state.go
+++ b/server/page_state.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"net/http"
+	"strings"
 	"time"
 
 	"m31labs.dev/gosx"
@@ -13,15 +14,16 @@ import (
 // PageState carries shared request-scoped page response state used by both
 // server.Context and route.RouteContext.
 type PageState struct {
-	requestPath string
-	headers     http.Header
-	status      int
-	metadata    Metadata
-	head        []gosx.Node
-	deferred    *DeferredRegistry
-	cache       *CacheState
-	runtime     *PageRuntime
-	nonce       string
+	requestPath    string
+	headers        http.Header
+	status         int
+	metadata       Metadata
+	head           []gosx.Node
+	deferred       *DeferredRegistry
+	cache          *CacheState
+	runtime        *PageRuntime
+	nonce          string
+	navigationHead func(nonce string) gosx.Node
 }
 
 // NewPageState creates an empty shared page-state container.
@@ -193,6 +195,20 @@ func (s *PageState) MetadataValue() Metadata {
 	return s.metadata
 }
 
+// SetNavigationHead registers the navigation-runtime head builder Head uses
+// to inject the client navigation script exactly once. App.decoratePageContext
+// sets this when EnableNavigation is on; route.Router.SetNavigationHead wires
+// the same builder in for file-routed apps mounted on such an App (see
+// server.NavigationConfigurable). A manual AddHead(NavigationScript(...)) call
+// still works: Head checks the assembled head for NavigationScriptAttr first
+// and skips the builder when the script is already present.
+func (s *PageState) SetNavigationHead(fn func(nonce string) gosx.Node) {
+	if s == nil {
+		return
+	}
+	s.navigationHead = fn
+}
+
 // AddHead appends arbitrary head nodes to the response document.
 func (s *PageState) AddHead(nodes ...gosx.Node) {
 	if s == nil {
@@ -222,6 +238,11 @@ func (s *PageState) Head() gosx.Node {
 		nodes = append(nodes, metaHead)
 	}
 	nodes = append(nodes, s.head...)
+	if s.navigationHead != nil && !headContainsNavigationScript(nodes) {
+		if nav := s.navigationHead(s.nonce); !nav.IsZero() {
+			nodes = append(nodes, nav)
+		}
+	}
 	if s.runtime != nil {
 		if runtimeHead := s.runtime.HeadWithNonce(s.nonce); !runtimeHead.IsZero() {
 			nodes = append(nodes, runtimeHead)
@@ -363,4 +384,23 @@ func (s *PageState) CacheState() *CacheState {
 		s.cache = NewCacheState()
 	}
 	return s.cache
+}
+
+// navigationScriptAttrMarker matches the attribute *assignment* NavigationScript
+// renders (`data-gosx-navigation="true"`), not just the attribute name. A plain
+// NavigationScriptAttr substring match would also fire on unrelated attributes
+// that merely start with the same name, such as data-gosx-navigation-state.
+const navigationScriptAttrMarker = NavigationScriptAttr + `="`
+
+// headContainsNavigationScript reports whether the already-assembled head
+// nodes carry a script tagged with NavigationScriptAttr. Head calls this
+// before invoking navigationHead, so a manual AddHead(NavigationScript(...))
+// call in a layout suppresses the automatic injection instead of duplicating it.
+func headContainsNavigationScript(nodes []gosx.Node) bool {
+	for _, node := range nodes {
+		if strings.Contains(gosx.RenderHTML(node), navigationScriptAttrMarker) {
+			return true
+		}
+	}
+	return false
 }

--- a/server/page_state_test.go
+++ b/server/page_state_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// TestPageStateAddHeadSetsNavigationScriptFlag covers PR #174 review M3:
+// AddHead must record the navigation-marker flag itself, at add time, instead
+// of leaving Head to rediscover it later by re-rendering every head node.
+func TestPageStateAddHeadSetsNavigationScriptFlag(t *testing.T) {
+	s := NewPageState()
+	if s.hasNavigationScript {
+		t.Fatal("expected hasNavigationScript to start false")
+	}
+
+	s.AddHead(gosx.El("meta", gosx.Attrs(gosx.Attr("name", "description"), gosx.Attr("content", "x"))))
+	if s.hasNavigationScript {
+		t.Fatal("expected an unrelated head node not to set hasNavigationScript")
+	}
+
+	s.AddHead(NavigationScript())
+	if !s.hasNavigationScript {
+		t.Fatal("expected AddHead(NavigationScript()) to set hasNavigationScript")
+	}
+}
+
+// TestPageStateHeadSkipsAutomaticInjectionWhenManuallyAdded is the end-to-end
+// counterpart: SetNavigationHead's builder must still defer to a manually
+// added NavigationScript node, using the AddHead-time flag rather than a
+// per-call render-and-scan.
+func TestPageStateHeadSkipsAutomaticInjectionWhenManuallyAdded(t *testing.T) {
+	s := NewPageState()
+	s.SetNavigationHead(NavigationScriptWithNonce)
+	s.AddHead(NavigationScript())
+
+	html := gosx.RenderHTML(s.Head())
+	if count := strings.Count(html, navigationScriptAttrMarker); count != 1 {
+		t.Fatalf("expected exactly one navigation script marker, got %d:\n%s", count, html)
+	}
+}
+
+// TestPageStateHeadCalledMultipleTimesStaysConsistent covers the doc comment
+// on Head: the document shell may call Head() more than once per request (once
+// per rendered layout level). Each call must see the same hasNavigationScript
+// flag AddHead set once, not recompute it, and must not accumulate duplicate
+// automatic injections across calls.
+func TestPageStateHeadCalledMultipleTimesStaysConsistent(t *testing.T) {
+	s := NewPageState()
+	s.SetNavigationHead(NavigationScriptWithNonce)
+
+	first := gosx.RenderHTML(s.Head())
+	second := gosx.RenderHTML(s.Head())
+	if strings.Count(first, navigationScriptAttrMarker) != 1 {
+		t.Fatalf("expected the automatic script on the first Head() call, got:\n%s", first)
+	}
+	if strings.Count(second, navigationScriptAttrMarker) != 1 {
+		t.Fatalf("expected the automatic script on the second Head() call, got:\n%s", second)
+	}
+}
+
+// TestHeadContainsNavigationScriptMarkerRequiresOpeningTag covers PR #174
+// review N1: the marker must match the literal opening tag
+// `<script data-gosx-navigation="true"`, not a bare `data-gosx-navigation="`
+// substring anywhere in the rendered node.
+func TestHeadContainsNavigationScriptMarkerRequiresOpeningTag(t *testing.T) {
+	if !headContainsNavigationScriptMarker(NavigationScript()) {
+		t.Fatal("expected the real navigation script node to match the marker")
+	}
+	if !headContainsNavigationScriptMarker(NavigationScriptWithNonce("abc123")) {
+		t.Fatal("expected the nonce variant to match the marker (nonce comes after the matched prefix)")
+	}
+
+	// A head script that only *queries* for the attribute — never opens a
+	// <script data-gosx-navigation="true" ...> tag itself — must not match.
+	queryOnly := gosx.RawHTML(`<script>if (document.querySelector('[data-gosx-navigation="true"]')) { /* noop */ }</script>`)
+	if headContainsNavigationScriptMarker(queryOnly) {
+		t.Fatal("expected a script that only queries the attribute not to match the marker")
+	}
+}
+
+// TestPageStateHeadScriptQueryingAttributeDoesNotSuppressInjection is the
+// false-positive regression PR #174 review explicitly calls out: a head
+// script that queries [data-gosx-navigation="true"] (e.g. to detect whether
+// the runtime is already present) must not be mistaken for the runtime script
+// itself and must not suppress the automatic injection.
+func TestPageStateHeadScriptQueryingAttributeDoesNotSuppressInjection(t *testing.T) {
+	s := NewPageState()
+	s.SetNavigationHead(NavigationScriptWithNonce)
+	s.AddHead(gosx.RawHTML(`<script>if (document.querySelector('[data-gosx-navigation="true"]')) { /* noop */ }</script>`))
+
+	if s.hasNavigationScript {
+		t.Fatal("expected the query-only script not to set hasNavigationScript")
+	}
+
+	html := gosx.RenderHTML(s.Head())
+	if count := strings.Count(html, navigationScriptAttrMarker); count != 1 {
+		t.Fatalf("expected the automatic navigation script injection to still occur exactly once, got %d:\n%s", count, html)
+	}
+}

--- a/server/server.go
+++ b/server/server.go
@@ -338,11 +338,32 @@ func (a *App) HandleRewrite(route RewriteRoute) {
 	}
 }
 
-// Mount registers an arbitrary HTTP handler under the given pattern.
+// NavigationConfigurable is implemented by mountable handlers — such as the
+// value route.Router.Build/BuildChecked returns — that keep a live reference
+// to their own document assembly and can accept the navigation-runtime head
+// builder. Mount uses this to carry EnableNavigation through to a file-routed
+// app: server cannot import route (route already imports server), so the seam
+// is a structural interface rather than a route.Router type check.
+type NavigationConfigurable interface {
+	SetNavigationHead(fn func(nonce string) gosx.Node)
+}
+
+// Mount registers an arbitrary HTTP handler under the given pattern. When
+// EnableNavigation is set and handler implements NavigationConfigurable, Mount
+// wires the navigation-runtime head builder into it, so a file-routed app
+// built with route.NewRouter and mounted here needs only
+// app.EnableNavigation() — no manual ctx.AddHead(server.NavigationScript())
+// in the layout. Call EnableNavigation before Mount; Mount reads a.navigation
+// once, at registration time.
 func (a *App) Mount(pattern string, handler http.Handler) {
 	pattern = strings.TrimSpace(pattern)
 	if pattern == "" || handler == nil {
 		return
+	}
+	if a.navigation {
+		if configurable, ok := handler.(NavigationConfigurable); ok {
+			configurable.SetNavigationHead(NavigationScriptWithNonce)
+		}
 	}
 	a.mounts[pattern] = registeredMountedRoute{
 		pattern: pattern,
@@ -925,7 +946,7 @@ func (a *App) decoratePageContext(ctx *Context) {
 	// Runtime head emission moved into PageState.Head() (lazy, at document
 	// render) so layout-registered engines reach the manifest.
 	if a.navigation {
-		ctx.AddHead(NavigationScriptWithNonce(ctx.Nonce()))
+		ctx.SetNavigationHead(NavigationScriptWithNonce)
 	}
 	for _, decorate := range a.headDecorators {
 		if decorate == nil {

--- a/server/server.go
+++ b/server/server.go
@@ -287,6 +287,11 @@ func (a *App) HandleAPI(route APIRoute) {
 
 // EnableNavigation injects the built-in client-side page navigation runtime
 // into document/head-aware responses.
+//
+// Call it any time before Build(): Build() is what wires the navigation-runtime
+// head builder into every mounted NavigationConfigurable handler (see Mount and
+// registerMountRoutes), so EnableNavigation, Mount, and MountApp may run in any
+// order relative to each other as long as all of them run before Build().
 func (a *App) EnableNavigation() {
 	a.navigation = true
 }
@@ -349,21 +354,16 @@ type NavigationConfigurable interface {
 }
 
 // Mount registers an arbitrary HTTP handler under the given pattern. When
-// EnableNavigation is set and handler implements NavigationConfigurable, Mount
-// wires the navigation-runtime head builder into it, so a file-routed app
-// built with route.NewRouter and mounted here needs only
+// EnableNavigation is set and handler implements NavigationConfigurable, Build
+// wires the navigation-runtime head builder into it (see registerMountRoutes),
+// so a file-routed app built with route.NewRouter and mounted here needs only
 // app.EnableNavigation() — no manual ctx.AddHead(server.NavigationScript())
-// in the layout. Call EnableNavigation before Mount; Mount reads a.navigation
-// once, at registration time.
+// in the layout. EnableNavigation and Mount may run in either order; only
+// Build reads a.navigation, so both must run before Build.
 func (a *App) Mount(pattern string, handler http.Handler) {
 	pattern = strings.TrimSpace(pattern)
 	if pattern == "" || handler == nil {
 		return
-	}
-	if a.navigation {
-		if configurable, ok := handler.(NavigationConfigurable); ok {
-			configurable.SetNavigationHead(NavigationScriptWithNonce)
-		}
 	}
 	a.mounts[pattern] = registeredMountedRoute{
 		pattern: pattern,
@@ -655,6 +655,15 @@ func (a *App) registerMountRoutes(mux *http.ServeMux) {
 	for _, route := range a.mounts {
 		pattern := route.pattern
 		handler := route.handler
+		// Wired here, at Build time, rather than back in Mount — see the N3
+		// ordering note on EnableNavigation and Mount. This makes
+		// EnableNavigation order-independent relative to Mount: it only has
+		// to run before Build.
+		if a.navigation {
+			if configurable, ok := handler.(NavigationConfigurable); ok {
+				configurable.SetNavigationHead(NavigationScriptWithNonce)
+			}
+		}
 		mux.Handle(pattern, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			MarkObservedRequest(r, "mount", pattern)
 			handler.ServeHTTP(w, r)


### PR DESCRIPTION
## Summary

Addresses two behavioral gaps in the GosX core. File-routed apps now correctly receive the page-navigation runtime script via `app.EnableNavigation()` without requiring manual `ctx.AddHead()` workarounds. Additionally, the static checker (`gosx check`) now catches the common `.length` slice-access pattern that previously evaluated to `nil` reflectively, causing silent mismatches between checks and renders.

## Changes

- **Fix navigation injection for file-routers**: Introduce `NavigationConfigurable` interface so `server.App.Mount` wires the navigation head builder into `route.Router` outputs. `PageState.Head()` now auto-injects the runtime script only when not already present, safely handling layouts that manually register the script to avoid duplicates.
- **Flag `.length` in legacy templates**: Implement AST-based validation in `ir.Validate` to detect `.length` member access in expression holes. The legacy reflective interpreter resolves untyped slice `.length` to `nil`, leading to silent `false` comparisons. The checker now exits with a clear diagnostic suggesting a precomputed DataLoader field or typed component instead.
- **Align export manifests with improved wiring**: Update the starter-template export test to expect `Capabilities.Navigation: true`, reflecting the corrected flow of `app.EnableNavigation()` into file-routed pages.

## Testing

- Run `go test ./ir/... ./route/... ./cmd/gosx/... ./server/...` to validate new diagnostics and navigation rendering.
- Create a legacy GSX file containing `<If cond={data.items.length > 0}>` and run `gosx check` to confirm it fails closed with a hint about `.length`.
- Mount a `route.Router` built via `route.NewRouter()` on an `App` with `EnableNavigation(true)`, serve a request, and assert exactly one `<script data-gosx-navigation="true">` tag exists in the HTML output.