### PR TITLE
add(strict components): Add strict concatenation and <If cond> support

### DIFF
--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -50,10 +50,49 @@ func Page() Node {
 			<span class="inline-code">int64</span>
 			range, a finite ungrouped decimal float, or one direct field on
 			<span class="inline-code">props</span>
-			whose type is a parity-safe built-in scalar declared in the same file. Nested selectors, indexing, calls, unary and binary operators, ordinary local declarations,
+			whose type is a parity-safe built-in scalar declared in the same file. Nested selectors, indexing, calls, unary operators, ordinary local declarations,
 			<span class="inline-code">if</span>
-			statements, free helper calls, imported function calls, and cross-file component calls are outside the v0.39 strict contract.
+			statements, free helper calls, imported function calls, and cross-file component calls are outside the v0.39 strict contract. v0.42 widens this contract in two narrow, typed ways; the next section covers both.
 		</p>
+		<h2 id="strict-expressions">Concatenation and conditional rendering</h2>
+		<p>
+			A hole may join a
+			<span class="inline-code">+</span>
+			chain of string literals and
+			<span class="inline-code">props</span>
+			field selectors. The chain needs at least one literal and at least one field. Each field must have the exact declared type
+			<span class="inline-code">string</span>
+			, not a named string type. Use this to build a class name or a label from a typed prop.
+		</p>
+		<CodeBlock lang="gosx" source={data.concatSample} />
+		<p>
+			A strict body may also render
+			<span class="inline-code">
+				&lt;If cond=
+				{"{"}
+				...
+				{"}"}
+				&gt;
+			</span>
+			. The
+			<span class="inline-code">cond</span>
+			attribute takes exactly one bool
+			<span class="inline-code">props</span>
+			field, bare or compared with
+			<span class="inline-code">== false</span>
+			. GoSX renders the children when
+			<span class="inline-code">cond</span>
+			is true and renders nothing otherwise. Write a second
+			<span class="inline-code">&lt;If&gt;</span>
+			with
+			<span class="inline-code">== false</span>
+			for the opposite branch;
+			<span class="inline-code">fallback</span>
+			and
+			<span class="inline-code">else</span>
+			attributes are not part of this form.
+		</p>
+		<CodeBlock lang="gosx" source={data.conditionalSample} />
 		<section class="callout">
 			<strong>Keep strict components local</strong>
 			<p>

--- a/examples/gosx-docs/app/docs/components/page.server.go
+++ b/examples/gosx-docs/app/docs/components/page.server.go
@@ -33,6 +33,39 @@ func Page() Node {
 	</main>
 }`
 
+const strictConcatSample = `package profile
+
+type BadgeProps struct {
+	Tone string
+}
+
+component Badge(props: BadgeProps) {
+	return <span class={"badge tone-" + props.Tone}>
+		{props.Tone}
+	</span>
+}
+
+component Page() {
+	return <main><Badge tone="alert" /></main>
+}`
+
+const strictConditionalSample = `package profile
+
+type BadgeProps struct {
+	Ready bool
+}
+
+component Badge(props: BadgeProps) {
+	return <span>
+		<If cond={props.Ready}>Ready</If>
+		<If cond={props.Ready == false}>Pending</If>
+	</span>
+}
+
+component Page() {
+	return <main><Badge ready={true} /></main>
+}`
+
 func init() {
 	docs.RegisterStaticDocsPage("Components", "Choose between strict typed and legacy Go-function GSX components.", route.FileModuleOptions{
 		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
@@ -49,8 +82,10 @@ func init() {
 					{"href": "#tooling", "label": "Tooling"},
 					{"href": "#choosing", "label": "Choosing a Style"},
 				},
-				"strictSample": strictComponentSample,
-				"legacySample": legacyComponentSample,
+				"strictSample":      strictComponentSample,
+				"legacySample":      legacyComponentSample,
+				"concatSample":      strictConcatSample,
+				"conditionalSample": strictConditionalSample,
 				"attributesSample": `type FieldProps struct {
 	ID    string
 	Class string

--- a/examples/gosx-docs/app/docs/components/page.server.go
+++ b/examples/gosx-docs/app/docs/components/page.server.go
@@ -77,6 +77,7 @@ func init() {
 				"toc": []map[string]string{
 					{"href": "#two-styles", "label": "Two Styles"},
 					{"href": "#strict-components", "label": "Strict Components"},
+					{"href": "#strict-expressions", "label": "Strict Expressions"},
 					{"href": "#legacy-components", "label": "Legacy Components"},
 					{"href": "#attributes", "label": "Elements & Attributes"},
 					{"href": "#tooling", "label": "Tooling"},

--- a/examples/gosx-docs/app/docs/components/page_test.go
+++ b/examples/gosx-docs/app/docs/components/page_test.go
@@ -1,6 +1,7 @@
 package docs
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -34,6 +35,44 @@ func TestDocumentedStrictComponentCompilesAndRenders(t *testing.T) {
 	}
 	if strings.Contains(html, "className") {
 		t.Fatalf("rendered HTML retained className alias: %q", html)
+	}
+}
+
+func TestDocumentedConcatSampleCompilesAndRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictConcatSample))
+	if err != nil {
+		t.Fatalf("compile documented concat sample: %v", err)
+	}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render documented concat sample: %v", err)
+	}
+	if !strings.Contains(html, `class="badge tone-alert"`) {
+		t.Fatalf("rendered HTML %q does not contain the concatenated class", html)
+	}
+}
+
+func TestDocumentedConditionalSampleCompilesAndRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictConditionalSample))
+	if err != nil {
+		t.Fatalf("compile documented conditional sample: %v", err)
+	}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render documented conditional sample: %v", err)
+	}
+	if !strings.Contains(html, "Ready") || strings.Contains(html, "Pending") {
+		t.Fatalf("rendered HTML %q does not match the cond=true branch", html)
+	}
+}
+
+func TestDocumentedComponentsPageCompilesAndTypeChecks(t *testing.T) {
+	source, err := os.ReadFile("page.gsx")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := gosx.Compile(source); err != nil {
+		t.Fatalf("compile components docs page: %v", err)
 	}
 }
 

--- a/format/strict_component_test.go
+++ b/format/strict_component_test.go
@@ -37,3 +37,47 @@ component Card(props: CardProps) {
 		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
 	}
 }
