### PR TITLE
fix: fix data-gosx-managed shorthand expansion and client interception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,28 @@
 # Changelog
 
+## v0.42.2 (2026-08-16)
+
+### Fixed: the managed-form shorthand was inert on .gsx-rendered forms
+
+- **`data-gosx-managed` now expands on forms rendered through the .gsx
+  pipeline, not only through the Go Node API.** v0.42.0 added the shorthand
+  and expanded it in `RenderHTML`, the Go Node API path. The `.gsx`
+  file-program renderer wrote form attributes through a separate path. That
+  path never called the expansion. A `.gsx`-authored form using the
+  shorthand served unmanaged in v0.42.0. The browser fell back to a native
+  full-page POST. `gosx check` gave the author no warning. Fixes #179.
+- The fix closes both render surfaces:
+  - The route package's file-program renderer now calls the same shared
+    expansion rule as `node.go` (`gosx.ManagedFormShorthandTruthy`). A bare
+    attribute or `"true"` expands the form. `"false"` opts out. An
+    author-written `data-gosx-form*` attribute next to the shorthand keeps
+    its authored value; the expansion does not overwrite it.
+  - The navigation runtime now accepts `data-gosx-managed` at the same
+    delegation point it already used for `data-gosx-form`. An island's
+    re-render can build a form entirely in client-side JS. That form is
+    still discovered and intercepted, even when no server render path ever
+    saw it.
+
 ## v0.42.1 (2026-08-16)
 
 ### The render loop runs for time-driven materials

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,26 +2,35 @@
 
 ## v0.42.2 (2026-08-16)
 
-### Fixed: the managed-form shorthand was inert on .gsx-rendered forms
+### Fixed: the managed-form shorthand did not expand consistently across server render surfaces
 
-- **`data-gosx-managed` now expands on forms rendered through the .gsx
-  pipeline, not only through the Go Node API.** v0.42.0 added the shorthand
-  and expanded it in `RenderHTML`, the Go Node API path. The `.gsx`
-  file-program renderer wrote form attributes through a separate path. That
-  path never called the expansion. A `.gsx`-authored form using the
-  shorthand served unmanaged in v0.42.0. The browser fell back to a native
-  full-page POST. `gosx check` gave the author no warning. Fixes #179.
-- The fix closes both render surfaces:
-  - The route package's file-program renderer now calls the same shared
-    expansion rule as `node.go` (`gosx.ManagedFormShorthandTruthy`). A bare
-    attribute or `"true"` expands the form. `"false"` opts out. An
-    author-written `data-gosx-form*` attribute next to the shorthand keeps
-    its authored value; the expansion does not overwrite it.
-  - The navigation runtime now accepts `data-gosx-managed` at the same
-    delegation point it already used for `data-gosx-form`. An island's
-    re-render can build a form entirely in client-side JS. That form is
-    still discovered and intercepted, even when no server render path ever
-    saw it.
+- **`data-gosx-managed` now expands the same way on all three server
+  render surfaces.** v0.42.0 added the shorthand and expanded it only in
+  `RenderHTML`, the Go Node API path. A `.gsx`-authored form using the
+  shorthand served unmanaged: the file-program renderer wrote form
+  attributes through a separate path that never called the expansion. The
+  browser fell back to a native full-page POST. `gosx check` gave the
+  author no warning. Fixes #179.
+- All three server render surfaces now call the same shared rule,
+  `gosx.ManagedFormShorthandTruthy`:
+  - `RenderHTML` (`node.go`), the Go Node API path, for a `gosx.Node` tree
+    built directly in Go.
+  - The route package's file-program renderer, for a `.gsx` page or
+    component served through the file-based router.
+  - The island package's resolved-tree renderer, for a `<form>` inside a
+    server-rendered island's initial HTML.
+
+  A bare attribute, `"true"`, and an empty string (`data-gosx-managed=""`)
+  all expand the form; only `"false"` opts out. An author-written
+  `data-gosx-form*` attribute next to the shorthand — including
+  `data-gosx-form-mode` — keeps its authored value; the expansion fills in
+  only the contract attributes the author did not already write.
+- The navigation runtime now also accepts `data-gosx-managed` on a
+  `<form>` element at the same delegation point it already used for
+  `data-gosx-form`. This covers a form a page builds after the initial
+  render — for example, inside an island's client-side re-render — which
+  no server render surface ever sees. That form is still discovered and
+  intercepted.
 
 ## v0.42.1 (2026-08-16)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Write `.gsx` components with strict typed declarations or ordinary Go-function syntax, compile through a real compiler pipeline, render on the server by default, and hydrate interactive islands with WebAssembly. No app-side JavaScript toolchain. No CGo. A deliberately small dependency budget.
 
-Current release: **v0.42.1**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.42.2**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -847,7 +847,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.42.1**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.42.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -4599,6 +4599,155 @@ test("navigation runtime intercepts managed GET forms and navigates with query p
   assert.equal(form.getAttribute("data-gosx-form-state"), "idle");
 });
 
