### PR TITLE
add(runtime): Add data-gosx-managed shorthand for form contract defaults

### DIFF
--- a/managed_form_shorthand_test.go
+++ b/managed_form_shorthand_test.go
@@ -1,0 +1,95 @@
+package gosx
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// wantManagedFormDefaults builds the exact five-attribute contract markup
+// ManagedFormAttrs(ManagedFormOptions{}) produces, from the runtime-contract
+// constants rather than string literals, so the test tracks the contract
+// even if an attribute name ever changes.
+func wantManagedFormDefaults() string {
+	return fmt.Sprintf(
+		`<form %s %s="idle" %s="form" %s="bootstrap" %s="native-form"></form>`,
+		ManagedFormAttr, ManagedFormStateAttr, EnhancementAttr, EnhancementLayerAttr, RuntimeFallbackAttr,
+	)
+}
+
+func TestManagedFormShorthandExpandsToContractDefaults(t *testing.T) {
+	node := El("form", Attrs(BoolAttr(ManagedFormShorthandAttr)))
+	if got, want := RenderHTML(node), wantManagedFormDefaults(); got != want {
+		t.Fatalf("RenderHTML bare shorthand = %q, want %q", got, want)
+	}
+}
+
+func TestManagedFormShorthandAcceptsExplicitTrueValue(t *testing.T) {
+	node := El("form", Attrs(Attr(ManagedFormShorthandAttr, "true")))
+	if got, want := RenderHTML(node), wantManagedFormDefaults(); got != want {
+		t.Fatalf(`RenderHTML data-gosx-managed="true" = %q, want %q`, got, want)
+	}
+}
+
+func TestManagedFormShorthandFalseValueOptsOut(t *testing.T) {
+	node := El("form", Attrs(Attr(ManagedFormShorthandAttr, "false")))
+	want := fmt.Sprintf(`<form %s="false"></form>`, ManagedFormShorthandAttr)
+	if got := RenderHTML(node); got != want {
+		t.Fatalf(`RenderHTML data-gosx-managed="false" = %q, want %q (expected no expansion)`, got, want)
+	}
+}
+
+func TestManagedFormShorthandOmittedLeavesFormUnmanaged(t *testing.T) {
+	node := El("form", Attrs(Attr("action", "/save")))
+	want := `<form action="/save"></form>`
+	if got := RenderHTML(node); got != want {
+		t.Fatalf("RenderHTML unmanaged form = %q, want %q", got, want)
+	}
+}
+
+// TestManagedFormShorthandKeepsAuthorOverride covers the merge rule: an
+// author-specified contract attribute survives with its authored value and
+// is not duplicated by the shorthand's default for the same name.
+func TestManagedFormShorthandKeepsAuthorOverride(t *testing.T) {
+	node := El("form", Attrs(
+		BoolAttr(ManagedFormShorthandAttr),
+		Attr(ManagedFormStateAttr, "pending"),
+	))
+	want := fmt.Sprintf(
+		`<form %s %s="form" %s="bootstrap" %s="native-form" %s="pending"></form>`,
+		ManagedFormAttr, EnhancementAttr, EnhancementLayerAttr, RuntimeFallbackAttr, ManagedFormStateAttr,
+	)
+	got := RenderHTML(node)
+	if got != want {
+		t.Fatalf("RenderHTML shorthand with override = %q, want %q", got, want)
+	}
+	if n := strings.Count(got, ManagedFormStateAttr); n != 1 {
+		t.Fatalf("expected %s to appear once, appeared %d times in %q", ManagedFormStateAttr, n, got)
+	}
+}
+
+// TestManagedFormShorthandNonFormElementLeftUntouched documents the
+// decision to scope expansion to <form> elements only: the managed-form
+// contract (submit interception, native fallback) is meaningless on any
+// other element, so the shorthand attribute passes through unexpanded
+// rather than silently attaching form semantics to, say, a <div>.
+func TestManagedFormShorthandNonFormElementLeftUntouched(t *testing.T) {
+	node := El("div", Attrs(BoolAttr(ManagedFormShorthandAttr)))
+	want := fmt.Sprintf(`<div %s></div>`, ManagedFormShorthandAttr)
+	if got := RenderHTML(node); got != want {
+		t.Fatalf("RenderHTML shorthand on non-form element = %q, want %q", got, want)
+	}
+}
+
+func TestManagedFormShorthandCaseInsensitiveFormTag(t *testing.T) {
+	node := El("FORM", Attrs(BoolAttr(ManagedFormShorthandAttr)))
+	got := RenderHTML(node)
+	for _, want := range []string{ManagedFormAttr, ManagedFormStateAttr, EnhancementAttr, EnhancementLayerAttr, RuntimeFallbackAttr} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("RenderHTML uppercase FORM tag missing %q: %s", want, got)
+		}
+	}
+	if strings.Contains(got, ManagedFormShorthandAttr) {
+		t.Fatalf("RenderHTML uppercase FORM tag left shorthand attribute in place: %s", got)
+	}
+}

