### PR TITLE
add(strictcomponent): Add nested prop reads to strict components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,46 @@
 # Changelog
 
+## Unreleased
+
+### Strict components: nested prop reads
+
+- **`props.A.B` and `props.A.B.C` in strict expressions.** A strict
+  component may now read a field through a same-file value struct, up to
+  three fields deep: `props.Player.Name`, `props.Player.Team.City`. The
+  rule is enforced at all three gates — the syntactic validator accepts a
+  props-rooted field chain of any depth as a shape (`ServerPropPath`
+  generalizes `ServerPropField`), the lowerer resolves each accepted path
+  against the same-file struct schema and reports the three-hop cap there
+  with full component context, and the generated check program proves
+  every field exists with the declared type through the real Go compiler.
+- **Pointer fields stay out of the strict surface.** A nested selector
+  through a pointer intermediate (`*Player`) still fails closed: the
+  map-backed file renderer dissolves a nil pointer to an empty string
+  where generated Go would panic, so admitting pointers would let a
+  strict component type-check one way and render another. Same for a
+  struct this `.gsx` file does not declare, an embedded (promoted) field,
+  and a chain deeper than three hops — each fails closed with a
+  diagnostic naming the component and the exact selector.
+- **The widened selector rule applies everywhere a selector is admitted.**
+  A concat operand (`"player-" + props.Player.Name`) and an `<If
+  cond={props.Player.Ready}>` selector both accept a nested path in this
+  same change, with the same type rules (concat still requires an exact
+  `string` leaf; `cond` still requires an exact `bool` leaf).
+- **`ir.Component.PropsPaths`** carries the resolved leaf type for every
+  nested read, alongside the existing `PropsFields`. It is additive and
+  absent-decodes to `nil` for a program serialized before this field
+  existed, matching `ComponentSyntax`'s zero-value convention — an
+  existing `.gsx` file's projection and render output are unchanged.
+- **The file renderer gained `requireStrictStructValue`**,
+  `requireStrictScalarType`'s counterpart for a nested-selector root: it
+  verifies an incoming struct is exactly the declared same-file type (not
+  a pointer, not an anonymous struct, not a map) and that every path the
+  component reads under it resolves to its declared scalar type, before
+  the component's body observes the value.
+- Re-audit of GitHub issue #171's motivating app: BoardRow now qualifies
+  (nested `props.player.*` combined with the v0.42.0 concatenation
+  extension), alongside TeamMark, RosterRow, and DraftTeam.
+
 ## v0.42.2 (2026-08-16)
 
 ### Fixed: the managed-form shorthand did not expand consistently across server render surfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,16 @@
   (nested `props.player.*` combined with the v0.42.0 concatenation
   extension), alongside TeamMark, RosterRow, and DraftTeam.
 
+### The `ir` package's compatibility contract is now written down
+
+- **`ir` is documented as experimental while gosx is pre-1.0.** A
+  breaking change to an exported `ir` type is called out in this
+  changelog with a migration note; a consumer that compiles against `ir`
+  directly (for example `gsxmail`, or any tool built against `ir` instead
+  of gosx's higher-level entry points) should pin an exact gosx version
+  rather than a version range. No behavior changes with this entry —
+  it states the policy the project already followed.
+
 ## v0.42.2 (2026-08-16)
 
 ### Fixed: the managed-form shorthand did not expand consistently across server render surfaces

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,11 @@
   generalizes `ServerPropField`), the lowerer resolves each accepted path
   against the same-file struct schema and reports the three-hop cap there
   with full component context, and the generated check program proves
-  every field exists with the declared type through the real Go compiler.
+  every field exists with its declared Go type through the real Go
+  compiler. The check program proves field existence and struct-literal
+  types; it does not re-prove the renderer's own scalar-leaf rule (exact
+  `string`, `bool`, integer, or floating-point builtins only) — the
+  lowerer alone enforces that.
 - **Pointer fields stay out of the strict surface.** A nested selector
   through a pointer intermediate (`*Player`) still fails closed: the
   map-backed file renderer dissolves a nil pointer to an empty string
@@ -40,6 +44,19 @@
 - Re-audit of GitHub issue #171's motivating app: BoardRow now qualifies
   (nested `props.player.*` combined with the v0.42.0 concatenation
   extension), alongside TeamMark, RosterRow, and DraftTeam.
+- **A `.gsx` file cannot forward a struct prop to a nested-read component
+  yet.** Nested reads work today for a generated-Go caller and for a
+  hand-built `ir.Program` that supplies the struct value directly. A
+  strict `.gsx` parent cannot pass one:
+  - it rejects rendering a struct-typed prop itself;
+  - a legacy (non-strict) component cannot call a strict component at
+    all; and
+  - a strict entry point cannot bind root props at all (file routes have
+    no way to supply one), so a struct prop cannot arrive from routing
+    either.
+
+  That composition — one `.gsx`-authored component forwarding another's
+  struct prop — arrives with the spread work (#184).
 
 ### The `ir` package's compatibility contract is now written down
 

--- a/README.md
+++ b/README.md
@@ -746,7 +746,7 @@ Three tiers:
 | Package | Purpose |
 |---------|---------|
 | `gosx` | Node API, grammar, parser, compiler |
-| `ir` | Intermediate representation, lowering, validation, expression parser |
+| `ir` | Intermediate representation, lowering, validation, expression parser. Experimental pre-1.0: pin an exact gosx version if you compile against it directly. |
 | `island` | Island renderer, manifest generation, program serialization |
 | `signal` | Reactive state: `Signal[T]`, `Computed[T]`, `Effect`, `Batch` |
 | `server` | HTTP server, page rendering, caching, streaming, i18n, edge annotations, assets |

--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.42.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.42.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/format/strict_component_test.go
+++ b/format/strict_component_test.go
@@ -81,3 +81,54 @@ component Card(props: CardProps) {
 		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
 	}
 }