+// gosx#179: data-gosx-managed is the .gsx template shorthand for the full
+// managed-form contract. The server expands it into data-gosx-form when it
+// can, but a form built by client-side JS (an island's re-render, or
+// hand-authored markup) may never pass through that expansion, so the
+// runtime must also recognize the shorthand directly at the matching level.
+test("navigation runtime intercepts forms carrying only the data-gosx-managed shorthand attribute", async () => {
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", "/search");
+  form.setAttribute("method", "get");
+  form.setAttribute("data-gosx-managed", "true");
+
+  const query = new FakeElement("input", null);
+  query.setAttribute("name", "q");
+  query.value = "shorthand";
+  form.appendChild(query);
+
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      "http://localhost:3000/search?q=shorthand": {
+        text: "__SHORTHAND_DOC__",
+        url: "http://localhost:3000/search?q=shorthand",
+      },
+    },
+    parseHTML(html) {
+      return parsedDocs.get(html);
+    },
+  });
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+
+  const results = new FakeElement("main", null);
+  results.id = "results";
+  results.textContent = "results";
+  parsedDocs.set("__SHORTHAND_DOC__", buildNavigatedDocument({
+    title: "Search",
+    bodyNodes: [results],
+  }));
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  let prevented = false;
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+      this.defaultPrevented = true;
+    },
+  });
+  await flushAsyncWork();
+
+  assert.equal(prevented, true);
+  assert.equal(env.fetchCalls[0].url, "http://localhost:3000/search?q=shorthand");
+  assert.equal(env.context.location.href, "http://localhost:3000/search?q=shorthand");
+});
+
+test("navigation runtime leaves data-gosx-managed=\"false\" forms to native submission", async () => {
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", "/search");
+  form.setAttribute("method", "get");
+  form.setAttribute("data-gosx-managed", "false");
+
+  const query = new FakeElement("input", null);
+  query.setAttribute("name", "q");
+  query.value = "opt-out";
+  form.appendChild(query);
+
+  const env = createContext({ elements: [form] });
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  let prevented = false;
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+      this.defaultPrevented = true;
+    },
+  });
+  await flushAsyncWork();
+
+  assert.equal(prevented, false);
+  assert.equal(env.fetchCalls.length, 0);
+});
+
+test("navigation runtime still intercepts an explicit data-gosx-form=\"true\" form", async () => {
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", "/search");
+  form.setAttribute("method", "get");
+  form.setAttribute("data-gosx-form", "true");
+
+  const query = new FakeElement("input", null);
+  query.setAttribute("name", "q");
+  query.value = "explicit";
+  form.appendChild(query);
+
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      "http://localhost:3000/search?q=explicit": {
+        text: "__EXPLICIT_DOC__",
+        url: "http://localhost:3000/search?q=explicit",
+      },
+    },
+    parseHTML(html) {
+      return parsedDocs.get(html);
+    },
+  });
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+
+  const results = new FakeElement("main", null);
+  results.id = "results";
+  results.textContent = "results";
+  parsedDocs.set("__EXPLICIT_DOC__", buildNavigatedDocument({
+    title: "Search",
+    bodyNodes: [results],
+  }));
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  let prevented = false;
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+      this.defaultPrevented = true;
+    },
+  });
+  await flushAsyncWork();
+
+  assert.equal(prevented, true);
+  assert.equal(env.fetchCalls[0].url, "http://localhost:3000/search?q=explicit");
+  assert.equal(env.context.location.href, "http://localhost:3000/search?q=explicit");
+});
+
 test("navigation runtime restores prior managed form lifecycle attrs after submit", async () => {
   const form = new FakeElement("form", null);
   form.setAttribute("action", "/search");

--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -4692,6 +4692,179 @@ test("navigation runtime leaves data-gosx-managed=\"false\" forms to native subm
   assert.equal(env.fetchCalls.length, 0);
 });
 
+// gosx#179 F5: managedForms/isManagedFormElement scope the
+// data-gosx-managed shorthand branch to <form> elements only, matching
+// every server render path (see managedFormAttrs in route/fileprogram.go
+// and expandIslandManagedFormAttrs in island/island.go, which both leave
+// the shorthand inert on a non-form element). A non-form element carrying
+// the shorthand must not be treated as a managed form or gain form-only
+// lifecycle attributes from refreshManagedForms.
+test("navigation runtime leaves a non-form element carrying data-gosx-managed untouched", async () => {
+  const panel = new FakeElement("div", null);
+  panel.setAttribute("data-gosx-managed", "true");
+
+  const env = createContext({ elements: [panel] });
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  assert.equal(panel.hasAttribute("data-gosx-form-state"), false);
+  assert.equal(panel.hasAttribute("data-gosx-form-mode"), false);
+
+  env.document.eventListeners.get("submit")?.[0]?.({
+    type: "submit",
+    target: panel,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {},
+  });
+  await flushAsyncWork();
+
+  assert.equal(panel.hasAttribute("data-gosx-form-state"), false);
+  assert.equal(panel.hasAttribute("data-gosx-form-mode"), false);
+});
+
+// gosx#179 F7: a bare shorthand attribute (`<form data-gosx-managed>`)
+// serializes through the DOM as `data-gosx-managed=""`, the same value
+// setAttribute(attr, "") produces — this is the case the F3 Go-side fix
+// (a trimmed empty string is truthy) mirrors on the browser side, where
+// managedFormShorthandTruthy already treated it as truthy.
+test("navigation runtime intercepts a bare data-gosx-managed shorthand attribute", async () => {
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", "/search");
+  form.setAttribute("method", "get");
+  form.setAttribute("data-gosx-managed", "");
+
+  const query = new FakeElement("input", null);
+  query.setAttribute("name", "q");
+  query.value = "bare";
+  form.appendChild(query);
+
+  const parsedDocs = new Map();
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      "http://localhost:3000/search?q=bare": {
+        text: "__BARE_DOC__",
+        url: "http://localhost:3000/search?q=bare",
+      },
+    },
+    parseHTML(html) {
+      return parsedDocs.get(html);
+    },
+  });
+  env.context.__gosx_dispose_page = async function() {};
+  env.context.__gosx_bootstrap_page = async function() {};
+
+  const results = new FakeElement("main", null);
+  results.id = "results";
+  results.textContent = "results";
+  parsedDocs.set("__BARE_DOC__", buildNavigatedDocument({
+    title: "Search",
+    bodyNodes: [results],
+  }));
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  let prevented = false;
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+      this.defaultPrevented = true;
+    },
+  });
+  await flushAsyncWork();
+
+  assert.equal(prevented, true);
+  assert.equal(env.fetchCalls[0].url, "http://localhost:3000/search?q=bare");
+  assert.equal(env.context.location.href, "http://localhost:3000/search?q=bare");
+});
+
+// gosx#179's exact reproduction shape: method="post" plus the shorthand,
+// with no data-gosx-form attribute at all. Before the fix this fell back
+// to a native full-page POST because the runtime matched FORM_ATTR only.
+test("navigation runtime intercepts a POST form carrying only the data-gosx-managed shorthand", async () => {
+  const actionURL = "http://localhost:3000/x/__actions/y";
+  const form = new FakeElement("form", null);
+  form.setAttribute("method", "post");
+  form.setAttribute("action", "/x/__actions/y");
+  form.setAttribute("data-gosx-managed", "true");
+
+  const query = new FakeElement("input", null);
+  query.setAttribute("name", "q");
+  query.value = "issue-179";
+  form.appendChild(query);
+
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      [actionURL]: { text: '{"ok":true}', url: actionURL },
+    },
+  });
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+
+  const submitListener = env.document.eventListeners.get("submit")[0];
+  let prevented = false;
+  submitListener({
+    type: "submit",
+    target: form,
+    submitter: null,
+    defaultPrevented: false,
+    preventDefault() {
+      prevented = true;
+      this.defaultPrevented = true;
+    },
+  });
+  await flushAsyncWork();
+
+  assert.equal(prevented, true);
+  assert.equal(env.fetchCalls[0].url, actionURL);
+  assert.equal(env.fetchCalls[0].init.method, "POST");
+  assert.equal(form.getAttribute("data-gosx-form-state"), "success");
+});
+
+// gosx#179 F7 + nativeSubmitForm: a form carrying only the data-gosx-managed
+// shorthand (never expanded server-side) must also fall back to a clean
+// native submission when the managed transport fails. nativeSubmitForm has
+// to strip the shorthand — not just FORM_ATTR — before requestSubmit(), or
+// isManagedFormElement would re-intercept its own fallback submission; it
+// must then restore the exact prior value so the DOM is unchanged afterward.
+test("nativeSubmitForm strips and restores the shorthand attribute around a native fallback submission", async () => {
+  const actionURL = "http://localhost:3000/save";
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", actionURL);
+  form.setAttribute("method", "post");
+  form.setAttribute("data-gosx-managed", "true");
+  const submitter = new FakeElement("button", null);
+  form.appendChild(submitter);
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      [actionURL]() { throw new Error("action transport failed"); },
+    },
+  });
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  env.document.eventListeners.get("submit")[0]({
+    type: "submit",
+    target: form,
+    submitter,
+    defaultPrevented: false,
+    preventDefault() { this.defaultPrevented = true; },
+  });
+  await flushAsyncWork();
+
+  assert.deepEqual(env.fetchCalls.map((call) => call.url), [actionURL]);
+  assert.equal(form.requestSubmitCalls.length, 1);
+  assert.equal(form.requestSubmitCalls[0][0], submitter);
+  assert.equal(form.submitCalls.length, 0);
+  assert.equal(form.getAttribute("data-gosx-managed"), "true");
+});
+
 test("navigation runtime still intercepts an explicit data-gosx-form=\"true\" form", async () => {
   const form = new FakeElement("form", null);
   form.setAttribute("action", "/search");

--- a/client/runtime/host/navigation.ts
+++ b/client/runtime/host/navigation.ts
@@ -17,6 +17,16 @@
   const LINK_PREFETCH_STATE_ATTR = "data-gosx-prefetch-state";
   const LINK_MANAGED_CURRENT_ATTR = "data-gosx-aria-current-managed";
   const FORM_ATTR = "data-gosx-form";
+  // FORM_MANAGED_SHORTHAND_ATTR is the .gsx template shorthand for the full
+  // managed-form contract (gosx#179). The server expands it into FORM_ATTR
+  // and the rest of the contract at render time when it can — see
+  // gosx.ManagedFormShorthandTruthy and route.fileManagedFormShorthandTruthy
+  // in the Go source — but a form built by client-side JS (an island's
+  // re-render, or hand-authored markup that bypasses gosx rendering
+  // entirely) never passes through that expansion. The runtime accepts the
+  // shorthand directly at the matching level so those forms are still
+  // discovered and intercepted.
+  const FORM_MANAGED_SHORTHAND_ATTR = "data-gosx-managed";
   const FORM_MODE_ATTR = "data-gosx-form-mode";
   const FORM_STATE_ATTR = "data-gosx-form-state";
   const FORM_PENDING_ATTR = "data-gosx-pending";
@@ -849,10 +859,34 @@
     }
   }
 