+
+// TestSourceFormatsStrictConcatAndCondIdempotently covers the v0.42
+// extensions: a concat hole in an attribute and text child, and a strict
+// <If cond> element, must format idempotently and keep compiling.
+func TestSourceFormatsStrictConcatAndCondIdempotently(t *testing.T) {
+	source := []byte(`package app
+type CardProps struct {
+	Ready bool
+	Tone string
+}
+
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}>
+		<span>{"Rank " + props.Tone}</span>
+		<If cond={props.Ready}>ready</If>
+		<If cond={props.Ready == false}>not ready</If>
+	</div>
+}
+`)
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	for _, want := range []string{
+		`class={"tone-" + props.Tone}`,
+		`{"Rank " + props.Tone}`,
+		`<If cond={props.Ready}>`,
+		`<If cond={props.Ready == false}>`,
+	} {
+		if !strings.Contains(string(formatted), want) {
+			t.Fatalf("formatting changed %q:\n%s", want, formatted)
+		}
+	}
+	if _, err := gosx.Compile(formatted); err != nil {
+		t.Fatalf("formatted strict source does not compile: %v\n%s", err, formatted)
+	}
+	again, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source second pass: %v", err)
+	}
+	if !bytes.Equal(formatted, again) {
+		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -19,20 +19,23 @@ var (
 // ValidateServerExpression accepts exactly the expression shapes implemented
 // by the file renderer for strict server components. The v0.39 contract is
 // intentionally small: literals and one direct props field (with parentheses).
-// Operators, indexing, and calls need static Go type/method information that
-// the map-backed file renderer does not retain, so they fail closed.
+// The v0.42 contract adds one narrow extension: a `+` chain that concatenates
+// string literals with props field selectors (ValidateConcatExpression
+// documents the accepted shape). Operators outside that one exception,
+// indexing, and calls need static Go type/method information that the
+// map-backed file renderer does not retain, so they fail closed.
 func ValidateServerExpression(source string) error {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return fmt.Errorf("invalid Go expression: %w", err)
 	}
-	if err := validate(expr); err != nil {
+	if err := validate(expr, source); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validate(expr ast.Expr) error {
+func validate(expr ast.Expr, source string) error {
 	switch node := expr.(type) {
 	case *ast.BasicLit:
 		return validateLiteral(node)
@@ -48,7 +51,7 @@ func validate(expr ast.Expr) error {
 			return fmt.Errorf("identifier %q is not available to the strict server renderer", node.Name)
 		}
 	case *ast.ParenExpr:
-		return validate(node.X)
+		return validate(node.X, source)
 	case *ast.SelectorExpr:
 		if _, ok := directPropsField(node); !ok {
 			return fmt.Errorf("selector must be one field directly on props; nested selector chains cannot preserve Go nil-pointer behavior")
@@ -59,12 +62,115 @@ func validate(expr ast.Expr) error {
 	case *ast.UnaryExpr:
 		return fmt.Errorf("unary operator %q is not supported by the strict server renderer because its dynamic coercion cannot preserve Go types", node.Op)
 	case *ast.BinaryExpr:
-		return fmt.Errorf("binary operator %q is not supported by the strict server renderer because its dynamic coercion cannot preserve Go types", node.Op)
+		if node.Op != token.ADD {
+			return fmt.Errorf("binary operator %q is not supported by the strict server renderer; only string concatenation with %q is renderable", node.Op, "+")
+		}
+		return validateConcatChain(node, source)
 	case *ast.CallExpr:
 		return fmt.Errorf("calls are not supported by the strict server renderer because typed Go methods are not retained in its props map")
 	default:
 		return fmt.Errorf("expression shape %T is not supported by the strict server renderer", expr)
 	}
+}
+
+// validateConcatChain accepts a `+` chain whose flattened operands are each a
+// string literal or a direct props field selector, with at least one of each.
+// The renderer's applyFileBinaryOp takes the string branch whenever either
+// side of `+` is a Go string (route/exprlower.go), so this is the one binary
+// shape the file renderer and generated Go execute identically.
+func validateConcatChain(node *ast.BinaryExpr, source string) error {
+	hasStringLiteral := false
+	hasPropsField := false
+	for _, operand := range flattenAddChain(node) {
+		text := operandText(operand, source)
+		switch classifyConcatOperand(operand) {
+		case concatOperandString:
+			hasStringLiteral = true
+		case concatOperandNonStringLiteral:
+			return fmt.Errorf("\"+\" operand `%s` is not a string literal; the strict server renderer does not perform numeric addition", text)
+		case concatOperandSelector:
+			hasPropsField = true
+		default:
+			return fmt.Errorf("\"+\" operand `%s` is not renderable; strict concatenation accepts string literals and props field selectors only", text)
+		}
+	}
+	if !hasStringLiteral {
+		return fmt.Errorf("strict concatenation requires at least one string literal operand")
+	}
+	if !hasPropsField {
+		return fmt.Errorf("strict concatenation requires at least one props field operand; fold literal-only chains by hand")
+	}
+	return nil
+}
+
+// concatOperandKind classifies one flattened `+` operand.
+type concatOperandKind int
+
+const (
+	concatOperandInvalid concatOperandKind = iota
+	concatOperandString
+	concatOperandNonStringLiteral
+	concatOperandSelector
+)
+
+func classifyConcatOperand(operand ast.Expr) concatOperandKind {
+	switch node := unwrapParens(operand).(type) {
+	case *ast.BasicLit:
+		if node.Kind == token.STRING {
+			if _, err := strconv.Unquote(node.Value); err != nil {
+				return concatOperandInvalid
+			}
+			return concatOperandString
+		}
+		return concatOperandNonStringLiteral
+	case *ast.SelectorExpr:
+		if _, ok := directPropsField(node); ok {
+			return concatOperandSelector
+		}
+		return concatOperandInvalid
+	default:
+		return concatOperandInvalid
+	}
+}
+
+// flattenAddChain splits a left-associative `+` chain into its operands,
+// unwrapping parentheses only at each chain link it walks through. A
+// parenthesized right-hand operand that is itself a `+` expression is
+// deliberately left intact as one operand — Go's left-associative parse
+// already puts every top-level `+` on the chain's left spine, so a
+// right-hand `+` only appears when the source wrote it in explicit
+// parentheses, and it stays a single (invalid) operand for diagnostics that
+// echo the exact source text back to the author.
+func flattenAddChain(expr ast.Expr) []ast.Expr {
+	if bin, ok := unwrapParens(expr).(*ast.BinaryExpr); ok && bin.Op == token.ADD {
+		return append(flattenAddChain(bin.X), bin.Y)
+	}
+	return []ast.Expr{expr}
+}
+
+// unwrapParens strips every layer of parentheses around expr.
+func unwrapParens(expr ast.Expr) ast.Expr {
+	for {
+		paren, ok := expr.(*ast.ParenExpr)
+		if !ok {
+			return expr
+		}
+		expr = paren.X
+	}
+}
+
+// operandText slices the exact source text of operand (parentheses
+// stripped) out of the original source string. parser.ParseExpr builds its
+// single-file token.FileSet at base 1, so a node's Pos/End are 1-based byte
+// offsets into source with no other adjustment needed.
+func operandText(operand ast.Expr, source string) string {
+	node := unwrapParens(operand)
+	start := int(node.Pos()) - 1
+	end := int(node.End()) - 1
+	if start < 0 || end > len(source) || start > end {
+		return source
+	}
+	return source[start:end]
 }
 
 func validateLiteral(literal *ast.BasicLit) error {
@@ -135,4 +241,103 @@ func directPropsField(selector *ast.SelectorExpr) (string, bool) {
 		return "", false
 	}
 	return selector.Sel.Name, true
+}
+
+// ServerExpressionPropFields reports every direct props field selector
+// (props.X) found anywhere in source, regardless of whether source's overall
+// shape passes ValidateServerExpression. Read-tracking passes use this to see
+// every props field an expression touches — not just the operands of one
+// accepted top-level shape — because the grammar's external attribute
+// scanner hands attribute-position expressions back as one opaque token with
+// no nested CST, unlike element/text children (jsx_expression_container),
+// whose nested Go sub-tree the CST-based read-tracking walk can see
+// directly. Attribute-position expressions are exactly where every v0.42
+// concatenation and <If cond> shape lives, so this closes that visibility
+// gap generally instead of only for the two new shapes.
+func ServerExpressionPropFields(source string) []string {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return nil
+	}
+	var fields []string
+	seen := make(map[string]struct{})
+	ast.Inspect(expr, func(n ast.Node) bool {
+		selector, ok := n.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if field, ok := directPropsField(selector); ok {
+			if _, dup := seen[field]; !dup {
+				seen[field] = struct{}{}
+				fields = append(fields, field)
+			}
+		}
+		return true
+	})
+	return fields
+}
+
+// ServerConcatPropFields reports, in operand order, the props fields read by
+// a validated string-concatenation chain (see ValidateServerExpression). It
+// returns ok=false when source's top-level shape (parentheses transparent)
+// is not a `+` expression — callers use that to skip the concat-specific
+// type pass for every other already-validated expression shape.
+func ServerConcatPropFields(source string) ([]string, bool) {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return nil, false
+	}
+	bin, ok := unwrapParens(expr).(*ast.BinaryExpr)
+	if !ok || bin.Op != token.ADD {
+		return nil, false
+	}
+	var fields []string
+	for _, operand := range flattenAddChain(bin) {
+		selector, ok := unwrapParens(operand).(*ast.SelectorExpr)
+		if !ok {
+			continue
+		}
+		if field, ok := directPropsField(selector); ok {
+			fields = append(fields, field)
+		}
+	}
+	return fields, true
+}
+
+// ValidateServerCondExpression accepts the two expression shapes a strict
+// <If cond={...}> attribute may use: a bare props field selector, or that
+// selector compared against the literal false with `==`. It reports the
+// props field read and whether the comparison negates it. Parentheses are
+// transparent at any level.
+func ValidateServerCondExpression(source string) (field string, negated bool, err error) {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return "", false, fmt.Errorf("invalid Go expression: %w", err)
+	}
+	root := unwrapParens(expr)
+
+	if bin, ok := root.(*ast.BinaryExpr); ok {
+		if bin.Op == token.EQL {
+			left := unwrapParens(bin.X)
+			right := unwrapParens(bin.Y)
+			if ident, ok := right.(*ast.Ident); ok && ident.Name == "true" {
+				return "", false, fmt.Errorf("comparison \"== true\" is not supported in strict cond; write the field bare")
+			}
+			if selector, ok := left.(*ast.SelectorExpr); ok {
+				if ident, ok := right.(*ast.Ident); ok && ident.Name == "false" {
+					if field, ok := directPropsField(selector); ok {
+						return field, true, nil
+					}
+				}
+			}
+		}
+		return "", false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
+	}
+
+	if selector, ok := root.(*ast.SelectorExpr); ok {
+		if field, ok := directPropsField(selector); ok {
+			return field, false, nil
+		}
+	}
+	return "", false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
 }

--- a/internal/strictcomponent/expression_test.go
+++ b/internal/strictcomponent/expression_test.go
@@ -1,0 +1,254 @@
+package strictcomponent
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateServerExpressionAcceptsV041Surface(t *testing.T) {
+	for _, source := range []string{
+		`"text"`,
+		"0",
+		"42",
+		"1.5",
+		".5",
+		"true",
+		"false",
+		"props.Title",
+		"(props.Title)",
+		"(props).Title",
+	} {
+		t.Run(source, func(t *testing.T) {
+			if err := ValidateServerExpression(source); err != nil {
+				t.Fatalf("ValidateServerExpression(%q) = %v, want nil", source, err)
+			}
+		})
+	}
+}
+
+func TestValidateServerExpressionAcceptsConcatChains(t *testing.T) {
+	for _, source := range []string{
+		`"a" + props.X`,
+		`props.X + "a"`,
+		`"a" + props.X + "b"`,
+		`("a") + (props.X)`,
+		`"tone-" + props.Tone`,
+		`"Remove " + props.Name + " from roster"`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			if err := ValidateServerExpression(source); err != nil {
+				t.Fatalf("ValidateServerExpression(%q) = %v, want nil", source, err)
+			}
+		})
+	}
+}
+
+func TestValidateServerExpressionRejectsWithExactMessages(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   string
+	}{
+		{
+			source: "props.A + props.B",
+			want:   "strict concatenation requires at least one string literal operand",
+		},
+		{
+			source: `"a" + "b"`,
+			want:   "strict concatenation requires at least one props field operand; fold literal-only chains by hand",
+		},
+		{
+			source: "1 + props.X",
+			want:   "\"+\" operand `1` is not a string literal; the strict server renderer does not perform numeric addition",
+		},
+		{
+			source: `props.X - "a"`,
+			want:   `binary operator "-" is not supported by the strict server renderer; only string concatenation with "+" is renderable`,
+		},
+		{
+			source: `"a" + props.X()`,
+			want:   "\"+\" operand `props.X()` is not renderable; strict concatenation accepts string literals and props field selectors only",
+		},
+		{
+			source: `"a" + x`,
+			want:   "\"+\" operand `x` is not renderable; strict concatenation accepts string literals and props field selectors only",
+		},
+		{
+			source: `"a" + (props.Count + 1)`,
+			want:   "\"+\" operand `props.Count + 1` is not renderable; strict concatenation accepts string literals and props field selectors only",
+		},
+		{
+			source: "props.A.B.C.D",
+			want:   "selector must be one field directly on props; nested selector chains cannot preserve Go nil-pointer behavior",
+		},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			err := ValidateServerExpression(tc.source)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("ValidateServerExpression(%q) = %v, want %q", tc.source, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateServerExpressionRejectsNonAddOperatorsWithNewMessage(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		op     string
+	}{
+		{"props.A * props.B", "*"},
+		{"props.A % props.B", "%"},
+		{"props.A && props.B", "&&"},
+		{"props.A > props.B", ">"},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			err := ValidateServerExpression(tc.source)
+			want := `binary operator "` + tc.op + `" is not supported by the strict server renderer; only string concatenation with "+" is renderable`
+			if err == nil || err.Error() != want {
+				t.Fatalf("ValidateServerExpression(%q) = %v, want %q", tc.source, err, want)
+			}
+		})
+	}
+}
+
+func TestServerPropFieldUnaffectedByConcatSupport(t *testing.T) {
+	for _, tc := range []struct {
+		source    string
+		wantField string
+		wantOK    bool
+	}{
+		{"props.Title", "Title", true},
+		{"(props.Title)", "Title", true},
+		{"(props).Title", "Title", true},
+		{`"a" + props.X`, "", false},
+		{"props", "", false},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			field, ok := ServerPropField(tc.source)
+			if field != tc.wantField || ok != tc.wantOK {
+				t.Fatalf("ServerPropField(%q) = (%q, %v), want (%q, %v)", tc.source, field, ok, tc.wantField, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestServerConcatPropFields(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   []string
+		wantOK bool
+	}{
+		{`"a" + props.X`, []string{"X"}, true},
+		{`props.X + "a"`, []string{"X"}, true},
+		{`"a" + props.X + "b"`, []string{"X"}, true},
+		{`"Remove " + props.Name + " from roster"`, []string{"Name"}, true},
+		{`props.A + props.B`, []string{"A", "B"}, true}, // fields extracted even though the syntax validator rejects the chain overall
+		{"props.Title", nil, false},
+		{`"a" + "b"`, nil, true},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			fields, ok := ServerConcatPropFields(tc.source)
+			if ok != tc.wantOK || !equalStrings(fields, tc.want) {
+				t.Fatalf("ServerConcatPropFields(%q) = (%v, %v), want (%v, %v)", tc.source, fields, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestValidateServerCondExpressionAcceptsBoolShapes(t *testing.T) {
+	for _, tc := range []struct {
+		source      string
+		wantField   string
+		wantNegated bool
+	}{
+		{"props.Ready", "Ready", false},
+		{"props.Ready == false", "Ready", true},
+		{"(props.Ready) == (false)", "Ready", true},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			field, negated, err := ValidateServerCondExpression(tc.source)
+			if err != nil {
+				t.Fatalf("ValidateServerCondExpression(%q) = %v, want nil error", tc.source, err)
+			}
+			if field != tc.wantField || negated != tc.wantNegated {
+				t.Fatalf("ValidateServerCondExpression(%q) = (%q, %v), want (%q, %v)", tc.source, field, negated, tc.wantField, tc.wantNegated)
+			}
+		})
+	}
+}
+
+func TestValidateServerCondExpressionRejectsWithExactMessages(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   string
+	}{
+		{
+			source: "props.Ready == true",
+			want:   `comparison "== true" is not supported in strict cond; write the field bare`,
+		},
+		{
+			source: "props.Ready != false",
+			want:   `strict cond must be a bool props field or a bool props field compared with "== false"; got "props.Ready != false"`,
+		},
+		{
+			source: "!props.Ready",
+			want:   `strict cond must be a bool props field or a bool props field compared with "== false"; got "!props.Ready"`,
+		},
+		{
+			source: "props.A == props.B",
+			want:   `strict cond must be a bool props field or a bool props field compared with "== false"; got "props.A == props.B"`,
+		},
+		{
+			source: "props.Score > 0",
+			want:   `strict cond must be a bool props field or a bool props field compared with "== false"; got "props.Score > 0"`,
+		},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			_, _, err := ValidateServerCondExpression(tc.source)
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("ValidateServerCondExpression(%q) = %v, want %q", tc.source, err, tc.want)
+			}
+		})
+	}
+}
+
+func TestServerExpressionPropFields(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   []string
+	}{
+		{"props.Title", []string{"Title"}},
+		{`"a" + props.X`, []string{"X"}},
+		{`"a" + props.X + props.Y`, []string{"X", "Y"}},
+		{"props.Ready == false", []string{"Ready"}},
+		{"props.A == props.B", []string{"A", "B"}},
+		{"props.A.B", []string{"A"}}, // the syntax validator rejects the chain overall; the root field still gets tracked for the explicit-supply rule
+		{`"a" + "b"`, nil},
+		{"props.X()", []string{"X"}}, // shape-invalid overall, but the read still matters for tracking
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			got := ServerExpressionPropFields(tc.source)
+			if !equalStrings(got, tc.want) {
+				t.Fatalf("ServerExpressionPropFields(%q) = %v, want %v", tc.source, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateServerCondExpressionRejectsInvalidGo(t *testing.T) {
+	_, _, err := ValidateServerCondExpression("props.(")
+	if err == nil || !strings.Contains(err.Error(), "invalid Go expression") {
+		t.Fatalf("ValidateServerCondExpression(malformed) = %v", err)
+	}
+}

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -983,6 +983,17 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 // file renderer must observe. Local strict calls must provide these fields
 // explicitly: generated Go composite literals otherwise synthesize typed zero
 // values while the map-backed renderer would observe a missing key as nil.
+//
+// jsx_attribute_expression (an attribute's `{...}` value) gets its own branch
+// because the grammar's external attribute scanner hands its content back as
+// one opaque token with no nested CST — unlike jsx_expression_container
+// (element/text children), whose Go sub-expression parses into real
+// selector_expression descendants this walk already finds. Every v0.42
+// concatenation and <If cond> shape in this spec's motivating examples lives
+// in attribute position (class, aria-label, cond), so without this branch
+// their props operands would never reach validateStrictRenderedProps, the
+// renderer-boundary type check, or the explicit-required-prop rule below —
+// exactly the class of divergence the strict contract exists to prevent.
 func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct{} {
 	reads := make(map[string]struct{})
 	var walk func(*gotreesitter.Node)
@@ -990,8 +1001,14 @@ func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct
 		if node == nil {
 			return
 		}
-		if l.nodeType(node) == "selector_expression" {
+		switch l.nodeType(node) {
+		case "selector_expression":
 			if field, ok := strictcomponent.ServerPropField(l.text(node)); ok {
+				reads[field] = struct{}{}
+			}
+		case "jsx_attribute_expression":
+			expr := stripGSXAttributeExpressionText(l.text(node))
+			for _, field := range strictcomponent.ServerExpressionPropFields(expr) {
 				reads[field] = struct{}{}
 			}
 		}
@@ -1169,6 +1186,10 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		l.errorf(n, "legacy component cannot call strict component %s; component styles may coexist but calls must stay within one style", tag)
 		return
 	}
+	if l.strictServer && tag == "If" && !strictCallee {
+		l.validateStrictConditionalCall(n, attrs)
+		return
+	}
 	if l.strictServer && IsComponent(tag) && !strictCallee {
 		l.errorf(n, "strict server component %s is not renderable; v0.39 strict server components may call only same-file strict components", tag)
 		return
@@ -1225,6 +1246,32 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 	}
 	if len(children) > 0 {
 		l.errorf(n, "strict component %s does not accept positional children", tag)
+	}
+}
+
+// validateStrictConditionalCall enforces the shape of a strict <If cond={...}>
+// call: exactly one attribute, named cond, of expression kind. It runs only
+// when tag "If" is not shadowed by a same-file strict component (the carve-out
+// in validateStrictComponentCall). Children are unrestricted — that is the
+// point of the tag — so this checks attributes only.
+func (l *lowerer) validateStrictConditionalCall(n *gotreesitter.Node, attrs []Attr) {
+	condCount := 0
+	for i := range attrs {
+		attr := &attrs[i]
+		if attr.Name == "cond" && attr.Kind == AttrExpr {
+			condCount++
+			continue
+		}
+		if attr.Kind == AttrSpread {
+			l.errorf(n, "strict <If> does not accept spread attributes; cond is the only supported attribute")
+			continue
+		}
+		if attr.Name != "cond" {
+			l.errorf(n, "strict <If> does not accept attribute %q; cond is the only supported attribute", attr.Name)
+		}
+	}
+	if condCount != 1 {
+		l.errorf(n, "strict <If> requires exactly one cond attribute")
 	}
 }
 
@@ -1437,7 +1484,7 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 	}
 
 	if !isIsland && !isEngine {
-		l.validateStrictServerExpressions(comp.Root)
+		l.validateStrictServerExpressions(comp.Root, componentName, propsType)
 	}
 	l.prog.Components = append(l.prog.Components, comp)
 }
@@ -1515,8 +1562,9 @@ func (l *lowerer) isSupportedStrictIslandDeclaration(n *gotreesitter.Node) bool 
 	return true
 }
 
-func (l *lowerer) validateStrictServerExpressions(root NodeID) {
+func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, propsType string) {
 	seen := make(map[NodeID]bool)
+	_, shadowedByStrict := l.strictNames["If"]
 	var visit func(NodeID)
 	visit = func(id NodeID) {
 		if seen[id] || int(id) >= len(l.prog.Nodes) {
@@ -1525,11 +1573,16 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID) {
 		seen[id] = true
 		node := &l.prog.Nodes[id]
 		if node.Kind == NodeExpr {
-			l.validateStrictServerExpression(node.Span, node.Text)
+			l.validateStrictServerExpression(node.Span, node.Text, componentName, propsType)
 		}
+		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && !shadowedByStrict
 		for _, attr := range node.Attrs {
+			if isBuiltinIf && attr.Name == "cond" && attr.Kind == AttrExpr {
+				l.validateStrictConditionalExpression(node.Span, attr.Expr, componentName, propsType)
+				continue
+			}
 			if attr.Kind == AttrExpr || attr.Kind == AttrSpread {
-				l.validateStrictServerExpression(node.Span, attr.Expr)
+				l.validateStrictServerExpression(node.Span, attr.Expr, componentName, propsType)
 			}
 		}
 		for _, child := range node.Children {
@@ -1539,12 +1592,70 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID) {
 	visit(root)
 }
 
-func (l *lowerer) validateStrictServerExpression(span Span, source string) {
+func (l *lowerer) validateStrictServerExpression(span Span, source, componentName, propsType string) {
 	if err := strictcomponent.ValidateServerExpression(source); err != nil {
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
 			Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(source), err),
 			Hint:    "use literals or props field selection; compute, index, and call methods before rendering",
+		})
+		return
+	}
+	l.validateStrictExpressionTypes(span, source, componentName, propsType)
+}
+
+// validateStrictExpressionTypes runs the type-side gate for expression shapes
+// the syntactic validator accepts but cannot itself type-check. In v0.42 that
+// is exactly the string-concatenation chain: every props field operand must
+// resolve, through the same-file struct schema, to declared type exactly
+// string — not a named string type, not []byte. Fields that are unknown or
+// that already fail the renderer-scalar-type gate are skipped here; those
+// diagnostics belong to the package checker and validateStrictRenderedProps
+// respectively, and duplicating them would just restate the same root cause.
+func (l *lowerer) validateStrictExpressionTypes(span Span, source, componentName, propsType string) {
+	fields, ok := strictcomponent.ServerConcatPropFields(source)
+	if !ok {
+		return
+	}
+	fieldTypes := l.structTypes[propsBaseType(propsType)]
+	for _, field := range fields {
+		fieldType, known := fieldTypes[field]
+		if !known || !strictRendererScalarType(fieldType) {
+			continue
+		}
+		if strings.TrimSpace(fieldType) != "string" {
+			l.errs = append(l.errs, Diagnostic{
+				Span:    span,
+				Message: fmt.Sprintf("strict component %s cannot concatenate props.%s of type %s; \"+\" operands must be exact string props fields", componentName, field, fieldType),
+			})
+		}
+	}
+}
+
+// validateStrictConditionalExpression validates a strict <If cond={...}>
+// attribute's expression content: the syntactic shape (bare bool selector or
+// selector == false) through the dedicated cond validator, then the exact
+// bool type through the same-file struct schema. General expression
+// positions never reach this function — only the cond attribute of an
+// unshadowed <If> does, dispatched from validateStrictServerExpressions.
+func (l *lowerer) validateStrictConditionalExpression(span Span, source, componentName, propsType string) {
+	field, _, err := strictcomponent.ValidateServerCondExpression(source)
+	if err != nil {
+		l.errs = append(l.errs, Diagnostic{
+			Span:    span,
+			Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(source), err),
+			Hint:    "use literals or props field selection; compute, index, and call methods before rendering",
+		})
+		return
+	}
+	fieldType, known := l.structTypes[propsBaseType(propsType)][field]
+	if !known || !strictRendererScalarType(fieldType) {
+		return
+	}
+	if strings.TrimSpace(fieldType) != "bool" {
+		l.errs = append(l.errs, Diagnostic{
+			Span:    span,
+			Message: fmt.Sprintf("strict component %s cannot use props.%s of type %s in <If cond>; cond requires an exact bool props field", componentName, field, fieldType),
 		})
 	}
 }

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1256,6 +1256,7 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 // point of the tag — so this checks attributes only.
 func (l *lowerer) validateStrictConditionalCall(n *gotreesitter.Node, attrs []Attr) {
 	condCount := 0
+	sawSpreadError := false
 	for i := range attrs {
 		attr := &attrs[i]
 		if attr.Name == "cond" && attr.Kind == AttrExpr {
@@ -1264,11 +1265,18 @@ func (l *lowerer) validateStrictConditionalCall(n *gotreesitter.Node, attrs []At
 		}
 		if attr.Kind == AttrSpread {
 			l.errorf(n, "strict <If> does not accept spread attributes; cond is the only supported attribute")
+			sawSpreadError = true
 			continue
 		}
 		if attr.Name != "cond" {
 			l.errorf(n, "strict <If> does not accept attribute %q; cond is the only supported attribute", attr.Name)
 		}
+	}
+	// A spread attribute already reported its own diagnostic above; the
+	// cond-count check below would otherwise double-report the same call
+	// (a spread never counts toward condCount, so it always fails it too).
+	if sawSpreadError {
+		return
 	}
 	if condCount != 1 {
 		l.errorf(n, "strict <If> requires exactly one cond attribute")

--- a/route/exprlower_test.go
+++ b/route/exprlower_test.go
@@ -129,6 +129,16 @@ var exprLowerCases = []string{
 	`data.lookup`,
 	`^data.count`,
 	`func() {}`,
+	// v0.42 strict-surface shapes: concatenation and cond's `== false` idiom.
+	// These are not new evaluator shapes — applyFileBinaryOp already handled
+	// ADD's string branch and EQL's reflect.DeepEqual comparison — but the
+	// strict extensions are what makes GoSX-authored source actually reach
+	// them, so the differential oracle gets explicit coverage here.
+	`"tone-" + data.name`,
+	`data.name + "-suffix"`,
+	`"a" + data.name + "b"`,
+	`data.on == false`,
+	`data.off == false`,
 }
 
 func TestLoweredExprMatchesReferenceInterpreter(t *testing.T) {

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -1,8 +1,10 @@
 package route
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -268,6 +270,122 @@ component Page() {
 	}
 	if html != "<p>0:false</p>" {
 		t.Fatalf("html = %q", html)
+	}
+}
+
+// TestStrictConcatAndCondParityWithGeneratedGo is the v0.42 render-parity
+// test: it renders through renderFileProgramHTML and compares against the
+// generated-Go equivalent (a hand-written gosx.El/gosx.If tree matching
+// exactly what transpile.Transpile emits for this source), for both the true
+// and false branches of the cond. Single-line JSX avoids a pre-existing,
+// unrelated whitespace-handling difference between the transpile path (which
+// drops whitespace-only text children) and the IR/file-render path (which
+// renders them as a single space) — see the investigation note in this
+// change's report; that gap predates this change and is not part of it.
+func TestStrictConcatAndCondParityWithGeneratedGo(t *testing.T) {
+	const source = `package app
+type CardProps struct {
+	Ready bool
+	Tone  string
+}
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}><If cond={props.Ready}>ready</If><If cond={props.Ready == false}>not ready</If></div>
+}
+component Page() {
+	return <Card ready={%s} tone="ok" />
+}
+`
+	for _, ready := range []bool{true, false} {
+		t.Run(strconv.FormatBool(ready), func(t *testing.T) {
+			prog, err := gosx.Compile([]byte(fmt.Sprintf(source, strconv.FormatBool(ready))))
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+			if err != nil {
+				t.Fatalf("RenderProgramComponent: %v", err)
+			}
+			want := gosx.RenderHTML(gosx.El("div", gosx.Attrs(gosx.Attr("class", "tone-"+"ok")),
+				gosx.If(ready, gosx.Fragment(gosx.Text("ready"))),
+				gosx.If(ready == false, gosx.Fragment(gosx.Text("not ready"))),
+			))
+			if html != want {
+				t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+			}
+		})
+	}
+}
+
+// TestStrictConcatEscapesHTMLInJoinedValue proves the concatenated result
+// runs through the same HTML-escaping path as any other attribute value —
+// concatenation happens before escaping, not after.
+func TestStrictConcatEscapesHTMLInJoinedValue(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type CardProps struct { Tone string }
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}>x</div>
+}
+component Page() {
+	return <Card tone={"\"<script>\""} />
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := gosx.RenderHTML(gosx.El("div", gosx.Attrs(gosx.Attr("class", "tone-"+`"<script>"`)), gosx.Text("x")))
+	if html != want {
+		t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+	}
+	if !strings.Contains(html, "&lt;script&gt;") {
+		t.Fatalf("expected the joined value to be HTML-escaped, got %q", html)
+	}
+}
+
+// TestRequireStrictScalarTypeRejectsConcatBoundaryMismatch exercises the
+// renderer boundary directly (requireStrictScalarType), mirroring
+// TestRenderProgramComponentCannotReceiveDivergentStrictExpression: a
+// same-file strict callee whose declared field is string, called with a
+// non-string value, must fail closed at the render boundary rather than
+// silently stringify.
+func TestRequireStrictScalarTypeRejectsConcatBoundaryMismatch(t *testing.T) {
+	if _, err := requireStrictScalarType(42, "string"); err == nil {
+		t.Fatal("requireStrictScalarType(42, \"string\") unexpectedly accepted a non-string value")
+	}
+}
+
+// TestIfConditionalParityMatchesGoSXIf checks writeConditional (the existing
+// "If"/"Show"/"When" builtin) against gosx.If directly for both branches,
+// confirming the v0.42 <If cond> extension needed zero renderer changes: the
+// strict validator only narrows which shapes reach the pre-existing builtin.
+func TestIfConditionalParityMatchesGoSXIf(t *testing.T) {
+	const source = `package app
+type Props struct { Ready bool }
+component Card(props: Props) {
+	return <main><If cond={props.Ready}>yes</If></main>
+}
+component Page() {
+	return <Card ready={%s} />
+}
+`
+	for _, ready := range []bool{true, false} {
+		t.Run(strconv.FormatBool(ready), func(t *testing.T) {
+			prog, err := gosx.Compile([]byte(fmt.Sprintf(source, strconv.FormatBool(ready))))
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			got, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+			if err != nil {
+				t.Fatalf("RenderProgramComponent: %v", err)
+			}
+			want := gosx.RenderHTML(gosx.El("main", nil, gosx.If(ready, gosx.Fragment(gosx.Text("yes")))))
+			if got != want {
+				t.Fatalf("ready=%v: file render = %q, gosx.If render = %q", ready, got, want)
+			}
+		})
 	}
 }
 

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -198,7 +198,6 @@ func TestCompileStrictServerRejectsTypeDivergentExpressions(t *testing.T) {
 		"props.A / props.B",
 		"props.OK && props.SideEffect()",
 		"props.OK || props.SideEffect()",
-		"props.A + props.B",
 		"-props.A",
 		"!props.OK",
 		"props.Items[0]",
@@ -212,6 +211,22 @@ func TestCompileStrictServerRejectsTypeDivergentExpressions(t *testing.T) {
 				t.Fatalf("error = %v", err)
 			}
 		})
+	}
+}
+
+// TestCompileStrictServerRejectsConcatChainsMissingALiteral covers the one
+// v0.41 rejection whose message changed under the v0.42 concatenation
+// extension: `props.A + props.B` used to fail the blanket "binary operator...
+// not supported" message; it still fails closed, but now with the
+// concat-specific diagnostic that names the missing literal operand instead.
+func TestCompileStrictServerRejectsConcatChainsMissingALiteral(t *testing.T) {
+	_, err := Compile([]byte(`package app
+component Page(props: Props) {
+	return <main>{props.A + props.B}</main>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "strict concatenation requires at least one string literal operand") {
+		t.Fatalf("error = %v", err)
 	}
 }
 
@@ -374,6 +389,238 @@ component Page(input: Props) {
 }
 `))
 	if err == nil || !strings.Contains(err.Error(), "must be named props") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+// TestCompileStrictServerAcceptsConcatOfExactStringFields covers the v0.42
+// concatenation extension (spec section 2.a): a `+` chain whose operands are
+// string literals and props field selectors of declared type string.
+func TestCompileStrictServerAcceptsConcatOfExactStringFields(t *testing.T) {
+	for _, expression := range []string{
+		`"tone-" + props.Tone`,
+		`props.Tone + "-tone"`,
+		`"Remove " + props.Name + " from roster"`,
+		`("tone-") + (props.Tone)`,
+	} {
+		t.Run(expression, func(t *testing.T) {
+			source := []byte("package app\ntype Props struct { Tone string; Name string }\ncomponent Page(props: Props) {\nreturn <main class={" + expression + "}>{" + expression + "}</main>\n}\n")
+			if _, err := Compile(source); err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+		})
+	}
+}
+
+// TestCompileStrictServerRejectsConcatOfNonStringField covers section 4.2:
+// a field that passes the general renderer-scalar-type gate (it is a valid
+// exact builtin) but is not exactly string still fails concatenation, named
+// specifically.
+func TestCompileStrictServerRejectsConcatOfNonStringField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Props struct { Count int }
+component RosterRow(props: Props) {
+	return <main>{"Rank " + props.Count}</main>
+}
+`))
+	want := `strict component RosterRow cannot concatenate props.Count of type int; "+" operands must be exact string props fields`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerConcatOfNamedStringTypeFailsClosedOnExistingGate
+// documents a spec divergence: section 4.2's second example message
+// ("named string types are outside the strict renderer contract") is not
+// separately reachable. Any field whose declared type is not one of the
+// known renderer-scalar builtins — including a named string type — already
+// fails validateStrictRenderedProps's pre-existing renderer-scalar-type gate
+// before the concat-specific pass would run. The component still fails
+// closed; it just does so with the existing, more general diagnostic
+// instead of a second, concat-specific one.
+//
+// This test also doubles as the regression check for a fail-open bug this
+// change fixes in collectStrictPropReads (see the doc comment there):
+// props.Tone here is read only inside the class attribute's `{...}` value,
+// and before the fix, attribute-position expressions were invisible to
+// read-tracking (the grammar hands them back as one opaque scanner token
+// with no nested CST), so validateStrictRenderedProps never saw this field
+// at all and this exact source compiled with no error.
+func TestCompileStrictServerConcatOfNamedStringTypeFailsClosedOnExistingGate(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Tone string
+type Props struct { Tone Tone }
+component TeamMark(props: Props) {
+	return <span class={"tone-" + props.Tone}>mark</span>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "renderer-visible props fields must use exact string, bool, integer, or floating-point builtins") {
+		t.Fatalf("error = %v", err)
+	}
+	if strings.Contains(err.Error(), "cannot concatenate") {
+		t.Fatalf("did not expect a duplicate concat-specific diagnostic: %v", err)
+	}
+}
+
+// TestCompileStrictServerTracksAttributePositionPropsReads is a direct
+// regression test for the collectStrictPropReads fix: a props field read
+// only inside attribute-position expressions (a concat operand and an <If
+// cond> selector) must still be subject to the explicit-required-prop rule
+// and the renderer-scalar-type gate, exactly as a text-child read would be.
+func TestCompileStrictServerTracksAttributePositionPropsReads(t *testing.T) {
+	const source = `package app
+type CardProps struct {
+	Ready bool
+	Tone  string
+}
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}><If cond={props.Ready}>ready</If></div>
+}
+component Page() {
+	return <Card />
+}
+`
+	_, err := Compile([]byte(source))
+	if err == nil {
+		t.Fatal("Compile unexpectedly accepted a call that omitted attribute-only-read props")
+	}
+	for _, want := range []string{"requires prop Ready", "requires prop Tone"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Compile error %q does not contain %q", err, want)
+		}
+	}
+}
+
+// TestCompileStrictServerRejectsConcatMissingAPropsFieldOperand covers the
+// "literal-only chain" rejection from section 2.a's non-goals.
+func TestCompileStrictServerRejectsConcatMissingAPropsFieldOperand(t *testing.T) {
+	_, err := Compile([]byte(`package app
+component Page() {
+	return <main>{"a" + "b"}</main>
+}
+`))
+	want := "strict concatenation requires at least one props field operand; fold literal-only chains by hand"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+// TestCompileStrictServerAcceptsBoolCond covers the v0.42 <If cond> extension
+// (spec section 2.c): a bare bool selector and its `== false` negation.
+func TestCompileStrictServerAcceptsBoolCond(t *testing.T) {
+	for _, cond := range []string{"props.Ready", "props.Ready == false", "(props.Ready) == (false)"} {
+		t.Run(cond, func(t *testing.T) {
+			source := []byte("package app\ntype Props struct { Ready bool }\ncomponent Page(props: Props) {\nreturn <main><If cond={" + cond + "}>content</If></main>\n}\n")
+			if _, err := Compile(source); err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+		})
+	}
+}
+
+// TestCompileStrictServerRejectsNonBoolCond covers section 4.4's cond-type
+// diagnostic: a props field of an exact renderer-scalar type that is not bool.
+func TestCompileStrictServerRejectsNonBoolCond(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Props struct { Label string }
+component SeatRow(props: Props) {
+	return <main><If cond={props.Label}>content</If></main>
+}
+`))
+	want := "strict component SeatRow cannot use props.Label of type string in <If cond>; cond requires an exact bool props field"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsIfShapeViolations covers section 4.4's shape
+// diagnostics: a second attribute and a missing cond attribute (the
+// `when=` legacy spelling does not satisfy the cond-only shape).
+func TestCompileStrictServerRejectsIfShapeViolations(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		body string
+		want string
+	}{
+		{
+			name: "second-attribute",
+			body: `<If cond={props.Ready} fallback="no">content</If>`,
+			want: `strict <If> does not accept attribute "fallback"; cond is the only supported attribute`,
+		},
+		{
+			name: "when-spelling",
+			body: `<If when={props.Ready}>content</If>`,
+			want: "strict <If> requires exactly one cond attribute",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte("package app\ntype Props struct { Ready bool }\ncomponent Page(props: Props) {\nreturn <main>" + tc.body + "</main>\n}\n")
+			_, err := Compile(source)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompileStrictServerRejectsIfCondComparisonShapes covers section 4.4's
+// cond-expression-shape diagnostics from the validator.
+func TestCompileStrictServerRejectsIfCondComparisonShapes(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		cond string
+		want string
+	}{
+		{"eq-true", "props.Ready == true", `comparison "== true" is not supported in strict cond; write the field bare`},
+		{"neq-false", "props.Ready != false", `strict cond must be a bool props field or a bool props field compared with "== false"; got "props.Ready != false"`},
+		{"negation", "!props.Ready", `strict cond must be a bool props field or a bool props field compared with "== false"; got "!props.Ready"`},
+		{"two-selectors", "props.A == props.B", `strict cond must be a bool props field or a bool props field compared with "== false"; got "props.A == props.B"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte("package app\ntype Props struct { Ready bool; A bool; B bool }\ncomponent Page(props: Props) {\nreturn <main><If cond={" + tc.cond + "}>content</If></main>\n}\n")
+			_, err := Compile(source)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+// TestCompileStrictServerIfShadowedBySameFileComponentStaysAComponentCall
+// covers the shadow regression from section 5.2: a same-file strict
+// component named If wins over the builtin, and the ordinary strict-call
+// rules (explicit rendered props, no positional children) still apply to it.
+func TestCompileStrictServerIfShadowedBySameFileComponentStaysAComponentCall(t *testing.T) {
+	prog, err := Compile([]byte(`package app
+type IfProps struct { Label string }
+component If(props: IfProps) {
+	return <em>{props.Label}</em>
+}
+component Page() {
+	return <If label="shadowed" />
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	page := prog.Components[1]
+	call := prog.NodeAt(page.Root)
+	if call == nil || call.Tag != "If" || len(call.Attrs) != 1 || call.Attrs[0].Name != "Label" {
+		t.Fatalf("shadowed If call not lowered as a component call: %#v", call)
+	}
+
+	// The ordinary strict-call rules still apply: omitting the rendered prop
+	// still fails closed instead of silently falling through to the builtin.
+	_, err = Compile([]byte(`package app
+type IfProps struct { Label string }
+component If(props: IfProps) {
+	return <em>{props.Label}</em>
+}
+component Page() {
+	return <If />
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "requires prop Label") {
 		t.Fatalf("error = %v", err)
 	}
 }

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1,6 +1,7 @@
 package gosx
 
 import (
+	"errors"
 	"strings"
 	"testing"
 
@@ -560,6 +561,32 @@ func TestCompileStrictServerRejectsIfShapeViolations(t *testing.T) {
 				t.Fatalf("error = %v, want to contain %q", err, tc.want)
 			}
 		})
+	}
+}
+
+// TestCompileStrictServerIfSpreadReportsOneDiagnostic covers the N1 review
+// fix: a spread attribute on strict <If> is always missing cond, but the
+// validator must not also report the separate cond-count violation — a
+// spread attribute report is enough on its own.
+func TestCompileStrictServerIfSpreadReportsOneDiagnostic(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Props struct { Extra bool }
+component Page(props: Props) {
+	return <main><If {...props.Extra}>content</If></main>
+}
+`))
+	if err == nil {
+		t.Fatal("expected validation diagnostics")
+	}
+	var diagErr *ir.DiagnosticsError
+	if !errors.As(err, &diagErr) {
+		t.Fatalf("expected diagnostics error, got %T: %v", err, err)
+	}
+	if len(diagErr.Diagnostics) != 1 {
+		t.Fatalf("expected 1 diagnostic, got %d: %v", len(diagErr.Diagnostics), diagErr.Diagnostics)
+	}
+	if !strings.Contains(diagErr.Diagnostics[0].Message, "strict <If> does not accept spread attributes") {
+		t.Fatalf("unexpected diagnostic %#v", diagErr.Diagnostics[0])
 	}
 }
 

--- a/strict_surface_expansion_integration_test.go
+++ b/strict_surface_expansion_integration_test.go
@@ -1,0 +1,99 @@
+package gosx_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gosx "m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+	"m31labs.dev/gosx/strictcheck"
+)
+
+// teamMarkFixtureSource is the re-audit checkpoint from the design spec
+// (GoSX Strict Component Expression Surface Expansion, section 5.7,
+// TeamMark row): a component like `func TeamMark(props any)` rewritten as
+// strict with `class={"team-mark tone-" + props.Tone}`, plus
+// `<If cond={props.Ready}>` / `<If cond={props.Ready == false}>` in the same
+// strict body — the exact pair the v0.42 (a)+(c) work packages exist to
+// qualify.
+func teamMarkFixtureSource(ready bool) string {
+	return fmt.Sprintf(`package app
+
+type TeamMarkProps struct {
+	Tone  string
+	Ready bool
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}><If cond={props.Ready}>ready</If><If cond={props.Ready == false}>pending</If></span>
+}
+
+component Page() {
+	return <TeamMark tone="home" ready={%v} />
+}
+`, ready)
+}
+
+// TestStrictSurfaceExpansionTeamMarkFixtureCompilesChecksAndRenders is the
+// integration fixture the re-audit checkpoint requires: it compiles the
+// TeamMark shape, runs it through the real gosx-check pipeline (Go compiler
+// backed, via strictcheck.CheckFileWithOptions against this module's real
+// gosx package), and renders it, comparing against the generated-Go
+// equivalent for both branches of the cond.
+func TestStrictSurfaceExpansionTeamMarkFixtureCompilesChecksAndRenders(t *testing.T) {
+	for _, ready := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ready=%v", ready), func(t *testing.T) {
+			source := teamMarkFixtureSource(ready)
+
+			// 1. Compiles: the IR lowerer accepts concatenation of a string
+			// props field and <If cond> on a bool props field together.
+			prog, err := gosx.Compile([]byte(source))
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+
+			// 2. Checks: the Go-compiler-backed pipeline (strictcheck) accepts
+			// the same source in a real module that depends on this gosx.
+			root, err := filepath.Abs(".")
+			if err != nil {
+				t.Fatal(err)
+			}
+			dir := t.TempDir()
+			goMod := "module example.test/teammark\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+			if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			goSum, err := os.ReadFile("go.sum")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+				t.Fatal(err)
+			}
+			path := filepath.Join(dir, "teammark.gsx")
+			if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			if err := strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"}); err != nil {
+				t.Fatalf("gosx check (strictcheck.CheckFileWithOptions): %v", err)
+			}
+
+			// 3. Renders: the file-route renderer produces exactly what the
+			// generated-Go equivalent produces, for this cond branch.
+			html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{})
+			if err != nil {
+				t.Fatalf("RenderProgramComponent: %v", err)
+			}
+			want := gosx.RenderHTML(gosx.El("span", gosx.Attrs(gosx.Attr("class", "team-mark tone-"+"home")),
+				gosx.If(ready, gosx.Fragment(gosx.Text("ready"))),
+				gosx.If(ready == false, gosx.Fragment(gosx.Text("pending"))),
+			))
+			if html != want {
+				t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+			}
+		})
+	}
+}

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -28,6 +28,7 @@ func Attr(string, any) AttrValue { return AttrValue{} }
 func Attrs(...AttrValue) any { return nil }
 func Props(values ...AttrValue) AttrList { return values }
 func Spread(any) AttrValue { return AttrValue{} }