+
+// TestSourceFormatsStrictNestedSelectorIdempotently covers section 2.b: a
+// nested selector text hole, a nested concat operand, and a nested <If
+// cond> selector all format idempotently and keep compiling.
+func TestSourceFormatsStrictNestedSelectorIdempotently(t *testing.T) {
+	source := []byte(`package app
+type Team struct {
+	City string
+}
+
+type Player struct {
+	Name  string
+	Ready bool
+	Team  Team
+}
+
+type RowProps struct {
+	Player Player
+}
+
+component Row(props: RowProps) {
+	return <div class={"player-" + props.Player.Name}>
+		<span>{props.Player.Team.City}</span>
+		<If cond={props.Player.Ready}>ready</If>
+	</div>
+}
+`)
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	for _, want := range []string{
+		`class={"player-" + props.Player.Name}`,
+		`{props.Player.Team.City}`,
+		`<If cond={props.Player.Ready}>`,
+	} {
+		if !strings.Contains(string(formatted), want) {
+			t.Fatalf("formatting changed %q:\n%s", want, formatted)
+		}
+	}
+	if _, err := gosx.Compile(formatted); err != nil {
+		t.Fatalf("formatted strict source does not compile: %v\n%s", err, formatted)
+	}
+	again, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source second pass: %v", err)
+	}
+	if !bytes.Equal(formatted, again) {
+		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -252,10 +252,12 @@ func propsSelectorPath(expr ast.Expr) ([]string, bool) {
 
 // ServerPropField reports the single props field read by a validated direct
 // selector (props.X) — ServerPropPath's length-1 case. Parentheses around
-// either the selector or props itself do not change the result. Kept as its
-// own function because collectStrictPropReads's CST walk (ir/lower.go) calls
-// it once per selector_expression node it visits, independent of any
-// top-level validated shape.
+// either the selector or props itself do not change the result.
+// collectStrictPropReads's CST walk (ir/lower.go) called this once per
+// selector_expression node before the nested-reads change generalized that
+// walk to ServerPropPath directly; ServerPropField has no production caller
+// today and is kept as a tested, documented length-1 convenience over
+// ServerPropPath for any future caller that only ever wants a bare field.
 func ServerPropField(source string) (string, bool) {
 	path, ok := ServerPropPath(source)
 	if !ok || len(path) != 1 {

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -9,6 +9,7 @@ import (
 	"go/token"
 	"regexp"
 	"strconv"
+	"strings"
 )
 
 var (
@@ -19,11 +20,18 @@ var (
 // ValidateServerExpression accepts exactly the expression shapes implemented
 // by the file renderer for strict server components. The v0.39 contract is
 // intentionally small: literals and one direct props field (with parentheses).
-// The v0.42 contract adds one narrow extension: a `+` chain that concatenates
-// string literals with props field selectors (ValidateConcatExpression
-// documents the accepted shape). Operators outside that one exception,
-// indexing, and calls need static Go type/method information that the
-// map-backed file renderer does not retain, so they fail closed.
+// v0.42 added a `+` chain that concatenates string literals with props field
+// selectors (validateConcatChain documents the accepted shape). This change
+// widens every props selector position (a bare read, a concat operand, an
+// <If cond>) to accept a field chain rooted at props up to three fields deep
+// (see ServerPropPath) instead of exactly one field. This function places no
+// upper bound on chain length itself: it is schema-blind, so it cannot know
+// where three hops actually lands against a given props struct. The lowerer
+// (ir/lower.go) resolves each accepted path against the same-file struct
+// schema and reports the three-hop cap there, with full component context.
+// Operators outside the one `+` exception, indexing, and calls need static
+// Go type/method information that the map-backed file renderer does not
+// retain, so they fail closed.
 func ValidateServerExpression(source string) error {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
@@ -53,8 +61,8 @@ func validate(expr ast.Expr, source string) error {
 	case *ast.ParenExpr:
 		return validate(node.X, source)
 	case *ast.SelectorExpr:
-		if _, ok := directPropsField(node); !ok {
-			return fmt.Errorf("selector must be one field directly on props; nested selector chains cannot preserve Go nil-pointer behavior")
+		if _, ok := propsSelectorPath(node); !ok {
+			return fmt.Errorf("selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior")
 		}
 		return nil
 	case *ast.IndexExpr:
@@ -124,7 +132,7 @@ func classifyConcatOperand(operand ast.Expr) concatOperandKind {
 		}
 		return concatOperandNonStringLiteral
 	case *ast.SelectorExpr:
-		if _, ok := directPropsField(node); ok {
+		if _, ok := propsSelectorPath(node); ok {
 			return concatOperandSelector
 		}
 		return concatOperandInvalid
@@ -205,84 +213,110 @@ func validateLiteral(literal *ast.BasicLit) error {
 	}
 }
 
-// ServerPropField reports the single props field read by a validated strict
-// server expression. Parentheses around either the selector or props itself do
-// not change the result.
-func ServerPropField(source string) (string, bool) {
+// ServerPropPath reports the ordered field path of a selector chain rooted
+// at the identifier props, for example props.Player.Name -> []string{
+// "Player", "Name"}. Parentheses are transparent at any level, including
+// around props itself and around any intermediate selector. It places no
+// upper bound on chain length — see ValidateServerExpression's doc comment
+// for why the depth cap lives in the lowerer instead.
+func ServerPropPath(source string) ([]string, bool) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
-		return "", false
+		return nil, false
 	}
-	for {
-		paren, ok := expr.(*ast.ParenExpr)
-		if !ok {
-			break
+	return propsSelectorPath(expr)
+}
+
+// propsSelectorPath is ServerPropPath's expression-tree implementation,
+// reused by the validator (selector shape, concat operand classification,
+// cond selector extraction) so every props selector position resolves
+// nested paths through one definition.
+func propsSelectorPath(expr ast.Expr) ([]string, bool) {
+	selector, ok := unwrapParens(expr).(*ast.SelectorExpr)
+	if !ok || selector.Sel == nil || selector.Sel.Name == "" {
+		return nil, false
+	}
+	receiver := unwrapParens(selector.X)
+	if ident, ok := receiver.(*ast.Ident); ok {
+		if ident.Name != "props" {
+			return nil, false
 		}
-		expr = paren.X
+		return []string{selector.Sel.Name}, true
 	}
-	selector, ok := expr.(*ast.SelectorExpr)
+	path, ok := propsSelectorPath(receiver)
 	if !ok {
-		return "", false
+		return nil, false
 	}
-	return directPropsField(selector)
+	return append(path, selector.Sel.Name), true
 }
 
-func directPropsField(selector *ast.SelectorExpr) (string, bool) {
-	var receiver ast.Expr = selector.X
-	for {
-		paren, ok := receiver.(*ast.ParenExpr)
-		if !ok {
-			break
-		}
-		receiver = paren.X
-	}
-	ident, ok := receiver.(*ast.Ident)
-	if !ok || ident.Name != "props" || selector.Sel == nil || selector.Sel.Name == "" {
+// ServerPropField reports the single props field read by a validated direct
+// selector (props.X) — ServerPropPath's length-1 case. Parentheses around
+// either the selector or props itself do not change the result. Kept as its
+// own function because collectStrictPropReads's CST walk (ir/lower.go) calls
+// it once per selector_expression node it visits, independent of any
+// top-level validated shape.
+func ServerPropField(source string) (string, bool) {
+	path, ok := ServerPropPath(source)
+	if !ok || len(path) != 1 {
 		return "", false
 	}
-	return selector.Sel.Name, true
+	return path[0], true
 }
 
-// ServerExpressionPropFields reports every direct props field selector
-// (props.X) found anywhere in source, regardless of whether source's overall
-// shape passes ValidateServerExpression. Read-tracking passes use this to see
-// every props field an expression touches — not just the operands of one
+// ServerExpressionPropPaths reports every maximal props-rooted selector path
+// found anywhere in source, regardless of whether source's overall shape
+// passes ValidateServerExpression. Read-tracking passes use this to see
+// every props path an expression touches — not just the operands of one
 // accepted top-level shape — because the grammar's external attribute
 // scanner hands attribute-position expressions back as one opaque token with
 // no nested CST, unlike element/text children (jsx_expression_container),
 // whose nested Go sub-tree the CST-based read-tracking walk can see
-// directly. Attribute-position expressions are exactly where every v0.42
+// directly. Attribute-position expressions are exactly where every
 // concatenation and <If cond> shape lives, so this closes that visibility
-// gap generally instead of only for the two new shapes.
-func ServerExpressionPropFields(source string) []string {
+// gap generally instead of only for those two shapes.
+//
+// "Maximal" matters for nested paths: once a *ast.SelectorExpr node yields a
+// full props path, this stops descending into that node's own operand
+// sub-tree. Otherwise a chain like props.Player.Name would also register its
+// inner props.Player sub-expression as an independent (and spurious) bare
+// read of a non-scalar field — the same class of fail-open gap
+// collectStrictPropReads was fixed for once already, in reverse: a false
+// rejection of a valid nested read instead of a missed one.
+func ServerExpressionPropPaths(source string) [][]string {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return nil
 	}
-	var fields []string
+	var paths [][]string
 	seen := make(map[string]struct{})
 	ast.Inspect(expr, func(n ast.Node) bool {
 		selector, ok := n.(*ast.SelectorExpr)
 		if !ok {
 			return true
 		}
-		if field, ok := directPropsField(selector); ok {
-			if _, dup := seen[field]; !dup {
-				seen[field] = struct{}{}
-				fields = append(fields, field)
-			}
+		path, ok := propsSelectorPath(selector)
+		if !ok {
+			return true
 		}
-		return true
+		key := strings.Join(path, ".")
+		if _, dup := seen[key]; !dup {
+			seen[key] = struct{}{}
+			paths = append(paths, path)
+		}
+		return false
 	})
-	return fields
+	return paths
 }
 
-// ServerConcatPropFields reports, in operand order, the props fields read by
-// a validated string-concatenation chain (see ValidateServerExpression). It
-// returns ok=false when source's top-level shape (parentheses transparent)
-// is not a `+` expression — callers use that to skip the concat-specific
-// type pass for every other already-validated expression shape.
-func ServerConcatPropFields(source string) ([]string, bool) {
+// ServerConcatPropPaths reports, in operand order, the props field paths
+// read by a validated string-concatenation chain (see
+// ValidateServerExpression); each entry is ServerPropPath's ordered field
+// list for that operand. It returns ok=false when source's top-level shape
+// (parentheses transparent) is not a `+` expression — callers use that to
+// skip the concat-specific type pass for every other already-validated
+// expression shape.
+func ServerConcatPropPaths(source string) ([][]string, bool) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return nil, false
@@ -291,28 +325,25 @@ func ServerConcatPropFields(source string) ([]string, bool) {
 	if !ok || bin.Op != token.ADD {
 		return nil, false
 	}
-	var fields []string
+	var paths [][]string
 	for _, operand := range flattenAddChain(bin) {
-		selector, ok := unwrapParens(operand).(*ast.SelectorExpr)
-		if !ok {
-			continue
-		}
-		if field, ok := directPropsField(selector); ok {
-			fields = append(fields, field)
+		if path, ok := propsSelectorPath(operand); ok {
+			paths = append(paths, path)
 		}
 	}
-	return fields, true
+	return paths, true
 }
 
 // ValidateServerCondExpression accepts the two expression shapes a strict
-// <If cond={...}> attribute may use: a bare props field selector, or that
-// selector compared against the literal false with `==`. It reports the
-// props field read and whether the comparison negates it. Parentheses are
-// transparent at any level.
-func ValidateServerCondExpression(source string) (field string, negated bool, err error) {
+// <If cond={...}> attribute may use: a props field selector (a direct field,
+// or a nested field path per ServerPropPath), or that selector compared
+// against the literal false with `==`. It reports the props path read and
+// whether the comparison negates it. Parentheses are transparent at any
+// level.
+func ValidateServerCondExpression(source string) (path []string, negated bool, err error) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
-		return "", false, fmt.Errorf("invalid Go expression: %w", err)
+		return nil, false, fmt.Errorf("invalid Go expression: %w", err)
 	}
 	root := unwrapParens(expr)
 
@@ -321,23 +352,19 @@ func ValidateServerCondExpression(source string) (field string, negated bool, er
 			left := unwrapParens(bin.X)
 			right := unwrapParens(bin.Y)
 			if ident, ok := right.(*ast.Ident); ok && ident.Name == "true" {
-				return "", false, fmt.Errorf("comparison \"== true\" is not supported in strict cond; write the field bare")
+				return nil, false, fmt.Errorf("comparison \"== true\" is not supported in strict cond; write the field bare")
 			}
-			if selector, ok := left.(*ast.SelectorExpr); ok {
+			if condPath, ok := propsSelectorPath(left); ok {
 				if ident, ok := right.(*ast.Ident); ok && ident.Name == "false" {
-					if field, ok := directPropsField(selector); ok {
-						return field, true, nil
-					}
+					return condPath, true, nil
 				}
 			}
 		}
-		return "", false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
+		return nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
 	}
 
-	if selector, ok := root.(*ast.SelectorExpr); ok {
-		if field, ok := directPropsField(selector); ok {
-			return field, false, nil
-		}
+	if condPath, ok := propsSelectorPath(root); ok {
+		return condPath, false, nil
 	}
-	return "", false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
+	return nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
 }

--- a/internal/strictcomponent/expression_test.go
+++ b/internal/strictcomponent/expression_test.go
@@ -34,6 +34,32 @@ func TestValidateServerExpressionAcceptsConcatChains(t *testing.T) {
 		`("a") + (props.X)`,
 		`"tone-" + props.Tone`,
 		`"Remove " + props.Name + " from roster"`,
+		`"a" + props.A.B`,
+		`"a" + props.A.B.C`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			if err := ValidateServerExpression(source); err != nil {
+				t.Fatalf("ValidateServerExpression(%q) = %v, want nil", source, err)
+			}
+		})
+	}
+}
+
+// TestValidateServerExpressionAcceptsNestedSelectors covers the widened
+// selector rule this change adds: a props-rooted field chain of any depth is
+// a valid shape. The lowerer (ir/lower.go), not this schema-blind validator,
+// enforces the three-hop resolution cap and every same-file-struct type
+// rule — see resolveStrictSelectorPath and its tests in strict_component_test.go.
+func TestValidateServerExpressionAcceptsNestedSelectors(t *testing.T) {
+	for _, source := range []string{
+		"props.A.B",
+		"props.A.B.C",
+		"(props.A).B",
+		"(props.A.B)",
+		// Deeper than the lowerer's three-hop cap: still a valid *shape*.
+		// TestCompileStrictServerRejectsSelectorTooDeep (root package)
+		// proves the lowerer rejects it with full component context.
+		"props.A.B.C.D",
 	} {
 		t.Run(source, func(t *testing.T) {
 			if err := ValidateServerExpression(source); err != nil {
@@ -77,8 +103,12 @@ func TestValidateServerExpressionRejectsWithExactMessages(t *testing.T) {
 			want:   "\"+\" operand `props.Count + 1` is not renderable; strict concatenation accepts string literals and props field selectors only",
 		},
 		{
-			source: "props.A.B.C.D",
-			want:   "selector must be one field directly on props; nested selector chains cannot preserve Go nil-pointer behavior",
+			source: "x.Field",
+			want:   "selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior",
+		},
+		{
+			source: "props.A[0].B",
+			want:   "selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior",
 		},
 	} {
 		t.Run(tc.source, func(t *testing.T) {
@@ -121,6 +151,10 @@ func TestServerPropFieldUnaffectedByConcatSupport(t *testing.T) {
 		{"(props).Title", "Title", true},
 		{`"a" + props.X`, "", false},
 		{"props", "", false},
+		// ServerPropField is ServerPropPath's length-1 case: a nested path
+		// is a valid ServerPropPath result but not a valid ServerPropField
+		// result.
+		{"props.A.B", "", false},
 	} {
 		t.Run(tc.source, func(t *testing.T) {
 			field, ok := ServerPropField(tc.source)
@@ -131,24 +165,51 @@ func TestServerPropFieldUnaffectedByConcatSupport(t *testing.T) {
 	}
 }
 
-func TestServerConcatPropFields(t *testing.T) {
+func TestServerPropPath(t *testing.T) {
 	for _, tc := range []struct {
 		source string
 		want   []string
 		wantOK bool
 	}{
-		{`"a" + props.X`, []string{"X"}, true},
-		{`props.X + "a"`, []string{"X"}, true},
-		{`"a" + props.X + "b"`, []string{"X"}, true},
-		{`"Remove " + props.Name + " from roster"`, []string{"Name"}, true},
-		{`props.A + props.B`, []string{"A", "B"}, true}, // fields extracted even though the syntax validator rejects the chain overall
+		{"props.Title", []string{"Title"}, true},
+		{"(props.Title)", []string{"Title"}, true},
+		{"(props).Title", []string{"Title"}, true},
+		{"props.A.B", []string{"A", "B"}, true},
+		{"props.A.B.C", []string{"A", "B", "C"}, true},
+		{"(props.A).B.C", []string{"A", "B", "C"}, true},
+		{"props.A.B.C.D", []string{"A", "B", "C", "D"}, true},
+		{"props", nil, false},
+		{"x.Field", nil, false},
+		{`"a" + props.X`, nil, false},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			path, ok := ServerPropPath(tc.source)
+			if ok != tc.wantOK || !equalStrings(path, tc.want) {
+				t.Fatalf("ServerPropPath(%q) = (%v, %v), want (%v, %v)", tc.source, path, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestServerConcatPropPaths(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		want   [][]string
+		wantOK bool
+	}{
+		{`"a" + props.X`, [][]string{{"X"}}, true},
+		{`props.X + "a"`, [][]string{{"X"}}, true},
+		{`"a" + props.X + "b"`, [][]string{{"X"}}, true},
+		{`"Remove " + props.Name + " from roster"`, [][]string{{"Name"}}, true},
+		{`props.A + props.B`, [][]string{{"A"}, {"B"}}, true}, // paths extracted even though the syntax validator rejects the chain overall
+		{`"a" + props.A.B`, [][]string{{"A", "B"}}, true},
 		{"props.Title", nil, false},
 		{`"a" + "b"`, nil, true},
 	} {
 		t.Run(tc.source, func(t *testing.T) {
-			fields, ok := ServerConcatPropFields(tc.source)
-			if ok != tc.wantOK || !equalStrings(fields, tc.want) {
-				t.Fatalf("ServerConcatPropFields(%q) = (%v, %v), want (%v, %v)", tc.source, fields, ok, tc.want, tc.wantOK)
+			paths, ok := ServerConcatPropPaths(tc.source)
+			if ok != tc.wantOK || !equalPathLists(paths, tc.want) {
+				t.Fatalf("ServerConcatPropPaths(%q) = (%v, %v), want (%v, %v)", tc.source, paths, ok, tc.want, tc.wantOK)
 			}
 		})
 	}
@@ -166,23 +227,37 @@ func equalStrings(a, b []string) bool {
 	return true
 }
 
+func equalPathLists(a, b [][]string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !equalStrings(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
+}
+
 func TestValidateServerCondExpressionAcceptsBoolShapes(t *testing.T) {
 	for _, tc := range []struct {
 		source      string
-		wantField   string
+		wantPath    []string
 		wantNegated bool
 	}{
-		{"props.Ready", "Ready", false},
-		{"props.Ready == false", "Ready", true},
-		{"(props.Ready) == (false)", "Ready", true},
+		{"props.Ready", []string{"Ready"}, false},
+		{"props.Ready == false", []string{"Ready"}, true},
+		{"(props.Ready) == (false)", []string{"Ready"}, true},
+		{"props.A.Ready", []string{"A", "Ready"}, false},
+		{"props.A.Ready == false", []string{"A", "Ready"}, true},
 	} {
 		t.Run(tc.source, func(t *testing.T) {
-			field, negated, err := ValidateServerCondExpression(tc.source)
+			path, negated, err := ValidateServerCondExpression(tc.source)
 			if err != nil {
 				t.Fatalf("ValidateServerCondExpression(%q) = %v, want nil error", tc.source, err)
 			}
-			if field != tc.wantField || negated != tc.wantNegated {
-				t.Fatalf("ValidateServerCondExpression(%q) = (%q, %v), want (%q, %v)", tc.source, field, negated, tc.wantField, tc.wantNegated)
+			if !equalStrings(path, tc.wantPath) || negated != tc.wantNegated {
+				t.Fatalf("ValidateServerCondExpression(%q) = (%v, %v), want (%v, %v)", tc.source, path, negated, tc.wantPath, tc.wantNegated)
 			}
 		})
 	}
@@ -223,24 +298,30 @@ func TestValidateServerCondExpressionRejectsWithExactMessages(t *testing.T) {
 	}
 }
 
-func TestServerExpressionPropFields(t *testing.T) {
+func TestServerExpressionPropPaths(t *testing.T) {
 	for _, tc := range []struct {
 		source string
-		want   []string
+		want   [][]string
 	}{
-		{"props.Title", []string{"Title"}},
-		{`"a" + props.X`, []string{"X"}},
-		{`"a" + props.X + props.Y`, []string{"X", "Y"}},
-		{"props.Ready == false", []string{"Ready"}},
-		{"props.A == props.B", []string{"A", "B"}},
-		{"props.A.B", []string{"A"}}, // the syntax validator rejects the chain overall; the root field still gets tracked for the explicit-supply rule
+		{"props.Title", [][]string{{"Title"}}},
+		{`"a" + props.X`, [][]string{{"X"}}},
+		{`"a" + props.X + props.Y`, [][]string{{"X"}, {"Y"}}},
+		{"props.Ready == false", [][]string{{"Ready"}}},
+		{"props.A == props.B", [][]string{{"A"}, {"B"}}},
+		// A nested chain registers as one maximal path, not also a spurious
+		// bare read of its own non-scalar inner selector (props.A alone,
+		// whose type is a struct, would otherwise fail the renderer-scalar
+		// gate even though the author never wrote a bare props.A anywhere).
+		{"props.A.B", [][]string{{"A", "B"}}},
+		{"props.A.B.C", [][]string{{"A", "B", "C"}}},
+		{`"a" + props.A.B`, [][]string{{"A", "B"}}},
 		{`"a" + "b"`, nil},
-		{"props.X()", []string{"X"}}, // shape-invalid overall, but the read still matters for tracking
+		{"props.X()", [][]string{{"X"}}}, // shape-invalid overall, but the read still matters for tracking
 	} {
 		t.Run(tc.source, func(t *testing.T) {
-			got := ServerExpressionPropFields(tc.source)
-			if !equalStrings(got, tc.want) {
-				t.Fatalf("ServerExpressionPropFields(%q) = %v, want %v", tc.source, got, tc.want)
+			got := ServerExpressionPropPaths(tc.source)
+			if !equalPathLists(got, tc.want) {
+				t.Fatalf("ServerExpressionPropPaths(%q) = %v, want %v", tc.source, got, tc.want)
 			}
 		})
 	}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -68,10 +68,23 @@ type Component struct {
 	// the exact name "props" because the file renderer binds that identifier.
 	PropsName string
 
-	// PropsFields records exact builtin types for fields read from a same-file
-	// strict props struct. The file renderer uses it to apply the same untyped-
-	// literal conversions as generated Go before the component observes them.
+	// PropsFields records, for the root field of every rendered props read,
+	// that root's own declared type: an exact renderer builtin for a direct
+	// read, or a same-file struct type name for a nested-selector read's
+	// root. The file renderer uses it to apply the same untyped-literal
+	// conversions as generated Go (for a builtin) or the struct boundary
+	// check (for a struct name) before the component observes the value.
 	PropsFields map[string]string
+
+	// PropsPaths records exact builtin leaf types for nested props reads
+	// (props.A.B[.C], added alongside PropsFields' struct-typed roots),
+	// keyed by the dot-joined path under its root ("Player.Name" ->
+	// "string"). It does not repeat PropsFields' direct-read entries: a
+	// path appears here only when it has at least one hop past its root.
+	// The zero value (a nil map) is absent and decodes unchanged for
+	// programs serialized before this field existed, matching the
+	// ComponentSyntax zero-value convention above.
+	PropsPaths map[string]string
 
 	// Syntax distinguishes legacy `func` components from strict
 	// `component Name(props: Type)` declarations.

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -3,6 +3,15 @@
 // The IR is the contract between syntax, validation, server renderer,
 // and client hydration. All references are index-based (no recursive pointers)
 // following the same pattern as Arbiter's flat-array IR.
+//
+// # Compatibility
+//
+// This package is experimental while gosx is pre-1.0. Breaking changes to
+// exported ir types are called out in CHANGELOG.md with a migration note.
+// A consumer that compiles against ir directly — for example gsxmail, or
+// any other tool that imports this package instead of going through gosx's
+// higher-level entry points — should pin an exact gosx version rather than
+// a version range.
 package ir
 
 import "strings"

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -979,21 +979,33 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	}
 }
 
-// collectStrictPropReads records the top-level props fields whose values the
-// file renderer must observe. Local strict calls must provide these fields
-// explicitly: generated Go composite literals otherwise synthesize typed zero
-// values while the map-backed renderer would observe a missing key as nil.
+// collectStrictPropReads records every props field path (dot-joined, e.g.
+// "Tone" or "Player.Name") whose value the file renderer must observe. Local
+// strict calls must provide the ROOT field of every registered path
+// explicitly: generated Go composite literals otherwise synthesize typed
+// zero values while the map-backed renderer would observe a missing key as
+// nil (see validateStrictComponentCall, which derives required root names
+// from these paths).
 //
 // jsx_attribute_expression (an attribute's `{...}` value) gets its own branch
 // because the grammar's external attribute scanner hands its content back as
 // one opaque token with no nested CST — unlike jsx_expression_container
 // (element/text children), whose Go sub-expression parses into real
-// selector_expression descendants this walk already finds. Every v0.42
-// concatenation and <If cond> shape in this spec's motivating examples lives
-// in attribute position (class, aria-label, cond), so without this branch
-// their props operands would never reach validateStrictRenderedProps, the
-// renderer-boundary type check, or the explicit-required-prop rule below —
-// exactly the class of divergence the strict contract exists to prevent.
+// selector_expression descendants this walk already finds. Concatenation and
+// <If cond> shapes live in attribute position (class, aria-label, cond), so
+// without this branch their props operands would never reach
+// validateStrictRenderedProps, the renderer-boundary type check, or the
+// explicit-required-prop rule below — exactly the class of divergence the
+// strict contract exists to prevent.
+//
+// Both branches register a nested chain (props.Player.Name) as one maximal
+// path and stop descending into its own inner selector once matched — see
+// strictcomponent.ServerExpressionPropPaths' doc comment. Falling through to
+// also register the chain's own props.Player sub-expression as an
+// independent bare read would fail closed on a struct-typed root that has no
+// bare use anywhere in the source, which is the same class of bug a prior
+// review caught in this collector once already (see CHANGELOG.md's v0.42.0
+// entry), just inverted from a missed read to a false rejection.
 func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct{} {
 	reads := make(map[string]struct{})
 	var walk func(*gotreesitter.Node)
@@ -1003,13 +1015,14 @@ func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct
 		}
 		switch l.nodeType(node) {
 		case "selector_expression":
-			if field, ok := strictcomponent.ServerPropField(l.text(node)); ok {
-				reads[field] = struct{}{}
+			if path, ok := strictcomponent.ServerPropPath(l.text(node)); ok {
+				reads[strings.Join(path, ".")] = struct{}{}
+				return
 			}
 		case "jsx_attribute_expression":
 			expr := stripGSXAttributeExpressionText(l.text(node))
-			for _, field := range strictcomponent.ServerExpressionPropFields(expr) {
-				reads[field] = struct{}{}
+			for _, path := range strictcomponent.ServerExpressionPropPaths(expr) {
+				reads[strings.Join(path, ".")] = struct{}{}
 			}
 		}
 		for i := 0; i < int(node.NamedChildCount()); i++ {
@@ -1101,27 +1114,113 @@ func (l *lowerer) validateStrictRenderedProps(n *gotreesitter.Node, componentNam
 		return
 	}
 	baseType := propsBaseType(propsType)
-	fieldTypes, declared := l.structTypes[baseType]
-	fields := make([]string, 0, len(reads))
-	for field := range reads {
-		fields = append(fields, field)
-	}
-	sort.Strings(fields)
-	if !declared {
+	if _, declared := l.structTypes[baseType]; !declared {
 		l.errorf(n, "strict component %s renders props fields from %s, whose struct schema is not declared in this .gsx file; declare the renderer-visible props struct beside the component", componentName, propsType)
 		return
 	}
-	for _, field := range fields {
-		fieldType, ok := fieldTypes[field]
-		if !ok {
-			// The package checker supplies the precise unknown/unexported-field
-			// diagnostic; this guard only owns known renderer schema types.
-			continue
+	paths := make([]string, 0, len(reads))
+	for path := range reads {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		l.resolveStrictSelectorPath(n, componentName, propsType, strings.Split(path, "."))
+	}
+}
+
+// strictSelectorPathDepthLimit caps how many struct-field hops a nested
+// selector path may cross: props.A.B.C is the deepest chain the strict
+// renderer resolves. strictcomponent.ServerPropPath itself places no upper
+// bound on shape (it is schema-blind), so this lowerer function is where the
+// cap is enforced, with full component context in the diagnostic.
+const strictSelectorPathDepthLimit = 3
+
+// resolveStrictSelectorPath walks a props-rooted field path (see
+// strictcomponent.ServerPropPath) against the same-file struct schema,
+// reporting exactly one diagnostic when any hop cannot preserve Go's
+// selector semantics in the map-backed file renderer: too deep, a pointer
+// intermediate, an intermediate whose type is a renderer scalar (nothing to
+// select further through), an intermediate struct type this .gsx file does
+// not declare, or a non-scalar leaf. The props base type itself is assumed
+// already declared in this file — validateStrictRenderedProps checks that
+// gate before calling this for any path.
+func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName, propsType string, path []string) {
+	if len(path) > strictSelectorPathDepthLimit {
+		l.errorf(n, "strict component %s selector props.%s is too deep; the strict renderer resolves at most three fields", componentName, strings.Join(path, "."))
+		return
+	}
+	currentType := propsBaseType(propsType)
+	pathText := "props"
+	for i, field := range path {
+		fieldType, known := l.structTypes[currentType][field]
+		if !known {
+			// Unknown field: the package checker supplies the precise
+			// unknown/unexported-field diagnostic; this guard only owns
+			// known renderer schema types.
+			return
 		}
-		if !strictRendererScalarType(fieldType) {
-			l.errorf(n, "strict component %s cannot render props.%s of type %s; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins", componentName, field, fieldType)
+		trimmed := strings.TrimSpace(fieldType)
+		pathText += "." + field
+		if i == len(path)-1 {
+			if !strictRendererScalarType(trimmed) {
+				l.errorf(n, "strict component %s cannot render %s of type %s; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins", componentName, pathText, trimmed)
+			}
+			return
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "*"):
+			l.errorf(n, "strict component %s cannot select through %s of pointer type %s; pointer fields cannot preserve Go nil-pointer behavior in the file renderer", componentName, pathText, trimmed)
+			return
+		case strictRendererScalarType(trimmed):
+			l.errorf(n, "strict component %s cannot select %q through %s of type %s; selector paths cross same-file struct fields only", componentName, path[i+1], pathText, trimmed)
+			return
+		default:
+			if _, isStruct := l.structTypes[trimmed]; isStruct {
+				currentType = trimmed
+				continue
+			}
+			l.errorf(n, "strict component %s cannot resolve %s.%s: struct %s is not declared in this .gsx file; declare the renderer-visible struct beside the component", componentName, pathText, path[i+1], trimmed)
+			return
 		}
 	}
+}
+
+// strictSelectorPathType is resolveStrictSelectorPath's silent counterpart:
+// it resolves path the same way but reports no diagnostic, returning
+// ok=false for any structural problem (too deep, an unknown field, a
+// pointer or otherwise non-struct intermediate, an undeclared intermediate
+// struct) and also for a leaf that is not a renderer scalar at all.
+// validateStrictRenderedProps already reports each registered read's own
+// root cause once (including "leaf is not a renderer scalar"); a second
+// caller (the concat exact-string pass, the <If cond> exact-bool pass)
+// restating it for the same path would just duplicate that diagnostic, so
+// those callers use this and skip emitting anything when ok is false.
+func (l *lowerer) strictSelectorPathType(propsType string, path []string) (string, bool) {
+	if len(path) == 0 || len(path) > strictSelectorPathDepthLimit {
+		return "", false
+	}
+	currentType := propsBaseType(propsType)
+	for i, field := range path {
+		fieldType, known := l.structTypes[currentType][field]
+		if !known {
+			return "", false
+		}
+		trimmed := strings.TrimSpace(fieldType)
+		if i == len(path)-1 {
+			if !strictRendererScalarType(trimmed) {
+				return "", false
+			}
+			return trimmed, true
+		}
+		if strings.HasPrefix(trimmed, "*") || strictRendererScalarType(trimmed) {
+			return "", false
+		}
+		if _, isStruct := l.structTypes[trimmed]; !isStruct {
+			return "", false
+		}
+		currentType = trimmed
+	}
+	return "", false
 }
 
 func lowerCamelInitialism(value string) string {
@@ -1224,8 +1323,17 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		// Let the package checker produce the authoritative unknown-field
 		// diagnostic before checking omissions in a same-file schema.
 		if !hasUnknownSameFileAttr {
-			fields := make([]string, 0, len(required))
-			for field := range required {
+			// required is keyed by dot-joined read path ("Player.Name"); the
+			// explicit-supply rule only needs each path's root field — the
+			// caller supplies the whole root value once, regardless of how
+			// many nested paths this callee reads under it.
+			roots := make(map[string]struct{}, len(required))
+			for path := range required {
+				root, _, _ := strings.Cut(path, ".")
+				roots[root] = struct{}{}
+			}
+			fields := make([]string, 0, len(roots))
+			for field := range roots {
 				fields = append(fields, field)
 			}
 			sort.Strings(fields)
@@ -1471,11 +1579,13 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 	l.strict = wasStrict
 	l.strictServer = wasStrictServer
 	scope := l.analyzeBody(bodyNode)
+	propsFields, propsPaths := l.copyStrictPropTypes(propsType, l.strictReads[componentName])
 	comp := Component{
 		Name:        componentName,
 		PropsType:   propsType,
 		PropsName:   propsName,
-		PropsFields: copyStrictPropTypes(l.structTypes[propsBaseType(propsType)], l.strictReads[componentName]),
+		PropsFields: propsFields,
+		PropsPaths:  propsPaths,
 		Syntax:      ComponentSyntaxStrict,
 		Root:        rootID,
 		IsIsland:    isIsland,
@@ -1497,17 +1607,41 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 	l.prog.Components = append(l.prog.Components, comp)
 }
 
-func copyStrictPropTypes(fields map[string]string, reads map[string]struct{}) map[string]string {
+// copyStrictPropTypes builds the two IR maps the renderer boundary uses.
+// PropsFields records, for the root field of every registered read path,
+// that root's own declared type (a scalar builtin for a direct read, or a
+// same-file struct name for a nested read's root). PropsPaths records, for
+// every read path with at least one hop past its root, the leaf field's
+// declared type keyed by the full dot-joined path — populated only when the
+// path resolves cleanly; a broken path already has its own diagnostic from
+// validateStrictRenderedProps, so this silently omits it rather than
+// producing partial data for a component that is failing to compile anyway.
+func (l *lowerer) copyStrictPropTypes(propsType string, reads map[string]struct{}) (map[string]string, map[string]string) {
+	fields := l.structTypes[propsBaseType(propsType)]
 	if len(fields) == 0 || len(reads) == 0 {
-		return nil
+		return nil, nil
 	}
-	out := make(map[string]string, len(reads))
-	for name := range reads {
-		if fieldType, ok := fields[name]; ok {
-			out[name] = fieldType
+	propsFields := make(map[string]string, len(reads))
+	var propsPaths map[string]string
+	for path := range reads {
+		segments := strings.Split(path, ".")
+		root := segments[0]
+		if fieldType, ok := fields[root]; ok {
+			propsFields[root] = fieldType
+		}
+		if len(segments) > 1 {
+			if leafType, ok := l.strictSelectorPathType(propsType, segments); ok {
+				if propsPaths == nil {
+					propsPaths = make(map[string]string)
+				}
+				propsPaths[path] = leafType
+			}
 		}
 	}
-	return out
+	if len(propsFields) == 0 {
+		propsFields = nil
+	}
+	return propsFields, propsPaths
 }
 
 func (l *lowerer) strictComponentGSXRoot(body *gotreesitter.Node, allowIslandDecls bool) *gotreesitter.Node {
@@ -1613,41 +1747,41 @@ func (l *lowerer) validateStrictServerExpression(span Span, source, componentNam
 }
 
 // validateStrictExpressionTypes runs the type-side gate for expression shapes
-// the syntactic validator accepts but cannot itself type-check. In v0.42 that
-// is exactly the string-concatenation chain: every props field operand must
-// resolve, through the same-file struct schema, to declared type exactly
-// string — not a named string type, not []byte. Fields that are unknown or
-// that already fail the renderer-scalar-type gate are skipped here; those
-// diagnostics belong to the package checker and validateStrictRenderedProps
-// respectively, and duplicating them would just restate the same root cause.
+// the syntactic validator accepts but cannot itself type-check: the
+// string-concatenation chain. Every props field operand — a direct field or
+// a nested path (props.A.B[.C]) — must resolve, through the same-file
+// struct schema, to declared type exactly string — not a named string type,
+// not []byte, not a struct. A path that fails to resolve at all is skipped
+// here; validateStrictRenderedProps already reports that root cause once,
+// and restating it would just duplicate the diagnostic.
 func (l *lowerer) validateStrictExpressionTypes(span Span, source, componentName, propsType string) {
-	fields, ok := strictcomponent.ServerConcatPropFields(source)
+	paths, ok := strictcomponent.ServerConcatPropPaths(source)
 	if !ok {
 		return
 	}
-	fieldTypes := l.structTypes[propsBaseType(propsType)]
-	for _, field := range fields {
-		fieldType, known := fieldTypes[field]
-		if !known || !strictRendererScalarType(fieldType) {
+	for _, path := range paths {
+		leafType, known := l.strictSelectorPathType(propsType, path)
+		if !known {
 			continue
 		}
-		if strings.TrimSpace(fieldType) != "string" {
+		if leafType != "string" {
 			l.errs = append(l.errs, Diagnostic{
 				Span:    span,
-				Message: fmt.Sprintf("strict component %s cannot concatenate props.%s of type %s; \"+\" operands must be exact string props fields", componentName, field, fieldType),
+				Message: fmt.Sprintf("strict component %s cannot concatenate props.%s of type %s; \"+\" operands must be exact string props fields", componentName, strings.Join(path, "."), leafType),
 			})
 		}
 	}
 }
 
 // validateStrictConditionalExpression validates a strict <If cond={...}>
-// attribute's expression content: the syntactic shape (bare bool selector or
-// selector == false) through the dedicated cond validator, then the exact
-// bool type through the same-file struct schema. General expression
-// positions never reach this function — only the cond attribute of an
-// unshadowed <If> does, dispatched from validateStrictServerExpressions.
+// attribute's expression content: the syntactic shape (bare bool selector,
+// possibly a nested path, or that selector == false) through the dedicated
+// cond validator, then the exact bool type through the same-file struct
+// schema. General expression positions never reach this function — only the
+// cond attribute of an unshadowed <If> does, dispatched from
+// validateStrictServerExpressions.
 func (l *lowerer) validateStrictConditionalExpression(span Span, source, componentName, propsType string) {
-	field, _, err := strictcomponent.ValidateServerCondExpression(source)
+	path, _, err := strictcomponent.ValidateServerCondExpression(source)
 	if err != nil {
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
@@ -1656,14 +1790,14 @@ func (l *lowerer) validateStrictConditionalExpression(span Span, source, compone
 		})
 		return
 	}
-	fieldType, known := l.structTypes[propsBaseType(propsType)][field]
-	if !known || !strictRendererScalarType(fieldType) {
+	fieldType, known := l.strictSelectorPathType(propsType, path)
+	if !known {
 		return
 	}
-	if strings.TrimSpace(fieldType) != "bool" {
+	if fieldType != "bool" {
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
-			Message: fmt.Sprintf("strict component %s cannot use props.%s of type %s in <If cond>; cond requires an exact bool props field", componentName, field, fieldType),
+			Message: fmt.Sprintf("strict component %s cannot use props.%s of type %s in <If cond>; cond requires an exact bool props field", componentName, strings.Join(path, "."), fieldType),
 		})
 	}
 }

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1141,9 +1141,23 @@ const strictSelectorPathDepthLimit = 3
 // selector semantics in the map-backed file renderer: too deep, a pointer
 // intermediate, an intermediate whose type is a renderer scalar (nothing to
 // select further through), an intermediate struct type this .gsx file does
-// not declare, or a non-scalar leaf. The props base type itself is assumed
-// already declared in this file — validateStrictRenderedProps checks that
-// gate before calling this for any path.
+// not declare, an unknown field past the root, or a non-scalar leaf. The
+// props base type itself is assumed already declared in this file —
+// validateStrictRenderedProps checks that gate before calling this for any
+// path.
+//
+// An unknown field at hop 0 (a direct field of the props struct itself) is
+// left to the package checker: the generated program's real props parameter
+// is exactly this same-file struct type, so an unknown or unexported field
+// there is a compile error in the check program regardless of what this
+// lowerer does. An unknown field at any later hop gets no such backstop:
+// field promotion through an embedded type is legal Go, so the check
+// program compiles a promoted, unexported, or genuinely absent field the
+// same way — silently deferring here would let the component compile while
+// the map-backed file renderer and generated Go disagree on what the
+// selector resolves to (or panic trying). This function fails closed for
+// all three shapes at hop i>0, exactly mirroring the lowerer rule
+// strictSelectorPathType applies for its own, diagnostic-free callers.
 func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName, propsType string, path []string) {
 	if len(path) > strictSelectorPathDepthLimit {
 		l.errorf(n, "strict component %s selector props.%s is too deep; the strict renderer resolves at most three fields", componentName, strings.Join(path, "."))
@@ -1154,9 +1168,13 @@ func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName,
 	for i, field := range path {
 		fieldType, known := l.structTypes[currentType][field]
 		if !known {
-			// Unknown field: the package checker supplies the precise
-			// unknown/unexported-field diagnostic; this guard only owns
-			// known renderer schema types.
+			if i == 0 {
+				// The props struct's own field: the package checker
+				// supplies the precise unknown/unexported-field diagnostic;
+				// this guard only owns known renderer schema types.
+				return
+			}
+			l.errorf(n, "strict component %s cannot resolve %s.%s: struct %s declares no visible field %s; promoted, unexported, and unknown fields cannot cross the file renderer boundary", componentName, pathText, field, currentType, field)
 			return
 		}
 		trimmed := strings.TrimSpace(fieldType)
@@ -1187,14 +1205,18 @@ func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName,
 
 // strictSelectorPathType is resolveStrictSelectorPath's silent counterpart:
 // it resolves path the same way but reports no diagnostic, returning
-// ok=false for any structural problem (too deep, an unknown field, a
-// pointer or otherwise non-struct intermediate, an undeclared intermediate
-// struct) and also for a leaf that is not a renderer scalar at all.
-// validateStrictRenderedProps already reports each registered read's own
-// root cause once (including "leaf is not a renderer scalar"); a second
-// caller (the concat exact-string pass, the <If cond> exact-bool pass)
-// restating it for the same path would just duplicate that diagnostic, so
-// those callers use this and skip emitting anything when ok is false.
+// ok=false for any structural problem (too deep, an unknown field at hop 0
+// or later, a pointer or otherwise non-struct intermediate, an undeclared
+// intermediate struct) and also for a leaf that is not a renderer scalar at
+// all. It applies the same hop-0-vs-later distinction resolveStrictSelectorPath
+// documents for an unknown field, just without ever emitting a diagnostic
+// itself: validateStrictRenderedProps already reports each registered
+// read's own root cause once (an hop-0 unknown field by deferring to the
+// package checker, an hop-i>0 unknown field — promoted, unexported, or
+// absent — as its own error); a second caller (the concat exact-string
+// pass, the <If cond> exact-bool pass) restating either for the same path
+// would just duplicate that diagnostic, so those callers use this and skip
+// emitting anything when ok is false.
 func (l *lowerer) strictSelectorPathType(propsType string, path []string) (string, bool) {
 	if len(path) == 0 || len(path) > strictSelectorPathDepthLimit {
 		return "", false
@@ -1203,6 +1225,10 @@ func (l *lowerer) strictSelectorPathType(propsType string, path []string) (strin
 	for i, field := range path {
 		fieldType, known := l.structTypes[currentType][field]
 		if !known {
+			// Unknown at hop 0 or later: both fail closed here (no leaf
+			// type, ok=false). Only resolveStrictSelectorPath's own copy of
+			// this check treats the two differently, since only it decides
+			// whether to emit a diagnostic.
 			return "", false
 		}
 		trimmed := strings.TrimSpace(fieldType)
@@ -1220,6 +1246,10 @@ func (l *lowerer) strictSelectorPathType(propsType string, path []string) (strin
 		}
 		currentType = trimmed
 	}
+	// Unreachable: the top-of-function guard rejects an empty path, so the
+	// final iteration always has i == len(path)-1 and returns from the
+	// branch above. Go cannot prove that for a for-range loop, so this
+	// satisfies the compiler's return-statement requirement.
 	return "", false
 }
 

--- a/ir/propspaths_roundtrip_test.go
+++ b/ir/propspaths_roundtrip_test.go
@@ -1,0 +1,64 @@
+package ir
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestComponentPropsPathsDecodesAbsentFromOlderPrograms proves the
+// compatibility rule PropsPaths' doc comment states, matching
+// ComponentSyntax's established zero-value convention: a Component encoded
+// before this field existed decodes into the current type with PropsPaths
+// absent (nil), not an error and not a present-but-empty map that would
+// compare unequal to the legacy zero value. legacyComponentJSON is a
+// hand-written encoding of a pre-#183 Component — every field this change
+// adds is absent, exactly as a program serialized before PropsPaths existed
+// would be.
+func TestComponentPropsPathsDecodesAbsentFromOlderPrograms(t *testing.T) {
+	const legacyComponentJSON = `{
+		"Name": "Card",
+		"PropsType": "CardProps",
+		"PropsName": "props",
+		"PropsFields": {"Tone": "string"},
+		"Syntax": 1,
+		"Root": 3
+	}`
+	var comp Component
+	if err := json.Unmarshal([]byte(legacyComponentJSON), &comp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if comp.PropsPaths != nil {
+		t.Fatalf("PropsPaths = %#v, want nil (absent) for a program serialized before this field existed", comp.PropsPaths)
+	}
+	if comp.Name != "Card" || comp.PropsFields["Tone"] != "string" || comp.Syntax != ComponentSyntaxStrict {
+		t.Fatalf("legacy fields did not decode unchanged: %#v", comp)
+	}
+}
+
+// TestComponentPropsPathsRoundTripsThroughJSON proves the new field itself
+// round-trips: a Component with a populated PropsPaths encodes and decodes
+// back to an equal value, alongside its PropsFields root-type entry.
+func TestComponentPropsPathsRoundTripsThroughJSON(t *testing.T) {
+	comp := Component{
+		Name:        "Row",
+		PropsType:   "RowProps",
+		PropsName:   "props",
+		PropsFields: map[string]string{"Player": "Player"},
+		PropsPaths:  map[string]string{"Player.Name": "string"},
+		Syntax:      ComponentSyntaxStrict,
+	}
+	data, err := json.Marshal(comp)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded Component
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if decoded.PropsPaths["Player.Name"] != "string" {
+		t.Fatalf("PropsPaths did not round-trip: %#v", decoded.PropsPaths)
+	}
+	if decoded.Name != comp.Name || decoded.PropsFields["Player"] != "Player" {
+		t.Fatalf("Component did not round-trip: %#v", decoded)
+	}
+}

--- a/route/exprlower_test.go
+++ b/route/exprlower_test.go
@@ -44,6 +44,15 @@ func referenceEvalFileNode(expr ast.Expr, env fileRenderEnv) any {
 	}
 }
 
+// exprLowerNestedStruct backs the nested-selector differential case below: a
+// real Go struct value (not a map), so chained selector_expression
+// evaluation exercises the same reflection-based selectStructValue path a
+// nested props read (props.Player.Name) does at the strict-component
+// renderer boundary.
+type exprLowerNestedStruct struct {
+	Value string
+}
+
 func exprLowerTestEnv() fileRenderEnv {
 	return fileRenderEnv{
 		values: map[string]any{
@@ -57,6 +66,7 @@ func exprLowerTestEnv() fileRenderEnv {
 				"lookup": map[string]int{"a": 1, "b": 2},
 				"blank":  "",
 				"none":   nil,
+				"nested": exprLowerNestedStruct{Value: "leaf"},
 			},
 			"total": 10,
 			"label": "Hello",
@@ -139,6 +149,14 @@ var exprLowerCases = []string{
 	`"a" + data.name + "b"`,
 	`data.on == false`,
 	`data.off == false`,
+	// Nested prop reads (props.A.B[.C]): selectValue's struct branch is
+	// pre-existing and untouched by this change, but nothing exercised a
+	// chained selector through a real struct value here before — the
+	// nested-selector strict-surface extension is what makes GoSX-authored
+	// source actually reach it via props.Player.Name-shaped expressions, so
+	// the differential oracle gets explicit coverage.
+	`data.nested.Value`,
+	`"leaf-" + data.nested.Value`,
 }
 
 func TestLoweredExprMatchesReferenceInterpreter(t *testing.T) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1370,7 +1370,7 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 		fieldType, rendered := comp.PropsFields[attr.Name]
 		var value any
 		if rendered {
-			converted, err := strictComponentAttrValue(attr, env, fieldType)
+			converted, err := strictComponentAttrValue(comp, attr, env, fieldType)
 			if err != nil {
 				return nil, fmt.Errorf("prop %s (%s): %w", attr.Name, fieldType, err)
 			}
@@ -1387,7 +1387,16 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 	return props, nil
 }
 
-func strictComponentAttrValue(attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
+func strictComponentAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
+	if !strictScalarFieldType(fieldType) {
+		// A rendered field whose declared type is not one of the renderer's
+		// exact scalar builtins is a nested-selector root (ir.Component.
+		// PropsPaths): a same-file struct, provable at every strict-call
+		// boundary but not renderable directly (ir/lower.go's
+		// validateStrictRenderedProps only ever admits a struct-typed root
+		// when at least one nested path under it resolves to a scalar leaf).
+		return strictComponentStructAttrValue(comp, attr, env, fieldType)
+	}
 	var value any
 	switch attr.Kind {
 	case ir.AttrStatic:
@@ -1403,6 +1412,94 @@ func strictComponentAttrValue(attr ir.Attr, env fileRenderEnv, fieldType string)
 		return nil, fmt.Errorf("spread attributes are not supported")
 	}
 	return requireStrictScalarType(value, fieldType)
+}
+
+// strictScalarFieldType reports whether fieldType is one of the renderer's
+// exact scalar builtins. Duplicated from ir.strictRendererScalarType (an
+// unexported ir-package function route cannot import) rather than exported,
+// since it is a small, stable, closed set and this is its only other
+// reference point.
+func strictScalarFieldType(fieldType string) bool {
+	switch fieldType {
+	case "string", "bool",
+		"int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"byte", "rune", "float32", "float64":
+		return true
+	default:
+		return false
+	}
+}
+
+// strictComponentStructAttrValue handles a rendered prop whose declared type
+// is a same-file struct. A struct value can only arrive through an AttrExpr
+// — there is no static or boolean spelling for one — so every other
+// attribute kind fails closed with the same shape of error a type mismatch
+// would produce.
+func strictComponentStructAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
+	if attr.Kind != ir.AttrExpr {
+		return nil, fmt.Errorf("value has no struct spelling, want exact struct %s", fieldType)
+	}
+	value := evalFileExpr(attr.Expr, env)
+	return requireStrictStructValue(value, fieldType, strictStructPropsPaths(comp, attr.Name))
+}
+
+// strictStructPropsPaths filters comp.PropsPaths — keyed by the full
+// dot-joined path including its root, e.g. "Player.Name" — down to the
+// sub-paths under one root field, with the root segment removed (e.g.
+// "Name"), for requireStrictStructValue to walk.
+func strictStructPropsPaths(comp *ir.Component, root string) map[string]string {
+	if comp == nil || len(comp.PropsPaths) == 0 {
+		return nil
+	}
+	prefix := root + "."
+	var out map[string]string
+	for path, leafType := range comp.PropsPaths {
+		if sub, ok := strings.CutPrefix(path, prefix); ok {
+			if out == nil {
+				out = make(map[string]string, len(comp.PropsPaths))
+			}
+			out[sub] = leafType
+		}
+	}
+	return out
+}
+
+// requireStrictStructValue is requireStrictScalarType's counterpart for a
+// nested-selector root: value must be exactly the same-file declared struct
+// type typeName (not a pointer, not an anonymous struct, not a map), and
+// every read path this component resolves under that root (paths, keyed by
+// the dot-joined sub-path with the root segment removed) must resolve by
+// FieldByName to a value of its declared leaf type. A mismatch anywhere
+// fails closed; the caller (strictComponentAttrValue, through
+// localComponentProps) wraps the error with the attribute name and field
+// type, matching the scalar boundary's existing error shape.
+func requireStrictStructValue(value any, typeName string, paths map[string]string) (any, error) {
+	if value == nil {
+		return nil, fmt.Errorf("value is nil")
+	}
+	rv := reflect.ValueOf(value)
+	rt := rv.Type()
+	if rt.Kind() != reflect.Struct || rt.PkgPath() == "" || rt.Name() != typeName {
+		return nil, fmt.Errorf("runtime value has type %s, want exact struct %s", rt, typeName)
+	}
+	for subPath, leafType := range paths {
+		fv := rv
+		for _, segment := range strings.Split(subPath, ".") {
+			if fv.Kind() != reflect.Struct {
+				return nil, fmt.Errorf("path %s.%s: value has type %s, want struct", typeName, subPath, fv.Type())
+			}
+			field := fv.FieldByName(segment)
+			if !field.IsValid() || !field.CanInterface() {
+				return nil, fmt.Errorf("path %s.%s: field %s not found", typeName, subPath, segment)
+			}
+			fv = field
+		}
+		if _, err := requireStrictScalarType(fv.Interface(), leafType); err != nil {
+			return nil, fmt.Errorf("path %s.%s: %w", typeName, subPath, err)
+		}
+	}
+	return value, nil
 }
 
 func strictGoConstant(source string) (constant.Value, bool) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1367,10 +1367,12 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 	}
 	props := make(map[string]any, len(attrs)+4)
 	for _, attr := range attrs {
-		fieldType, rendered := comp.PropsFields[attr.Name]
+		field, fieldType, rendered := resolvePropsFieldAlias(comp.PropsFields, attr.Name)
 		var value any
 		if rendered {
-			converted, err := strictComponentAttrValue(comp, attr, env, fieldType)
+			resolved := attr
+			resolved.Name = field
+			converted, err := strictComponentAttrValue(comp, resolved, env, fieldType)
 			if err != nil {
 				return nil, fmt.Errorf("prop %s (%s): %w", attr.Name, fieldType, err)
 			}
@@ -1431,6 +1433,60 @@ func strictScalarFieldType(fieldType string) bool {
 	}
 }
 
+// resolvePropsFieldAlias resolves attr's rendered-prop name against
+// comp.PropsFields, trying an exact match first and then the
+// lowerCamelInitialism alias the lowerer accepts at a same-file strict call
+// site (ir/lower.go's normalizeStrictComponentAttrs and
+// validateStrictComponentCall). A program the lowerer itself compiled
+// already carries the canonical spelling by the time it reaches this
+// boundary — normalizeStrictComponentAttrs rewrites it during lowering —
+// but ir.Program is plain data a generated-Go caller or a hand-built
+// program can also produce directly, without ever running through that
+// rewrite. Without this fallback, an alias-spelled attribute misses the
+// exact-key lookup, rendered comes back false, and the value skips
+// strictComponentAttrValue's whole type-checked boundary (conversion,
+// requireStrictScalarType, requireStrictStructValue) while still landing in
+// the runtime props map under both spellings via setComponentProp — this
+// closes that gap by resolving the alias before the lookup instead.
+func resolvePropsFieldAlias(fields map[string]string, name string) (field, fieldType string, ok bool) {
+	if fieldType, exact := fields[name]; exact {
+		return name, fieldType, true
+	}
+	for candidate, candidateType := range fields {
+		if lowerCamelInitialism(candidate) != name {
+			continue
+		}
+		if field != "" {
+			// Ambiguous: two declared fields alias to the same name. Fail
+			// closed the same way an unresolved attribute already does,
+			// rather than guessing.
+			return "", "", false
+		}
+		field, fieldType = candidate, candidateType
+	}
+	return field, fieldType, field != ""
+}
+
+// lowerCamelInitialism lower-cases a leading initialism run (HTMLFor ->
+// htmlFor, URL -> url) the same way ir's unexported function of the same
+// name does for a strict call site's alias-named attributes. Duplicated
+// rather than exported for the same reason strictScalarFieldType is: a
+// small, stable transform route needs at exactly one other boundary and
+// cannot import from ir (unexported).
+func lowerCamelInitialism(value string) string {
+	if value == "" || value[0] < 'A' || value[0] > 'Z' {
+		return value
+	}
+	end := 1
+	for end < len(value) && value[end] >= 'A' && value[end] <= 'Z' {
+		if end+1 < len(value) && value[end+1] >= 'a' && value[end+1] <= 'z' {
+			break
+		}
+		end++
+	}
+	return strings.ToLower(value[:end]) + value[end:]
+}
+
 // strictComponentStructAttrValue handles a rendered prop whose declared type
 // is a same-file struct. A struct value can only arrive through an AttrExpr
 // — there is no static or boolean spelling for one — so every other
@@ -1466,14 +1522,18 @@ func strictStructPropsPaths(comp *ir.Component, root string) map[string]string {
 }
 
 // requireStrictStructValue is requireStrictScalarType's counterpart for a
-// nested-selector root: value must be exactly the same-file declared struct
-// type typeName (not a pointer, not an anonymous struct, not a map), and
-// every read path this component resolves under that root (paths, keyed by
-// the dot-joined sub-path with the root segment removed) must resolve by
-// FieldByName to a value of its declared leaf type. A mismatch anywhere
-// fails closed; the caller (strictComponentAttrValue, through
-// localComponentProps) wraps the error with the attribute name and field
-// type, matching the scalar boundary's existing error shape.
+// nested-selector root: value's runtime type must match typeName by name
+// (not a pointer, not an anonymous struct, not a map — PkgPath must be
+// non-empty), and every read path this component resolves under that root
+// (paths, keyed by the dot-joined sub-path with the root segment removed)
+// must resolve to a value of its declared leaf type. The name check is
+// nominal only: it does not compare package paths against this file's own
+// package, since a rendered program's caller can live in any package; the
+// per-path leaf-type walk below is what actually proves the value shape a
+// same-file .gsx struct declares. A mismatch anywhere fails closed; the
+// caller (strictComponentAttrValue, through localComponentProps) wraps the
+// error with the attribute name and field type, matching the scalar
+// boundary's existing error shape.
 func requireStrictStructValue(value any, typeName string, paths map[string]string) (any, error) {
 	if value == nil {
 		return nil, fmt.Errorf("value is nil")
@@ -1489,11 +1549,26 @@ func requireStrictStructValue(value any, typeName string, paths map[string]strin
 			if fv.Kind() != reflect.Struct {
 				return nil, fmt.Errorf("path %s.%s: value has type %s, want struct", typeName, subPath, fv.Type())
 			}
-			field := fv.FieldByName(segment)
-			if !field.IsValid() || !field.CanInterface() {
+			// Resolve through the TYPE first, not Value.FieldByName: the
+			// latter also walks embedded-field promotion and indirects
+			// through any pointer along the way, which panics when that
+			// pointer is nil ("reflect: indirection through nil pointer to
+			// embedded struct") for a value whose runtime shape does not
+			// match what the .gsx schema declared. sf.Index has length 1
+			// for a field declared directly on the struct and length >1 for
+			// a promoted field reached through one or more embeddings — the
+			// lowerer already rejects a promoted field at this same path
+			// shape (ir/lower.go's resolveStrictSelectorPath), so a length
+			// other than 1 here only reaches a caller that fed a struct
+			// value the lowerer never validated.
+			sf, ok := fv.Type().FieldByName(segment)
+			if !ok || !sf.IsExported() {
 				return nil, fmt.Errorf("path %s.%s: field %s not found", typeName, subPath, segment)
 			}
-			fv = field
+			if len(sf.Index) != 1 {
+				return nil, fmt.Errorf("path %s.%s: field %s is a promoted (embedded) field; only fields declared directly on the struct resolve here", typeName, subPath, segment)
+			}
+			fv = fv.Field(sf.Index[0])
 		}
 		if _, err := requireStrictScalarType(fv.Interface(), leafType); err != nil {
 			return nil, fmt.Errorf("path %s.%s: %w", typeName, subPath, err)

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -434,6 +434,24 @@ type routeTestTeam struct {
 	City string
 }
 
+// routeTestTeamEmbed and routeTestPlayerEmbeddedPtr back the M2
+// (requireStrictStructValue panic) tests below: a value-embedded and a
+// pointer-embedded struct, both promoting City. A .gsx-compiled program can
+// no longer produce PropsPaths naming a promoted field at all (B1 rejects
+// it at compile time), so these stand in for a generated-Go caller or
+// hand-built ir.Program whose runtime struct shape was never validated by
+// the lowerer — exactly the "foreign type passing the nominal gate" case
+// requireStrictStructValue's own boundary must still fail closed against.
+type routeTestTeamEmbed struct {
+	routeTestTeam
+	Age int
+}
+
+type routeTestPlayerEmbeddedPtr struct {
+	*routeTestTeam
+	Age int
+}
+
 // TestRequireStrictStructValueAcceptsMatchingStruct is the struct-boundary
 // accept case, mirroring TestRequireStrictScalarTypeRejectsConcatBoundaryMismatch's
 // direct-call pattern for the new function.
@@ -520,6 +538,93 @@ func TestRequireStrictStructValueRejectsPathThroughScalarField(t *testing.T) {
 	value := routeTestPlayer{Name: "Ada"}
 	if _, err := requireStrictStructValue(value, "routeTestPlayer", map[string]string{"Name.Extra": "string"}); err == nil {
 		t.Fatal("requireStrictStructValue unexpectedly accepted a path through a scalar field")
+	}
+}
+
+// TestRequireStrictStructValueRejectsPromotedFieldWithoutPanicking is M2's
+// core reproduction: value.FieldByName used to walk promotion and panic on
+// this exact shape when the promoting field was a nil pointer (see the next
+// test); here the embedding is a plain value, non-nil, so the pre-fix code
+// did not panic — it silently accepted the promoted field and returned its
+// value. The fix rejects a promoted field (StructField.Index length > 1) at
+// the type level before ever touching the value, matching the lowerer's own
+// rule that a promoted field cannot cross this boundary.
+func TestRequireStrictStructValueRejectsPromotedFieldWithoutPanicking(t *testing.T) {
+	value := routeTestTeamEmbed{routeTestTeam: routeTestTeam{City: "Springfield"}, Age: 7}
+	_, err := requireStrictStructValue(value, "routeTestTeamEmbed", map[string]string{"City": "string"})
+	if err == nil {
+		t.Fatal("requireStrictStructValue unexpectedly accepted a promoted field")
+	}
+	want := "field City is a promoted (embedded) field"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want it to contain %q", err, want)
+	}
+}
+
+// TestRequireStrictStructValueRejectsNilEmbeddedPointerWithoutPanicking is
+// M2's nil-pointer reproduction: reflect.Value.FieldByName indirects
+// through every embedded pointer on the way to a promoted field and panics
+// ("reflect: indirection through nil pointer to embedded struct") when one
+// is nil. The Team pointer here is nil (zero value), so a pre-fix call
+// would panic instead of returning an error; requireStrictStructValue must
+// fail closed with an ordinary error, and RenderProgramComponent (the
+// public API sitting above it) must never let that panic through.
+func TestRequireStrictStructValueRejectsNilEmbeddedPointerWithoutPanicking(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("requireStrictStructValue panicked: %v", r)
+		}
+	}()
+	value := routeTestPlayerEmbeddedPtr{Age: 3}
+	_, err := requireStrictStructValue(value, "routeTestPlayerEmbeddedPtr", map[string]string{"City": "string"})
+	if err == nil {
+		t.Fatal("requireStrictStructValue unexpectedly accepted a field through a nil embedded pointer")
+	}
+	want := "field City is a promoted (embedded) field"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want it to contain %q", err, want)
+	}
+}
+
+// TestRenderProgramComponentDoesNotPanicOnNilEmbeddedPointerPromotedField is
+// the end-to-end proof that M2's fix reaches the public API: a hand-built
+// ir.Program feeding a nil-embedded-pointer struct through the render
+// boundary (the same reflect.FieldByName panic vector, one layer up) must
+// return an error from RenderProgramComponent, never panic out of it.
+func TestRenderProgramComponentDoesNotPanicOnNilEmbeddedPointerPromotedField(t *testing.T) {
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("RenderProgramComponent panicked: %v", r)
+		}
+	}()
+	prog := &ir.Program{}
+	exprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Player.City"})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "p", Children: []ir.NodeID{exprID}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Row",
+		PropsName:   "props",
+		PropsType:   "RowProps",
+		PropsFields: map[string]string{"Player": "routeTestPlayerEmbeddedPtr"},
+		PropsPaths:  map[string]string{"Player.City": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        rowRoot,
+	})
+	rowCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Row",
+		Attrs: []ir.Attr{{Name: "Player", Kind: ir.AttrExpr, Expr: "playerVar"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:   "Page",
+		Syntax: ir.ComponentSyntaxLegacy,
+		Root:   rowCall,
+	})
+
+	_, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"playerVar": routeTestPlayerEmbeddedPtr{Age: 3}},
+	})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly accepted a nil-embedded-pointer promoted field")
 	}
 }
 
@@ -622,4 +727,66 @@ func TestStrictNestedSelectorRejectsWrongTypedStructAtRouteBoundary(t *testing.T
 	if !strings.Contains(err.Error(), "render strict component Row") {
 		t.Fatalf("error = %v, want it to name the failing strict component", err)
 	}
+}
+
+// TestLocalComponentPropsResolvesAliasBeforePropsFieldsLookup is m5's
+// reproduction: comp.PropsFields is keyed by the exact Go field spelling
+// ("TeamName"), but a generated-Go caller or hand-built ir.Program can
+// supply the lowerCamelInitialism alias ("teamName") directly, without ever
+// running through the lowerer's own normalizeStrictComponentAttrs rewrite
+// (that rewrite only fires for a call the lowerer itself compiled). Before
+// the fix, an exact-key lookup on the alias name missed comp.PropsFields,
+// "rendered" came back false, and the value skipped
+// strictComponentAttrValue's whole type-checked boundary (conversion,
+// requireStrictScalarType) while still landing in the runtime props map —
+// a caller supplying the wrong type under an alias name sailed through
+// un-rejected. The reject sub-test is the actual regression proof: a
+// mistyped value under the alias must fail exactly as it would under the
+// canonical spelling.
+func TestLocalComponentPropsResolvesAliasBeforePropsFieldsLookup(t *testing.T) {
+	newProg := func(attrExpr string) *ir.Program {
+		prog := &ir.Program{}
+		exprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.TeamName"})
+		rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "p", Children: []ir.NodeID{exprID}})
+		prog.Components = append(prog.Components, ir.Component{
+			Name:        "Row",
+			PropsName:   "props",
+			PropsType:   "RowProps",
+			PropsFields: map[string]string{"TeamName": "string"},
+			Syntax:      ir.ComponentSyntaxStrict,
+			Root:        rowRoot,
+		})
+		rowCall := prog.AddNode(ir.Node{
+			Kind:  ir.NodeComponent,
+			Tag:   "Row",
+			Attrs: []ir.Attr{{Name: "teamName", Kind: ir.AttrExpr, Expr: attrExpr}},
+		})
+		prog.Components = append(prog.Components, ir.Component{
+			Name:   "Page",
+			Syntax: ir.ComponentSyntaxLegacy,
+			Root:   rowCall,
+		})
+		return prog
+	}
+
+	t.Run("accepts a correctly typed value under the alias", func(t *testing.T) {
+		html, err := RenderProgramComponent(newProg(`"Meteors"`), "Page", ProgramRenderEnv{})
+		if err != nil {
+			t.Fatalf("RenderProgramComponent: %v", err)
+		}
+		if html != "<p>Meteors</p>" {
+			t.Fatalf("html = %q, want %q", html, "<p>Meteors</p>")
+		}
+	})
+
+	t.Run("rejects a mistyped value under the alias instead of skipping the boundary", func(t *testing.T) {
+		_, err := RenderProgramComponent(newProg("42"), "Page", ProgramRenderEnv{})
+		if err == nil {
+			t.Fatal("RenderProgramComponent unexpectedly accepted an int literal for an alias-named string prop")
+		}
+		want := "prop teamName (string)"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	})
 }

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
 )
 
 const strictInitialismSource = `package app
@@ -416,5 +417,209 @@ component Page() {
 	))
 	if html != want {
 		t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+	}
+}
+
+// routeTestPlayer and routeTestTeam back the nested-selector renderer
+// boundary tests below. They stand in for a same-file .gsx-declared struct:
+// a real Go type, declared in this package, so reflect.Type.Name() and
+// PkgPath() behave exactly as they would for a struct the strict lowerer
+// resolved from a .gsx file's own schema.
+type routeTestPlayer struct {
+	Name string
+	Team routeTestTeam
+}
+
+type routeTestTeam struct {
+	City string
+}
+
+// TestRequireStrictStructValueAcceptsMatchingStruct is the struct-boundary
+// accept case, mirroring TestRequireStrictScalarTypeRejectsConcatBoundaryMismatch's
+// direct-call pattern for the new function.
+func TestRequireStrictStructValueAcceptsMatchingStruct(t *testing.T) {
+	value := routeTestPlayer{Name: "Ada", Team: routeTestTeam{City: "Springfield"}}
+	got, err := requireStrictStructValue(value, "routeTestPlayer", map[string]string{
+		"Name":      "string",
+		"Team.City": "string",
+	})
+	if err != nil {
+		t.Fatalf("requireStrictStructValue: %v", err)
+	}
+	if got != value {
+		t.Fatalf("requireStrictStructValue returned %#v, want %#v", got, value)
+	}
+}
+
+// TestRequireStrictStructValueRejectsBoundaryMismatches exercises the
+// renderer boundary directly for every §2.b rejection shape reachable at
+// the struct boundary: a wrong declared type name, a pointer masquerading
+// as the value struct, a map masquerading as the struct, and a struct whose
+// runtime leaf field does not match its declared scalar type.
+func TestRequireStrictStructValueRejectsBoundaryMismatches(t *testing.T) {
+	type otherStruct struct{ Name string }
+
+	for _, tc := range []struct {
+		name  string
+		value any
+		paths map[string]string
+	}{
+		{
+			name:  "nil value",
+			value: nil,
+			paths: nil,
+		},
+		{
+			name:  "wrong declared type",
+			value: otherStruct{Name: "Ada"},
+			paths: nil,
+		},
+		{
+			name:  "pointer to the struct is not the struct",
+			value: &routeTestPlayer{Name: "Ada"},
+			paths: nil,
+		},
+		{
+			name:  "map masquerading as the struct",
+			value: map[string]any{"Name": "Ada"},
+			paths: nil,
+		},
+		{
+			name:  "leaf field type mismatch",
+			value: struct{ Name int }{Name: 1},
+			paths: map[string]string{"Name": "string"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := requireStrictStructValue(tc.value, "routeTestPlayer", tc.paths); err == nil {
+				t.Fatalf("requireStrictStructValue(%#v) unexpectedly accepted", tc.value)
+			}
+		})
+	}
+}
+
+// TestRequireStrictStructValueRejectsMissingNestedField covers a leaf path
+// that does not exist on the runtime value at all — the "companion Go
+// struct diverged from the .gsx schema copy" scenario section 5.4 assigns to
+// strictcheck's Go-compiler-backed half; this proves the renderer boundary
+// also fails closed for the same shape instead of panicking or rendering
+// empty.
+func TestRequireStrictStructValueRejectsMissingNestedField(t *testing.T) {
+	value := routeTestPlayer{Name: "Ada"}
+	if _, err := requireStrictStructValue(value, "routeTestPlayer", map[string]string{"Missing": "string"}); err == nil {
+		t.Fatal("requireStrictStructValue unexpectedly accepted a path with no matching field")
+	}
+}
+
+// TestRequireStrictStructValueRejectsPathThroughScalarField covers a
+// registered sub-path that tries to select through a leaf that already
+// bottomed out at a scalar (a slice-through-a-string shape mirroring
+// section 2.b's "selector paths cross same-file struct fields only" rule,
+// exercised here at the runtime boundary rather than at compile time).
+func TestRequireStrictStructValueRejectsPathThroughScalarField(t *testing.T) {
+	value := routeTestPlayer{Name: "Ada"}
+	if _, err := requireStrictStructValue(value, "routeTestPlayer", map[string]string{"Name.Extra": "string"}); err == nil {
+		t.Fatal("requireStrictStructValue unexpectedly accepted a path through a scalar field")
+	}
+}
+
+// TestStrictNestedSelectorRendersRealStructThroughRouteBoundary is the
+// nested-selector render-parity proof. Open question 1 in the design spec
+// notes that a strict .gsx caller cannot construct a struct value to
+// forward — there is no composite-literal spelling in the strict surface —
+// so no compiled .gsx source can feed a real struct through the file-route
+// boundary today; "generated-Go callers feed them" is the documented path.
+// This test exercises that same boundary code (writeLocalComponent ->
+// localComponentProps -> strictComponentAttrValue -> requireStrictStructValue
+// -> the callee body's props.Player.Name read through the pre-existing,
+// unchanged selectValue chain in fileeval.go) with a hand-built ir.Program
+// standing in for a generated-Go/typed caller, since ir.Program is plain
+// data and gosx.Compile is not the only legitimate way to produce one.
+func TestStrictNestedSelectorRendersRealStructThroughRouteBoundary(t *testing.T) {
+	prog := &ir.Program{}
+
+	// Row's body: <p>{props.Player.Name}</p>
+	exprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Player.Name"})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "p", Children: []ir.NodeID{exprID}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Row",
+		PropsName:   "props",
+		PropsType:   "RowProps",
+		PropsFields: map[string]string{"Player": "routeTestPlayer"},
+		PropsPaths:  map[string]string{"Player.Name": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        rowRoot,
+	})
+
+	// Page's body: <Row player={playerVar} />. Page itself carries no
+	// props (a zero-props Legacy root satisfies renderFileProgramHTML's
+	// root-props gate the same way a real zero-props Page component would);
+	// playerVar resolves through env.Values, standing in for a value a
+	// generated-Go/typed caller would pass directly.
+	rowCall := prog.AddNode(ir.Node{
+		Kind: ir.NodeComponent,
+		Tag:  "Row",
+		Attrs: []ir.Attr{
+			{Name: "Player", Kind: ir.AttrExpr, Expr: "playerVar"},
+		},
+	})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:   "Page",
+		Syntax: ir.ComponentSyntaxLegacy,
+		Root:   rowCall,
+	})
+
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"playerVar": routeTestPlayer{Name: "Ada"}},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if html != "<p>Ada</p>" {
+		t.Fatalf("html = %q, want %q", html, "<p>Ada</p>")
+	}
+}
+
+// TestStrictNestedSelectorRejectsWrongTypedStructAtRouteBoundary is the
+// reject half of the same end-to-end wiring: Row still declares its player
+// prop as exactly routeTestPlayer, so a caller handing it any other struct
+// — even one with a same-named, same-typed Name field, the classic "looks
+// right by field but is not the declared type" mismatch — fails closed at
+// the render boundary instead of rendering whatever the mismatched value
+// happens to expose.
+func TestStrictNestedSelectorRejectsWrongTypedStructAtRouteBoundary(t *testing.T) {
+	type otherPlayer struct{ Name string }
+
+	prog := &ir.Program{}
+	exprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Player.Name"})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "p", Children: []ir.NodeID{exprID}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Row",
+		PropsName:   "props",
+		PropsType:   "RowProps",
+		PropsFields: map[string]string{"Player": "routeTestPlayer"},
+		PropsPaths:  map[string]string{"Player.Name": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        rowRoot,
+	})
+	rowCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Row",
+		Attrs: []ir.Attr{{Name: "Player", Kind: ir.AttrExpr, Expr: "playerVar"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:   "Page",
+		Syntax: ir.ComponentSyntaxLegacy,
+		Root:   rowCall,
+	})
+
+	_, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"playerVar": otherPlayer{Name: "Ada"}},
+	})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly accepted a struct of the wrong declared type")
+	}
+	if !strings.Contains(err.Error(), "render strict component Row") {
+		t.Fatalf("error = %v, want it to name the failing strict component", err)
 	}
 }

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -129,7 +129,15 @@ component Page(props: Props) {
 	}
 }
 
-func TestCompileStrictServerRejectsNestedPropsSelectors(t *testing.T) {
+// TestCompileStrictServerRejectsNestedSelectorThroughPointerField flips
+// polarity from the v0.41 blanket nested-selector rejection: a pointer
+// intermediate stays rejected under extension (b), but the diagnostic now
+// comes from the lowerer's path resolution (section 4.3), naming the
+// component and the exact pointer type, because the syntax itself
+// (props.Nested.Value) is now a valid shape — see
+// TestCompileStrictServerAcceptsValueStructNestedSelectors below for the
+// case this test used to conflate with pointer rejection.
+func TestCompileStrictServerRejectsNestedSelectorThroughPointerField(t *testing.T) {
 	_, err := Compile([]byte(`package app
 type Nested struct { Value string }
 type Props struct { Nested *Nested }
@@ -137,8 +145,241 @@ component Page(props: Props) {
 	return <main>{props.Nested.Value}</main>
 }
 `))
-	if err == nil || !strings.Contains(err.Error(), "one field directly on props") {
-		t.Fatalf("error = %v", err)
+	want := "strict component Page cannot select through props.Nested of pointer type *Nested; pointer fields cannot preserve Go nil-pointer behavior in the file renderer"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerAcceptsValueStructNestedSelectors is the accept
+// half of section 2.b: a two- and three-hop selector chain through same-file
+// value (non-pointer) structs resolves to a scalar leaf and compiles.
+func TestCompileStrictServerAcceptsValueStructNestedSelectors(t *testing.T) {
+	source := []byte(`package app
+type Team struct { City string }
+type Player struct { Name string; Team Team }
+type Props struct { Player Player }
+component Row(props: Props) {
+	return <p>{props.Player.Name}: {props.Player.Team.City}</p>
+}
+`)
+	prog, err := Compile(source)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	row := prog.Components[0]
+	if row.PropsFields["Player"] != "Player" {
+		t.Fatalf("PropsFields[Player] = %q, want %q", row.PropsFields["Player"], "Player")
+	}
+	if row.PropsPaths["Player.Name"] != "string" {
+		t.Fatalf("PropsPaths[Player.Name] = %q, want %q", row.PropsPaths["Player.Name"], "string")
+	}
+	if row.PropsPaths["Player.Team.City"] != "string" {
+		t.Fatalf("PropsPaths[Player.Team.City] = %q, want %q", row.PropsPaths["Player.Team.City"], "string")
+	}
+}
+
+// TestCompileStrictServerRejectsSelectorThroughScalarField covers section
+// 4.3's first message: a selector tries to select a further field through
+// an intermediate that already resolved to a renderer scalar (nothing to
+// select through).
+func TestCompileStrictServerRejectsSelectorThroughScalarField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Props struct { Player string }
+component BoardRow(props: Props) {
+	return <main>{props.Player.Name}</main>
+}
+`))
+	want := `strict component BoardRow cannot select "Name" through props.Player of type string; selector paths cross same-file struct fields only`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsSelectorThroughUndeclaredStruct covers
+// section 4.3's third message: an intermediate field's type is a plausible
+// struct reference, but this .gsx file does not declare that struct.
+func TestCompileStrictServerRejectsSelectorThroughUndeclaredStruct(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Player struct { Team Team }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <main>{props.Player.Team.City}</main>
+}
+`))
+	want := "strict component BoardRow cannot resolve props.Player.Team.City: struct Team is not declared in this .gsx file; declare the renderer-visible struct beside the component"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsSelectorTooDeep covers section 4.3's fourth
+// message: the lowerer's three-hop resolution cap. The syntax itself is
+// valid (see TestValidateServerExpressionAcceptsNestedSelectors in
+// internal/strictcomponent); the cap is a lowerer concern with full
+// component context, not a schema-blind shape concern.
+func TestCompileStrictServerRejectsSelectorTooDeep(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type C struct { D string }
+type B struct { C C }
+type A struct { B B }
+type Props struct { A A }
+component BoardRow(props: Props) {
+	return <main>{props.A.B.C.D}</main>
+}
+`))
+	want := "strict component BoardRow selector props.A.B.C.D is too deep; the strict renderer resolves at most three fields"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsNestedSelectorNonScalarLeaf covers a leaf
+// that resolves cleanly through the schema but is not itself a renderer
+// scalar (a struct-typed leaf within the three-hop cap) — the same
+// "renderer-visible props fields" message the depth-1 case already uses,
+// generalized to a full path instead of a bare field name.
+func TestCompileStrictServerRejectsNestedSelectorNonScalarLeaf(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Team struct { City string }
+type Player struct { Team Team }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <main>{props.Player.Team}</main>
+}
+`))
+	want := "strict component BoardRow cannot render props.Player.Team of type Team; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsNestedSelectorEmbeddedField covers section
+// 2.b's embedded-field non-goal: collectStructSchemas only records
+// field_identifier children, so a promoted field through an embedded struct
+// is invisible to the same-file schema and fails closed the same way an
+// undeclared struct does.
+func TestCompileStrictServerRejectsNestedSelectorEmbeddedField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Team struct { City string }
+type Player struct { Team }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <main>{props.Player.City}</main>
+}
+`))
+	if err == nil {
+		t.Fatal("Compile unexpectedly accepted a promoted (embedded) field selector")
+	}
+}
+
+// TestCompileStrictServerAcceptsConcatOfNestedStringField covers the
+// interaction note: a concat operand accepts a nested selector path, not
+// just a direct field, in the same change that admits nested reads
+// generally.
+func TestCompileStrictServerAcceptsConcatOfNestedStringField(t *testing.T) {
+	source := []byte(`package app
+type Player struct { Name string }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <span class={"player-" + props.Player.Name}>{props.Player.Name}</span>
+}
+`)
+	if _, err := Compile(source); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+}
+
+// TestCompileStrictServerRejectsConcatOfNestedNonStringField mirrors
+// TestCompileStrictServerRejectsConcatOfNonStringField for a nested operand:
+// the leaf must be exactly string, named by its full path.
+func TestCompileStrictServerRejectsConcatOfNestedNonStringField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Player struct { Number int }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <span>{"No. " + props.Player.Number}</span>
+}
+`))
+	want := `strict component BoardRow cannot concatenate props.Player.Number of type int; "+" operands must be exact string props fields`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerAcceptsConcatOfNestedFieldPointerRootStillFailsClosed
+// proves the pointer rule applies uniformly to a concat operand, not just a
+// bare nested read — the interaction note's "widened selector rule applies
+// consistently wherever selectors are admitted" requirement.
+func TestCompileStrictServerAcceptsConcatOfNestedFieldPointerRootStillFailsClosed(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Player struct { Name string }
+type Props struct { Player *Player }
+component BoardRow(props: Props) {
+	return <span>{"player-" + props.Player.Name}</span>
+}
+`))
+	want := "strict component BoardRow cannot select through props.Player of pointer type *Player; pointer fields cannot preserve Go nil-pointer behavior in the file renderer"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerAcceptsBoolCondOnNestedSelector covers the
+// interaction note for <If cond>: a nested selector is accepted in cond
+// position the same release that admits it as a bare read, both the direct
+// and the == false spelling.
+func TestCompileStrictServerAcceptsBoolCondOnNestedSelector(t *testing.T) {
+	for _, cond := range []string{"props.Player.Ready", "props.Player.Ready == false"} {
+		t.Run(cond, func(t *testing.T) {
+			source := []byte("package app\ntype Player struct { Ready bool }\ntype Props struct { Player Player }\ncomponent BoardRow(props: Props) {\nreturn <main><If cond={" + cond + "}>content</If></main>\n}\n")
+			if _, err := Compile(source); err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+		})
+	}
+}
+
+// TestCompileStrictServerRejectsNonBoolNestedCond mirrors
+// TestCompileStrictServerRejectsNonBoolCond for a nested selector.
+func TestCompileStrictServerRejectsNonBoolNestedCond(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Player struct { Label string }
+type Props struct { Player Player }
+component SeatRow(props: Props) {
+	return <main><If cond={props.Player.Label}>content</If></main>
+}
+`))
+	want := "strict component SeatRow cannot use props.Player.Label of type string in <If cond>; cond requires an exact bool props field"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictLocalCallRequiresRootOfNestedSelectorOnce covers the
+// interaction note's explicit-supply rule: a callee that reads two different
+// nested paths under the same root requires that root supplied exactly
+// once, not once per nested path.
+func TestCompileStrictLocalCallRequiresRootOfNestedSelectorOnce(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Player struct { Name string; Number int }
+type Props struct { Player Player }
+component BoardRow(props: Props) {
+	return <p>{props.Player.Name}: {props.Player.Number}</p>
+}
+component Page() {
+	return <BoardRow />
+}
+`))
+	if err == nil {
+		t.Fatal("Compile unexpectedly accepted a call that omitted the nested selector's root prop")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "requires prop Player") {
+		t.Fatalf("error = %v, want it to require prop Player", err)
+	}
+	if strings.Count(msg, "requires prop Player") != 1 {
+		t.Fatalf("error = %v, want exactly one \"requires prop Player\" diagnostic for two nested reads under one root", err)
 	}
 }
 

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -257,19 +257,44 @@ component BoardRow(props: Props) {
 // TestCompileStrictServerRejectsNestedSelectorEmbeddedField covers section
 // 2.b's embedded-field non-goal: collectStructSchemas only records
 // field_identifier children, so a promoted field through an embedded struct
-// is invisible to the same-file schema and fails closed the same way an
-// undeclared struct does.
+// is invisible to the same-file schema. Player also carries its own named
+// sibling field (Age) so structTypes registers Player at all — with a
+// host struct that has no named field of its own, Player never enters
+// structTypes and the call fails on the separate "struct is not declared"
+// gate instead of the promoted-field gate this test means to cover (this
+// was B1: the promoted-field gate silently deferred at hop i>0 and let the
+// call compile).
 func TestCompileStrictServerRejectsNestedSelectorEmbeddedField(t *testing.T) {
 	_, err := Compile([]byte(`package app
 type Team struct { City string }
-type Player struct { Team }
+type Player struct { Team; Age int }
 type Props struct { Player Player }
 component BoardRow(props: Props) {
 	return <main>{props.Player.City}</main>
 }
 `))
-	if err == nil {
-		t.Fatal("Compile unexpectedly accepted a promoted (embedded) field selector")
+	want := "strict component BoardRow cannot resolve props.Player.City: struct Player declares no visible field City; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerRejectsNestedSelectorUnexportedLeaf covers the
+// other B1 shape: an unexported leaf field on a same-file declared struct
+// (not promoted, just lowercase) hits the identical hop-i>0 unknown-field
+// gate, since collectStructSchemas never records an unexported field at
+// all.
+func TestCompileStrictServerRejectsNestedSelectorUnexportedLeaf(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Team struct { city string; Zone string }
+type Props struct { Team Team }
+component BoardRow(props: Props) {
+	return <main>{props.Team.city}</main>
+}
+`))
+	want := "strict component BoardRow cannot resolve props.Team.city: struct Team declares no visible field city; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
 	}
 }
 

--- a/strict_surface_expansion_integration_test.go
+++ b/strict_surface_expansion_integration_test.go
@@ -37,6 +37,96 @@ component Page() {
 `, ready)
 }
 
+// boardRowFixtureSource is the re-audit checkpoint for GitHub issue
+// odvcencio/gosx#171's BoardRow row ("nested props.player.* + concat"): a
+// component that reads a nested struct-typed prop two hops deep, combined
+// with string concatenation of a nested operand in the same body — the
+// shape extension (b) exists to qualify (design spec section 5.7: "BoardRow
+// ... Qualifies (a)+(b)").
+func boardRowFixtureSource() string {
+	return `package app
+
+type Team struct {
+	City string
+}
+
+type Player struct {
+	Name string
+	Team Team
+}
+
+type BoardRowProps struct {
+	Player Player
+}
+
+component BoardRow(props: BoardRowProps) {
+	return <tr><td class={"player-" + props.Player.Name}>{props.Player.Name}</td><td>{props.Player.Team.City}</td></tr>
+}
+
+component Page() {
+	return <main>ok</main>
+}
+`
+}
+
+// TestStrictSurfaceExpansionBoardRowFixtureCompilesAndChecks re-runs the
+// BoardRow disqualifier from issue #171 mechanically: it compiles the
+// nested-selector-plus-concat shape (the IR lowerer accepts it and records
+// PropsPaths for the render boundary) and runs it through the real
+// gosx-check pipeline (Go compiler backed, via strictcheck.CheckFileWithOptions
+// against this module's real gosx package). Page does not call BoardRow:
+// open question 1 in the design spec notes a strict .gsx caller has no
+// composite-literal spelling to construct a struct prop, so a zero-props
+// Page cannot feed BoardRow real data — route's
+// TestStrictNestedSelectorRendersRealStructThroughRouteBoundary proves the
+// render boundary and body-read evaluation for the "generated-Go caller
+// feeds it" path this fixture's shape is declared for.
+func TestStrictSurfaceExpansionBoardRowFixtureCompilesAndChecks(t *testing.T) {
+	source := boardRowFixtureSource()
+
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	boardRow := prog.Components[0]
+	if boardRow.Name != "BoardRow" {
+		t.Fatalf("unexpected component order: %#v", prog.Components)
+	}
+	if boardRow.PropsFields["Player"] != "Player" {
+		t.Fatalf("PropsFields[Player] = %q, want %q", boardRow.PropsFields["Player"], "Player")
+	}
+	if boardRow.PropsPaths["Player.Name"] != "string" {
+		t.Fatalf("PropsPaths[Player.Name] = %q, want %q", boardRow.PropsPaths["Player.Name"], "string")
+	}
+	if boardRow.PropsPaths["Player.Team.City"] != "string" {
+		t.Fatalf("PropsPaths[Player.Team.City] = %q, want %q", boardRow.PropsPaths["Player.Team.City"], "string")
+	}
+
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module example.test/boardrow\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSum, err := os.ReadFile("go.sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "boardrow.gsx")
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"}); err != nil {
+		t.Fatalf("gosx check (strictcheck.CheckFileWithOptions): %v", err)
+	}
+}
+
 // TestStrictSurfaceExpansionTeamMarkFixtureCompilesChecksAndRenders is the
 // integration fixture the re-audit checkpoint requires: it compiles the
 // TeamMark shape, runs it through the real gosx-check pipeline (Go compiler

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -385,6 +385,98 @@ component Page() {
 	}
 }
 
+// TestCheckFileAcceptsNestedSelector is the strictcheck half of extension
+// (b): a two-hop selector through a same-file value struct passes the real
+// Go compiler. Row is never called — open question 1 in the design spec
+// notes that a strict .gsx caller has no composite-literal spelling to
+// construct a struct prop, so a zero-props Page cannot feed Row real data
+// (see route's TestStrictNestedSelectorRendersRealStructThroughRouteBoundary
+// for the "generated-Go caller feeds it" path this proves compiles). The Go
+// compiler still fully type-checks Row's declaration and body as an
+// ordinary top-level func, uncalled or not.
+func TestCheckFileAcceptsNestedSelector(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type Player struct {
+	Name string
+}
+type RowProps struct {
+	Player Player
+}
+component Row(props: RowProps) {
+	return <p>{props.Player.Name}</p>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsNestedSelectorThroughPointerField proves the pointer
+// rejection propagates through the full strictcheck pipeline: gosx.Compile
+// runs first (transpile.Transpile re-runs the IR semantic gate), so the
+// lowerer's rejection surfaces here exactly as it does through Compile
+// directly.
+func TestCheckFileRejectsNestedSelectorThroughPointerField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type Player struct {
+	Name string
+}
+type RowProps struct {
+	Player *Player
+}
+component Row(props: RowProps) {
+	return <p>{props.Player.Name}</p>
+}
+component Page() {
+	return <Row />
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "pointer fields cannot preserve Go nil-pointer behavior") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileRejectsNestedSelectorUnknownLeafField covers section 5.4's
+// Go-compiler backstop for a nested selector: an unresolvable leaf field
+// (Nickname is not declared on Player) is exactly the class of mismatch
+// resolveStrictSelectorPath intentionally leaves silent — an unknown field
+// anywhere along a path returns early with no lowerer diagnostic, deferring
+// to "the package checker supplies the precise unknown/unexported-field
+// diagnostic" (the same rule the depth-1 case already followed). This
+// proves the Go compiler is still the backstop for nested paths, including
+// the companion-.go-file-diverged-from-the-.gsx-schema-copy shape section
+// 5.4 describes, of which an unknown nested field is one concrete instance.
+func TestCheckFileRejectsNestedSelectorUnknownLeafField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type Player struct {
+	Name string
+}
+type RowProps struct {
+	Player Player
+}
+component Row(props: RowProps) {
+	return <p>{props.Player.Nickname}</p>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "Nickname") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
 func TestCheckFileRejectsPropsBearingStrictRenderEntry(t *testing.T) {
 	dir := newTestModule(t)
 	path := filepath.Join(dir, "page.gsx")

--- a/transpile/strict_component_test.go
+++ b/transpile/strict_component_test.go
@@ -253,6 +253,78 @@ func Page() Node {
 	}
 }
 
+// TestTranspileStrictNestedSelectorEmitsVerbatimGo covers section 2.b's
+// "no transpiler change" claim: a nested-selector text hole, a nested
+// operand inside a concat chain, and a nested <If cond> selector all appear
+// verbatim in the projected Go, exactly like a direct field read.
+func TestTranspileStrictNestedSelectorEmitsVerbatimGo(t *testing.T) {
+	source := []byte(`package app
+
+type Team struct {
+	City string
+}
+
+type Player struct {
+	Name  string
+	Ready bool
+	Team  Team
+}
+
+type RowProps struct {
+	Player Player
+}
+
+component Row(props: RowProps) {
+	return <p class={"player-" + props.Player.Name}><If cond={props.Player.Ready}>{props.Player.Team.City}</If></p>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	for _, want := range []string{
+		`func Row(props RowProps) gosx.Node`,
+		`gosx.Attr("class", "player-" + props.Player.Name)`,
+		`gosx.If(props.Player.Ready, gosx.Fragment(gosx.Expr(props.Player.Team.City)))`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTranspileStrictNestedSelectorForwardsStructPropVerbatim covers the
+// generated-Go-caller path open question 1 describes: a strict component
+// declared with a struct-typed field forwards it as a plain composite
+// literal field, and the Go compiler — not the transpiler — proves the
+// field exists with the declared type.
+func TestTranspileStrictNestedSelectorForwardsStructPropVerbatim(t *testing.T) {
+	source := []byte(`package app
+
+type Player struct {
+	Name string
+}
+
+type RowProps struct {
+	Player Player
+}
+
+component Row(props: RowProps) {
+	return <p>{props.Player.Name}</p>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(out, `func Row(props RowProps) gosx.Node`) {
+		t.Fatalf("missing typed func signature:\n%s", out)
+	}
+	if !strings.Contains(out, `gosx.Expr(props.Player.Name)`) {
+		t.Fatalf("missing verbatim nested read:\n%s", out)
+	}
+}
+
 func TestTranspileStrictExplicitZeroPropsMatchFileRendererContract(t *testing.T) {
 	source := []byte(`package app
 type BadgeProps struct {


### PR DESCRIPTION
## Summary

Extends the strict component surface to accept same-file value struct nesting up to three hops deep (e.g., `props.Player.Name`, `props.Player.Team.City`). The change separates syntactic acceptance from semantic resolution: the expression validator admits any depth, while the lowerer resolves paths against the declared schema, enforcing a three-hop cap, rejecting pointer intermediates, and verifying scalar leaves. It also introduces `ir.Component.PropsPaths` to carry resolved leaf types and tightens the file-renderer prop boundary.

## Changes

- Widen syntactic validators and AST extractors (`ValidateServerExpression`, `ServerPropPath`, `ServerConcatPropPaths`, `ServerExpressionPropPaths`) to accept `props.A.B[.C]` selector chains rooted at `props`, replacing flat string returns with ordered path slices to prevent spurious duplicate registrations of non-scalar inner selectors.
- Enforce the three-hop depth limit in `ir/lower.go` (`resolveStrictSelectorPath`), emitting precise diagnostics for pointer intermediates, undeclared structs, scalar intermediates, promoted/embedded fields, unknown fields, and non-scalar leaves.
- Introduce `ir.Component.PropsPaths` alongside existing `PropsFields` to map dot-joined nested paths to their exact scalar leaf types; decodes as `nil` for legacy serialized programs to maintain backward compatibility.
- Update the file renderer boundary (`route/fileprogram.go`) with `requireStrictStructValue` to verify incoming struct values match declared runtime types and validate every resolved nested path against its expected leaf type before the component body observes them.
- Refactor render-time prop field resolution (`resolvePropsFieldAlias`, `lowerCamelInitialism`) to correctly handle canonical vs. aliased attribute names prior to strict type checking, preventing skipped boundary validations.
- Document `ir` package compatibility policy in `README.md` and `CHANGELOG.md`, clarifying that the package is experimental pre-1.0 and consumers compiling directly against it should pin exact gosx versions.

## Testing

- Run `go test ./...` to verify all updated unit tests for expression parsing, lowering diagnostics, IR round-trips, and renderer boundary checks pass cleanly.
- Compile a `.gsx` component using two- and three-hop nested selectors (e.g., `props.Player.Team.City`), then run the generated program with a matching struct value to confirm correct rendering.
- Verify legacy serialized programs decode without `PropsPaths` errors by running `go test -run TestComponentPropsPathsDecodesAbsentFromOlderPrograms ./ir`.
- Test failure modes: compile selectors through pointer fields, undeclared structs, intermediate scalars, promoted fields, and four-hop chains to confirm each fails closed with the expected diagnostic message.

## Review Focus

Focus on the three-hop depth limit enforcement and `requireStrictStructValue` boundary checks. Ensure pointer/struct type safety strictly mirrors generated Go semantics, especially around embedded fields, nil pointers, and cross-package struct name matching.