+  // managedFormShorthandTruthy mirrors the server's truthy rule for
+  // FORM_MANAGED_SHORTHAND_ATTR (gosx.ManagedFormShorthandTruthy in the Go
+  // source, the single definition both server render paths call): a bare
+  // attribute is truthy, "false" (case-insensitive) opts out, and any other
+  // non-empty value is truthy so `data-gosx-managed="true"` also works.
+  function managedFormShorthandTruthy(value) {
+    if (value == null) return false;
+    const trimmed = String(value).trim();
+    if (trimmed === "") return true;
+    return trimmed.toLowerCase() !== "false";
+  }
+
+  // isManagedFormElement is the single place the runtime decides whether a
+  // <form> is under managed navigation, so a form still carrying the raw
+  // FORM_MANAGED_SHORTHAND_ATTR (never expanded server-side, or built
+  // directly by client JS) is discovered exactly like one already carrying
+  // the full FORM_ATTR contract.
+  function isManagedFormElement(node) {
+    if (!node || !node.hasAttribute) return false;
+    if (node.hasAttribute(FORM_ATTR)) return true;
+    if (node.hasAttribute(FORM_MANAGED_SHORTHAND_ATTR)) {
+      return managedFormShorthandTruthy(node.getAttribute(FORM_MANAGED_SHORTHAND_ATTR));
+    }
+    return false;
+  }
+
   function managedForms(root) {
-    return collectElements(root, function(node) {
-      return node.hasAttribute && node.hasAttribute(FORM_ATTR);
-    });
+    return collectElements(root, isManagedFormElement);
   }
 
   function normalizeManagedFormMode(value) {
@@ -1505,7 +1539,7 @@
   }
 
   function shouldHandleForm(form, event) {
-    if (!form || !form.hasAttribute || !form.hasAttribute(FORM_ATTR)) return false;
+    if (!isManagedFormElement(form)) return false;
     if (event.defaultPrevented) return false;
     const submitter = event && event.submitter ? event.submitter : null;
     if (formSubmitTarget(form, submitter)) return false;
@@ -1964,12 +1998,18 @@
   }
 
   function nativeSubmitForm(form, submitter) {
-    if (!form) return;
-    const previousManaged = form.getAttribute(FORM_ATTR);
-    if (previousManaged == null) {
-      return;
-    }
-    form.removeAttribute(FORM_ATTR);
+    if (!form || !isManagedFormElement(form)) return;
+    // Strip every attribute that makes isManagedFormElement true — FORM_ATTR
+    // and/or the shorthand — so form.requestSubmit() below dispatches a
+    // fresh "submit" event that shouldHandleForm lets through natively,
+    // instead of re-intercepting it. Both are restored once the native
+    // submission has been requested.
+    const hadForm = form.hasAttribute(FORM_ATTR);
+    const previousForm = hadForm ? form.getAttribute(FORM_ATTR) : null;
+    const hadShorthand = form.hasAttribute(FORM_MANAGED_SHORTHAND_ATTR);
+    const previousShorthand = hadShorthand ? form.getAttribute(FORM_MANAGED_SHORTHAND_ATTR) : null;
+    if (hadForm) form.removeAttribute(FORM_ATTR);
+    if (hadShorthand) form.removeAttribute(FORM_MANAGED_SHORTHAND_ATTR);
     try {
       if (typeof form.requestSubmit === "function") {
         if (submitter) {
@@ -1987,7 +2027,8 @@
         form.submit();
       }
     } finally {
-      form.setAttribute(FORM_ATTR, previousManaged);
+      if (hadForm) form.setAttribute(FORM_ATTR, previousForm);
+      if (hadShorthand) form.setAttribute(FORM_MANAGED_SHORTHAND_ATTR, previousShorthand);
     }
   }
 

--- a/client/runtime/host/navigation.ts
+++ b/client/runtime/host/navigation.ts
@@ -861,9 +861,14 @@
 
   // managedFormShorthandTruthy mirrors the server's truthy rule for
   // FORM_MANAGED_SHORTHAND_ATTR (gosx.ManagedFormShorthandTruthy in the Go
-  // source, the single definition both server render paths call): a bare
-  // attribute is truthy, "false" (case-insensitive) opts out, and any other
-  // non-empty value is truthy so `data-gosx-managed="true"` also works.
+  // source, the single definition all three server render paths call): a
+  // bare attribute and its `=""` spelling are indistinguishable once
+  // parsed and both are truthy, "false" (case-insensitive, surrounding
+  // whitespace ignored) opts out, and any other value is truthy — so
+  // `data-gosx-managed`, `data-gosx-managed=""`, and
+  // `data-gosx-managed="true"` all opt in. A null value (the attribute is
+  // absent) is falsy; isManagedFormElement below only calls this after
+  // confirming the attribute exists, so that branch is defensive only.
   function managedFormShorthandTruthy(value) {
     if (value == null) return false;
     const trimmed = String(value).trim();
@@ -876,10 +881,19 @@
   // FORM_MANAGED_SHORTHAND_ATTR (never expanded server-side, or built
   // directly by client JS) is discovered exactly like one already carrying
   // the full FORM_ATTR contract.
+  //
+  // The shorthand branch below is scoped to <form> elements only (gosx#179
+  // F5): every server render path leaves the shorthand inert on a non-form
+  // element (see managedFormAttrs in route/fileprogram.go), so a
+  // data-gosx-managed on, say, a <div> is not a managed form and must not
+  // gain form-only lifecycle attributes (data-gosx-form-mode,
+  // data-gosx-form-state) from refreshManagedForms. FORM_ATTR is left
+  // unguarded: it is a framework-written attribute, never hand-authored on
+  // a non-form element, so no equivalent risk exists there.
   function isManagedFormElement(node) {
     if (!node || !node.hasAttribute) return false;
     if (node.hasAttribute(FORM_ATTR)) return true;
-    if (node.hasAttribute(FORM_MANAGED_SHORTHAND_ATTR)) {
+    if (isElement(node, "FORM") && node.hasAttribute(FORM_MANAGED_SHORTHAND_ATTR)) {
       return managedFormShorthandTruthy(node.getAttribute(FORM_MANAGED_SHORTHAND_ATTR));
     }
     return false;

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.42.1"
+const Current = "v0.42.2"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.42.1"
+const Number = "0.42.2"
 
 // MinGo is the lowest Go toolchain release that can build GoSX. It must equal
 // the go directive in the repository go.mod.

--- a/island/island.go
+++ b/island/island.go
@@ -1447,7 +1447,11 @@ func renderResolvedNodeInto(b *strings.Builder, resolved *vm.ResolvedTree, nodeI
 	b.WriteByte('<')
 	b.WriteString(safeTag)
 
-	for _, attr := range renderResolvedAttrs(&node, path) {
+	attrs := renderResolvedAttrs(&node, path)
+	if strings.EqualFold(node.Tag, "form") {
+		attrs = expandIslandManagedFormAttrs(attrs)
+	}
+	for _, attr := range attrs {
 		safeName := html.EscapeString(attr.Name)
 		if attr.Bool {
 			b.WriteByte(' ')
@@ -1471,6 +1475,71 @@ func renderResolvedNodeInto(b *strings.Builder, resolved *vm.ResolvedTree, nodeI
 	b.WriteString("</")
 	b.WriteString(safeTag)
 	b.WriteByte('>')
+}
+
+// expandIslandManagedFormAttrs applies the data-gosx-managed shorthand
+// expansion to a resolved <form> element's attributes (gosx#179 F2). Before
+// this, the island renderer was a third form-rendering surface that never
+// expanded the shorthand: it copied a resolved node's attributes straight
+// through, so a served island form kept the raw shorthand attribute
+// instead of the managed-form contract. The browser navigation runtime
+// still intercepted it — see managedFormShorthandTruthy in
+// client/runtime/host/navigation.ts — so the form was never left both
+// un-expanded and un-managed, but the server HTML did not match the other
+// two render paths' output.
+//
+// This mirrors node.go's expandManagedFormAttrs: it calls the same shared
+// truthy rule (gosx.ManagedFormShorthandTruthy) and inserts the same
+// default contract attributes in place of the shorthand attribute, only
+// filling in a contract attribute the author has not already written.
+// Like the other two render paths, it does not add
+// gosx.ManagedFormModeAttr — the HTML method attribute, if present, stays
+// authoritative for the navigation runtime. If the shorthand attribute is
+// absent, or present but not truthy, attrs is returned unchanged.
+func expandIslandManagedFormAttrs(attrs []vm.ResolvedAttr) []vm.ResolvedAttr {
+	idx := -1
+	for i, attr := range attrs {
+		if attr.Name == gosx.ManagedFormShorthandAttr {
+			idx = i
+			break
+		}
+	}
+	if idx < 0 {
+		return attrs
+	}
+	shorthand := attrs[idx]
+	var value any
+	if !shorthand.Bool {
+		value = shorthand.Value
+	}
+	if !gosx.ManagedFormShorthandTruthy(shorthand.Bool, value) {
+		return attrs
+	}
+
+	have := make(map[string]bool, len(attrs))
+	for _, attr := range attrs {
+		have[attr.Name] = true
+	}
+
+	defaults := []vm.ResolvedAttr{
+		{Name: gosx.ManagedFormAttr, Bool: true},
+		{Name: gosx.ManagedFormStateAttr, Value: "idle"},
+		{Name: gosx.EnhancementAttr, Value: "form"},
+		{Name: gosx.EnhancementLayerAttr, Value: "bootstrap"},
+		{Name: gosx.RuntimeFallbackAttr, Value: "native-form"},
+	}
+	var fill []vm.ResolvedAttr
+	for _, d := range defaults {
+		if !have[d.Name] {
+			fill = append(fill, d)
+		}
+	}
+
+	out := make([]vm.ResolvedAttr, 0, len(attrs)-1+len(fill))
+	out = append(out, attrs[:idx]...)
+	out = append(out, fill...)
+	out = append(out, attrs[idx+1:]...)
+	return out
 }
 
 func renderResolvedAttrs(node *vm.ResolvedNode, path string) []vm.ResolvedAttr {

--- a/island/island_test.go
+++ b/island/island_test.go
@@ -1108,6 +1108,120 @@ func TestRenderIslandFromProgramRendersDynamicAttrs(t *testing.T) {
 	}
 }
 
+// hasIslandManagedFormAttr reports whether html contains the bare
+// gosx.ManagedFormAttr contract attribute as its own attribute, not merely
+// as a prefix of a longer attribute sharing the same name (for example
+// data-gosx-form-state) — see hasManagedFormAttr in
+// route/managed_form_shorthand_test.go for the same rule applied to the
+// file-program renderer's output.
+func hasIslandManagedFormAttr(html string) bool {
+	return strings.Contains(html, " "+gosx.ManagedFormAttr+" ") ||
+		strings.Contains(html, " "+gosx.ManagedFormAttr+">")
+}
+
+// TestRenderIslandFromProgramExpandsManagedFormShorthand covers gosx#179
+// F2: the island renderer was a third form render surface that never
+// expanded data-gosx-managed. renderResolvedNodeInto (called through
+// RenderIslandFromProgram -> renderProgramHTML -> RenderResolvedHTML) used
+// to copy a resolved <form> node's attributes straight through, so an
+// island form authored with the shorthand served with the raw attribute
+// instead of the managed-form contract, unlike the same shorthand on a
+// .gsx page rendered outside an island (route/fileprogram.go) or through
+// the Go Node API (node.go). The navigation runtime still intercepted the
+// unexpanded form client-side, so this was never a fail-open bug — only a
+// mismatch between what the three render surfaces served.
+func TestRenderIslandFromProgramExpandsManagedFormShorthand(t *testing.T) {
+	r := NewRenderer("main")
+	r.SetBundle("main", "/gosx/runtime.wasm")
+	r.SetProgramDir("/gosx/islands")
+
+	prog := &program.Program{
+		Name: "ShorthandForm",
+		Nodes: []program.Node{
+			{ // 0: form root, bare shorthand
+				Kind: program.NodeElement,
+				Tag:  "form",
+				Attrs: []program.Attr{
+					{Kind: program.AttrStatic, Name: "method", Value: "post"},
+					{Kind: program.AttrStatic, Name: "action", Value: "/x/__actions/y"},
+					{Kind: program.AttrBool, Name: "data-gosx-managed"},
+				},
+				Children: []program.NodeID{1},
+			},
+			{ // 1: input
+				Kind: program.NodeElement,
+				Tag:  "input",
+				Attrs: []program.Attr{
+					{Kind: program.AttrStatic, Name: "name", Value: "q"},
+				},
+			},
+		},
+		Root: 0,
+	}
+
+	node := r.RenderIslandFromProgram(prog, nil)
+	html := gosx.RenderHTML(node)
+
+	for _, want := range []string{
+		`method="post"`,
+		`action="/x/__actions/y"`,
+		gosx.ManagedFormStateAttr + `="idle"`,
+		gosx.EnhancementAttr + `="form"`,
+		gosx.EnhancementLayerAttr + `="bootstrap"`,
+		gosx.RuntimeFallbackAttr + `="native-form"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in island-rendered managed-shorthand form html %q", want, html)
+		}
+	}
+	if !hasIslandManagedFormAttr(html) {
+		t.Fatalf("expected the bare %s attribute in island-rendered form html %q", gosx.ManagedFormAttr, html)
+	}
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute removed from island output, got %q", html)
+	}
+	// The shorthand must not add a mode attribute — the HTML method
+	// attribute stays authoritative, matching node.go's and the
+	// file-program renderer's expansion rule.
+	if strings.Contains(html, gosx.ManagedFormModeAttr) {
+		t.Fatalf("expected no %s from the shorthand alone, got %q", gosx.ManagedFormModeAttr, html)
+	}
+}
+
+// TestRenderIslandFromProgramManagedFormShorthandFalseOptsOut is the
+// island-render counterpart to the .gsx and Node-API opt-out tests: a
+// falsy shorthand value must not expand, and must survive unchanged.
+func TestRenderIslandFromProgramManagedFormShorthandFalseOptsOut(t *testing.T) {
+	r := NewRenderer("main")
+	r.SetBundle("main", "/gosx/runtime.wasm")
+	r.SetProgramDir("/gosx/islands")
+
+	prog := &program.Program{
+		Name: "ShorthandFormOptOut",
+		Nodes: []program.Node{
+			{
+				Kind: program.NodeElement,
+				Tag:  "form",
+				Attrs: []program.Attr{
+					{Kind: program.AttrStatic, Name: "action", Value: "/x/__actions/y"},
+					{Kind: program.AttrStatic, Name: "data-gosx-managed", Value: "false"},
+				},
+			},
+		},
+		Root: 0,
+	}
+
+	node := r.RenderIslandFromProgram(prog, nil)
+	html := gosx.RenderHTML(node)
+
+	if !strings.Contains(html, `data-gosx-managed="false"`) {
+		t.Fatalf("expected the literal opt-out attribute in island output, got %q", html)
+	}
+	if hasIslandManagedFormAttr(html) {
+		t.Fatalf("expected no expansion for data-gosx-managed=\"false\" in island output, got %q", html)
+	}
+}
+
 func TestLoadDefaultBuildManifestRespectsSetManifestRoot(t *testing.T) {
 	// Create a temp dir with a build.json
 	dir := t.TempDir()

--- a/managed_form_shorthand_test.go
+++ b/managed_form_shorthand_test.go
@@ -81,6 +81,28 @@ func TestManagedFormShorthandNonFormElementLeftUntouched(t *testing.T) {
 	}
 }
 
+// TestManagedFormShorthandEmptyStringValueIsTruthy covers gosx#179 F3: a
+// trimmed empty string (data-gosx-managed="") expands the same way as the
+// bare attribute. A bare HTML boolean attribute and its `=""` spelling are
+// indistinguishable once parsed, so the two must not diverge.
+func TestManagedFormShorthandEmptyStringValueIsTruthy(t *testing.T) {
+	node := El("form", Attrs(Attr(ManagedFormShorthandAttr, "")))
+	if got, want := RenderHTML(node), wantManagedFormDefaults(); got != want {
+		t.Fatalf(`RenderHTML data-gosx-managed="" = %q, want %q`, got, want)
+	}
+}
+
+// TestManagedFormShorthandTruthyTreatsNilAsAbsent covers gosx#179 F3's nil
+// alignment: ManagedFormShorthandTruthy(false, nil) must return false, the
+// same "not present" judgment fileManagedFormShorthandTruthy
+// (route/fileprogram.go) always made for a nil attrValue result, so the two
+// callers agree without either one special-casing nil itself.
+func TestManagedFormShorthandTruthyTreatsNilAsAbsent(t *testing.T) {
+	if got := ManagedFormShorthandTruthy(false, nil); got {
+		t.Fatalf("ManagedFormShorthandTruthy(false, nil) = %v, want false", got)
+	}
+}
+
 func TestManagedFormShorthandCaseInsensitiveFormTag(t *testing.T) {
 	node := El("FORM", Attrs(BoolAttr(ManagedFormShorthandAttr)))
 	got := RenderHTML(node)

--- a/node.go
+++ b/node.go
@@ -284,26 +284,13 @@ func expandManagedFormAttrs(attrs []nodeAttr) []nodeAttr {
 }
 
 // managedFormShorthandTruthy reports whether a ManagedFormShorthandAttr
-// value opts the element in. A bare attribute (BoolAttr, presence=true) and
-// any non-empty value other than "false" (case-insensitive) are truthy, so
-// both `data-gosx-managed` and `data-gosx-managed="true"` work from .gsx
-// templates; `data-gosx-managed="false"` is an explicit opt-out.
+// value opts the element in. It delegates to ManagedFormShorthandTruthy
+// (runtime_contract.go), the single shared definition of the truthy rule
+// used by both this Node render path and the route package's .gsx render
+// path, so `data-gosx-managed` and `data-gosx-managed="true"` opt in and
+// `data-gosx-managed="false"` opts out the same way in either surface.
 func managedFormShorthandTruthy(attr nodeAttr) bool {
-	if attr.presence {
-		return true
-	}
-	switch v := attr.value.(type) {
-	case bool:
-		return v
-	case string:
-		v = strings.TrimSpace(v)
-		if v == "" {
-			return false
-		}
-		return !strings.EqualFold(v, "false")
-	default:
-		return true
-	}
+	return ManagedFormShorthandTruthy(attr.presence, attr.value)
 }
 
 func renderAttrHTML(b *strings.Builder, attr nodeAttr) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -124,12 +124,27 @@ func (r *fileProgramRenderer) writeNode(b *strings.Builder, nodeID ir.NodeID, en
 
 func (r *fileProgramRenderer) writeElement(b *strings.Builder, node *ir.Node, env fileRenderEnv) {
 	tag := html.EscapeString(node.Tag)
-	formContract := fileAutoManagedFormContract(node.Attrs, env, strings.EqualFold(node.Tag, "form"))
+	isForm := strings.EqualFold(node.Tag, "form")
+	formContract := fileAutoManagedFormContract(node.Attrs, env, isForm)
+	// gosx#179: a <form data-gosx-managed> shorthand attribute expands the
+	// same way here as it does through node.go's RenderHTML (Go Node API
+	// path) — see fileManagedFormShorthandTruthy and
+	// gosx.ManagedFormShorthandTruthy, the shared truthy rule both paths
+	// call. Unlike the method-based auto-detection above, the shorthand
+	// does not set a mode: the HTML method attribute, if present, stays
+	// authoritative for the navigation runtime.
+	shorthandManaged := isForm && fileManagedFormShorthandTruthy(node.Attrs, env)
+	if shorthandManaged {
+		formContract.Managed = true
+	}
 	b.WriteByte('<')
 	b.WriteString(tag)
 	attrs := node.Attrs
+	if shorthandManaged {
+		attrs = stripManagedFormShorthandAttr(attrs)
+	}
 	if formContract.Managed {
-		attrs = managedFormAttrs(node.Attrs)
+		attrs = managedFormAttrs(attrs)
 	}
 	r.renderAttrs(b, attrs, env)
 	r.writeManagedFormContract(b, node.Attrs, env, formContract)
@@ -1618,6 +1633,39 @@ func managedFormAttrs(attrs []ir.Attr) []ir.Attr {
 	for _, attr := range attrs {
 		switch strings.TrimSpace(attr.Name) {
 		case "actionName", server.NavigationFormModeAttr:
+			continue
+		}
+		out = append(out, attr)
+	}
+	return out
+}
+
+// fileManagedFormShorthandTruthy reports whether attrs carries a truthy
+// gosx.ManagedFormShorthandAttr (data-gosx-managed). attrValue already
+// resolves a static value, a dynamic {expr} attribute expression, an
+// AttrBool presence attribute, and a spread attribute to the same "value
+// present or not" shape, so this covers every way the shorthand can appear
+// in a .gsx template. A nil result — the attribute is absent, or a dynamic
+// expression evaluated to nil — means "not present"; only a value that
+// exists is handed to gosx.ManagedFormShorthandTruthy for the truthy
+// judgment, matching how node.go only calls its truthy check once it has
+// found the attribute in the list.
+func fileManagedFormShorthandTruthy(attrs []ir.Attr, env fileRenderEnv) bool {
+	value := attrValue(attrs, env, gosx.ManagedFormShorthandAttr)
+	if value == nil {
+		return false
+	}
+	return gosx.ManagedFormShorthandTruthy(false, value)
+}
+
+// stripManagedFormShorthandAttr removes the data-gosx-managed attribute
+// from attrs. Called only once the shorthand has expanded, matching
+// node.go's rule that the shorthand attribute itself does not survive into
+// the rendered output.
+func stripManagedFormShorthandAttr(attrs []ir.Attr) []ir.Attr {
+	out := make([]ir.Attr, 0, len(attrs))
+	for _, attr := range attrs {
+		if attr.Name == gosx.ManagedFormShorthandAttr {
 			continue
 		}
 		out = append(out, attr)

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -128,11 +128,12 @@ func (r *fileProgramRenderer) writeElement(b *strings.Builder, node *ir.Node, en
 	formContract := fileAutoManagedFormContract(node.Attrs, env, isForm)
 	// gosx#179: a <form data-gosx-managed> shorthand attribute expands the
 	// same way here as it does through node.go's RenderHTML (Go Node API
-	// path) — see fileManagedFormShorthandTruthy and
-	// gosx.ManagedFormShorthandTruthy, the shared truthy rule both paths
-	// call. Unlike the method-based auto-detection above, the shorthand
-	// does not set a mode: the HTML method attribute, if present, stays
-	// authoritative for the navigation runtime.
+	// path) and the island package's resolved-tree renderer — see
+	// fileManagedFormShorthandTruthy and gosx.ManagedFormShorthandTruthy,
+	// the shared truthy rule all three render paths call. Unlike the
+	// method-based auto-detection above, the shorthand does not set a
+	// mode: the HTML method attribute, if present, stays authoritative
+	// for the navigation runtime.
 	shorthandManaged := isForm && fileManagedFormShorthandTruthy(node.Attrs, env)
 	if shorthandManaged {
 		formContract.Managed = true
@@ -140,13 +141,20 @@ func (r *fileProgramRenderer) writeElement(b *strings.Builder, node *ir.Node, en
 	b.WriteByte('<')
 	b.WriteString(tag)
 	attrs := node.Attrs
+	// excludeSpreadKey filters the shorthand key back out of a
+	// {...extra}-supplied spread map, matching stripManagedFormShorthandAttr's
+	// removal of a directly-written shorthand attribute above (gosx#179 F4).
+	// Only set once the shorthand has actually expanded — an opted-out or
+	// absent shorthand must stay visible in the output exactly as authored.
+	excludeSpreadKey := ""
 	if shorthandManaged {
 		attrs = stripManagedFormShorthandAttr(attrs)
+		excludeSpreadKey = gosx.ManagedFormShorthandAttr
 	}
 	if formContract.Managed {
-		attrs = managedFormAttrs(attrs)
+		attrs = managedFormAttrs(attrs, formContract.Mode)
 	}
-	r.renderAttrs(b, attrs, env)
+	r.renderAttrs(b, attrs, env, excludeSpreadKey)
 	r.writeManagedFormContract(b, node.Attrs, env, formContract)
 	// Match node.go's renderNodeHTML: only self-close a void element that has
 	// no children. The old branch dropped children silently.
@@ -487,7 +495,13 @@ func (r *fileProgramRenderer) writeManagedForm(b *strings.Builder, node *ir.Node
 	if action := strings.TrimSpace(opts.defaultAction); action != "" && attrValue(node.Attrs, env, "action") == nil {
 		fmt.Fprintf(b, ` action="%s"`, html.EscapeString(action))
 	}
-	r.renderAttrs(b, managedFormAttrs(node.Attrs), env)
+	// The <Form>/<ActionForm> builtins are always managed, so an author-
+	// written data-gosx-managed shorthand alongside them is always noise —
+	// strip it (both a directly-written and a {...extra}-supplied copy)
+	// instead of rendering it beside the full contract it did nothing to
+	// produce (gosx#179 F9).
+	attrs := stripManagedFormShorthandAttr(node.Attrs)
+	r.renderAttrs(b, managedFormAttrs(attrs, contract.Mode), env, gosx.ManagedFormShorthandAttr)
 	r.writeManagedFormContract(b, node.Attrs, env, contract)
 	b.WriteByte('>')
 	r.writeChildren(b, node.Children, env)
@@ -1095,9 +1109,14 @@ func (r *fileProgramRenderer) renderChildren(children []ir.NodeID, env fileRende
 	return b.String()
 }
 
-func (r *fileProgramRenderer) renderAttrs(b *strings.Builder, attrs []ir.Attr, env fileRenderEnv) {
+// renderAttrs writes attrs as HTML attribute text. excludeSpreadKey, when
+// non-empty, drops a matching key out of any {...spread} attribute's
+// evaluated map before it renders (gosx#179 F4) — used to keep an already-
+// expanded data-gosx-managed shorthand from surviving into the output when
+// it was only supplied through a spread instead of written directly.
+func (r *fileProgramRenderer) renderAttrs(b *strings.Builder, attrs []ir.Attr, env fileRenderEnv, excludeSpreadKey string) {
 	for _, attr := range attrs {
-		renderFileAttr(b, attr, env)
+		renderFileAttr(b, attr, env, excludeSpreadKey)
 	}
 }
 
@@ -1137,7 +1156,7 @@ func writeFileAttrName(b *strings.Builder, name string) {
 	b.WriteString(name)
 }
 
-func renderFileAttr(b *strings.Builder, attr ir.Attr, env fileRenderEnv) {
+func renderFileAttr(b *strings.Builder, attr ir.Attr, env fileRenderEnv, excludeSpreadKey string) {
 	name := html.EscapeString(attr.Name)
 	switch attr.Kind {
 	case ir.AttrStatic:
@@ -1147,14 +1166,14 @@ func renderFileAttr(b *strings.Builder, attr ir.Attr, env fileRenderEnv) {
 	case ir.AttrBool:
 		writeFileAttrName(b, name)
 	case ir.AttrSpread:
-		renderFileSpreadAttrs(b, evalFileExpr(attr.Expr, env))
+		renderFileSpreadAttrs(b, evalFileExpr(attr.Expr, env), excludeSpreadKey)
 	}
 }
 
-func renderFileSpreadAttrs(b *strings.Builder, value any) {
+func renderFileSpreadAttrs(b *strings.Builder, value any, excludeKey string) {
 	for _, entry := range sortedSpreadProps(value) {
 		normalized := normalizeFileAttrName(entry.Key)
-		if normalized == "" {
+		if normalized == "" || normalized == excludeKey {
 			continue
 		}
 		renderFileEvaluatedAttr(b, normalized, entry.Value)
@@ -1628,12 +1647,25 @@ func normalizeFileAttrName(name string) string {
 	}
 }
 
-func managedFormAttrs(attrs []ir.Attr) []ir.Attr {
+// managedFormAttrs drops the attributes the managed-form contract writes
+// itself so they are not duplicated: actionName (an ActionForm prop, never
+// real HTML) always, and server.NavigationFormModeAttr only when the
+// contract computed its own mode (contractMode != ""), because that mode
+// is about to be written by writeManagedFormContract. When contractMode is
+// "" — the common case for the data-gosx-managed shorthand, which never
+// computes a mode of its own (gosx#179 F1) — an author-written
+// data-gosx-form-mode is left in attrs untouched, so it survives into the
+// output instead of silently disappearing.
+func managedFormAttrs(attrs []ir.Attr, contractMode string) []ir.Attr {
 	out := make([]ir.Attr, 0, len(attrs))
 	for _, attr := range attrs {
 		switch strings.TrimSpace(attr.Name) {
-		case "actionName", server.NavigationFormModeAttr:
+		case "actionName":
 			continue
+		case server.NavigationFormModeAttr:
+			if contractMode != "" {
+				continue
+			}
 		}
 		out = append(out, attr)
 	}
@@ -1645,17 +1677,14 @@ func managedFormAttrs(attrs []ir.Attr) []ir.Attr {
 // resolves a static value, a dynamic {expr} attribute expression, an
 // AttrBool presence attribute, and a spread attribute to the same "value
 // present or not" shape, so this covers every way the shorthand can appear
-// in a .gsx template. A nil result — the attribute is absent, or a dynamic
-// expression evaluated to nil — means "not present"; only a value that
-// exists is handed to gosx.ManagedFormShorthandTruthy for the truthy
-// judgment, matching how node.go only calls its truthy check once it has
-// found the attribute in the list.
+// in a .gsx template. attrValue returns nil when the attribute is absent,
+// or when a dynamic expression evaluated to nil; gosx.ManagedFormShorthandTruthy
+// treats a nil value as "not present" and returns false — the same rule
+// node.go and the island renderer apply, so this function delegates the
+// whole judgment (including the nil case) to the one shared definition
+// instead of special-casing nil here too.
 func fileManagedFormShorthandTruthy(attrs []ir.Attr, env fileRenderEnv) bool {
-	value := attrValue(attrs, env, gosx.ManagedFormShorthandAttr)
-	if value == nil {
-		return false
-	}
-	return gosx.ManagedFormShorthandTruthy(false, value)
+	return gosx.ManagedFormShorthandTruthy(false, attrValue(attrs, env, gosx.ManagedFormShorthandAttr))
 }
 
 // stripManagedFormShorthandAttr removes the data-gosx-managed attribute

--- a/route/fileprogram_boolean_attr_test.go
+++ b/route/fileprogram_boolean_attr_test.go
@@ -15,7 +15,7 @@ func TestFileRendererUsesNamedHTMLBooleanSemantics(t *testing.T) {
 	renderFileEvaluatedAttr(&b, "checked", true)
 	renderFileEvaluatedAttr(&b, "aria-pressed", false)
 	renderFileEvaluatedAttr(&b, "spellcheck", false)
-	renderFileAttr(&b, ir.Attr{Kind: ir.AttrStatic, Name: "hidden", Value: "until-found"}, fileRenderEnv{})
+	renderFileAttr(&b, ir.Attr{Kind: ir.AttrStatic, Name: "hidden", Value: "until-found"}, fileRenderEnv{}, "")
 	html := b.String()
 
 	if strings.Contains(html, `hidden="false"`) || strings.Contains(html, `required="false"`) {

--- a/route/filesystem_test.go
+++ b/route/filesystem_test.go
@@ -2281,6 +2281,65 @@ func Page() Node {
 	}
 }
 
+// TestRouterAddDirServesPageWithManagedFormShorthand is the httptest
+// end-to-end assertion gosx#179 F7 asks for: a real page file, served over
+// the same file-based router a dev/prod server uses, whose form carries
+// only the data-gosx-managed shorthand. This closes the exact wrong-layer
+// loop that produced #179 — earlier server-render tests in this package
+// call RenderProgramComponent directly, which proved the file-program
+// renderer expands the shorthand but not that a request through the full
+// file router actually reaches that code path.
+func TestRouterAddDirServesPageWithManagedFormShorthand(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", `package docs
+
+func Page() Node {
+	return <main>
+		<form method="post" action="/save" data-gosx-managed>
+			<input name="q"></input>
+		</form>
+	</main>
+}
+`)
+
+	router := NewRouter()
+	router.SetLayout(func(ctx *RouteContext, body gosx.Node) gosx.Node {
+		return server.HTMLDocument(ctx.Title("Docs"), ctx.Head(), body)
+	})
+	if err := router.AddDir(root, FileRoutesOptions{}); err != nil {
+		t.Fatal(err)
+	}
+
+	handler := router.Build()
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	body := w.Body.String()
+	for _, want := range []string{
+		`method="post"`,
+		`action="/save"`,
+		gosx.ManagedFormStateAttr + `="idle"`,
+		gosx.EnhancementAttr + `="form"`,
+		gosx.EnhancementLayerAttr + `="bootstrap"`,
+		gosx.RuntimeFallbackAttr + `="native-form"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("expected %q in served page html, got %q", want, body)
+		}
+	}
+	if !strings.Contains(body, " "+gosx.ManagedFormAttr+" ") && !strings.Contains(body, " "+gosx.ManagedFormAttr+">") {
+		t.Fatalf("expected the bare %s attribute in served page html, got %q", gosx.ManagedFormAttr, body)
+	}
+	if strings.Contains(body, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute stripped from served html, got %q", body)
+	}
+}
+
 func TestRouterAddDirComposesDefaultAndNestedFileLayoutsWithRouteGroups(t *testing.T) {
 	root := t.TempDir()
 	writeRouteFile(t, root, "layout.gsx", `package docs

--- a/route/managed_form_shorthand_test.go
+++ b/route/managed_form_shorthand_test.go
@@ -19,6 +19,20 @@ import (
 // renderer in this package lowers .gsx templates and wrote attributes
 // through its own path, which never called the shared expansion helper.
 
+// hasManagedFormAttr reports whether html contains the bare
+// gosx.ManagedFormAttr contract attribute as its own attribute — not
+// merely as a prefix of a longer attribute that happens to share the name,
+// such as data-gosx-form-state or data-gosx-form-mode. A plain
+// strings.Contains(html, gosx.ManagedFormAttr) check passes on either of
+// those alone, which would let a regression that dropped the bare
+// attribute go undetected (gosx#179 F6). The bare attribute is always
+// preceded by a space (it never opens a tag), and is followed by either
+// another space (another attribute follows) or the tag's closing ">".
+func hasManagedFormAttr(html string) bool {
+	return strings.Contains(html, " "+gosx.ManagedFormAttr+" ") ||
+		strings.Contains(html, " "+gosx.ManagedFormAttr+">")
+}
+
 func compileManagedFormFixture(t *testing.T, formOpenTag string) string {
 	t.Helper()
 	src := "package docs\n\n" +
@@ -46,7 +60,6 @@ func TestFileRendererExpandsManagedFormShorthandTrue(t *testing.T) {
 	for _, want := range []string{
 		`method="post"`,
 		`action="/x/__actions/y"`,
-		gosx.ManagedFormAttr,
 		gosx.ManagedFormStateAttr + `="idle"`,
 		gosx.EnhancementAttr + `="form"`,
 		gosx.EnhancementLayerAttr + `="bootstrap"`,
@@ -55,6 +68,9 @@ func TestFileRendererExpandsManagedFormShorthandTrue(t *testing.T) {
 		if !strings.Contains(html, want) {
 			t.Fatalf("expected %q in rendered managed-shorthand form html %q", want, html)
 		}
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the bare %s attribute in rendered managed-shorthand form html %q", gosx.ManagedFormAttr, html)
 	}
 	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
 		t.Fatalf("expected shorthand attribute removed from output, got %q", html)
@@ -70,7 +86,6 @@ func TestFileRendererExpandsManagedFormShorthandBare(t *testing.T) {
 	html := compileManagedFormFixture(t, `<form action="/save" data-gosx-managed>`)
 
 	for _, want := range []string{
-		gosx.ManagedFormAttr,
 		gosx.ManagedFormStateAttr + `="idle"`,
 		gosx.EnhancementAttr + `="form"`,
 		gosx.EnhancementLayerAttr + `="bootstrap"`,
@@ -79,6 +94,9 @@ func TestFileRendererExpandsManagedFormShorthandBare(t *testing.T) {
 		if !strings.Contains(html, want) {
 			t.Fatalf("expected %q in rendered bare-shorthand form html %q", want, html)
 		}
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the bare %s attribute in rendered bare-shorthand form html %q", gosx.ManagedFormAttr, html)
 	}
 	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
 		t.Fatalf("expected shorthand attribute removed from output, got %q", html)
@@ -114,7 +132,6 @@ func TestFileRendererManagedFormShorthandKeepsAuthorOverride(t *testing.T) {
 		t.Fatalf("expected %s to appear once, appeared %d times in %q", gosx.ManagedFormStateAttr, n, html)
 	}
 	for _, want := range []string{
-		gosx.ManagedFormAttr,
 		gosx.EnhancementAttr + `="form"`,
 		gosx.EnhancementLayerAttr + `="bootstrap"`,
 		gosx.RuntimeFallbackAttr + `="native-form"`,
@@ -122,6 +139,9 @@ func TestFileRendererManagedFormShorthandKeepsAuthorOverride(t *testing.T) {
 		if !strings.Contains(html, want) {
 			t.Fatalf("expected %q in rendered override html %q", want, html)
 		}
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the bare %s attribute in rendered override html %q", gosx.ManagedFormAttr, html)
 	}
 }
 
@@ -169,7 +189,7 @@ func Page() Node {
 	if err != nil {
 		t.Fatalf("render (managed=true): %v", err)
 	}
-	if !strings.Contains(managedHTML, gosx.ManagedFormAttr) {
+	if !hasManagedFormAttr(managedHTML) {
 		t.Fatalf("expected expansion when the expression evaluates truthy, got %q", managedHTML)
 	}
 	if strings.Contains(managedHTML, gosx.ManagedFormShorthandAttr) {
@@ -184,5 +204,158 @@ func Page() Node {
 	}
 	if strings.Contains(unmanagedHTML, gosx.ManagedFormAttr) {
 		t.Fatalf("expected no expansion when the expression evaluates falsy, got %q", unmanagedHTML)
+	}
+}
+
+// TestFileRendererManagedFormShorthandPreservesAuthorModeAttribute covers
+// gosx#179 F1: managedFormAttrs used to strip server.NavigationFormModeAttr
+// unconditionally, so an author-written data-gosx-form-mode next to the
+// shorthand silently vanished — a managed-GET form (method="post" plus
+// data-gosx-form-mode="get") would then be rewritten to managed POST by
+// the client runtime's refreshManagedForms, which reads the HTML method
+// attribute once no data-gosx-form-mode survives. The fix only strips the
+// mode attribute when the contract computed its own (contractMode != ""),
+// which the shorthand alone never does.
+func TestFileRendererManagedFormShorthandPreservesAuthorModeAttribute(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form method="post" action="/a" data-gosx-form-mode="get" data-gosx-managed>`)
+
+	if !strings.Contains(html, gosx.ManagedFormModeAttr+`="get"`) {
+		t.Fatalf("expected author-written %s=\"get\" to survive, got %q", gosx.ManagedFormModeAttr, html)
+	}
+	if n := strings.Count(html, gosx.ManagedFormModeAttr); n != 1 {
+		t.Fatalf("expected %s to appear once, appeared %d times in %q", gosx.ManagedFormModeAttr, n, html)
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the bare %s attribute in rendered html %q", gosx.ManagedFormAttr, html)
+	}
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute removed from output, got %q", html)
+	}
+}
+
+// TestFileRendererManagedFormShorthandDropsActionNameOnRawForm documents a
+// known, low-impact side effect of the shorthand-expansion strip logic
+// (gosx#179 F8): a raw <form>'s author-written actionName attribute — a
+// prop meaningful only on the <ActionForm> builtin, never real HTML — does
+// not survive expansion. managedFormAttrs strips actionName
+// unconditionally, a rule the F1 fix (which only made the mode-attribute
+// strip conditional) leaves untouched. This has no runtime impact: a raw
+// <form>'s actionName was never valid HTML and the browser ignores it
+// either way.
+func TestFileRendererManagedFormShorthandDropsActionNameOnRawForm(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form method="post" action="/a" actionName="save" data-gosx-managed>`)
+
+	if strings.Contains(html, "actionName") {
+		t.Fatalf("expected actionName stripped from expanded raw <form>, got %q", html)
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the form still expanded, got %q", html)
+	}
+}
+
+// TestFileRendererStripsSpreadSuppliedManagedFormShorthand covers gosx#179
+// F4: stripManagedFormShorthandAttr matches attrs by ir.Attr.Name, but a
+// {...extra}-supplied shorthand has no Name of its own — the key lives
+// inside the spread map's evaluated value, rendered later by
+// renderFileSpreadAttrs. Detection already worked (attrValue searches
+// spread maps too), so the shorthand still expanded; only the strip step
+// missed it, leaving the raw data-gosx-managed key rendered beside the full
+// contract it triggered.
+func TestFileRendererStripsSpreadSuppliedManagedFormShorthand(t *testing.T) {
+	src := []byte(`package docs
+
+func Page() Node {
+	return <main>
+		<form method="post" action="/save" {...extra}>
+			<input name="q" value="docs"></input>
+		</form>
+	</main>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"extra": map[string]any{"data-gosx-managed": "true"}},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the spread-supplied shorthand to expand, got %q", html)
+	}
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected the spread-supplied shorthand key stripped from output, got %q", html)
+	}
+}
+
+// TestFileRendererSpreadShorthandFalseLeavesFormUnmanaged is the opt-out
+// counterpart to the spread-supplied truthy case above: when the
+// spread-supplied value is falsy, the shorthand key must survive exactly
+// as authored, matching the direct-attribute opt-out rule
+// (TestFileRendererManagedFormShorthandFalseOptsOut).
+func TestFileRendererSpreadShorthandFalseLeavesFormUnmanaged(t *testing.T) {
+	src := []byte(`package docs
+
+func Page() Node {
+	return <main>
+		<form method="post" action="/save" {...extra}>
+			<input name="q" value="docs"></input>
+		</form>
+	</main>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"extra": map[string]any{"data-gosx-managed": "false"}},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if !strings.Contains(html, `data-gosx-managed="false"`) {
+		t.Fatalf("expected the literal opt-out attribute in output, got %q", html)
+	}
+	if hasManagedFormAttr(html) {
+		t.Fatalf("expected no expansion for a falsy spread-supplied shorthand, got %q", html)
+	}
+}
+
+// TestFileRendererManagedFormBuiltinStripsShorthand covers gosx#179 F9: the
+// <Form>/<ActionForm> builtins are always managed, so an author-written
+// data-gosx-managed shorthand beside them is pure noise. writeManagedForm
+// used to render it unchanged next to the full contract it did nothing to
+// produce; it must now be stripped, matching how the shorthand disappears
+// once it does something on a raw <form>.
+func TestFileRendererManagedFormBuiltinStripsShorthand(t *testing.T) {
+	src := []byte(`package docs
+
+func Page() Node {
+	return <main>
+		<Form method="post" action="/save" data-gosx-managed>
+			<input name="q" value="docs"></input>
+		</Form>
+	</main>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute stripped from <Form> builtin output, got %q", html)
+	}
+	if !hasManagedFormAttr(html) {
+		t.Fatalf("expected the builtin's own contract in output, got %q", html)
 	}
 }

--- a/route/managed_form_shorthand_test.go
+++ b/route/managed_form_shorthand_test.go
@@ -1,0 +1,188 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// These tests render a .gsx fixture through the real pipeline —
+// gosx.Compile followed by RenderProgramComponent, the same entry point
+// route.RenderProgramComponent documents and cmd/gosx's `gosx render` and
+// the file-based dev/prod server both use — so they catch a regression in
+// the actual .gsx render path, not just in a Node-API-only helper.
+//
+// gosx#179: data-gosx-managed on a <form> rendered through the .gsx
+// pipeline used to serve unexpanded, because only node.go's RenderHTML
+// (the Go Node API path) expanded the shorthand. The file-program
+// renderer in this package lowers .gsx templates and wrote attributes
+// through its own path, which never called the shared expansion helper.
+
+func compileManagedFormFixture(t *testing.T, formOpenTag string) string {
+	t.Helper()
+	src := "package docs\n\n" +
+		"func Page() Node {\n" +
+		"\treturn <main>\n" +
+		"\t\t" + formOpenTag + "\n" +
+		"\t\t\t<input name=\"q\" value=\"docs\"></input>\n" +
+		"\t\t</form>\n" +
+		"\t</main>\n" +
+		"}\n"
+	prog, err := gosx.Compile([]byte(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	return html
+}
+
+func TestFileRendererExpandsManagedFormShorthandTrue(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form method="post" action="/x/__actions/y" data-gosx-managed="true">`)
+
+	for _, want := range []string{
+		`method="post"`,
+		`action="/x/__actions/y"`,
+		gosx.ManagedFormAttr,
+		gosx.ManagedFormStateAttr + `="idle"`,
+		gosx.EnhancementAttr + `="form"`,
+		gosx.EnhancementLayerAttr + `="bootstrap"`,
+		gosx.RuntimeFallbackAttr + `="native-form"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in rendered managed-shorthand form html %q", want, html)
+		}
+	}
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute removed from output, got %q", html)
+	}
+	// The shorthand must not add a mode attribute — the HTML method
+	// attribute stays authoritative, matching node.go's expansion rule.
+	if strings.Contains(html, gosx.ManagedFormModeAttr) {
+		t.Fatalf("expected no %s from the shorthand alone, got %q", gosx.ManagedFormModeAttr, html)
+	}
+}
+
+func TestFileRendererExpandsManagedFormShorthandBare(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form action="/save" data-gosx-managed>`)
+
+	for _, want := range []string{
+		gosx.ManagedFormAttr,
+		gosx.ManagedFormStateAttr + `="idle"`,
+		gosx.EnhancementAttr + `="form"`,
+		gosx.EnhancementLayerAttr + `="bootstrap"`,
+		gosx.RuntimeFallbackAttr + `="native-form"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in rendered bare-shorthand form html %q", want, html)
+		}
+	}
+	if strings.Contains(html, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute removed from output, got %q", html)
+	}
+}
+
+func TestFileRendererManagedFormShorthandFalseOptsOut(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form action="/save" data-gosx-managed="false">`)
+
+	if !strings.Contains(html, `data-gosx-managed="false"`) {
+		t.Fatalf("expected the literal opt-out attribute in output, got %q", html)
+	}
+	for _, unwanted := range []string{
+		gosx.ManagedFormAttr,
+		gosx.ManagedFormStateAttr,
+		gosx.EnhancementAttr,
+		gosx.EnhancementLayerAttr,
+		gosx.RuntimeFallbackAttr,
+	} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("expected no expansion for data-gosx-managed=\"false\", found %q in %q", unwanted, html)
+		}
+	}
+}
+
+func TestFileRendererManagedFormShorthandKeepsAuthorOverride(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form action="/save" data-gosx-managed data-gosx-form-state="pending">`)
+
+	if !strings.Contains(html, gosx.ManagedFormStateAttr+`="pending"`) {
+		t.Fatalf("expected author-written %s=\"pending\" to survive, got %q", gosx.ManagedFormStateAttr, html)
+	}
+	if n := strings.Count(html, gosx.ManagedFormStateAttr); n != 1 {
+		t.Fatalf("expected %s to appear once, appeared %d times in %q", gosx.ManagedFormStateAttr, n, html)
+	}
+	for _, want := range []string{
+		gosx.ManagedFormAttr,
+		gosx.EnhancementAttr + `="form"`,
+		gosx.EnhancementLayerAttr + `="bootstrap"`,
+		gosx.RuntimeFallbackAttr + `="native-form"`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("expected %q in rendered override html %q", want, html)
+		}
+	}
+}
+
+// TestFileRendererManagedFormShorthandOmittedLeavesFormUnmanaged documents
+// that a plain POST form without the shorthand (and without an auto-managed
+// GET method) stays unmanaged, so the shorthand test set above proves an
+// actual change of behavior rather than a form the renderer always manages.
+func TestFileRendererManagedFormShorthandOmittedLeavesFormUnmanaged(t *testing.T) {
+	html := compileManagedFormFixture(t, `<form method="post" action="/save">`)
+
+	for _, unwanted := range []string{
+		gosx.ManagedFormAttr,
+		gosx.ManagedFormStateAttr,
+		gosx.EnhancementAttr,
+	} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("expected unmanaged form, found %q in %q", unwanted, html)
+		}
+	}
+}
+
+// TestFileRendererManagedFormShorthandDynamicExpressionExpands covers the
+// shorthand reaching a form through a .gsx dynamic attribute expression
+// (data-gosx-managed={expr}) instead of a string literal, the other way the
+// shorthand can appear in a .gsx template.
+func TestFileRendererManagedFormShorthandDynamicExpressionExpands(t *testing.T) {
+	src := []byte(`package docs
+
+func Page() Node {
+	return <main>
+		<form action="/save" data-gosx-managed={managed}>
+			<input name="q" value="docs"></input>
+		</form>
+	</main>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	managedHTML, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"managed": true},
+	})
+	if err != nil {
+		t.Fatalf("render (managed=true): %v", err)
+	}
+	if !strings.Contains(managedHTML, gosx.ManagedFormAttr) {
+		t.Fatalf("expected expansion when the expression evaluates truthy, got %q", managedHTML)
+	}
+	if strings.Contains(managedHTML, gosx.ManagedFormShorthandAttr) {
+		t.Fatalf("expected shorthand attribute removed from output, got %q", managedHTML)
+	}
+
+	unmanagedHTML, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"managed": false},
+	})
+	if err != nil {
+		t.Fatalf("render (managed=false): %v", err)
+	}
+	if strings.Contains(unmanagedHTML, gosx.ManagedFormAttr) {
+		t.Fatalf("expected no expansion when the expression evaluates falsy, got %q", unmanagedHTML)
+	}
+}

--- a/runtime_contract.go
+++ b/runtime_contract.go
@@ -24,9 +24,11 @@ const (
 	// ManagedFormShorthandAttr is a single-attribute alternative to writing
 	// out the ManagedFormAttrs default set by hand on a <form> element. A
 	// .gsx template author writes `<form data-gosx-managed>` (or
-	// `data-gosx-managed="true"`) instead of the five contract attributes;
-	// RenderHTML expands it on any <form> element at render time. See
-	// expandManagedFormAttrs in node.go for the expansion and merge rules.
+	// `data-gosx-managed="true"`) instead of the five contract attributes.
+	// Both server render paths expand it on any <form> element at render
+	// time: RenderHTML (see expandManagedFormAttrs in node.go) for the Go
+	// Node API, and the route package's file-program renderer for .gsx
+	// pages. See ManagedFormShorthandTruthy for the shared truthy rule.
 	ManagedFormShorthandAttr = "data-gosx-managed"
 
 	ActionAttr           = "data-gosx-action"
@@ -107,6 +109,37 @@ func ManagedFormAttrs(opts ManagedFormOptions) AttrList {
 		Fallback: fallback,
 	})...)
 	return attrs
+}
+
+// ManagedFormShorthandTruthy reports whether a ManagedFormShorthandAttr
+// value opts a <form> element into the managed-form contract. A bare
+// attribute (presence with no value) is truthy; among valued attributes,
+// any non-empty value other than "false" (case-insensitive) is truthy, so
+// both `data-gosx-managed` and `data-gosx-managed="true"` opt in and
+// `data-gosx-managed="false"` opts out.
+//
+// This is the single definition of the shorthand's truthy rule. Both server
+// render paths call it: node.go's expandManagedFormAttrs for the Go Node
+// API, and the route package's file-program renderer for .gsx pages, so a
+// form written in either surface expands the same way. A caller decides
+// separately whether the attribute is present at all; this function only
+// judges a value already known to exist.
+func ManagedFormShorthandTruthy(presence bool, value any) bool {
+	if presence {
+		return true
+	}
+	switch v := value.(type) {
+	case bool:
+		return v
+	case string:
+		v = strings.TrimSpace(v)
+		if v == "" {
+			return false
+		}
+		return !strings.EqualFold(v, "false")
+	default:
+		return true
+	}
 }
 
 // RuntimeSurfaceOptions describes the framework-owned attributes on an

--- a/runtime_contract.go
+++ b/runtime_contract.go
@@ -25,10 +25,11 @@ const (
 	// out the ManagedFormAttrs default set by hand on a <form> element. A
 	// .gsx template author writes `<form data-gosx-managed>` (or
 	// `data-gosx-managed="true"`) instead of the five contract attributes.
-	// Both server render paths expand it on any <form> element at render
-	// time: RenderHTML (see expandManagedFormAttrs in node.go) for the Go
-	// Node API, and the route package's file-program renderer for .gsx
-	// pages. See ManagedFormShorthandTruthy for the shared truthy rule.
+	// All three server render paths expand it on a <form> element at
+	// render time: RenderHTML (see expandManagedFormAttrs in node.go) for
+	// the Go Node API, the route package's file-program renderer for .gsx
+	// pages, and the island package's resolved-tree renderer for island
+	// forms. See ManagedFormShorthandTruthy for the shared truthy rule.
 	ManagedFormShorthandAttr = "data-gosx-managed"
 
 	ActionAttr           = "data-gosx-action"
@@ -112,31 +113,36 @@ func ManagedFormAttrs(opts ManagedFormOptions) AttrList {
 }
 
 // ManagedFormShorthandTruthy reports whether a ManagedFormShorthandAttr
-// value opts a <form> element into the managed-form contract. A bare
-// attribute (presence with no value) is truthy; among valued attributes,
-// any non-empty value other than "false" (case-insensitive) is truthy, so
-// both `data-gosx-managed` and `data-gosx-managed="true"` opt in and
-// `data-gosx-managed="false"` opts out.
+// value opts a <form> element into the managed-form contract. The exact
+// rule: a bare attribute (presence with no value) is truthy; a nil value —
+// the attribute was never found — is falsy; every other value is truthy
+// unless it equals "false" (case-insensitive, surrounding whitespace
+// ignored). This makes `data-gosx-managed`, `data-gosx-managed=""`, and
+// `data-gosx-managed="true"` all opt in; only `data-gosx-managed="false"`
+// opts out. Treating an empty string as truthy mirrors the DOM: a bare
+// HTML boolean attribute and its `=""` spelling parse identically, and the
+// browser-side mirror of this rule (managedFormShorthandTruthy in
+// client/runtime/host/navigation.ts) has no way to tell them apart either,
+// since both read back as the empty string from getAttribute.
 //
-// This is the single definition of the shorthand's truthy rule. Both server
-// render paths call it: node.go's expandManagedFormAttrs for the Go Node
-// API, and the route package's file-program renderer for .gsx pages, so a
-// form written in either surface expands the same way. A caller decides
-// separately whether the attribute is present at all; this function only
-// judges a value already known to exist.
+// This is the single definition of the shorthand's truthy rule. All three
+// server render paths call it: node.go's expandManagedFormAttrs for the Go
+// Node API, the route package's file-program renderer for .gsx pages, and
+// the island package's resolved-tree renderer for island forms — so a form
+// written in any surface expands the same way. A caller decides separately
+// whether the attribute is present at all; this function only judges a
+// value already known to exist (or its explicit absence, via a nil value).
 func ManagedFormShorthandTruthy(presence bool, value any) bool {
 	if presence {
 		return true
 	}
 	switch v := value.(type) {
+	case nil:
+		return false
 	case bool:
 		return v
 	case string:
-		v = strings.TrimSpace(v)
-		if v == "" {
-			return false
-		}
-		return !strings.EqualFold(v, "false")
+		return !strings.EqualFold(strings.TrimSpace(v), "false")
 	default:
 		return true
 	}


### PR DESCRIPTION
## Summary

Ensures the `data-gosx-managed` shorthand expands consistently across all three server render surfaces (Node API, `.gsx` file-program renderer, and island renderer) and updates the client navigation runtime to recognize the shorthand directly. This resolves a regression where forms served via islands or authored entirely on the client would bypass managed navigation and trigger native full-page POSTs instead.

## Changes

- Extracted `ManagedFormShorthandTruthy` into `runtime_contract.go` as the single shared truthy rule evaluated by all server render paths and the JS navigation runtime.
- Updated the `.gsx` file-program renderer (`route/fileprogram.go`) to expand the shorthand uniformly, including proper handling of dynamic expressions, spread-attribute values, and preservation of author-written `data-gosx-form-mode` overrides.
- Ported the same expansion logic to the island renderer (`island/island.go`) so initial island HTML matches the output format of the other two surfaces.
- Extended `client/runtime/host/navigation.ts` to intercept forms carrying only the raw `data-gosx-managed` shorthand and updated `nativeSubmitForm` to temporarily strip the shorthand during fallback submissions to prevent re-interception loops.
- Scoped the shorthand detection in `isManagedFormElement` strictly to `<form>` elements to avoid incorrectly applying form lifecycle attributes to arbitrary DOM nodes.
- Added comprehensive tests across Go and JS test suites covering bare attributes, empty strings, explicit `"false"` opt-outs, spread maps, and native submission fallbacks.
- Bumped release version to v0.42.2 and updated documentation.

## Testing

- Run the Go test suite to verify render path expansion and truthy rules: `go test ./...`
- Execute the JavaScript navigation runtime tests to confirm shorthand interception and fallback behavior.