+func If(cond bool, child Node) Node { return Node{} }
 `)
 	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.test/app\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => "+filepath.ToSlash(stub)+"\n")
 	return dir
@@ -287,6 +288,100 @@ component Page() {
 `)
 	if err := CheckFile(context.Background(), path); err != nil {
 		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileAcceptsConcatAndCondTogether is the v0.42 acceptance case: a
+// strict component that concatenates a string prop and gates a child on a
+// bool prop through <If cond> must pass CheckFile end to end (IR lowering,
+// Go-compiler projection, and go list).
+func TestCheckFileAcceptsConcatAndCondTogether(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type CardProps struct {
+	Ready bool
+	Tone  string
+}
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}><If cond={props.Ready}>ready</If><If cond={props.Ready == false}>not ready</If></div>
+}
+component Page() {
+	return <Card ready={true} tone="ok" />
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsConcatOfNonStringField is the strictcheck half of the
+// concat type rule: a concat of an int prop must fail the generated check
+// program, and the Go compiler's own diagnostic must still name the field.
+func TestCheckFileRejectsConcatOfNonStringField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type RowProps struct {
+	Count int
+}
+component Row(props: RowProps) {
+	return <p>{"Rank " + props.Count}</p>
+}
+component Page() {
+	return <Row count={3} />
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "cannot concatenate props.Count") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileRejectsConcatOfUnknownField proves the Go-compiler backstop
+// still owns unknown-field diagnostics for concat operands, exactly as it
+// does for a v0.41 direct-field selector.
+func TestCheckFileRejectsConcatOfUnknownField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type RowProps struct {
+	Tone string
+}
+component Row(props: RowProps) {
+	return <p>{"tone-" + props.Tonee}</p>
+}
+component Page() {
+	return <Row tone="ok" />
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "Tonee") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileRejectsCondOfNonBoolField is the strictcheck half of section
+// 4.4's cond-type rule: cond on an int field must fail with a diagnostic
+// naming the field, both at the IR gate and (if it ever got that far) at the
+// Go compiler's "cannot use ... as bool" boundary.
+func TestCheckFileRejectsCondOfNonBoolField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type RowProps struct {
+	Count int
+}
+component Row(props: RowProps) {
+	return <p><If cond={props.Count}>x</If></p>
+}
+component Page() {
+	return <Row count={3} />
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "cond requires an exact bool props field") {
+		t.Fatalf("CheckFile error = %v", err)
 	}
 }
 

