### PR TITLE
add(navigation): Add declarative periodic page revalidation

### DIFF
--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -518,6 +518,255 @@ test("navigation fetch epoch does not commit when page application fails", async
   env.context.__gosx_dispose_page = async function() {};
 });
 
+test("declarative revalidation logs one warning and stays disabled for an invalid interval", () => {
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "10h");
+  const env = createContext({ elements: [main] });
+  const timers = installManualTimers(env.context);
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  assert.equal(timers.count(), 0);
+  assert.equal(env.consoleLogs.warn.length, 1);
+  assert.match(env.consoleLogs.warn[0], /data-gosx-revalidate-interval/);
+});
+
+test("declarative revalidation logs one warning and stays disabled for a cross-origin src", () => {
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "https://other.example/api/version");
+  const env = createContext({ elements: [main] });
+  const timers = installManualTimers(env.context);
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  assert.equal(timers.count(), 0);
+  assert.equal(env.consoleLogs.warn.length, 1);
+  assert.match(env.consoleLogs.warn[0], /data-gosx-revalidate-src/);
+});
+
+test("declarative revalidation without a src revalidates unconditionally on the interval", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const main = new FakeElement("main", null);
+  main.id = "scoreboard";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [url]: { text: "__SCOREBOARD_REFRESH__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const freshMain = new FakeElement("main", null);
+  freshMain.id = "scoreboard";
+  freshMain.setAttribute("data-gosx-revalidate-interval", "4s");
+  parsedDocs.set("__SCOREBOARD_REFRESH__", buildNavigatedDocument({
+    title: "Scoreboard",
+    bodyNodes: [freshMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+
+  assert.equal(env.fetchCalls.filter((call) => call.url === url).length, 1);
+  assert.equal(timers.count(), 1, "the refreshed page still carries the attribute, so the timer survives");
+});
+
+test("declarative revalidation triggers exactly once when its src body changes, and never while it stays the same", async () => {
+  const url = "http://localhost:3000/draft-room";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const main = new FakeElement("main", null);
+  main.id = "draft-room";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  let versionBody = '{"version":1}';
+  let versionCalls = 0;
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: () => {
+        versionCalls += 1;
+        return { text: versionBody };
+      },
+      [url]: { text: "__DRAFT_ROOM_REFRESH__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const freshMain = new FakeElement("main", null);
+  freshMain.id = "draft-room";
+  freshMain.setAttribute("data-gosx-revalidate-interval", "4s");
+  freshMain.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  parsedDocs.set("__DRAFT_ROOM_REFRESH__", buildNavigatedDocument({
+    title: "Draft room",
+    bodyNodes: [freshMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 1, "the first successful poll only records the baseline");
+  assert.equal(env.fetchCalls.filter((call) => call.url === url).length, 0);
+
+  versionBody = '{"version":2}';
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 2);
+  assert.equal(env.fetchCalls.filter((call) => call.url === url).length, 1, "a changed body triggers exactly one revalidate");
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 3);
+  assert.equal(env.fetchCalls.filter((call) => call.url === url).length, 1, "an unchanged body never triggers a second revalidate");
+
+  const versionRequest = env.fetchCalls.find((call) => call.url === versionURL);
+  assert.equal(versionRequest.init.headers.Accept, "application/json");
+  assert.equal(versionRequest.init.cache, "no-store");
+});
+
+test("declarative revalidation skips a tick while the document is hidden", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: { text: '{"version":1}' },
+    },
+  });
+  env.context.location.href = url;
+  env.document.visibilityState = "hidden";
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+
+  assert.equal(env.fetchCalls.length, 0, "a hidden document must skip the tick entirely");
+});
+
+test("declarative revalidation skips a tick while an input, textarea, or select is focused", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  const input = new FakeElement("input", null);
+  main.appendChild(input);
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: { text: '{"version":1}' },
+    },
+  });
+  env.context.location.href = url;
+  env.document.activeElement = input;
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+
+  assert.equal(env.fetchCalls.length, 0, "a focused form control must skip the tick entirely");
+});
+
+test("declarative revalidation skips a tick while a navigation is already in flight", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const otherURL = "http://localhost:3000/other";
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  let resolvePending;
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: { text: '{"version":1}' },
+      [otherURL]: () => new Promise((resolve) => { resolvePending = resolve; }),
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  parsedDocs.set("__OTHER_PAGE__", buildNavigatedDocument({
+    title: "Other",
+    bodyNodes: [new FakeElement("main", null)],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  const pending = env.context.__gosx.navigation.navigate(otherURL, { replace: false });
+  await Promise.resolve();
+  assert.equal(env.context.__gosx.navigation.getState().phase, "pending");
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === versionURL).length,
+    0,
+    "an in-flight navigation must skip the tick entirely",
+  );
+
+  resolvePending({ text: "__OTHER_PAGE__", url: otherURL });
+  assert.equal(await pending, true);
+});
+
+test("declarative revalidation tears down its interval when a soft navigation lands on a page without the attribute", async () => {
+  const url = "http://localhost:3000/plain-page";
+  const main = new FakeElement("main", null);
+  main.id = "draft-room";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [url]: { text: "__PLAIN_PAGE__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const plainMain = new FakeElement("main", null);
+  plainMain.id = "plain-page";
+  parsedDocs.set("__PLAIN_PAGE__", buildNavigatedDocument({
+    title: "Plain page",
+    bodyNodes: [plainMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  assert.equal(await env.context.__gosx.navigation.navigate(url, { replace: false }), true);
+  await flushAsyncWork();
+
+  assert.equal(timers.count(), 0, "the new page carries no revalidate attribute, so the timer must be cleared");
+});
+
 test("navigation runtime sends typed beacons once per soft navigation path", async () => {
   function beaconScript() {
     const script = new FakeElement("script", null);

--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -767,6 +767,328 @@ test("declarative revalidation tears down its interval when a soft navigation la
   assert.equal(timers.count(), 0, "the new page carries no revalidate attribute, so the timer must be cleared");
 });
 
+test("declarative revalidation discards a stale-generation poll that settles after navigation moved on", async () => {
+  const pageBURL = "http://localhost:3000/draft-room-b";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const main = new FakeElement("main", null);
+  main.id = "draft-room";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+
+  let versionCalls = 0;
+  let resolveStalePoll;
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: () => {
+        versionCalls += 1;
+        if (versionCalls === 2) {
+          // Held pending so it settles only after the test navigates away.
+          return new Promise((resolve) => { resolveStalePoll = resolve; });
+        }
+        return { text: '{"version":1}' };
+      },
+      [pageBURL]: { text: "__PAGE_B__", url: pageBURL },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = "http://localhost:3000/draft-room";
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+
+  const pageBMain = new FakeElement("main", null);
+  pageBMain.id = "draft-room-b";
+  pageBMain.setAttribute("data-gosx-revalidate-interval", "4s");
+  pageBMain.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  parsedDocs.set("__PAGE_B__", buildNavigatedDocument({
+    title: "Draft room B",
+    bodyNodes: [pageBMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  // The first tick on page A records the version=1 baseline.
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 1);
+
+  // The second tick on page A starts a poll this test holds open.
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 2);
+
+  // Navigate to page B while that poll is still in flight. finalizeNavigation
+  // re-runs setupPageRevalidation, which must bump the generation counter so
+  // the still-pending page-A poll can no longer write page B's baseline.
+  assert.equal(await env.context.__gosx.navigation.navigate(pageBURL, { replace: false }), true);
+  await flushAsyncWork();
+  assert.equal(timers.count(), 1, "page B also declares periodic revalidation");
+
+  // Resolve the stale page-A poll with a changed body. Without the
+  // generation guard this would wrongly seed page B's baseline and skip
+  // page B's own first (baseline-only) tick.
+  resolveStalePoll({ text: '{"version":2}' });
+  await flushAsyncWork();
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === pageBURL).length,
+    1,
+    "the stale poll must not trigger a revalidate navigation",
+  );
+
+  // Page B's own first tick must still behave like a fresh baseline read.
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 3);
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === pageBURL).length,
+    1,
+    "page B's first tick only records its own baseline",
+  );
+});
+
+test("declarative revalidation logs one warning and stays disabled for an interval past the 32-bit timer bound", () => {
+  const main = new FakeElement("main", null);
+  // 2147484s = 2147484000ms, one second's worth of interval steps past the
+  // 32-bit setInterval/setTimeout delay bound (2147483647ms).
+  main.setAttribute("data-gosx-revalidate-interval", "2147484s");
+  const env = createContext({ elements: [main] });
+  const timers = installManualTimers(env.context);
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  assert.equal(timers.count(), 0);
+  assert.equal(env.consoleLogs.warn.length, 1);
+  assert.match(env.consoleLogs.warn[0], /data-gosx-revalidate-interval/);
+});
+
+test("declarative revalidation clamps an interval over 1 hour and warns once", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const main = new FakeElement("main", null);
+  main.id = "scoreboard";
+  main.setAttribute("data-gosx-revalidate-interval", "90m");
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [url]: { text: "__SCOREBOARD_REFRESH__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const freshMain = new FakeElement("main", null);
+  freshMain.id = "scoreboard";
+  freshMain.setAttribute("data-gosx-revalidate-interval", "90m");
+  parsedDocs.set("__SCOREBOARD_REFRESH__", buildNavigatedDocument({
+    title: "Scoreboard",
+    bodyNodes: [freshMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  assert.equal(timers.count(), 1);
+  assert.equal(env.consoleLogs.warn.length, 1);
+  assert.match(env.consoleLogs.warn[0], /data-gosx-revalidate-interval/);
+  assert.match(env.consoleLogs.warn[0], /1 hour/);
+  assert.equal(
+    timers.runInterval(60 * 60 * 1000),
+    1,
+    "the 90-minute interval must be clamped to a 1 hour timer delay",
+  );
+});
+
+test("declarative revalidation skips a tick while the previous poll has not settled", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const versionURL = "http://localhost:3000/api/league/version";
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  main.setAttribute("data-gosx-revalidate-src", "/api/league/version");
+  let versionCalls = 0;
+  let resolveVersion;
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [versionURL]: () => {
+        versionCalls += 1;
+        return new Promise((resolve) => { resolveVersion = resolve; });
+      },
+    },
+  });
+  env.context.location.href = url;
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 1, "the first tick starts a poll this test holds open");
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 1, "a second tick must not start an overlapping poll while the first is in flight");
+
+  resolveVersion({ text: '{"version":1}' });
+  await flushAsyncWork();
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(versionCalls, 2, "once the first poll settles, the next tick starts a new one");
+});
+
+test("declarative revalidation runs one immediate tick when a full interval elapsed while the document was hidden", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const main = new FakeElement("main", null);
+  main.id = "scoreboard";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [url]: { text: "__SCOREBOARD_REFRESH__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const freshMain = new FakeElement("main", null);
+  freshMain.id = "scoreboard";
+  freshMain.setAttribute("data-gosx-revalidate-interval", "4s");
+  parsedDocs.set("__SCOREBOARD_REFRESH__", buildNavigatedDocument({
+    title: "Scoreboard",
+    bodyNodes: [freshMain],
+  }));
+
+  const clock = installManualClock(env.context, 0);
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  env.document.visibilityState = "hidden";
+  env.document.dispatchEvent({ type: "visibilitychange" });
+
+  clock.advance(4000);
+  env.document.visibilityState = "visible";
+  env.document.dispatchEvent({ type: "visibilitychange" });
+  await flushAsyncWork();
+
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === url).length,
+    1,
+    "one full interval elapsed while hidden, so visibility recovery runs an immediate tick",
+  );
+
+  // A second visible event without an intervening hidden period must not
+  // fire another catch-up tick.
+  env.document.dispatchEvent({ type: "visibilitychange" });
+  await flushAsyncWork();
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === url).length,
+    1,
+    "the catch-up tick fires at most once per hidden period",
+  );
+});
+
+test("declarative revalidation skips the catch-up tick when less than a full interval elapsed while hidden", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const main = new FakeElement("main", null);
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  const env = createContext({
+    elements: [main],
+    fetchRoutes: {
+      [url]: { text: "__SCOREBOARD_REFRESH__", url },
+    },
+  });
+  env.context.location.href = url;
+
+  const clock = installManualClock(env.context, 0);
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  env.document.visibilityState = "hidden";
+  env.document.dispatchEvent({ type: "visibilitychange" });
+
+  clock.advance(2000);
+  env.document.visibilityState = "visible";
+  env.document.dispatchEvent({ type: "visibilitychange" });
+  await flushAsyncWork();
+
+  assert.equal(env.fetchCalls.length, 0, "under one interval elapsed while hidden, so no catch-up tick runs");
+});
+
+test("declarative revalidation skips a tick while a managed form submission is in flight", async () => {
+  const url = "http://localhost:3000/scoreboard";
+  const actionURL = "http://localhost:3000/scoreboard/__actions/save";
+  const main = new FakeElement("main", null);
+  main.id = "scoreboard";
+  main.setAttribute("data-gosx-revalidate-interval", "4s");
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", actionURL);
+  form.setAttribute("method", "post");
+  form.setAttribute("data-gosx-form", "");
+
+  let resolveAction;
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [main, form],
+    fetchRoutes: {
+      [actionURL]: () => new Promise((resolve) => { resolveAction = resolve; }),
+      [url]: { text: "__SCOREBOARD_REFRESH__", url },
+    },
+    parseHTML(html) { return parsedDocs.get(html); },
+  });
+  env.context.location.href = url;
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+  const freshMain = new FakeElement("main", null);
+  freshMain.id = "scoreboard";
+  freshMain.setAttribute("data-gosx-revalidate-interval", "4s");
+  parsedDocs.set("__SCOREBOARD_REFRESH__", buildNavigatedDocument({
+    title: "Scoreboard",
+    bodyNodes: [freshMain],
+  }));
+
+  const timers = installManualTimers(env.context);
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  assert.equal(timers.count(), 1);
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {},
+  });
+  await flushAsyncWork();
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === url).length,
+    0,
+    "a pending managed form submission must skip the tick entirely",
+  );
+
+  resolveAction({ text: "{}" });
+  await flushAsyncWork();
+
+  timers.runInterval(4000);
+  await flushAsyncWork();
+  assert.equal(
+    env.fetchCalls.filter((call) => call.url === url).length,
+    1,
+    "once the submission settles, the next tick runs normally",
+  );
+});
+
 test("navigation runtime sends typed beacons once per soft navigation path", async () => {
   function beaconScript() {
     const script = new FakeElement("script", null);

--- a/client/runtime/host/navigation.ts
+++ b/client/runtime/host/navigation.ts
@@ -73,6 +73,21 @@
   let revalidateSrc = "";
   let revalidateHasBaseline = false;
   let revalidateLastBody = null;
+  // revalidateGeneration is bumped every time setupPageRevalidation runs
+  // (page boot and every soft navigation). pollRevalidateSrc captures it
+  // before its fetch and re-checks it after: a poll that started on the
+  // page this counter belonged to, but settles after navigation moved on,
+  // discards its response instead of writing a baseline (or triggering a
+  // revalidate) for whatever page is current now.
+  let revalidateGeneration = 0;
+  let revalidateIntervalMs = 0;
+  // Set the instant the document goes hidden, cleared on the next visible
+  // transition. Backs the visibilitychange catch-up tick below.
+  let revalidateHiddenSince = null;
+  // True while pollRevalidateSrc's own fetch/text() awaits are unresolved.
+  // Guards against an interval tick or visibility catch-up starting a
+  // second overlapping poll before the first one has settled.
+  let revalidatePollInFlight = false;
   gosxHost.navigationScriptCache = scriptCache;
   gosxHost.navigationPageCache = pageCache;
   gosxHostCompatibility.install("__gosx_loaded_scripts", scriptCache);
@@ -2314,10 +2329,21 @@
     return navigationState.phase === "pending" || pendingManagedForms.size > 0;
   }
 
+  // A JS timer's delay is a 32-bit signed int internally; a larger value
+  // does not error, it just fires almost immediately (or never, depending
+  // on the engine) instead of after the requested delay. Reject a
+  // declarative interval that would exceed this bound outright, the same
+  // way any other malformed value is rejected below.
+  const REVALIDATE_MAX_INTERVAL_MS = 2147483647;
+  // A poll slower than this is a config mistake, not a real requirement —
+  // clamp instead of rejecting outright so the page still revalidates.
+  const REVALIDATE_INTERVAL_CLAMP_MS = 60 * 60 * 1000;
+
   // parseRevalidateInterval accepts only whole-second or whole-minute
   // Go-style duration literals ("4s", "90s", "2m") — this is a small
-  // declarative subset, not a general Go duration parser. Anything else, or
-  // a duration under one second, is invalid.
+  // declarative subset, not a general Go duration parser. Anything else, a
+  // duration under one second, or a duration past the 32-bit timer bound,
+  // is invalid.
   function parseRevalidateInterval(value) {
     const trimmed = String(value == null ? "" : value).trim();
     const match = /^([0-9]+)(s|m)$/.exec(trimmed);
@@ -2325,7 +2351,8 @@
     const amount = Number(match[1]);
     if (!Number.isFinite(amount) || amount <= 0) return null;
     const ms = match[2] === "m" ? amount * 60000 : amount * 1000;
-    return ms >= 1000 ? ms : null;
+    if (ms < 1000 || ms > REVALIDATE_MAX_INTERVAL_MS) return null;
+    return ms;
   }
 
   function findRevalidateElement() {
@@ -2342,6 +2369,8 @@
     revalidateSrc = "";
     revalidateHasBaseline = false;
     revalidateLastBody = null;
+    revalidateIntervalMs = 0;
+    revalidateHiddenSince = null;
   }
 
   function triggerPeriodicRevalidation() {
@@ -2353,36 +2382,57 @@
   }
 
   async function pollRevalidateSrc() {
-    let response;
-    try {
-      response = await gosxRuntimeRequest(revalidateSrc, {
-        headers: { Accept: "application/json" },
-        cache: "no-store",
-      });
-    } catch (_error) {
-      return; // Fetch errors skip silently; the next tick tries again.
-    }
-    if (!response || !response.ok) {
+    // Skip if the previous poll's fetch/text() awaits have not settled yet
+    // — an overlapping request in flight for the same src answers nothing
+    // an already-pending one won't, and would race it for revalidateLastBody.
+    if (revalidatePollInFlight) {
       return;
     }
-    let body;
+    revalidatePollInFlight = true;
+    const generation = revalidateGeneration;
     try {
-      body = await response.text();
-    } catch (_error) {
-      return;
-    }
-    if (!revalidateHasBaseline) {
-      // The first successful poll only records the baseline — it never
-      // triggers a revalidation on its own.
-      revalidateHasBaseline = true;
+      let response;
+      try {
+        response = await gosxRuntimeRequest(revalidateSrc, {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        });
+      } catch (_error) {
+        return; // Fetch errors skip silently; the next tick tries again.
+      }
+      if (generation !== revalidateGeneration) {
+        // Navigation moved on while this fetch was in flight. This response
+        // belongs to whatever page was current when it started, not the one
+        // current now — discard it rather than writing its baseline.
+        return;
+      }
+      if (!response || !response.ok) {
+        return;
+      }
+      let body;
+      try {
+        body = await response.text();
+      } catch (_error) {
+        return;
+      }
+      if (generation !== revalidateGeneration) {
+        return;
+      }
+      if (!revalidateHasBaseline) {
+        // The first successful poll only records the baseline — it never
+        // triggers a revalidation on its own.
+        revalidateHasBaseline = true;
+        revalidateLastBody = body;
+        return;
+      }
+      if (body === revalidateLastBody) {
+        return;
+      }
       revalidateLastBody = body;
-      return;
+      triggerPeriodicRevalidation();
+    } finally {
+      revalidatePollInFlight = false;
     }
-    if (body === revalidateLastBody) {
-      return;
-    }
-    revalidateLastBody = body;
-    triggerPeriodicRevalidation();
   }
 
   function runRevalidateTick() {
@@ -2396,12 +2446,38 @@
     pollRevalidateSrc();
   }
 
+  // onRevalidateVisibilityChange runs a catch-up tick the moment the
+  // document becomes visible again, if at least one full interval elapsed
+  // while it was hidden — runRevalidateTick's own documentIsHidden() guard
+  // otherwise means a page hidden for hours only revalidates once it is
+  // looked at again, which can be long after its data went stale.
+  function onRevalidateVisibilityChange() {
+    if (documentIsHidden()) {
+      if (revalidateHiddenSince == null) {
+        revalidateHiddenSince = Date.now();
+      }
+      return;
+    }
+    const hiddenSince = revalidateHiddenSince;
+    revalidateHiddenSince = null;
+    if (hiddenSince == null || !revalidateIntervalMs) {
+      return;
+    }
+    if (Date.now() - hiddenSince >= revalidateIntervalMs) {
+      runRevalidateTick();
+    }
+  }
+
   // setupPageRevalidation scans for the FIRST element carrying
   // data-gosx-revalidate-interval on page boot and after every soft
   // navigation (see finalizeNavigation and the initial-document replay
   // below), tearing down any previous timer first so a page without the
   // attribute, or with new attribute values, always gets a fresh read.
   function setupPageRevalidation() {
+    // Every call — page boot and every soft navigation — starts a new
+    // generation, even one that ends up disabling or not finding periodic
+    // revalidation. See revalidateGeneration's declaration for why.
+    revalidateGeneration += 1;
     teardownPageRevalidation();
     const target = findRevalidateElement();
     if (!target) {
@@ -2409,13 +2485,20 @@
     }
 
     const rawInterval = target.getAttribute(REVALIDATE_INTERVAL_ATTR);
-    const intervalMs = parseRevalidateInterval(rawInterval);
+    let intervalMs = parseRevalidateInterval(rawInterval);
     if (intervalMs == null) {
       console.warn(
         "[gosx] invalid " + REVALIDATE_INTERVAL_ATTR + " value "
         + JSON.stringify(String(rawInterval || "")) + "; periodic revalidation is disabled for this page",
       );
       return;
+    }
+    if (intervalMs > REVALIDATE_INTERVAL_CLAMP_MS) {
+      console.warn(
+        "[gosx] " + REVALIDATE_INTERVAL_ATTR + " value " + JSON.stringify(String(rawInterval || ""))
+        + " exceeds the 1 hour maximum for periodic revalidation; clamping to 1 hour",
+      );
+      intervalMs = REVALIDATE_INTERVAL_CLAMP_MS;
     }
 
     const rawSrc = target.hasAttribute(REVALIDATE_SRC_ATTR) ? target.getAttribute(REVALIDATE_SRC_ATTR) : "";
@@ -2431,6 +2514,7 @@
       revalidateSrc = parsedSrc ? parsedSrc.href : "";
     }
 
+    revalidateIntervalMs = intervalMs;
     revalidateTimerHandle = setInterval(runRevalidateTick, intervalMs);
   }
 
@@ -2524,6 +2608,7 @@
   document.addEventListener("mouseover", onMouseOver);
   document.addEventListener("focusin", onFocusIn);
   document.addEventListener("submit", onSubmit);
+  document.addEventListener("visibilitychange", onRevalidateVisibilityChange);
   if (typeof window.addEventListener === "function") {
     window.addEventListener("popstate", onPopState);
   }

--- a/client/runtime/host/navigation.ts
+++ b/client/runtime/host/navigation.ts
@@ -27,6 +27,8 @@
   const NAV_STATE_ATTR = "data-gosx-navigation-state";
   const NAV_CURRENT_PATH_ATTR = "data-gosx-navigation-current-path";
   const NAV_PENDING_URL_ATTR = "data-gosx-navigation-pending-url";
+  const REVALIDATE_INTERVAL_ATTR = "data-gosx-revalidate-interval";
+  const REVALIDATE_SRC_ATTR = "data-gosx-revalidate-src";
   const MAIN_ATTR = "data-gosx-main";
   const ANNOUNCE_ATTR = "data-gosx-announce";
   const ANNOUNCER_ATTR = "data-gosx-announcer";
@@ -61,8 +63,16 @@
   let announceSeq = 0;
   let formErrorSeq = 0;
   let navigationFrameSequence = 0;
-  const pendingManagedForms = new WeakSet();
+  // A Set (not a WeakSet) so its size doubles as the "a managed form
+  // submission is in flight" signal periodic revalidation reads — see
+  // navigationOrFormSubmissionInFlight below. submitForm's try/finally keeps
+  // every entry reliably removed once its submission settles.
+  const pendingManagedForms = new Set();
   const sentNavigationBeacons = new Set();
+  let revalidateTimerHandle = null;
+  let revalidateSrc = "";
+  let revalidateHasBaseline = false;
+  let revalidateLastBody = null;
   gosxHost.navigationScriptCache = scriptCache;
   gosxHost.navigationPageCache = pageCache;
   gosxHostCompatibility.install("__gosx_loaded_scripts", scriptCache);
@@ -2266,6 +2276,162 @@
     focusElement(a11y.focusTarget, true);
     const announcement = announceNavigation(a11y.announcement);
     dispatchNavigate(url, opts.replace, announcement, a11y.focusTarget);
+    // Runs after every soft navigation this function completes, whether it
+    // fetched a new document or reconciled the already-current page — see
+    // setupPageRevalidation's doc comment.
+    setupPageRevalidation();
+  }
+
+  // documentIsHidden prefers the real, read-only document.hidden a browser
+  // provides. Test doubles (and any host that only tracks visibilityState)
+  // fall back to the same "hidden" comparison mount-viewport.ts already uses
+  // for its own pageVisible fallback.
+  function documentIsHidden() {
+    if (typeof document.hidden === "boolean") {
+      return document.hidden;
+    }
+    return String(document.visibilityState || "visible").toLowerCase() === "hidden";
+  }
+
+  function focusedControlBlocksRevalidation() {
+    const active = document.activeElement;
+    if (!active) return false;
+    switch (String(active.tagName || "").toUpperCase()) {
+      case "INPUT":
+      case "TEXTAREA":
+      case "SELECT":
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  // Reuses the runtime's own in-flight state: navigationState.phase covers a
+  // soft navigation (including a GET form, which navigates) and
+  // pendingManagedForms covers a POST/action form submission, which fetches
+  // outside the navigate() path.
+  function navigationOrFormSubmissionInFlight() {
+    return navigationState.phase === "pending" || pendingManagedForms.size > 0;
+  }
+
+  // parseRevalidateInterval accepts only whole-second or whole-minute
+  // Go-style duration literals ("4s", "90s", "2m") — this is a small
+  // declarative subset, not a general Go duration parser. Anything else, or
+  // a duration under one second, is invalid.
+  function parseRevalidateInterval(value) {
+    const trimmed = String(value == null ? "" : value).trim();
+    const match = /^([0-9]+)(s|m)$/.exec(trimmed);
+    if (!match) return null;
+    const amount = Number(match[1]);
+    if (!Number.isFinite(amount) || amount <= 0) return null;
+    const ms = match[2] === "m" ? amount * 60000 : amount * 1000;
+    return ms >= 1000 ? ms : null;
+  }
+
+  function findRevalidateElement() {
+    return findElement(document.body, function(node) {
+      return node.hasAttribute && node.hasAttribute(REVALIDATE_INTERVAL_ATTR);
+    });
+  }
+
+  function teardownPageRevalidation() {
+    if (revalidateTimerHandle != null) {
+      clearInterval(revalidateTimerHandle);
+    }
+    revalidateTimerHandle = null;
+    revalidateSrc = "";
+    revalidateHasBaseline = false;
+    revalidateLastBody = null;
+  }
+
+  function triggerPeriodicRevalidation() {
+    revalidateNavigation().catch(function(error) {
+      reportNavigationFailure("periodic revalidation", error, {
+        source: revalidateSrc || windowLocationHref(),
+      });
+    });
+  }
+
+  async function pollRevalidateSrc() {
+    let response;
+    try {
+      response = await gosxRuntimeRequest(revalidateSrc, {
+        headers: { Accept: "application/json" },
+        cache: "no-store",
+      });
+    } catch (_error) {
+      return; // Fetch errors skip silently; the next tick tries again.
+    }
+    if (!response || !response.ok) {
+      return;
+    }
+    let body;
+    try {
+      body = await response.text();
+    } catch (_error) {
+      return;
+    }
+    if (!revalidateHasBaseline) {
+      // The first successful poll only records the baseline — it never
+      // triggers a revalidation on its own.
+      revalidateHasBaseline = true;
+      revalidateLastBody = body;
+      return;
+    }
+    if (body === revalidateLastBody) {
+      return;
+    }
+    revalidateLastBody = body;
+    triggerPeriodicRevalidation();
+  }
+
+  function runRevalidateTick() {
+    if (documentIsHidden() || focusedControlBlocksRevalidation() || navigationOrFormSubmissionInFlight()) {
+      return;
+    }
+    if (!revalidateSrc) {
+      triggerPeriodicRevalidation();
+      return;
+    }
+    pollRevalidateSrc();
+  }
+
+  // setupPageRevalidation scans for the FIRST element carrying
+  // data-gosx-revalidate-interval on page boot and after every soft
+  // navigation (see finalizeNavigation and the initial-document replay
+  // below), tearing down any previous timer first so a page without the
+  // attribute, or with new attribute values, always gets a fresh read.
+  function setupPageRevalidation() {
+    teardownPageRevalidation();
+    const target = findRevalidateElement();
+    if (!target) {
+      return;
+    }
+
+    const rawInterval = target.getAttribute(REVALIDATE_INTERVAL_ATTR);
+    const intervalMs = parseRevalidateInterval(rawInterval);
+    if (intervalMs == null) {
+      console.warn(
+        "[gosx] invalid " + REVALIDATE_INTERVAL_ATTR + " value "
+        + JSON.stringify(String(rawInterval || "")) + "; periodic revalidation is disabled for this page",
+      );
+      return;
+    }
+
+    const rawSrc = target.hasAttribute(REVALIDATE_SRC_ATTR) ? target.getAttribute(REVALIDATE_SRC_ATTR) : "";
+    if (rawSrc) {
+      if (!isSameOriginNavigation(rawSrc, windowLocationHref())) {
+        console.warn(
+          "[gosx] " + REVALIDATE_SRC_ATTR + " must be same-origin: " + JSON.stringify(String(rawSrc))
+          + "; periodic revalidation is disabled for this page",
+        );
+        return;
+      }
+      const parsedSrc = navigationURLParts(rawSrc);
+      revalidateSrc = parsedSrc ? parsedSrc.href : "";
+    }
+
+    revalidateTimerHandle = setInterval(runRevalidateTick, intervalMs);
   }
 
   function revalidateNavigation(options) {
@@ -2296,6 +2462,7 @@
     // navigation replay. Both operations are synchronous and idempotent.
     refreshNavigationState();
     prefetchManagedLinks("render");
+    setupPageRevalidation();
     const actions = window.__gosx && window.__gosx.actions;
     if (actions && typeof actions.refreshBindings === "function") {
       actions.refreshBindings();
@@ -2367,6 +2534,7 @@
     pendingURL: "",
   }, "init");
   prefetchManagedLinks("render");
+  setupPageRevalidation();
   if (document.readyState === "loading") {
     document.addEventListener("DOMContentLoaded", refreshInitialDocumentNavigation, { once: true });
   }

--- a/examples/gosx-docs/app/docs/runtime/page.gsx
+++ b/examples/gosx-docs/app/docs/runtime/page.gsx
@@ -83,6 +83,53 @@ func Page() Node {
 	await window.__gosx.navigation.revalidate()
 	console.log(window.__gosx.navigation.getState())`)}
 		</section>
+		<section id="periodic-revalidation">
+			<h2>Periodic revalidation</h2>
+			<p>
+				Add
+				<span class="inline-code">data-gosx-revalidate-interval</span>
+				to the first matching element on a page. The runtime revalidates on that interval, with zero application JavaScript.
+			</p>
+			{CodeBlock("gosx", `<main data-gosx-revalidate-interval="4s" data-gosx-revalidate-src="/api/league/version">
+	    <!-- draft room, scoreboard, or other live server state -->
+	</main>`)}
+			<p>
+				The interval accepts whole seconds or whole minutes only, for example
+				<span class="inline-code">"4s"</span>
+				or
+				<span class="inline-code">"2m"</span>
+				, and must resolve to at least one second. An invalid interval logs one console warning and disables periodic revalidation for the page.
+			</p>
+			<p>
+				Add
+				<span class="inline-code">data-gosx-revalidate-src</span>
+				to poll a same-origin JSON endpoint instead of revalidating on every tick. The runtime fetches it with
+				<span class="inline-code">no-store</span>
+				and keeps the last response body. It revalidates only when the body changes; the first poll records a baseline and never revalidates. Without
+				<span class="inline-code">data-gosx-revalidate-src</span>
+				, the runtime revalidates on every interval.
+			</p>
+			<p>
+				A tick skips entirely, with no fetch and no revalidation, in these cases:
+			</p>
+			<ul>
+				<li>The document is hidden.</li>
+				<li>
+					An input, textarea, or select has focus.
+				</li>
+				<li>
+					A navigation or form submission is in flight.
+				</li>
+			</ul>
+			<p>
+				A cross-origin
+				<span class="inline-code">data-gosx-revalidate-src</span>
+				logs one console warning and disables periodic revalidation for the page. Fetch errors skip silently, and the next tick tries again.
+			</p>
+			<p>
+				Teardown is automatic. A soft navigation to a page without the attribute clears the interval. A soft navigation to a page with the attribute reads it again.
+			</p>
+		</section>
 		<section id="lifecycle-scripts">
 			<h2>Managed and lifecycle scripts</h2>
 			<p>

--- a/examples/gosx-docs/app/docs/runtime/page.server.go
+++ b/examples/gosx-docs/app/docs/runtime/page.server.go
@@ -15,10 +15,11 @@ func init() {
 					"mode":        "light",
 					"title":       "Runtime",
 					"description": "Managed navigation, script roles, prefetch, telemetry, and page disposal.",
-					"tags":        []string{"navigation", "transitions", "lifecycle", "prefetch", "telemetry", "observability"},
+					"tags":        []string{"navigation", "transitions", "lifecycle", "prefetch", "revalidation", "telemetry", "observability"},
 					"toc": []map[string]string{
 						{"href": "#client-navigation", "label": "Client navigation"},
 						{"href": "#page-transitions", "label": "Transition ownership"},
+						{"href": "#periodic-revalidation", "label": "Periodic revalidation"},
 						{"href": "#lifecycle-scripts", "label": "Managed scripts"},
 						{"href": "#prefetch", "label": "Prefetch"},
 						{"href": "#runtime-telemetry", "label": "Telemetry"},

--- a/server/navigation_contract.go
+++ b/server/navigation_contract.go
@@ -25,6 +25,14 @@ const (
 	NavigationFormModeAttr    = gosx.ManagedFormModeAttr
 	NavigationFormStateAttr   = gosx.ManagedFormStateAttr
 	NavigationFormProjectAttr = gosx.ManagedFormProjectAttr
+
+	// NavigationRevalidateIntervalAttr and NavigationRevalidateSrcAttr declare
+	// periodic revalidation on an element. The navigation runtime polls
+	// NavigationRevalidateSrcAttr (same-origin only) on the
+	// NavigationRevalidateIntervalAttr period and revalidates the page when the
+	// response body changes; without a src it revalidates unconditionally.
+	NavigationRevalidateIntervalAttr = "data-gosx-revalidate-interval"
+	NavigationRevalidateSrcAttr      = "data-gosx-revalidate-src"
 )
 
 // NormalizeNavigationLinkCurrentPolicy normalizes the declarative "current"

--- a/server/navigation_contract_revalidate_test.go
+++ b/server/navigation_contract_revalidate_test.go
@@ -1,0 +1,12 @@
+package server
+
+import "testing"
+
+func TestNavigationRevalidateAttrConstants(t *testing.T) {
+	if got, want := NavigationRevalidateIntervalAttr, "data-gosx-revalidate-interval"; got != want {
+		t.Fatalf("NavigationRevalidateIntervalAttr = %q, want %q", got, want)
+	}
+	if got, want := NavigationRevalidateSrcAttr, "data-gosx-revalidate-src"; got != want {
+		t.Fatalf("NavigationRevalidateSrcAttr = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces declarative periodic page revalidation via `data-gosx-revalidate-interval` and `data-gosx-revalidate-src` attributes. Pages can now self-revalidate at a specified interval without writing application JavaScript. The runtime optionally polls a same-origin JSON endpoint to trigger revalidation only when server state changes, and intelligently pauses ticks while the document is hidden, a form control is focused, or a navigation is in flight.

## Changes

- Add support for `data-gosx-revalidate-interval` to declare a poll frequency using Go-style durations (e.g., "4s", "2m"), validating format and enforcing a minimum one-second duration.
- Add support for `data-gosx-revalidate-src` to specify a same-origin JSON endpoint; the runtime fetches it with `no-store` and triggers a full revalidation only when the response body differs from the recorded baseline.
- Implement automatic lifecycle management: scans for the target element on initial boot and after every soft navigation, tearing down previous timers and initializing new ones as needed.
- Skip revalidation ticks entirely when the document is hidden, an `<input>`, `<textarea>`, or `<select>` has focus, or a navigation/form submission is already in flight to prevent UI interruptions and wasted requests.
- Log a console warning and disable the feature for invalid intervals or cross-origin `src` URLs.
- Export `NavigationRevalidateIntervalAttr` and `NavigationRevalidateSrcAttr` constants in the Go server package with unit tests verifying their exact string values.
- Add comprehensive client-side Jest tests covering validation, polling logic, guard conditions, navigation teardown, and error resilience.
- Update runtime documentation with usage examples, constraints, and behavior notes.

## Testing

- Run the client test suite (`npm run test` or equivalent) to verify all new Jest assertions pass.
- Run Go tests in the server directory (`go test ./...`) to confirm constant exports and unit tests.
- Review the updated documentation in `examples/gosx-docs/app/docs/runtime/` to ensure it accurately reflects the new attributes, parsing rules, and skip conditions.