--- a/node.go
+++ b/node.go
@@ -205,7 +205,11 @@ func renderNodeHTML(b *strings.Builder, n Node) {
 		safeTag := html.EscapeString(n.tag)
 		b.WriteByte('<')
 		b.WriteString(safeTag)
-		for _, attr := range n.attrs {
+		attrs := n.attrs
+		if strings.EqualFold(n.tag, "form") {
+			attrs = expandManagedFormAttrs(attrs)
+		}
+		for _, attr := range attrs {
 			renderAttrHTML(b, attr)
 		}
 		if isVoidElement(n.tag) && len(n.children) == 0 {
@@ -233,6 +237,72 @@ func renderNodeHTML(b *strings.Builder, n Node) {
 
 	case kindRawHTML:
 		b.WriteString(n.text)
+	}
+}
+
+// expandManagedFormAttrs replaces a truthy ManagedFormShorthandAttr on a
+// <form> element's attribute list with the ManagedFormAttrs default set
+// (state idle, layer bootstrap, fallback native-form). The HTML method
+// attribute, if present on the same element, stays authoritative for the
+// navigation runtime; the shorthand does not add ManagedFormModeAttr.
+//
+// Merge rule: any contract attribute the author already wrote (for example
+// an explicit data-gosx-form-state) is left exactly as authored, in its
+// original position — only the missing contract attributes are inserted,
+// in place of the shorthand attribute. Attribute order and values outside
+// the contract are untouched. If the shorthand attribute is absent, or
+// present but not truthy, attrs is returned unchanged.
+func expandManagedFormAttrs(attrs []nodeAttr) []nodeAttr {
+	idx := -1
+	for i, attr := range attrs {
+		if attr.name == ManagedFormShorthandAttr {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 || !managedFormShorthandTruthy(attrs[idx]) {
+		return attrs
+	}
+
+	have := make(map[string]bool, len(attrs))
+	for _, attr := range attrs {
+		have[attr.name] = true
+	}
+
+	var fill []nodeAttr
+	for _, d := range ManagedFormAttrs(ManagedFormOptions{}) {
+		if !have[d.name] {
+			fill = append(fill, d)
+		}
+	}
+
+	out := make([]nodeAttr, 0, len(attrs)-1+len(fill))
+	out = append(out, attrs[:idx]...)
+	out = append(out, fill...)
+	out = append(out, attrs[idx+1:]...)
+	return out
+}
+
+// managedFormShorthandTruthy reports whether a ManagedFormShorthandAttr
+// value opts the element in. A bare attribute (BoolAttr, presence=true) and
+// any non-empty value other than "false" (case-insensitive) are truthy, so
+// both `data-gosx-managed` and `data-gosx-managed="true"` work from .gsx
+// templates; `data-gosx-managed="false"` is an explicit opt-out.
+func managedFormShorthandTruthy(attr nodeAttr) bool {
+	if attr.presence {
+		return true
+	}
+	switch v := attr.value.(type) {
+	case bool:
+		return v
+	case string:
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return false
+		}
+		return !strings.EqualFold(v, "false")
+	default:
+		return true
 	}
 }
 

--- a/runtime_contract.go
+++ b/runtime_contract.go
@@ -21,6 +21,13 @@ const (
 	// ManagedFormProjectAttr controls framework projection of JSON action
 	// messages and field errors. The default is enabled; "off" opts out.
 	ManagedFormProjectAttr = "data-gosx-form-project"
+	// ManagedFormShorthandAttr is a single-attribute alternative to writing
+	// out the ManagedFormAttrs default set by hand on a <form> element. A
+	// .gsx template author writes `<form data-gosx-managed>` (or
+	// `data-gosx-managed="true"`) instead of the five contract attributes;
+	// RenderHTML expands it on any <form> element at render time. See
+	// expandManagedFormAttrs in node.go for the expansion and merge rules.
+	ManagedFormShorthandAttr = "data-gosx-managed"
 
 	ActionAttr           = "data-gosx-action"
 	ActionResetAttr      = "data-gosx-reset"

--- a/transpile/transpile_test.go
+++ b/transpile/transpile_test.go
@@ -2,6 +2,8 @@ package transpile
 
 import (
 	"errors"
+	"go/parser"
+	"go/token"
 	"strings"
 	"testing"
 
@@ -84,6 +86,71 @@ func Box(attrs gosx.AttrList) Node {
 	}
 	if !strings.Contains(out, `Box(gosx.Props(gosx.Attr("class", "panel")))`) {
 		t.Fatalf("expected attr-list component to keep gosx.Props, got:\n%s", out)
+	}
+}
+
+// TestTranspileManagedFormShorthandRoundTrips covers issue #168: a .gsx
+// author writes the single data-gosx-managed shorthand on a <form> instead
+// of the five-attribute ManagedFormAttrs block. The .gsx grammar needs no
+// change for this — a bare boolean attribute already parses, per
+// emitAttrValue's nil-value branch — so this test only has to confirm the
+// transpiler carries the attribute through to valid Go source unmangled;
+// node_test.go / managed_form_shorthand_test.go in the root package cover
+// what RenderHTML does with the emitted gosx.BoolAttr call.
+func TestTranspileManagedFormShorthandRoundTrips(t *testing.T) {
+	source := []byte(`package main
+
+type Node = gosx.Node
+
+func LoginForm(action string) Node {
+	return <form method="post" action={action} data-gosx-managed>
+		<button type="submit">Log in</button>
+	</form>
+}
+`)
+
+	out, err := Transpile(source, Options{SourceFile: "managed_form.gsx"})
+	if err != nil {
+		t.Fatalf("transpile: %v", err)
+	}
+	if !strings.Contains(out, `gosx.BoolAttr("data-gosx-managed")`) {
+		t.Fatalf("expected the bare shorthand attribute to transpile to gosx.BoolAttr, got:\n%s", out)
+	}
+	if !strings.Contains(out, `gosx.El("form", gosx.Attrs(`) {
+		t.Fatalf("expected the form element to transpile through gosx.El, got:\n%s", out)
+	}
+
+	if _, err := parser.ParseFile(token.NewFileSet(), "managed_form_out.go", out, parser.AllErrors); err != nil {
+		t.Fatalf("transpiled output is not valid Go: %v\n%s", err, out)
+	}
+}
+
+// TestTranspileManagedFormShorthandExplicitValueRoundTrips covers the
+// data-gosx-managed="true" spelling, documented as the explicit-value form
+// of the shorthand for dialects or authors that prefer not to rely on bare
+// boolean attributes.
+func TestTranspileManagedFormShorthandExplicitValueRoundTrips(t *testing.T) {
+	source := []byte(`package main
+
+type Node = gosx.Node
+
+func LoginForm(action string) Node {
+	return <form method="post" action={action} data-gosx-managed="true">
+		<button type="submit">Log in</button>
+	</form>
+}
+`)
+
+	out, err := Transpile(source, Options{SourceFile: "managed_form_explicit.gsx"})
+	if err != nil {
+		t.Fatalf("transpile: %v", err)
+	}
+	if !strings.Contains(out, `gosx.Attr("data-gosx-managed", "true")`) {
+		t.Fatalf(`expected data-gosx-managed="true" to transpile to gosx.Attr, got:`+"\n%s", out)
+	}
+
+	if _, err := parser.ParseFile(token.NewFileSet(), "managed_form_explicit_out.go", out, parser.AllErrors); err != nil {
+		t.Fatalf("transpiled output is not valid Go: %v\n%s", err, out)
 	}
 }
 


### PR DESCRIPTION
## Summary

Introduce a single `data-gosx-managed` boolean attribute as a shorthand for authoring managed forms. At render time, the shorthand expands on `<form>` elements to the standard set of managed form contract attributes, automatically preserving any explicitly authored attributes while keeping the existing runtime behavior intact.

## Changes

- Introduce `data-gosx-managed` as a single-attribute alternative to manually writing the full `ManagedFormAttrs` block, reducing boilerplate in `.gsx` templates.
- Expand the shorthand at render time into the five default contract attributes on `<form>` elements, improving developer ergonomics without changing runtime behavior.
- Implement a merge rule that preserves author-specified attributes in their original positions, preventing duplicate contract markers.
- Restrict expansion exclusively to `<form>` tags to avoid silently attaching form semantics to unrelated elements.
- Support both bare boolean attributes and explicit string values (`"true"`/`"false"`) via updated transpiler validation and expand logic.
- Add comprehensive tests covering render-time expansion, override handling, cross-tag scoping, case-insensitive tags, and transpiler round-trips.

## Testing

- `go test ./... -run TestManagedFormShorthand`
- `go test ./transpile -run TestTranspileManagedFormShorthand`