--- a/transpile/package_test.go
+++ b/transpile/package_test.go
@@ -39,7 +39,7 @@ func Legacy() Node {
 }
 
 component Badge(props: BadgeProps) {
-	return <span data-when={props.When}>{props.Label}</span>
+	return <span>{props.Label}</span>
 }
 
 component Page() {

--- a/transpile/package_test.go
+++ b/transpile/package_test.go
@@ -28,8 +28,9 @@ import (
 )
 
 type BadgeProps struct {
-	Label string
-	When clock.Time
+	Label    string
+	When     bool
+	Recorded clock.Time
 }
 
 const BadgeLimit = 3
@@ -39,11 +40,11 @@ func Legacy() Node {
 }
 
 component Badge(props: BadgeProps) {
-	return <span>{props.Label}</span>
+	return <span data-when={props.When}>{props.Label}</span>
 }
 
 component Page() {
-	return <Badge label="ready" />
+	return <Badge label="ready" when={true} />
 }
 `)
 	got, strict, err := StrictProjection(file)
@@ -57,7 +58,7 @@ component Page() {
 		`clock "time"`,
 		`gx "m31labs.dev/gosx"`,
 		`func Badge(props BadgeProps) gx.Node`,
-		`Badge(BadgeProps{Label: "ready"})`,
+		`Badge(BadgeProps{Label: "ready", When: true})`,
 		`const BadgeLimit = 3`,
 	} {
 		if !strings.Contains(got, want) {

--- a/transpile/strict_component_test.go
+++ b/transpile/strict_component_test.go
@@ -127,6 +127,132 @@ component Page() {
 	}
 }
 
+// TestTranspileStrictConcatAndCondEmitVerbatimGo covers the v0.42 extensions:
+// a concat hole appears verbatim inside gosx.Attr/gosx.Expr, and a strict
+// <If cond={...}> emits gosx.If(cond, gosx.Fragment(children...)).
+func TestTranspileStrictConcatAndCondEmitVerbatimGo(t *testing.T) {
+	source := []byte(`package app
+
+type CardProps struct {
+	Ready bool
+	Tone  string
+}
+
+component Card(props: CardProps) {
+	return <div class={"tone-" + props.Tone}>{"Rank " + props.Tone}<If cond={props.Ready}>ready</If><If cond={props.Ready == false}>not ready</If></div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	for _, want := range []string{
+		`gosx.Attr("class", "tone-" + props.Tone)`,
+		`gosx.Expr("Rank " + props.Tone)`,
+		`gosx.If(props.Ready, gosx.Fragment(gosx.Text("ready")))`,
+		`gosx.If(props.Ready == false, gosx.Fragment(gosx.Text("not ready")))`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTranspileStrictConditionalHonorsGoSXAliasInjection mirrors
+// TestTranspileStrictComponentRespectsExistingGoSXImportStyle and
+// TestTranspileStrictComponentInjectsCollisionSafeGoSXAlias for the new <If>
+// emission: it must reference whatever alias (or dot import) the rest of the
+// file's gosx emission uses, exactly like every other gosxRef call.
+func TestTranspileStrictConditionalHonorsGoSXAliasInjection(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		imp  string
+		want string
+	}{
+		{"alias", `gx "m31labs.dev/gosx"`, `gx.If(props.Ready, gx.Fragment(gx.Text("ready")))`},
+		{"dot", `. "m31labs.dev/gosx"`, `If(props.Ready, Fragment(Text("ready")))`},
+		{"collision", `gosx "example.test/unrelated"`, `gosxgen1.If(props.Ready, gosxgen1.Fragment(gosxgen1.Text("ready")))`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte("package app\nimport " + tc.imp + "\ntype Props struct { Ready bool }\ncomponent Page(props: Props) {\nreturn <main><If cond={props.Ready}>ready</If></main>\n}\n")
+			out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+			if err != nil {
+				t.Fatalf("Transpile: %v", err)
+			}
+			if !strings.Contains(out, tc.want) {
+				t.Fatalf("missing %q in:\n%s", tc.want, out)
+			}
+		})
+	}
+}
+
+// TestTranspileStrictConditionalSelfClosingHasEmptyFragment covers the
+// zero-children shape: <If cond={...} /> still emits a (empty) gosx.Fragment
+// so If's single-child signature holds.
+func TestTranspileStrictConditionalSelfClosingHasEmptyFragment(t *testing.T) {
+	source := []byte(`package app
+type Props struct { Ready bool }
+component Page(props: Props) {
+	return <main><If cond={props.Ready} /></main>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `gosx.If(props.Ready, gosx.Fragment())`; !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+}
+
+// TestTranspileStrictConditionalShadowedByLocalComponentStaysAComponentCall
+// covers the shadow rule: a same-file strict component named If must keep
+// its ordinary typed-composite-literal emission instead of the gosx.If
+// builtin projection.
+func TestTranspileStrictConditionalShadowedByLocalComponentStaysAComponentCall(t *testing.T) {
+	source := []byte(`package app
+type IfProps struct { Label string }
+component If(props: IfProps) {
+	return <em>{props.Label}</em>
+}
+component Page() {
+	return <If label="shadowed" />
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(out, `If(IfProps{Label: "shadowed"})`) {
+		t.Fatalf("shadowed If lost its component-call emission:\n%s", out)
+	}
+	if strings.Contains(out, "gosx.If(") {
+		t.Fatalf("shadowed If incorrectly emitted the builtin:\n%s", out)
+	}
+}
+
+// TestTranspileLegacyIfKeepsExistingEmission covers the compatibility note in
+// spec section 6: legacy (non-strict) bodies never reach the new strict <If>
+// emission path (t.strict stays 0), so their existing If(...) component-call
+// projection is unchanged.
+func TestTranspileLegacyIfKeepsExistingEmission(t *testing.T) {
+	source := []byte(`package app
+func If(cond bool, child Node) Node {
+	return child
+}
+func Page() Node {
+	return <main><If cond={true}>legacy</If></main>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if strings.Contains(out, "gosx.If(") {
+		t.Fatalf("legacy body incorrectly used the strict builtin emission:\n%s", out)
+	}
+}
+
 func TestTranspileStrictExplicitZeroPropsMatchFileRendererContract(t *testing.T) {
 	source := []byte(`package app
 type BadgeProps struct {

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -89,6 +89,7 @@ type transpiler struct {
 	imports          map[string]string // alias -> path
 	propsTypes       map[string]string
 	propsFields      map[string]map[string]string
+	strictNames      map[string]struct{} // same-file gosx_component_declaration names, props or not
 	errs             []string
 	hasStrict        bool
 	strict           int
@@ -568,6 +569,12 @@ func (t *transpiler) collectComponentProps(n *gotreesitter.Node) {
 		if !isComponent(name) {
 			continue
 		}
+		if typ == "gosx_component_declaration" {
+			if t.strictNames == nil {
+				t.strictNames = make(map[string]struct{})
+			}
+			t.strictNames[name] = struct{}{}
+		}
 		if propsType := t.extractPropsType(child); propsType != "" {
 			t.propsTypes[name] = propsType
 		}
@@ -668,6 +675,12 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 	tag := t.extractTagName(openNode)
 	children := t.emitChildren(n)
 
+	if t.isStrictConditionalTag(tag) {
+		if cond, ok := t.strictConditionalCondExpr(openNode); ok {
+			return t.emitStrictConditional(cond, children)
+		}
+	}
+
 	if isComponent(tag) {
 		if propsType, ok := t.typedPropsType(tag); ok {
 			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, openNode), children)
@@ -675,6 +688,52 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 		return t.emitComponentCall(tag, t.emitAttrs(openNode), children)
 	}
 	return t.emitElementCall(tag, t.emitHTMLAttrs(openNode), children)
+}
+
+// isStrictConditionalTag reports whether tag resolves to the strict <If>
+// builtin rather than a same-file component named If. It mirrors the
+// shadow rule in validateStrictComponentCall (ir/lower.go): the IR semantic
+// gate (gosx.Compile, run before any emission in Transpile) has already
+// proven the file compiles under that same rule, so by the time emission
+// runs, tag=="If" outside t.strictNames can only be the builtin.
+func (t *transpiler) isStrictConditionalTag(tag string) bool {
+	if t.strict == 0 || tag != "If" {
+		return false
+	}
+	_, shadowed := t.strictNames[tag]
+	return !shadowed
+}
+
+// strictConditionalCondExpr extracts the verbatim source of a strict <If>'s
+// cond attribute. validateStrictConditionalCall (ir/lower.go) has already
+// rejected every other attribute shape before transpile emission runs, so
+// this is an extraction step, not a second validation pass.
+func (t *transpiler) strictConditionalCondExpr(openNode *gotreesitter.Node) (string, bool) {
+	for i := 0; i < int(openNode.NamedChildCount()); i++ {
+		child := openNode.NamedChild(i)
+		if t.nodeType(child) != "jsx_attribute" {
+			continue
+		}
+		nameNode := t.childByField(child, "name")
+		if nameNode == nil || t.text(nameNode) != "cond" {
+			continue
+		}
+		value, boolAttr, ok := t.emitAttrValue(child)
+		if !ok || boolAttr {
+			return "", false
+		}
+		return value, true
+	}
+	return "", false
+}
+
+// emitStrictConditional projects a strict <If cond={...}> call as a call to
+// gosx.If, so the Go compiler proves cond is exactly bool
+// (func If(cond bool, child Node) Node, helpers.go). Children collapse into
+// one gosx.Fragment so If's single-child signature holds whether the source
+// wrote zero, one, or many GSX children.
+func (t *transpiler) emitStrictConditional(cond string, children []string) string {
+	return fmt.Sprintf("%s(%s, %s(%s))", t.gosxRef("If"), cond, t.gosxRef("Fragment"), strings.Join(children, ", "))
 }
 
 // emitRawTextElement emits <script>/<style>. Their bodies are script or
@@ -735,6 +794,12 @@ func rawTextBody(raw string) string {
 
 func (t *transpiler) emitSelfClosing(n *gotreesitter.Node) string {
 	tag := t.extractTagName(n)
+
+	if t.isStrictConditionalTag(tag) {
+		if cond, ok := t.strictConditionalCondExpr(n); ok {
+			return t.emitStrictConditional(cond, nil)
+		}
+	}
 
 	if isComponent(tag) {
 		if propsType, ok := t.typedPropsType(tag); ok {


### PR DESCRIPTION
## Summary

Introduces narrow, typed extensions to the strict server component expression surface: string concatenation chains and conditional rendering. The new syntax allows joining string literals with direct props field selectors in attributes and text children, plus an &lt;If cond={...}&gt; builtin for branching logic. These additions preserve the strict contract's static guarantees while closing common UI gaps without widening to untyped or method-call expressions.

## Changes

- Extend the strict server expression validator to accept left-associative `+` chains containing at least one string literal and one direct props field selector, rejecting numeric addition and type-mismatched fields.
- Implement `<If cond={...}>` as a strict conditional builtin that accepts a bare bool props field or a `== false` negation, enforcing exact bool type checking and rejecting other operators or shape violations.
- Patch read-tracking in `collectStrictPropReads` to parse opaque `jsx_attribute_expression` tokens, ensuring props used inside attribute concat chains and cond values are tracked for explicit-required-prop rules and scalar-type gates.
- Update IR lowering and the Go transpiler to enforce expression types, generate `gosx.If(cond, gosx.Fragment(children))` calls, and correctly handle local component shadowing of the `If` builtin.
- Add comprehensive compilation, runtime parity, formatting, and strictcheck pipeline tests covering both valid uses and precise rejection messages for disallowed shapes.
- Refresh documentation examples to showcase concatenation and conditional rendering patterns in strict components.

## Testing

- Run `go test ./... -run Strict.*|Transpile.*|Check.*` to verify all compilation validations, render-parity comparisons, and type-check rejections pass.
- Run `make build` or compile the `examples/gosx-docs` module to ensure updated documentation samples render without errors.
- Verify format idempotency by running `go test ./format -run TestSourceFormatsStrictConcatAndCondIdempotently`.