### PR TITLE
fix: fix strict spread, Each binding, and render boundary checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -199,6 +199,58 @@
   The runtime checks it at render time instead, and leaves the element
   untouched on a bad value.
 
+### Strict components: typed `<Each>` loops and checked spread call sites
+
+- **`<Each of={props.Field} as="row">` in a strict body.** A strict
+  component may now loop, when the `of` source's declared type reads
+  exactly `[]T` and `T` is a value struct declared in the same file. The
+  binding (`row`) resolves selectors the same way `props` does, against
+  `T`'s fields, up to three hops deep (`row.Stat.Label`), and composes
+  with a concat operand and `<If cond>` under the same exact-type rules.
+  An optional `index="i"` attribute binds the loop index as a plain
+  `int`; it renders bare but admits no selector. `[]*T`, `[]string`,
+  `map[K]V`, `[N]T` arrays, and a named slice type (`type Rows []T`) all
+  fail closed with a diagnostic naming the field and its declared type.
+  Fixes #182.
+- **A strict call site may spread one value.** `<Callee {...source}>` is
+  admitted at exactly one shape: a single spread attribute and nothing
+  else. A strict caller's spread source must have a declared type,
+  resolved against the caller's own schema, that is exactly the callee's
+  props type — proved by the lowerer and the Go compiler, and emitted
+  verbatim (`Callee(source)`) with zero synthesis. A legacy caller's
+  single spread is provable only at the file-renderer boundary (legacy
+  expressions carry no declared type); the boundary re-proves it
+  structurally: the source must be a non-nil struct — never a
+  `map[string]any`, which can omit a key where a typed call would supply
+  a zero value — with every field the callee renders present at its
+  exact declared type. Spread plus named attributes, and more than one
+  spread, stay rejected at every call site. Fixes #184.
+- **`ir.Component.PropsSlices`** records, per `<Each of>` loop-source
+  read, the element struct name and the binding-relative fields the loop
+  body reads with their leaf types — the render boundary's
+  `requireStrictSliceValue` checks the runtime value's reflect *type*
+  once per call (not once per element), so a well-typed slice's elements
+  are all provably safe to select through. Additive; absent decodes to
+  `nil` for a program serialized before this field existed, matching
+  `ComponentSyntax` and `PropsPaths`' zero-value convention.
+- **The cross-style call ban narrows in one direction.** A legacy body
+  may now call a same-file strict component through the single-spread
+  shape; every other legacy-to-strict shape, and every strict-to-legacy
+  call regardless of shape, keep failing closed with their existing
+  messages (the legacy-to-strict named-attributes message now names the
+  supported spread spelling instead).
+- **`internal/strictcomponent`'s validator functions gain scope-aware
+  variants** (`ValidateServerExpressionScope`, `ServerSelectorPath`,
+  `ServerExpressionRootedPaths`, `ServerConcatRootedPaths`,
+  `ValidateServerCondExpressionScope`), admitting a selector rooted at an
+  `<Each>` item binding alongside `props`. The pre-#182/#184 signatures
+  remain as empty-scope wrappers and behave byte-identically to v0.42.2
+  for every existing case.
+- This closes issue #182 (gsxmail upstream ask U2's loop half) and #184
+  (the gridiron-2000 adoption stall at zero spread-blocked components);
+  together they convert RosterRow (`<Each>` body plus a legacy `{...player}`
+  call), DraftTeam, and TeamMark (both call sites) end to end.
+
 ### Strict components: nested prop reads
 
 - **`props.A.B` and `props.A.B.C` in strict expressions.** A strict

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -93,6 +93,51 @@ func Page() Node {
 			attributes are not part of this form.
 		</p>
 		<CodeBlock lang="gosx" source={data.conditionalSample} />
+		<h2 id="strict-loops-and-spread">Loops and spread props</h2>
+		<p>
+			A strict body may also loop with
+			<span class="inline-code">
+				&lt;Each of=
+				{"{"}
+				...
+				{"}"}
+				as="name"&gt;
+			</span>
+			. The
+			<span class="inline-code">of</span>
+			source must be a
+			<span class="inline-code">props</span>
+			field declared
+			<span class="inline-code">[]T</span>
+			, where
+			<span class="inline-code">T</span>
+			is a value struct declared in the same file. Inside the loop, the binding resolves selectors exactly like
+			<span class="inline-code">props</span>
+			does, against
+			<span class="inline-code">T</span>
+			's fields. An optional
+			<span class="inline-code">index="i"</span>
+			attribute binds the loop index as a plain
+			<span class="inline-code">int</span>
+			; it renders bare but admits no selector. An empty or nil slice renders nothing — write an
+			<span class="inline-code">&lt;If&gt;</span>
+			sibling for the empty state.
+		</p>
+		<CodeBlock lang="gosx" source={data.eachSample} />
+		<p>
+			A strict call site may also spread exactly one value and nothing else:
+			<span class="inline-code">
+				&lt;Callee
+				{"{"}
+				...source
+				{"}"}
+				/&gt;
+			</span>
+			. A strict caller's spread source must have exactly the callee's declared props type — the Go compiler proves this like any other typed call. A legacy caller's single spread is proved instead at the file-renderer boundary: the source must be a struct with every field the callee renders, of the exact declared type; a
+			<span class="inline-code">map[string]any</span>
+			source is always rejected, because a map can omit a key where the typed call would supply a zero value, and map keys have no declared type to check ahead of time. Spread plus named attributes, and more than one spread, stay rejected at every call site.
+		</p>
+		<CodeBlock lang="gosx" source={data.spreadSample} />
 		<section class="callout">
 			<strong>Keep strict components local</strong>
 			<p>
@@ -143,11 +188,15 @@ func Page() Node {
 		</p>
 		<h2 id="attributes">Elements and attributes</h2>
 		<p>
-			Lowercase tags create HTML elements. Static quoted attributes, boolean attributes, expression attributes, expression children, and fragments are available in both styles within their validation contracts. Strict capitalized tags resolve only to same-file strict components; renderer builtins and element spread attributes remain legacy-only in v0.39.
+			Lowercase tags create HTML elements. Static quoted attributes, boolean attributes, expression attributes, expression children, and fragments are available in both styles within their validation contracts. Strict capitalized tags resolve only to same-file strict components, plus the
+			<span class="inline-code">If</span>
+			and
+			<span class="inline-code">Each</span>
+			builtins covered above; every other renderer builtin and element spread attributes remain legacy-only.
 		</p>
 		<CodeBlock lang="gosx" source={data.attributesSample} />
 		<p>
-			A strict component call is intentionally narrower than an HTML element: pass named attributes that match the props struct. Strict component calls reject spread props and positional child content; use a legacy caller-and-callee chain when component composition needs nested Node content in v0.39.
+			A strict component call is intentionally narrower than an HTML element: pass named attributes that match the props struct, or the single proven spread described above. Positional child content stays rejected either way; use a legacy caller-and-callee chain when component composition needs nested Node content.
 		</p>
 		<p>
 			Strict markup also accepts the familiar aliases

--- a/examples/gosx-docs/app/docs/components/page.server.go
+++ b/examples/gosx-docs/app/docs/components/page.server.go
@@ -66,6 +66,48 @@ component Page() {
 	return <main><Badge ready={true} /></main>
 }`
 
+const strictEachSample = `package profile
+
+type Stat struct {
+	Label string
+	Value string
+}
+
+type CardProps struct {
+	Stats []Stat
+}
+
+component Card(props: CardProps) {
+	return <ul>
+		<Each of={props.Stats} as="stat" index="i">
+			<li>{i}: {stat.Label} = {stat.Value}</li>
+		</Each>
+	</ul>
+}
+
+func Page() Node {
+	return <main><Card {...loaderCard} /></main>
+}`
+
+const strictSpreadSample = `package profile
+
+type BadgeProps struct {
+	Label string
+	Count int
+}
+
+component Badge(props: BadgeProps) {
+	return <span>{props.Label}: {props.Count}</span>
+}
+
+component Panel(props: BadgeProps) {
+	return <div class="panel"><Badge {...props} /></div>
+}
+
+func Page() Node {
+	return <main><Badge {...data.loaderRow} /></main>
+}`
+
 func init() {
 	docs.RegisterStaticDocsPage("Components", "Choose between strict typed and legacy Go-function GSX components.", route.FileModuleOptions{
 		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
@@ -78,6 +120,7 @@ func init() {
 					{"href": "#two-styles", "label": "Two Styles"},
 					{"href": "#strict-components", "label": "Strict Components"},
 					{"href": "#strict-expressions", "label": "Strict Expressions"},
+					{"href": "#strict-loops-and-spread", "label": "Loops & Spread Props"},
 					{"href": "#legacy-components", "label": "Legacy Components"},
 					{"href": "#attributes", "label": "Elements & Attributes"},
 					{"href": "#tooling", "label": "Tooling"},
@@ -87,6 +130,8 @@ func init() {
 				"legacySample":      legacyComponentSample,
 				"concatSample":      strictConcatSample,
 				"conditionalSample": strictConditionalSample,
+				"eachSample":        strictEachSample,
+				"spreadSample":      strictSpreadSample,
 				"attributesSample": `type FieldProps struct {
 	ID    string
 	Class string

--- a/examples/gosx-docs/app/docs/components/page.server.go
+++ b/examples/gosx-docs/app/docs/components/page.server.go
@@ -105,7 +105,7 @@ component Panel(props: BadgeProps) {
 }
 
 func Page() Node {
-	return <main><Badge {...data.loaderRow} /></main>
+	return <main><Panel {...data.loaderRow} /></main>
 }`
 
 func init() {

--- a/examples/gosx-docs/app/docs/components/page_test.go
+++ b/examples/gosx-docs/app/docs/components/page_test.go
@@ -100,8 +100,11 @@ func TestDocumentedEachSampleCompilesAndRenders(t *testing.T) {
 }
 
 // TestDocumentedSpreadSampleCompilesAndRenders proves the #184 docs
-// sample: a strict-to-strict tier-1 spread (Panel forwarding its own
-// props verbatim) and a legacy tier-2 spread both compile and render.
+// sample end to end: Page (legacy) spreads a loader-shaped struct into
+// Panel (a legacy tier-2 spread), and Panel forwards its own props
+// verbatim to Badge with a bare {...props} spread (a strict-to-strict
+// tier-1 spread, gosx#182/#184 M-1) — both the outer call and Panel's own
+// forwarding call must render, not just compile.
 func TestDocumentedSpreadSampleCompilesAndRenders(t *testing.T) {
 	prog, err := gosx.Compile([]byte(strictSpreadSample))
 	if err != nil {
@@ -123,6 +126,9 @@ func TestDocumentedSpreadSampleCompilesAndRenders(t *testing.T) {
 	}
 	if !strings.Contains(html, "Inbox: 3") {
 		t.Fatalf("rendered HTML %q does not contain the spread values", html)
+	}
+	if want := `<div class="panel"><span>Inbox: 3</span></div>`; !strings.Contains(html, want) {
+		t.Fatalf("rendered HTML %q does not contain Panel's own forwarding call %q", html, want)
 	}
 }
 

--- a/examples/gosx-docs/app/docs/components/page_test.go
+++ b/examples/gosx-docs/app/docs/components/page_test.go
@@ -66,6 +66,66 @@ func TestDocumentedConditionalSampleCompilesAndRenders(t *testing.T) {
 	}
 }
 
+// TestDocumentedEachSampleCompilesAndRenders proves the #182 docs sample:
+// a strict <Each of={...} as="stat" index="i"> loop over a same-file
+// struct slice, called from a legacy Page via a single tier-2 spread.
+func TestDocumentedEachSampleCompilesAndRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictEachSample))
+	if err != nil {
+		t.Fatalf("compile documented each sample: %v", err)
+	}
+	// Stat's name must match the .gsx element schema's bare struct name
+	// exactly (case-sensitive) — requireStrictSliceValue proves identity by
+	// reflect.Type.Name(), not by field-shape compatibility.
+	type Stat struct {
+		Label string
+		Value string
+	}
+	type loaderCard struct {
+		Stats []Stat
+	}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{
+		Values: map[string]any{
+			"loaderCard": loaderCard{Stats: []Stat{{Label: "Views", Value: "12"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("render documented each sample: %v", err)
+	}
+	for _, want := range []string{"<li>0: Views = 12</li>"} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML %q does not contain %q", html, want)
+		}
+	}
+}
+
+// TestDocumentedSpreadSampleCompilesAndRenders proves the #184 docs
+// sample: a strict-to-strict tier-1 spread (Panel forwarding its own
+// props verbatim) and a legacy tier-2 spread both compile and render.
+func TestDocumentedSpreadSampleCompilesAndRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictSpreadSample))
+	if err != nil {
+		t.Fatalf("compile documented spread sample: %v", err)
+	}
+	type loaderRow struct {
+		Label string
+		Count int
+	}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{
+		Values: map[string]any{
+			"data": map[string]any{
+				"loaderRow": loaderRow{Label: "Inbox", Count: 3},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("render documented spread sample: %v", err)
+	}
+	if !strings.Contains(html, "Inbox: 3") {
+		t.Fatalf("rendered HTML %q does not contain the spread values", html)
+	}
+}
+
 func TestDocumentedComponentsPageCompilesAndTypeChecks(t *testing.T) {
 	source, err := os.ReadFile("page.gsx")
 	if err != nil {
@@ -118,9 +178,17 @@ component Card(props: Props) {
 	}
 }
 
+// TestStrictComponentCallsRejectSpreadPropsAndPositionalChildren covers the
+// v0.39 shape rejections that remain unconditional; the v0.44 (#182/#184)
+// docs page ("Loops and spread props" below) covers the two narrow cases
+// v0.44 admits: a spread whose source type exactly matches the callee's
+// props type (a strict caller) or a legacy caller's single spread. The
+// "spread props" case here uses a mismatched source type so it stays
+// rejected under the new, narrower rule — a bare-props spread of the exact
+// same type is now valid, so this fixture must not reuse that shape.
 func TestStrictComponentCallsRejectSpreadPropsAndPositionalChildren(t *testing.T) {
 	tests := map[string]string{
-		"spread props": `package profile
+		"spread props of mismatched type": `package profile
 
 type BadgeProps struct { Label string }
 
@@ -128,7 +196,9 @@ component Badge(props: BadgeProps) {
 	return <span>{props.Label}</span>
 }
 
-component Page(props: BadgeProps) {
+type PageProps struct { Label string }
+
+component Page(props: PageProps) {
 	return <Badge {...props} />
 }`,
 		"positional children": `package profile

--- a/examples/gosx-docs/docs_truth_test.go
+++ b/examples/gosx-docs/docs_truth_test.go
@@ -117,7 +117,7 @@ func TestRuntimeDeploymentSceneAndRelayDocsUseCurrentContracts(t *testing.T) {
 		{
 			page: "components",
 			required: []string{
-				"Strict component calls reject spread props and positional child content",
+				"Positional child content stays rejected either way",
 				"gosx export .",
 			},
 		},

--- a/format/strict_component_test.go
+++ b/format/strict_component_test.go
@@ -82,6 +82,107 @@ component Card(props: CardProps) {
 	}
 }
 
+// TestSourceFormatsStrictEachIdempotently covers #182: a strict <Each
+// of={...} as="row" index="i"> block, including binding-rooted selector,
+// concat, and cond holes inside its body, formats idempotently and keeps
+// compiling.
+func TestSourceFormatsStrictEachIdempotently(t *testing.T) {
+	source := []byte(`package app
+type BreakdownRow struct {
+	Scored bool
+	Label string
+}
+
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row" index="i">
+			<div class={"tone-" + row.Label} data-scored={row.Scored}>
+				<span>{row.Label}</span>
+				<span>{i}</span>
+				<If cond={row.Scored}>scored</If>
+			</div>
+		</Each>
+	</div>
+}
+`)
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	for _, want := range []string{
+		`<Each of={props.Breakdown} as="row" index="i">`,
+		`class={"tone-" + row.Label}`,
+		`data-scored={row.Scored}`,
+		`{row.Label}`,
+		`{i}`,
+		`<If cond={row.Scored}>`,
+	} {
+		if !strings.Contains(string(formatted), want) {
+			t.Fatalf("formatting changed %q:\n%s", want, formatted)
+		}
+	}
+	if _, err := gosx.Compile(formatted); err != nil {
+		t.Fatalf("formatted strict source does not compile: %v\n%s", err, formatted)
+	}
+	again, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source second pass: %v", err)
+	}
+	if !bytes.Equal(formatted, again) {
+		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}
+
+// TestSourceFormatsStrictSpreadCallSitesIdempotently covers #184: a tier-1
+// spread at a strict call site and a tier-2 spread from a legacy body both
+// format idempotently and keep compiling.
+func TestSourceFormatsStrictSpreadCallSitesIdempotently(t *testing.T) {
+	source := []byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+
+component Wrap(props: TeamMarkProps) {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+
+func Page() Node {
+	team := map[string]any{"Tone": "red"}
+	return <div><TeamMark {...team}></TeamMark></div>
+}
+`)
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	for _, want := range []string{
+		`<TeamMark {...props}>`,
+		`<TeamMark {...team}>`,
+	} {
+		if !strings.Contains(string(formatted), want) {
+			t.Fatalf("formatting changed %q:\n%s", want, formatted)
+		}
+	}
+	if _, err := gosx.Compile(formatted); err != nil {
+		t.Fatalf("formatted strict source does not compile: %v\n%s", err, formatted)
+	}
+	again, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source second pass: %v", err)
+	}
+	if !bytes.Equal(formatted, again) {
+		t.Fatalf("format is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, again)
+	}
+}
+
 // TestSourceFormatsStrictNestedSelectorIdempotently covers section 2.b: a
 // nested selector text hole, a nested concat operand, and a nested <If
 // cond> selector all format idempotently and keep compiling.

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -17,33 +17,88 @@ var (
 	strictDecimalFloat   = regexp.MustCompile(`^(([0-9]+\.[0-9]*|\.[0-9]+)([eE][+-]?[0-9]+)?|[0-9]+[eE][+-]?[0-9]+)$`)
 )
 
+// Scope names the <Each> loop bindings visible to a strict expression at its
+// position in the IR tree — the lowerer's active binding set (see
+// ir/lower.go's validateStrictServerExpressions), pushed on an unshadowed
+// <Each> node before its children validate (design spec section 2.2).
+//
+// Items and Indices are kept apart because they admit different shapes: an
+// Item name is a valid selector root (row.Label), the same way props is,
+// but never a valid bare reference — a loop element is always a struct, and
+// the renderer has no single-value spelling for one. An Index name is the
+// opposite: always a plain int, so it is a valid bare reference (bare {i}
+// renders like an int props field) but never a valid selector root — this
+// function knows that unconditionally, with no schema lookup, because an
+// index binding's type never varies. Both are still accepted as syntactic
+// selector roots by rootedSelectorPath below, so a misuse such as i.Field
+// reaches the lowerer's schema-aware diagnostic (design spec section 4.2)
+// instead of this schema-blind validator's generic message.
+type Scope struct {
+	Items   []string
+	Indices []string
+}
+
+func (s Scope) isItem(name string) bool {
+	for _, item := range s.Items {
+		if item == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Scope) isIndex(name string) bool {
+	for _, index := range s.Indices {
+		if index == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (s Scope) isBinding(name string) bool {
+	return s.isItem(name) || s.isIndex(name)
+}
+
 // ValidateServerExpression accepts exactly the expression shapes implemented
 // by the file renderer for strict server components. The v0.39 contract is
 // intentionally small: literals and one direct props field (with parentheses).
 // v0.42 added a `+` chain that concatenates string literals with props field
-// selectors (validateConcatChain documents the accepted shape). This change
-// widens every props selector position (a bare read, a concat operand, an
-// <If cond>) to accept a field chain rooted at props up to three fields deep
-// (see ServerPropPath) instead of exactly one field. This function places no
-// upper bound on chain length itself: it is schema-blind, so it cannot know
-// where three hops actually lands against a given props struct. The lowerer
-// (ir/lower.go) resolves each accepted path against the same-file struct
-// schema and reports the three-hop cap there, with full component context.
-// Operators outside the one `+` exception, indexing, and calls need static
-// Go type/method information that the map-backed file renderer does not
-// retain, so they fail closed.
+// selectors (validateConcatChain documents the accepted shape). v0.42's
+// nested-selector change widens every props selector position (a bare read,
+// a concat operand, an <If cond>) to accept a field chain rooted at props up
+// to three fields deep (see ServerPropPath) instead of exactly one field.
+// This function places no upper bound on chain length itself: it is
+// schema-blind, so it cannot know where three hops actually lands against a
+// given props struct. The lowerer (ir/lower.go) resolves each accepted path
+// against the same-file struct schema and reports the three-hop cap there,
+// with full component context. Operators outside the one `+` exception,
+// indexing, and calls need static Go type/method information that the
+// map-backed file renderer does not retain, so they fail closed.
+//
+// ValidateServerExpression is ValidateServerExpressionScope's empty-scope
+// wrapper: it behaves byte-identically to the pre-#182/#184 signature for
+// every existing caller, admitting only props as a selector root.
 func ValidateServerExpression(source string) error {
+	return ValidateServerExpressionScope(source, Scope{})
+}
+
+// ValidateServerExpressionScope is ValidateServerExpression, generalized to
+// admit a selector chain rooted at any name in scope alongside props — the
+// #182 (`<Each>`) extension. See Scope's doc comment for the Items/Indices
+// distinction.
+func ValidateServerExpressionScope(source string, scope Scope) error {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return fmt.Errorf("invalid Go expression: %w", err)
 	}
-	if err := validate(expr, source); err != nil {
+	if err := validate(expr, source, scope); err != nil {
 		return err
 	}
 	return nil
 }
 
-func validate(expr ast.Expr, source string) error {
+func validate(expr ast.Expr, source string, scope Scope) error {
 	switch node := expr.(type) {
 	case *ast.BasicLit:
 		return validateLiteral(node)
@@ -56,12 +111,22 @@ func validate(expr ast.Expr, source string) error {
 		case "props":
 			return fmt.Errorf("bare props is not supported; select a props field")
 		default:
+			if scope.isIndex(node.Name) {
+				// An Each index binding is always a plain int — the same
+				// parity class already proven for an int props field, so a
+				// bare reference renders exactly the way {props.SomeInt}
+				// does. See design spec section 2.5.
+				return nil
+			}
+			if scope.isItem(node.Name) {
+				return fmt.Errorf("bare %s is not supported; select a field on %s", node.Name, node.Name)
+			}
 			return fmt.Errorf("identifier %q is not available to the strict server renderer", node.Name)
 		}
 	case *ast.ParenExpr:
-		return validate(node.X, source)
+		return validate(node.X, source, scope)
 	case *ast.SelectorExpr:
-		if _, ok := propsSelectorPath(node); !ok {
+		if _, _, ok := rootedSelectorPath(node, scope); !ok {
 			return fmt.Errorf("selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior")
 		}
 		return nil
@@ -73,7 +138,7 @@ func validate(expr ast.Expr, source string) error {
 		if node.Op != token.ADD {
 			return fmt.Errorf("binary operator %q is not supported by the strict server renderer; only string concatenation with %q is renderable", node.Op, "+")
 		}
-		return validateConcatChain(node, source)
+		return validateConcatChain(node, source, scope)
 	case *ast.CallExpr:
 		return fmt.Errorf("calls are not supported by the strict server renderer because typed Go methods are not retained in its props map")
 	default:
@@ -82,16 +147,16 @@ func validate(expr ast.Expr, source string) error {
 }
 
 // validateConcatChain accepts a `+` chain whose flattened operands are each a
-// string literal or a direct props field selector, with at least one of each.
-// The renderer's applyFileBinaryOp takes the string branch whenever either
-// side of `+` is a Go string (route/exprlower.go), so this is the one binary
-// shape the file renderer and generated Go execute identically.
-func validateConcatChain(node *ast.BinaryExpr, source string) error {
+// string literal or a direct props/binding field selector, with at least one
+// of each. The renderer's applyFileBinaryOp takes the string branch whenever
+// either side of `+` is a Go string (route/exprlower.go), so this is the one
+// binary shape the file renderer and generated Go execute identically.
+func validateConcatChain(node *ast.BinaryExpr, source string, scope Scope) error {
 	hasStringLiteral := false
 	hasPropsField := false
 	for _, operand := range flattenAddChain(node) {
 		text := operandText(operand, source)
-		switch classifyConcatOperand(operand) {
+		switch classifyConcatOperand(operand, scope) {
 		case concatOperandString:
 			hasStringLiteral = true
 		case concatOperandNonStringLiteral:
@@ -121,7 +186,7 @@ const (
 	concatOperandSelector
 )
 
-func classifyConcatOperand(operand ast.Expr) concatOperandKind {
+func classifyConcatOperand(operand ast.Expr, scope Scope) concatOperandKind {
 	switch node := unwrapParens(operand).(type) {
 	case *ast.BasicLit:
 		if node.Kind == token.STRING {
@@ -132,7 +197,7 @@ func classifyConcatOperand(operand ast.Expr) concatOperandKind {
 		}
 		return concatOperandNonStringLiteral
 	case *ast.SelectorExpr:
-		if _, ok := propsSelectorPath(node); ok {
+		if _, _, ok := rootedSelectorPath(node, scope); ok {
 			return concatOperandSelector
 		}
 		return concatOperandInvalid
@@ -218,36 +283,54 @@ func validateLiteral(literal *ast.BasicLit) error {
 // "Player", "Name"}. Parentheses are transparent at any level, including
 // around props itself and around any intermediate selector. It places no
 // upper bound on chain length — see ValidateServerExpression's doc comment
-// for why the depth cap lives in the lowerer instead.
+// for why the depth cap lives in the lowerer instead. ServerPropPath is
+// ServerSelectorPath's empty-scope wrapper, filtered to a props root, so
+// every pre-#182/#184 caller keeps its exact signature and behavior.
 func ServerPropPath(source string) ([]string, bool) {
-	expr, err := parser.ParseExpr(source)
-	if err != nil {
+	root, path, ok := ServerSelectorPath(source, Scope{})
+	if !ok || root != "props" {
 		return nil, false
 	}
-	return propsSelectorPath(expr)
+	return path, true
 }
 
-// propsSelectorPath is ServerPropPath's expression-tree implementation,
+// ServerSelectorPath generalizes ServerPropPath to report both the root
+// identifier and the ordered field path of a selector chain rooted at props
+// or at any name in scope — the #182 (`<Each>`) binding-selector extension
+// (design spec section 2.4: path resolution is (rootType, path), with props
+// and an Each item binding both valid roots at this syntactic layer).
+func ServerSelectorPath(source string, scope Scope) (root string, path []string, ok bool) {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return "", nil, false
+	}
+	return rootedSelectorPath(expr, scope)
+}
+
+// rootedSelectorPath is ServerSelectorPath's expression-tree implementation,
 // reused by the validator (selector shape, concat operand classification,
-// cond selector extraction) so every props selector position resolves
-// nested paths through one definition.
-func propsSelectorPath(expr ast.Expr) ([]string, bool) {
-	selector, ok := unwrapParens(expr).(*ast.SelectorExpr)
-	if !ok || selector.Sel == nil || selector.Sel.Name == "" {
-		return nil, false
+// cond selector extraction) so every selector position resolves rooted
+// paths through one definition. It admits props and, per scope, an Item or
+// Index binding name as syntactically valid roots — Scope's doc comment
+// explains why an Index root is admitted here even though it is never a
+// valid root once the lowerer resolves its type.
+func rootedSelectorPath(expr ast.Expr, scope Scope) (root string, path []string, ok bool) {
+	selector, isSelector := unwrapParens(expr).(*ast.SelectorExpr)
+	if !isSelector || selector.Sel == nil || selector.Sel.Name == "" {
+		return "", nil, false
 	}
 	receiver := unwrapParens(selector.X)
-	if ident, ok := receiver.(*ast.Ident); ok {
-		if ident.Name != "props" {
-			return nil, false
+	if ident, isIdent := receiver.(*ast.Ident); isIdent {
+		if ident.Name != "props" && !scope.isBinding(ident.Name) {
+			return "", nil, false
 		}
-		return []string{selector.Sel.Name}, true
+		return ident.Name, []string{selector.Sel.Name}, true
 	}
-	path, ok := propsSelectorPath(receiver)
+	root, path, ok = rootedSelectorPath(receiver, scope)
 	if !ok {
-		return nil, false
+		return "", nil, false
 	}
-	return append(path, selector.Sel.Name), true
+	return root, append(path, selector.Sel.Name), true
 }
 
 // ServerPropField reports the single props field read by a validated direct
@@ -266,45 +349,70 @@ func ServerPropField(source string) (string, bool) {
 	return path[0], true
 }
 
+// RootedPath is one maximal rooted selector path ServerExpressionRootedPaths
+// or ServerConcatRootedPaths finds — Root is "props" or a Scope binding
+// name, Path is ServerSelectorPath's ordered field list under that root.
+type RootedPath struct {
+	Root string
+	Path []string
+}
+
 // ServerExpressionPropPaths reports every maximal props-rooted selector path
 // found anywhere in source, regardless of whether source's overall shape
-// passes ValidateServerExpression. Read-tracking passes use this to see
-// every props path an expression touches — not just the operands of one
-// accepted top-level shape — because the grammar's external attribute
-// scanner hands attribute-position expressions back as one opaque token with
-// no nested CST, unlike element/text children (jsx_expression_container),
-// whose nested Go sub-tree the CST-based read-tracking walk can see
-// directly. Attribute-position expressions are exactly where every
-// concatenation and <If cond> shape lives, so this closes that visibility
-// gap generally instead of only for those two shapes.
+// passes ValidateServerExpression. ServerExpressionRootedPaths' empty-scope
+// wrapper, filtered to props roots, so every pre-#182/#184 caller keeps its
+// exact signature and behavior.
+func ServerExpressionPropPaths(source string) [][]string {
+	var paths [][]string
+	for _, rp := range ServerExpressionRootedPaths(source, Scope{}) {
+		if rp.Root == "props" {
+			paths = append(paths, rp.Path)
+		}
+	}
+	return paths
+}
+
+// ServerExpressionRootedPaths reports every maximal rooted selector path
+// (props- or scope-binding-rooted) found anywhere in source, regardless of
+// whether source's overall shape passes ValidateServerExpressionScope.
+// Read-tracking passes use this to see every path an expression touches —
+// not just the operands of one accepted top-level shape — because the
+// grammar's external attribute scanner hands attribute-position expressions
+// back as one opaque token with no nested CST, unlike element/text children
+// (jsx_expression_container), whose nested Go sub-tree the CST-based
+// read-tracking walk can see directly. Attribute-position expressions are
+// exactly where every concatenation and <If cond> shape lives, so this
+// closes that visibility gap generally instead of only for those two
+// shapes; the #182 generalization does the same for a loop binding's reads
+// inside an <Each> body.
 //
 // "Maximal" matters for nested paths: once a *ast.SelectorExpr node yields a
-// full props path, this stops descending into that node's own operand
+// full rooted path, this stops descending into that node's own operand
 // sub-tree. Otherwise a chain like props.Player.Name would also register its
 // inner props.Player sub-expression as an independent (and spurious) bare
 // read of a non-scalar field — the same class of fail-open gap
 // collectStrictPropReads was fixed for once already, in reverse: a false
 // rejection of a valid nested read instead of a missed one.
-func ServerExpressionPropPaths(source string) [][]string {
+func ServerExpressionRootedPaths(source string, scope Scope) []RootedPath {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return nil
 	}
-	var paths [][]string
+	var paths []RootedPath
 	seen := make(map[string]struct{})
 	ast.Inspect(expr, func(n ast.Node) bool {
 		selector, ok := n.(*ast.SelectorExpr)
 		if !ok {
 			return true
 		}
-		path, ok := propsSelectorPath(selector)
+		root, path, ok := rootedSelectorPath(selector, scope)
 		if !ok {
 			return true
 		}
-		key := strings.Join(path, ".")
+		key := root + "\x00" + strings.Join(path, ".")
 		if _, dup := seen[key]; !dup {
 			seen[key] = struct{}{}
-			paths = append(paths, path)
+			paths = append(paths, RootedPath{Root: root, Path: path})
 		}
 		return false
 	})
@@ -317,8 +425,28 @@ func ServerExpressionPropPaths(source string) [][]string {
 // list for that operand. It returns ok=false when source's top-level shape
 // (parentheses transparent) is not a `+` expression — callers use that to
 // skip the concat-specific type pass for every other already-validated
-// expression shape.
+// expression shape. ServerConcatRootedPaths' empty-scope wrapper, filtered
+// to props roots, so every pre-#182/#184 caller keeps its exact signature
+// and behavior.
 func ServerConcatPropPaths(source string) ([][]string, bool) {
+	rooted, ok := ServerConcatRootedPaths(source, Scope{})
+	if !ok {
+		return nil, false
+	}
+	var paths [][]string
+	for _, rp := range rooted {
+		if rp.Root == "props" {
+			paths = append(paths, rp.Path)
+		}
+	}
+	return paths, true
+}
+
+// ServerConcatRootedPaths generalizes ServerConcatPropPaths to report each
+// concat operand's root alongside its field path, admitting an operand
+// rooted at a Scope binding the same way ValidateServerExpressionScope's
+// concat pass does.
+func ServerConcatRootedPaths(source string, scope Scope) ([]RootedPath, bool) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return nil, false
@@ -327,10 +455,10 @@ func ServerConcatPropPaths(source string) ([][]string, bool) {
 	if !ok || bin.Op != token.ADD {
 		return nil, false
 	}
-	var paths [][]string
+	var paths []RootedPath
 	for _, operand := range flattenAddChain(bin) {
-		if path, ok := propsSelectorPath(operand); ok {
-			paths = append(paths, path)
+		if root, path, ok := rootedSelectorPath(operand, scope); ok {
+			paths = append(paths, RootedPath{Root: root, Path: path})
 		}
 	}
 	return paths, true
@@ -341,32 +469,42 @@ func ServerConcatPropPaths(source string) ([][]string, bool) {
 // or a nested field path per ServerPropPath), or that selector compared
 // against the literal false with `==`. It reports the props path read and
 // whether the comparison negates it. Parentheses are transparent at any
-// level.
+// level. ValidateServerCondExpressionScope's empty-scope wrapper, so every
+// pre-#182/#184 caller keeps its exact signature and behavior.
 func ValidateServerCondExpression(source string) (path []string, negated bool, err error) {
+	_, path, negated, err = ValidateServerCondExpressionScope(source, Scope{})
+	return path, negated, err
+}
+
+// ValidateServerCondExpressionScope generalizes ValidateServerCondExpression
+// to admit a cond selector rooted at a Scope binding (design spec section
+// 2.4), reporting the root alongside the path so the lowerer knows which
+// schema to resolve the leaf type against.
+func ValidateServerCondExpressionScope(source string, scope Scope) (root string, path []string, negated bool, err error) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
-		return nil, false, fmt.Errorf("invalid Go expression: %w", err)
+		return "", nil, false, fmt.Errorf("invalid Go expression: %w", err)
 	}
-	root := unwrapParens(expr)
+	top := unwrapParens(expr)
 
-	if bin, ok := root.(*ast.BinaryExpr); ok {
+	if bin, ok := top.(*ast.BinaryExpr); ok {
 		if bin.Op == token.EQL {
 			left := unwrapParens(bin.X)
 			right := unwrapParens(bin.Y)
 			if ident, ok := right.(*ast.Ident); ok && ident.Name == "true" {
-				return nil, false, fmt.Errorf("comparison \"== true\" is not supported in strict cond; write the field bare")
+				return "", nil, false, fmt.Errorf("comparison \"== true\" is not supported in strict cond; write the field bare")
 			}
-			if condPath, ok := propsSelectorPath(left); ok {
+			if condRoot, condPath, ok := rootedSelectorPath(left, scope); ok {
 				if ident, ok := right.(*ast.Ident); ok && ident.Name == "false" {
-					return condPath, true, nil
+					return condRoot, condPath, true, nil
 				}
 			}
 		}
-		return nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
+		return "", nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
 	}
 
-	if condPath, ok := propsSelectorPath(root); ok {
-		return condPath, false, nil
+	if condRoot, condPath, ok := rootedSelectorPath(top, scope); ok {
+		return condRoot, condPath, false, nil
 	}
-	return nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
+	return "", nil, false, fmt.Errorf("strict cond must be a bool props field or a bool props field compared with \"== false\"; got %q", source)
 }

--- a/internal/strictcomponent/expression_test.go
+++ b/internal/strictcomponent/expression_test.go
@@ -333,3 +333,173 @@ func TestValidateServerCondExpressionRejectsInvalidGo(t *testing.T) {
 		t.Fatalf("ValidateServerCondExpression(malformed) = %v", err)
 	}
 }
+
+// rowScope is the Scope a strict <Each of={...} as="row"> pushes for its
+// children (design spec section 2.2); rowIndexScope adds an index="i"
+// binding.
+var rowScope = Scope{Items: []string{"row"}}
+var rowIndexScope = Scope{Items: []string{"row"}, Indices: []string{"i"}}
+
+// TestValidateServerExpressionScopeAcceptsBindingSelectors covers #182's
+// widened selector rule: a binding-rooted selector, its parenthesized
+// forms, a concat operand, a cond selector, and a bare index reference are
+// all accepted with an active Scope.
+func TestValidateServerExpressionScopeAcceptsBindingSelectors(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		scope  Scope
+	}{
+		{"row.Label", rowScope},
+		{"(row).Label", rowScope},
+		{`"x-" + row.Tone`, rowScope},
+		{"row.Scored", rowScope},
+		{"row.Stat.Label", rowScope},
+		{"i", rowIndexScope},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			if err := ValidateServerExpressionScope(tc.source, tc.scope); err != nil {
+				t.Fatalf("ValidateServerExpressionScope(%q, %v) = %v, want nil", tc.source, tc.scope, err)
+			}
+		})
+	}
+}
+
+// TestValidateServerExpressionScopeRejectsWithExactMessages covers the
+// reject half: a bare binding, an unbound name even though a binding is
+// active, a binding used with an empty scope (falls back to the ordinary
+// identifier message), and a mixed chain that fails the widened rule for
+// an unrelated reason.
+func TestValidateServerExpressionScopeRejectsWithExactMessages(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		source string
+		scope  Scope
+		want   string
+	}{
+		{
+			name:   "bare item binding",
+			source: "row",
+			scope:  rowScope,
+			want:   `bare row is not supported; select a field on row`,
+		},
+		{
+			name:   "unbound selector root",
+			source: "rowKey.X",
+			scope:  rowScope,
+			want:   `selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior`,
+		},
+		{
+			name:   "binding used with empty scope",
+			source: "item.X",
+			scope:  Scope{},
+			want:   `selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior`,
+		},
+		{
+			name:   "row.Label with empty scope",
+			source: "row.Label",
+			scope:  Scope{},
+			want:   `selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior`,
+		},
+		{
+			name:   "index binding used as a selector root",
+			source: "i.Field",
+			scope:  rowIndexScope,
+			// Syntactically admitted here (an index name is a valid scope
+			// root candidate — see Scope's doc comment); the lowerer's
+			// walkStrictHops rejects it with schema context, since an
+			// index is never a struct. This validator has no schema, so it
+			// accepts the shape.
+			want: "",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateServerExpressionScope(tc.source, tc.scope)
+			if tc.want == "" {
+				if err != nil {
+					t.Fatalf("ValidateServerExpressionScope(%q, %v) = %v, want nil", tc.source, tc.scope, err)
+				}
+				return
+			}
+			if err == nil || err.Error() != tc.want {
+				t.Fatalf("ValidateServerExpressionScope(%q, %v) = %v, want %q", tc.source, tc.scope, err, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateServerExpressionUnaffectedByScopeGeneralization is the
+// signature regression WP-4 requires: the empty-scope wrapper behaves
+// byte-identically to the pre-#182/#184 signature for every existing case,
+// re-run here through the new Scope-aware entry point at Scope{}.
+func TestValidateServerExpressionUnaffectedByScopeGeneralization(t *testing.T) {
+	for _, source := range []string{
+		`"text"`, "props.Title", "props.A.B.C", `"a" + props.X`,
+	} {
+		t.Run(source, func(t *testing.T) {
+			want := ValidateServerExpression(source)
+			got := ValidateServerExpressionScope(source, Scope{})
+			if (want == nil) != (got == nil) {
+				t.Fatalf("scope wrapper diverged: ValidateServerExpression=%v ValidateServerExpressionScope=%v", want, got)
+			}
+			if want != nil && want.Error() != got.Error() {
+				t.Fatalf("scope wrapper message diverged: %q vs %q", want.Error(), got.Error())
+			}
+		})
+	}
+}
+
+func TestServerSelectorPathReportsRoot(t *testing.T) {
+	for _, tc := range []struct {
+		source   string
+		scope    Scope
+		wantRoot string
+		wantPath []string
+		wantOK   bool
+	}{
+		{"props.Tone", Scope{}, "props", []string{"Tone"}, true},
+		{"row.Label", rowScope, "row", []string{"Label"}, true},
+		{"row.Stat.Label", rowScope, "row", []string{"Stat", "Label"}, true},
+		{"other.Label", rowScope, "", nil, false},
+		{"row.Label", Scope{}, "", nil, false},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			root, path, ok := ServerSelectorPath(tc.source, tc.scope)
+			if ok != tc.wantOK || root != tc.wantRoot || !equalStrings(path, tc.wantPath) {
+				t.Fatalf("ServerSelectorPath(%q, %v) = (%q, %v, %v), want (%q, %v, %v)", tc.source, tc.scope, root, path, ok, tc.wantRoot, tc.wantPath, tc.wantOK)
+			}
+		})
+	}
+}
+
+func TestServerExpressionRootedPathsFindsBindingReads(t *testing.T) {
+	for _, tc := range []struct {
+		source string
+		scope  Scope
+		want   []RootedPath
+	}{
+		{"row.Label", rowScope, []RootedPath{{Root: "row", Path: []string{"Label"}}}},
+		{`"x-" + row.Tone + props.Suffix`, rowScope, []RootedPath{{Root: "row", Path: []string{"Tone"}}, {Root: "props", Path: []string{"Suffix"}}}},
+	} {
+		t.Run(tc.source, func(t *testing.T) {
+			got := ServerExpressionRootedPaths(tc.source, tc.scope)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ServerExpressionRootedPaths(%q, %v) = %v, want %v", tc.source, tc.scope, got, tc.want)
+			}
+			for i := range got {
+				if got[i].Root != tc.want[i].Root || !equalStrings(got[i].Path, tc.want[i].Path) {
+					t.Fatalf("ServerExpressionRootedPaths(%q, %v)[%d] = %v, want %v", tc.source, tc.scope, i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestValidateServerCondExpressionScopeAcceptsBindingRoot(t *testing.T) {
+	root, path, negated, err := ValidateServerCondExpressionScope("row.Scored == false", rowScope)
+	if err != nil {
+		t.Fatalf("ValidateServerCondExpressionScope: %v", err)
+	}
+	if root != "row" || !equalStrings(path, []string{"Scored"}) || !negated {
+		t.Fatalf("ValidateServerCondExpressionScope = (%q, %v, %v), want (row, [Scored], true)", root, path, negated)
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -95,6 +95,18 @@ type Component struct {
 	// ComponentSyntax zero-value convention above.
 	PropsPaths map[string]string
 
+	// PropsSlices records loop-source props reads for strict components: a
+	// same-file <Each of={props.Field}> whose element type is a same-file
+	// value struct. Keys are the dot-joined props path the of attribute
+	// resolves (this release resolves only depth-1 paths — see
+	// resolveStrictEachSourceType's doc comment in ir/lower.go — so a key
+	// is always a bare field name today, but the dot-joined convention
+	// matches PropsPaths so a future nested of source needs no key-shape
+	// migration). The zero value (a nil map) is absent and decodes
+	// unchanged for programs serialized before this field existed,
+	// matching the ComponentSyntax zero-value convention above.
+	PropsSlices map[string]SlicePropSchema
+
 	// Syntax distinguishes legacy `func` components from strict
 	// `component Name(props: Type)` declarations.
 	Syntax ComponentSyntax
@@ -132,6 +144,23 @@ type Component struct {
 	// component's function body. Populated by the body analyzer when
 	// the source is a .gsx file with a full component body.
 	Scope *ComponentScope
+}
+
+// SlicePropSchema records the element struct type and the binding-relative
+// read paths a strict <Each> loop needs, so the file renderer boundary can
+// re-prove a loop source's runtime value once per call (type-level, O(read
+// paths)) instead of walking every element — see requireStrictSliceValue in
+// route/fileprogram.go.
+type SlicePropSchema struct {
+	// Elem is the bare same-file struct name every element of the loop
+	// source must have, e.g. "BreakdownRow".
+	Elem string
+
+	// Reads maps each binding-relative field path the loop body reads to
+	// its exact declared leaf type, dot-joined for a nested selector
+	// through a same-file value struct (e.g. "Label" -> "string",
+	// "Stat.Label" -> "string"), matching PropsPaths' convention.
+	Reads map[string]string
 }
 
 // SurfaceHandlerRef records a single on* attribute binding on a surface

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -988,6 +988,21 @@ func (l *lowerer) lowerSourceFile(root *gotreesitter.Node) {
 	}
 }
 
+// collectStrictSchemas runs in two passes over root's top-level
+// declarations rather than one, precisely because collectStrictPropReads
+// (via collectStrictElementReads' isSpreadForwardTag check) needs
+// l.strictNames complete for the WHOLE file before it can classify any
+// component's spread reads correctly (gosx#182/#184 M-3). A single pass
+// populated l.strictNames incrementally in file order, so a spread source
+// forwarded to a same-file strict callee declared LATER in the file — e.g.
+// Outer declared before Mark, with Outer's body containing
+// <Mark {...props.Away}> — was not yet in l.strictNames when Outer's own
+// reads were collected. isSpreadForwardTag then read false, the spread
+// fell through to the generic scalar-read walk, and
+// validateStrictRenderedProps rejected the struct-typed props.Away as "not
+// ... string, bool, integer, or floating-point" — a real compile failure
+// that depended only on declaration order, not on any type-safety
+// difference between the two orders.
 func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.strictNames = make(map[string]struct{})
 	l.legacyNames = make(map[string]struct{})
@@ -995,6 +1010,10 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.strictReads = make(map[string]map[string]strictReadClass)
 	l.structFields = make(map[string]map[string]string)
 	l.structTypes = make(map[string]map[string]string)
+	// Pass 1: every same-file strict component's name and props type,
+	// every legacy (non-strict) top-level renderer function's name, and
+	// every declared struct's field schema — nothing here depends on
+	// declaration order among components.
 	for i := 0; i < int(root.NamedChildCount()); i++ {
 		child := root.NamedChild(i)
 		switch l.nodeType(child) {
@@ -1012,12 +1031,29 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 				l.strictNames[componentName] = struct{}{}
 				if propsType != "" {
 					l.strictProps[componentName] = propsType
-					l.strictReads[componentName] = l.collectStrictPropReads(child)
 				}
 			}
 		case "type_declaration":
 			l.collectStructSchemas(child)
 		}
+	}
+	// Pass 2: each strict component's prop reads, now that l.strictNames
+	// holds every same-file strict component regardless of where in the
+	// file it is declared.
+	for i := 0; i < int(root.NamedChildCount()); i++ {
+		child := root.NamedChild(i)
+		if l.nodeType(child) != "gosx_component_declaration" {
+			continue
+		}
+		name := l.childByField(child, "name")
+		if name == nil {
+			continue
+		}
+		componentName := l.text(name)
+		if _, hasProps := l.strictProps[componentName]; !hasProps {
+			continue
+		}
+		l.strictReads[componentName] = l.collectStrictPropReads(child)
 	}
 }
 
@@ -1123,16 +1159,26 @@ func (l *lowerer) collectStrictElementReads(node *gotreesitter.Node, reads map[s
 	tag := l.extractTagName(open)
 	isEach := tag == "Each"
 	_, isStrictCallee := l.strictNames[tag]
-	// Forward-referenced same-file strict components (declared later in
-	// this file than the component currently being collected) are not yet
-	// in l.strictNames at this point in collectStrictSchemas' single pass;
-	// such a spread's read simply is not pre-registered here. That is a
-	// narrow completeness gap in the explicit-supply rule and PropsFields
-	// for THIS component only — the actual type safety is unaffected,
-	// because validateStrictComponentCall's tier-1 check independently
-	// re-resolves and proves the same source once l.strictNames is
-	// complete, later in lowering.
-	isSpreadForwardTag := isStrictCallee && tag != "If" && tag != "Each"
+	// l.strictNames is complete for the whole file by the time this runs —
+	// collectStrictSchemas' pass 2 (gosx#182/#184 M-3) only starts
+	// collecting any component's reads after its pass 1 has recorded every
+	// same-file strict component's name, regardless of declaration order.
+	// A forward-referenced strict callee (declared later in the file than
+	// the caller) is therefore seen here exactly as an earlier-declared one
+	// is.
+	// isStrictCallee alone decides this (gosx#182/#184 minor m-6): it is
+	// already false for the builtin If/Each (neither is ever a key in
+	// l.strictNames), so an explicit "tag != If/Each" exclusion here only
+	// ever changed anything for the one case it should NOT have — a
+	// same-file strict component literally named If or Each (a legitimate
+	// shadow, section 2.1's carve-out). A spread into a shadowed If/Each
+	// used to fall through to the generic scalar-read walk instead of
+	// getting the spread-forward class, so validateStrictRenderedProps'
+	// later pass saw a struct-typed source registered as a scalar read
+	// and rejected it with the scalar diagnostic — even when
+	// validateStrictToStrictSpreadCall (a separate pass) would have
+	// accepted the very same call as a valid E2 tier-1 spread.
+	isSpreadForwardTag := isStrictCallee
 	for i := 0; i < int(open.NamedChildCount()); i++ {
 		attrChild := open.NamedChild(i)
 		if isEach && l.nodeType(attrChild) == "jsx_attribute" {
@@ -1312,12 +1358,23 @@ const (
 	strictHopPointer
 	strictHopThroughScalar
 	strictHopUndeclaredStruct
-	// strictHopUnknownField is silent, and only ever returned for hop 0: the
-	// package checker supplies the precise unknown/unexported-field
-	// diagnostic for the root's own field, since the generated program's
-	// real root value (props, or an <Each> binding bound to its concrete
-	// element type) is exactly this same-file struct type. Every caller of
-	// walkStrictHops skips emitting anything for this kind.
+	// strictHopUnknownField is only ever returned for hop 0 (the root's own
+	// field), and its two callers treat it differently:
+	//   - An <Each> binding root (validateEachBindingRead): the binding's
+	//     element struct is fully known here, and the projection compiles
+	//     in the SAME package as its declaration, so Go resolves a
+	//     promoted or unexported field there exactly as it resolves a
+	//     declared one — there is no compiler backstop. This caller does
+	//     NOT skip this kind; it reports it, reusing
+	//     strictHopUnknownFieldDeep's wording with the binding root
+	//     substituted (gosx#182/#184).
+	//   - The props root (resolveStrictSelectorPath and its siblings):
+	//     still skips emitting anything for this kind, deferring to the
+	//     package checker. That deferral is sound only for a genuinely
+	//     absent field, which IS a compile error there; for a promoted or
+	//     unexported field it is not — Go resolves those too, same as for
+	//     an Each binding, so this is a known, inherited-from-main gap, not
+	//     a backstop, tracked in gosx#195.
 	strictHopUnknownField
 	// strictHopUnknownFieldDeep is gosx#183's B1 fix, generalized: an
 	// unknown field at hop i>0 gets no compiler backstop. Field promotion
@@ -1372,10 +1429,13 @@ func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) stri
 		fieldType, known := l.structTypes[currentType][field]
 		if !known {
 			if i == 0 {
-				// The root's own field: the package checker supplies the
-				// precise unknown/unexported-field diagnostic; this guard
-				// only owns known renderer schema types.
-				return strictHopResult{pathText: pathText, failKind: strictHopUnknownField}
+				// The root's own field. failField/failType are populated
+				// the same way as the i>0 branch below so a caller that
+				// upgrades this kind to an error (an <Each> binding root —
+				// see strictHopUnknownField's doc comment) can format the
+				// identical message; a caller that defers instead (the
+				// props root) ignores both.
+				return strictHopResult{pathText: pathText, failKind: strictHopUnknownField, failField: field, failType: currentType}
 			}
 			// gosx#183's B1 fix, generalized to any root: a promoted,
 			// unexported, or genuinely absent field past the root fails
@@ -1404,13 +1464,18 @@ func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) stri
 }
 
 // strictHopMessage formats every walkStrictHops structural failure except
-// strictHopOK and strictHopUnknownField (both handled by their caller, not
-// here) with full component context. One definition keeps the message text
-// identical regardless of which selector position (a props read, a loop-
-// source read, an Each binding read) triggered it — the failure is about
-// the schema shape, not what the path is used for.
+// strictHopOK with full component context. One definition keeps the
+// message text identical regardless of which selector position (a props
+// read, a loop-source read, an Each binding read) triggered it — the
+// failure is about the schema shape, not what the path is used for.
+// strictHopUnknownField (hop 0) is included here only for a caller that
+// has decided to upgrade it to an error (an <Each> binding root — see its
+// doc comment); a caller that instead defers hop 0 (the props root) keeps
+// its own early "case strictHopUnknownField: return" and never reaches
+// this function for that kind.
 //
-// strictHopUnknownFieldDeep reuses gosx#183's B1 wording verbatim,
+// strictHopUnknownFieldDeep and (when a caller reports it)
+// strictHopUnknownField both reuse gosx#183's B1 wording verbatim,
 // substituting only the root: the original fix names props explicitly
 // ("struct %s declares no visible field %s"); this generalized copy
 // composes the identical sentence from res.pathText, which already carries
@@ -1426,7 +1491,7 @@ func strictHopMessage(componentName string, res strictHopResult) string {
 		return fmt.Sprintf("strict component %s cannot select %q through %s of type %s; selector paths cross same-file struct fields only", componentName, res.failField, res.pathText, res.failType)
 	case strictHopUndeclaredStruct:
 		return fmt.Sprintf("strict component %s cannot resolve %s.%s: struct %s is not declared in this .gsx file; declare the renderer-visible struct beside the component", componentName, res.pathText, res.failField, res.failType)
-	case strictHopUnknownFieldDeep:
+	case strictHopUnknownFieldDeep, strictHopUnknownField:
 		return fmt.Sprintf("strict component %s cannot resolve %s.%s: struct %s declares no visible field %s; promoted, unexported, and unknown fields cannot cross the file renderer boundary", componentName, res.pathText, res.failField, res.failType, res.failField)
 	default:
 		return ""
@@ -1445,10 +1510,15 @@ func strictHopMessage(componentName string, res strictHopResult) string {
 // path.
 //
 // An unknown field at hop 0 (a direct field of the props struct itself) is
-// left to the package checker: the generated program's real props parameter
-// is exactly this same-file struct type, so an unknown or unexported field
-// there is a compile error in the check program regardless of what this
-// lowerer does. An unknown field at any later hop gets no such backstop:
+// left to the package checker. That deferral is a real backstop only for a
+// genuinely absent field — the check program's real props parameter is
+// exactly this same-file struct type, so a field this .gsx file never
+// declares anywhere is a compile error there regardless of what this
+// lowerer does. It is NOT a backstop for a promoted or unexported field:
+// the check program compiles those exactly as it compiles a directly
+// declared field, so this lowerer's silence here is a known, inherited
+// gap (tracked in gosx#195), not a guarantee. An unknown field at any
+// later hop gets no such backstop, for any field shape:
 // field promotion through an embedded type is legal Go, so the check
 // program compiles a promoted, unexported, or genuinely absent field the
 // same way — silently deferring here would let the component compile while
@@ -1961,6 +2031,27 @@ func (l *lowerer) lowerImportSpec(n *gotreesitter.Node) {
 	l.recordSignalImport(imp)
 }
 
+// isImportAlias reports whether name is this file's explicit alias for an
+// import (import name "path"). Imports lower before any component
+// (lowerSourceFile's single pass visits import_declaration before any
+// gosx_component_declaration — Go itself requires imports at the top of
+// the file), so l.prog.Imports is complete by the time strictEachShape
+// calls this. Only an EXPLICIT alias is checked: a bare `import "path"`'s
+// effective identifier is the imported package's own declared name, which
+// this lowerer does not resolve, so that narrower collision is left
+// alone (gosx#182/#184 nit n-1).
+func (l *lowerer) isImportAlias(name string) bool {
+	if name == "" {
+		return false
+	}
+	for _, imp := range l.prog.Imports {
+		if imp.Alias == name {
+			return true
+		}
+	}
+	return false
+}
+
 func (l *lowerer) recordSignalImport(imp Import) {
 	if strings.TrimSpace(imp.Path) != "m31labs.dev/gosx/signal" {
 		return
@@ -2402,6 +2493,15 @@ func (l *lowerer) validateStrictBindingReadTypes(span Span, source, componentNam
 // section 2.4 to a binding root), reports exactly one diagnostic on
 // failure, and records a clean scalar resolution into the owning scope
 // level's SlicePropSchema.Reads.
+//
+// Unlike the props-rooted callers, a hop-0 unknown field here (root's own
+// field on the element struct) is NOT deferred: the element struct is
+// fully known — this is the whole point of a typed <Each> — and the
+// package checker gives no backstop for a promoted or unexported field (it
+// resolves those the same as a declared one, same package). Deferring
+// would let this exact field read compile while the transpiled Go and the
+// map-backed file renderer diverge on what it resolves to (gosx#182/#184
+// M-2). So this reports the same message an hop-i>0 unknown field gets.
 func (l *lowerer) validateEachBindingRead(span Span, componentName string, scope *eachScope, root string, path []string) {
 	itemType, isIndex, found := scope.resolve(root)
 	if !found {
@@ -2413,8 +2513,6 @@ func (l *lowerer) validateEachBindingRead(span Span, componentName string, scope
 	}
 	res := l.walkStrictHops(root, itemType, path)
 	switch res.failKind {
-	case strictHopUnknownField:
-		return
 	case strictHopOK:
 		if !strictRendererScalarType(res.leafType) {
 			l.errs = append(l.errs, Diagnostic{Span: span, Message: fmt.Sprintf("strict component %s cannot render %s of type %s; loop selectors must reach an exact scalar field", componentName, res.pathText, res.leafType)})
@@ -2591,10 +2689,17 @@ func (l *lowerer) enterStrictEach(node *Node, componentName, propsType string, s
 // static as attribute, at most one static index attribute, and no others;
 // then the binding-name rules (section 2.2): valid Go identifier syntax,
 // not reserved (props/children), not shared between as and index, and not
-// already bound by an enclosing <Each>.
+// already bound by an enclosing <Each>. Each of of/as/index is counted
+// across all attributes on the node — a duplicate (e.g. two as attributes)
+// is rejected the same way validateStrictConditionalCall rejects a
+// duplicate cond: silently accepting the last-wins attribute here would
+// diverge from route/fileprogram.go's attrValue, which binds the FIRST
+// match, producing two components that compile clean but bind different
+// values at transpile time vs. file-render time.
 func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, indexName string, ofAttr *Attr, ok bool) {
 	ok = true
 	var asAttr, indexAttrPtr *Attr
+	ofCount, asCount, indexCount := 0, 0, 0
 	for i := range node.Attrs {
 		attr := &node.Attrs[i]
 		switch {
@@ -2602,6 +2707,7 @@ func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, index
 			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> does not accept spread attributes; of, as, and index are the only supported attributes"})
 			ok = false
 		case attr.Name == "of":
+			ofCount++
 			if attr.Kind != AttrExpr {
 				l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one of attribute with an expression value"})
 				ok = false
@@ -2609,23 +2715,34 @@ func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, index
 			}
 			ofAttr = attr
 		case attr.Name == "as":
+			asCount++
 			asAttr = attr
 		case attr.Name == "index":
+			indexCount++
 			indexAttrPtr = attr
 		default:
 			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> does not accept attribute %q; of, as, and index are the only supported attributes", attr.Name)})
 			ok = false
 		}
 	}
-	if ofAttr == nil {
+	if ofCount > 1 {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one of attribute with an expression value"})
+		ok = false
+	} else if ofAttr == nil {
 		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one of attribute with an expression value"})
 		ok = false
 	}
-	if asAttr == nil || asAttr.Kind != AttrStatic || strings.TrimSpace(asAttr.Value) == "" {
+	if asCount > 1 {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one as attribute naming the loop binding"})
+		ok = false
+	} else if asAttr == nil || asAttr.Kind != AttrStatic || strings.TrimSpace(asAttr.Value) == "" {
 		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires a static as attribute naming the loop binding"})
 		ok = false
 	}
-	if indexAttrPtr != nil && (indexAttrPtr.Kind != AttrStatic || strings.TrimSpace(indexAttrPtr.Value) == "") {
+	if indexCount > 1 {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one index attribute naming the index binding"})
+		ok = false
+	} else if indexAttrPtr != nil && (indexAttrPtr.Kind != AttrStatic || strings.TrimSpace(indexAttrPtr.Value) == "") {
 		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires a static index attribute naming the index binding"})
 		ok = false
 	}
@@ -2647,6 +2764,19 @@ func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, index
 		}
 		if binding == "props" || binding == "children" {
 			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is reserved; choose another name", binding)})
+			ok = false
+			continue
+		}
+		if l.isImportAlias(binding) {
+			// gosx#182/#184 nit n-1: a binding named after an explicit
+			// import alias already fails closed in the strictcheck
+			// projection (the generated Go shadows the package alias
+			// inside the loop body, so a package-qualified reference to it
+			// there resolves to the loop variable instead and the
+			// projection fails to compile) — but with a confusing Go
+			// compiler error far from the .gsx source, not a clear one
+			// here. Reject it at the source instead.
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q shadows this file's %q import; choose another name", binding, binding)})
 			ok = false
 		}
 	}

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -30,6 +30,7 @@ import (
 	"fmt"
 	"html"
 	"path"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -68,11 +69,52 @@ type lowerer struct {
 	strictNames   map[string]struct{}
 	legacyNames   map[string]struct{}
 	strictProps   map[string]string
-	strictReads   map[string]map[string]struct{}
+	strictReads   map[string]map[string]strictReadClass
 	structFields  map[string]map[string]string
 	structTypes   map[string]map[string]string
 	strictServer  bool
+
+	// currentStrictComponent and currentStrictPropsType name the strict
+	// component whose body lowerGSXNode is currently walking (empty
+	// outside strict lowering). E2 tier 1 (validateStrictToStrictSpreadCall)
+	// resolves a spread source's declared type against the CALLER's own
+	// schema, so it needs this context even though it fires from the
+	// generic per-element validateStrictComponentCall, which has no other
+	// way to see which component's body it is validating.
+	currentStrictComponent string
+	currentStrictPropsType string
+
+	// strictEachElems records, per strict component and per depth-1
+	// props-rooted <Each of> path, the same-file element struct name that
+	// path's loopable-type check (section 2.3) resolved — populated by
+	// validateStrictRenderedProps (the early, component-span diagnostic
+	// pass) and consumed by the second validation pass
+	// (validateStrictServerExpressions) so a structurally invalid of
+	// source is reported exactly once instead of twice.
+	strictEachElems map[string]map[string]string
 }
+
+// strictReadClass records the position(s) a props read appears in, so
+// validateStrictRenderedProps can apply the right admission rule per
+// position: a field read as a scalar (bare, concat operand, cond selector)
+// keeps the exact-scalar rule; a field read as an <Each of> loop source
+// takes section 2.3's loopable-[]T-of-struct rule; a field read as an E2
+// spread source (design spec section 3.2, "the predecessor's open question
+// 1, answered narrowly: struct values reach strict props by forwarding")
+// admits any same-file declared struct type with no requirement of nested
+// reads underneath — the callee, not the read tracker, owns which fields
+// it actually needs. More than one bit can be set for one path — a field
+// used more than one way keeps its own diagnostic for each position it
+// appears in (section 2.6).
+type strictReadClass uint8
+
+const (
+	strictReadScalar strictReadClass = 1 << iota
+	strictReadLoopSource
+	strictReadSpreadForward
+)
+
+func (c strictReadClass) has(bit strictReadClass) bool { return c&bit != 0 }
 
 // text returns the source text covered by node n. It substrings the
 // pre-converted srcStr instead of reallocating per call — Go strings
@@ -950,7 +992,7 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.strictNames = make(map[string]struct{})
 	l.legacyNames = make(map[string]struct{})
 	l.strictProps = make(map[string]string)
-	l.strictReads = make(map[string]map[string]struct{})
+	l.strictReads = make(map[string]map[string]strictReadClass)
 	l.structFields = make(map[string]map[string]string)
 	l.structTypes = make(map[string]map[string]string)
 	for i := 0; i < int(root.NamedChildCount()); i++ {
@@ -1006,8 +1048,22 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 // bare use anywhere in the source, which is the same class of bug a prior
 // review caught in this collector once already (see CHANGELOG.md's v0.42.0
 // entry), just inverted from a missed read to a false rejection.
-func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct{} {
-	reads := make(map[string]struct{})
+//
+// A third branch (element open tags) special-cases a strict <Each>'s of
+// attribute: its props source is a loop-source read (section 2.3's
+// loopable-[]T-of-struct rule), not a scalar read, so it must not fall
+// through to the jsx_attribute_expression branch above, which would apply
+// the scalar rule and reject a legitimate []T slice field. The tag is
+// matched by name only, not shadow-checked against l.strictNames — that map
+// is not reliably complete this early for a same-file forward reference
+// (collectStrictSchemas is still populating it), so a file that declares an
+// actual component named Each and also happens to use <Each of=...> before
+// declaring it is a known, narrow limitation, not engineered around here;
+// validateStrictComponentCall and the second validation pass, both of which
+// run once every component's schema is known, are the real authority on
+// whether a given <Each> is the builtin or a shadowing component call.
+func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]strictReadClass {
+	reads := make(map[string]strictReadClass)
 	var walk func(*gotreesitter.Node)
 	walk = func(node *gotreesitter.Node) {
 		if node == nil {
@@ -1016,14 +1072,18 @@ func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct
 		switch l.nodeType(node) {
 		case "selector_expression":
 			if path, ok := strictcomponent.ServerPropPath(l.text(node)); ok {
-				reads[strings.Join(path, ".")] = struct{}{}
+				registerStrictPropRead(reads, path, strictReadScalar)
 				return
 			}
 		case "jsx_attribute_expression":
 			expr := stripGSXAttributeExpressionText(l.text(node))
 			for _, path := range strictcomponent.ServerExpressionPropPaths(expr) {
-				reads[strings.Join(path, ".")] = struct{}{}
+				registerStrictPropRead(reads, path, strictReadScalar)
 			}
+			return
+		case "jsx_element", "jsx_self_closing_element":
+			l.collectStrictElementReads(node, reads, walk)
+			return
 		}
 		for i := 0; i < int(node.NamedChildCount()); i++ {
 			walk(node.NamedChild(i))
@@ -1031,6 +1091,91 @@ func (l *lowerer) collectStrictPropReads(n *gotreesitter.Node) map[string]struct
 	}
 	walk(n)
 	return reads
+}
+
+// registerStrictPropRead OR's class into path's entry, so a field read in
+// both a scalar position and a loop-source position (section 2.6) keeps
+// both bits instead of one overwriting the other.
+func registerStrictPropRead(reads map[string]strictReadClass, path []string, class strictReadClass) {
+	reads[strings.Join(path, ".")] |= class
+}
+
+// collectStrictElementReads walks one element's open-tag attributes and, for
+// jsx_element, its children — the same subtree collectStrictPropReads' walk
+// would otherwise cover directly — special-casing a strict <Each>'s of
+// attribute and, on an actual same-file strict component tag, a spread
+// attribute's own top-level expression (see the two per-caller doc
+// comments below). Every other attribute and every child still runs
+// through walk unchanged, including a spread on If, Each, an HTML element,
+// or an unresolved component tag — those keep the pre-#184 behavior of
+// falling through to the generic selector_expression case, since their own
+// shape rules (validateStrictConditionalCall, validateStrictHTMLElement,
+// the "not renderable" rejection) do not turn on a read's class the way a
+// strict callee's spread-forward proof does.
+func (l *lowerer) collectStrictElementReads(node *gotreesitter.Node, reads map[string]strictReadClass, walk func(*gotreesitter.Node)) {
+	open := node
+	isElement := l.nodeType(node) == "jsx_element"
+	if isElement {
+		if o := l.childByField(node, "open"); o != nil {
+			open = o
+		}
+	}
+	tag := l.extractTagName(open)
+	isEach := tag == "Each"
+	_, isStrictCallee := l.strictNames[tag]
+	// Forward-referenced same-file strict components (declared later in
+	// this file than the component currently being collected) are not yet
+	// in l.strictNames at this point in collectStrictSchemas' single pass;
+	// such a spread's read simply is not pre-registered here. That is a
+	// narrow completeness gap in the explicit-supply rule and PropsFields
+	// for THIS component only — the actual type safety is unaffected,
+	// because validateStrictComponentCall's tier-1 check independently
+	// re-resolves and proves the same source once l.strictNames is
+	// complete, later in lowering.
+	isSpreadForwardTag := isStrictCallee && tag != "If" && tag != "Each"
+	for i := 0; i < int(open.NamedChildCount()); i++ {
+		attrChild := open.NamedChild(i)
+		if isEach && l.nodeType(attrChild) == "jsx_attribute" {
+			nameNode := l.childByField(attrChild, "name")
+			if nameNode != nil && l.text(nameNode) == "of" {
+				if valueNode := l.childByField(attrChild, "value"); valueNode != nil && l.nodeType(valueNode) == "jsx_attribute_expression" {
+					expr := stripGSXAttributeExpressionText(l.text(valueNode))
+					for _, path := range strictcomponent.ServerExpressionPropPaths(expr) {
+						registerStrictPropRead(reads, path, strictReadLoopSource)
+					}
+				}
+				continue
+			}
+		}
+		if isSpreadForwardTag && l.nodeType(attrChild) == "jsx_spread_attribute" {
+			// A spread's own top-level expression is, by the E2 shape rule
+			// (design spec section 3.1), exactly props or a props field
+			// selector — never some larger expression a struct-typed
+			// selector could be buried inside. Registering it directly
+			// here, instead of falling through to walk (which would find
+			// the same inner selector_expression and register it with the
+			// scalar class instead), is what gives a struct-typed spread
+			// source the spread-forward admission rule.
+			if exprNode := l.childByField(attrChild, "expression"); exprNode != nil {
+				if path, ok := strictcomponent.ServerPropPath(l.text(exprNode)); ok {
+					registerStrictPropRead(reads, path, strictReadSpreadForward)
+				}
+			}
+			continue
+		}
+		walk(attrChild)
+	}
+	if !isElement {
+		return
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		typ := l.nodeType(child)
+		if typ == "jsx_opening_element" || typ == "jsx_closing_element" {
+			continue
+		}
+		walk(child)
+	}
 }
 
 func (l *lowerer) collectStructSchemas(n *gotreesitter.Node) {
@@ -1124,16 +1269,169 @@ func (l *lowerer) validateStrictRenderedProps(n *gotreesitter.Node, componentNam
 	}
 	sort.Strings(paths)
 	for _, path := range paths {
-		l.resolveStrictSelectorPath(n, componentName, propsType, strings.Split(path, "."))
+		class := reads[path]
+		segments := strings.Split(path, ".")
+		if class.has(strictReadScalar) {
+			l.resolveStrictSelectorPath(n, componentName, propsType, segments)
+		}
+		if class.has(strictReadLoopSource) {
+			if elem := l.resolveStrictEachSourceType(n, componentName, propsType, segments); elem != "" {
+				if l.strictEachElems == nil {
+					l.strictEachElems = make(map[string]map[string]string)
+				}
+				if l.strictEachElems[componentName] == nil {
+					l.strictEachElems[componentName] = make(map[string]string)
+				}
+				l.strictEachElems[componentName][path] = elem
+			}
+		}
+		if class.has(strictReadSpreadForward) {
+			l.resolveStrictSpreadForwardType(n, componentName, propsType, segments)
+		}
 	}
 }
 
 // strictSelectorPathDepthLimit caps how many struct-field hops a nested
-// selector path may cross: props.A.B.C is the deepest chain the strict
-// renderer resolves. strictcomponent.ServerPropPath itself places no upper
-// bound on shape (it is schema-blind), so this lowerer function is where the
-// cap is enforced, with full component context in the diagnostic.
+// selector path may cross: props.A.B.C (or, for an Each binding, row.A.B.C)
+// is the deepest chain the strict renderer resolves. strictcomponent's path
+// extractors place no upper bound on shape (they are schema-blind), so this
+// lowerer function is where the cap is enforced, with full component
+// context in the diagnostic.
 const strictSelectorPathDepthLimit = 3
+
+// strictHopFailKind classifies why walkStrictHops stopped short of the
+// final hop. strictHopOK is not a failure — the walk reached the final hop
+// cleanly and res.leafType holds its raw declared type text, unfiltered by
+// any admission rule; every caller applies its own (scalar, loopable-[]T,
+// or E2 tier-1 struct-identity).
+type strictHopFailKind int
+
+const (
+	strictHopOK strictHopFailKind = iota
+	strictHopTooDeep
+	strictHopPointer
+	strictHopThroughScalar
+	strictHopUndeclaredStruct
+	// strictHopUnknownField is silent, and only ever returned for hop 0: the
+	// package checker supplies the precise unknown/unexported-field
+	// diagnostic for the root's own field, since the generated program's
+	// real root value (props, or an <Each> binding bound to its concrete
+	// element type) is exactly this same-file struct type. Every caller of
+	// walkStrictHops skips emitting anything for this kind.
+	strictHopUnknownField
+	// strictHopUnknownFieldDeep is gosx#183's B1 fix, generalized: an
+	// unknown field at hop i>0 gets no compiler backstop. Field promotion
+	// through an embedded type, and same-package unexported access, are
+	// both legal Go, so the check program resolves a promoted, unexported,
+	// or genuinely absent field the same way it resolves a declared one,
+	// while the map-backed file renderer's structTypes schema never records
+	// a promoted or unexported field at any hop. Deferring here would let
+	// the component compile while the two renderers disagree on what the
+	// selector resolves to, or panic trying. Every caller of walkStrictHops
+	// reports this kind through strictHopMessage instead of skipping it —
+	// for a props root and, gosx#182/#184, for an <Each> binding root.
+	strictHopUnknownFieldDeep
+)
+
+// strictHopResult is walkStrictHops' outcome: either a clean resolution
+// (strictHopOK, with leafType set) or the first structural failure, with
+// enough context for strictHopMessage to format a diagnostic.
+type strictHopResult struct {
+	leafType  string
+	pathText  string
+	failKind  strictHopFailKind
+	failField string
+	failType  string
+}
+
+// walkStrictHops is the one implementation of the strict selector path
+// resolution rule every strict expression position composes on: given
+// (rootLabel, rootType) and a field path, it walks each hop through the
+// same-file struct schema and either returns the final hop's raw declared
+// type or the first structural problem. rootLabel only affects the
+// returned pathText, which every diagnostic quotes back to the author. This
+// generalizes the pre-#182/#184 resolveStrictSelectorPath to the (rootType,
+// path) composition contract in the design spec's section 2.4: a props
+// read resolves with rootLabel "props" and rootType the props struct; an
+// Each item binding read resolves with rootLabel the binding's name and
+// rootType its element struct — both are just a (rootLabel, rootType) pair
+// to this function, and it applies the identical pointer-ban,
+// scalar-cannot-be-selected-through, undeclared-struct, depth-cap, and
+// (gosx#183's B1 fix) hop-0-vs-later unknown-field rules to either root: an
+// unknown field at hop 0 is the root's own field, deferred to the package
+// checker; an unknown field at any later hop — promoted, unexported, or
+// genuinely absent — fails closed here, since no compiler backstop catches
+// it for either root shape (see strictHopUnknownFieldDeep).
+func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) strictHopResult {
+	if len(path) > strictSelectorPathDepthLimit {
+		return strictHopResult{pathText: rootLabel + "." + strings.Join(path, "."), failKind: strictHopTooDeep}
+	}
+	currentType := rootType
+	pathText := rootLabel
+	for i, field := range path {
+		fieldType, known := l.structTypes[currentType][field]
+		if !known {
+			if i == 0 {
+				// The root's own field: the package checker supplies the
+				// precise unknown/unexported-field diagnostic; this guard
+				// only owns known renderer schema types.
+				return strictHopResult{pathText: pathText, failKind: strictHopUnknownField}
+			}
+			// gosx#183's B1 fix, generalized to any root: a promoted,
+			// unexported, or genuinely absent field past the root fails
+			// closed here — see strictHopUnknownFieldDeep.
+			return strictHopResult{pathText: pathText, failKind: strictHopUnknownFieldDeep, failField: field, failType: currentType}
+		}
+		trimmed := strings.TrimSpace(fieldType)
+		pathText += "." + field
+		if i == len(path)-1 {
+			return strictHopResult{leafType: trimmed, pathText: pathText, failKind: strictHopOK}
+		}
+		switch {
+		case strings.HasPrefix(trimmed, "*"):
+			return strictHopResult{pathText: pathText, failKind: strictHopPointer, failType: trimmed}
+		case strictRendererScalarType(trimmed):
+			return strictHopResult{pathText: pathText, failKind: strictHopThroughScalar, failField: path[i+1], failType: trimmed}
+		default:
+			if _, isStruct := l.structTypes[trimmed]; isStruct {
+				currentType = trimmed
+				continue
+			}
+			return strictHopResult{pathText: pathText, failKind: strictHopUndeclaredStruct, failField: path[i+1], failType: trimmed}
+		}
+	}
+	return strictHopResult{pathText: pathText, failKind: strictHopOK}
+}
+
+// strictHopMessage formats every walkStrictHops structural failure except
+// strictHopOK and strictHopUnknownField (both handled by their caller, not
+// here) with full component context. One definition keeps the message text
+// identical regardless of which selector position (a props read, a loop-
+// source read, an Each binding read) triggered it — the failure is about
+// the schema shape, not what the path is used for.
+//
+// strictHopUnknownFieldDeep reuses gosx#183's B1 wording verbatim,
+// substituting only the root: the original fix names props explicitly
+// ("struct %s declares no visible field %s"); this generalized copy
+// composes the identical sentence from res.pathText, which already carries
+// whichever root (props or an <Each> binding name) walkStrictHops was
+// given.
+func strictHopMessage(componentName string, res strictHopResult) string {
+	switch res.failKind {
+	case strictHopTooDeep:
+		return fmt.Sprintf("strict component %s selector %s is too deep; the strict renderer resolves at most three fields", componentName, res.pathText)
+	case strictHopPointer:
+		return fmt.Sprintf("strict component %s cannot select through %s of pointer type %s; pointer fields cannot preserve Go nil-pointer behavior in the file renderer", componentName, res.pathText, res.failType)
+	case strictHopThroughScalar:
+		return fmt.Sprintf("strict component %s cannot select %q through %s of type %s; selector paths cross same-file struct fields only", componentName, res.failField, res.pathText, res.failType)
+	case strictHopUndeclaredStruct:
+		return fmt.Sprintf("strict component %s cannot resolve %s.%s: struct %s is not declared in this .gsx file; declare the renderer-visible struct beside the component", componentName, res.pathText, res.failField, res.failType)
+	case strictHopUnknownFieldDeep:
+		return fmt.Sprintf("strict component %s cannot resolve %s.%s: struct %s declares no visible field %s; promoted, unexported, and unknown fields cannot cross the file renderer boundary", componentName, res.pathText, res.failField, res.failType, res.failField)
+	default:
+		return ""
+	}
+}
 
 // resolveStrictSelectorPath walks a props-rooted field path (see
 // strictcomponent.ServerPropPath) against the same-file struct schema,
@@ -1159,47 +1457,104 @@ const strictSelectorPathDepthLimit = 3
 // all three shapes at hop i>0, exactly mirroring the lowerer rule
 // strictSelectorPathType applies for its own, diagnostic-free callers.
 func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName, propsType string, path []string) {
-	if len(path) > strictSelectorPathDepthLimit {
-		l.errorf(n, "strict component %s selector props.%s is too deep; the strict renderer resolves at most three fields", componentName, strings.Join(path, "."))
+	res := l.walkStrictHops("props", propsBaseType(propsType), path)
+	switch res.failKind {
+	case strictHopUnknownField:
 		return
+	case strictHopOK:
+		if !strictRendererScalarType(res.leafType) {
+			l.errorf(n, "strict component %s cannot render %s of type %s; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins", componentName, res.pathText, res.leafType)
+		}
+	default:
+		l.errorf(n, "%s", strictHopMessage(componentName, res))
 	}
-	currentType := propsBaseType(propsType)
-	pathText := "props"
-	for i, field := range path {
-		fieldType, known := l.structTypes[currentType][field]
-		if !known {
-			if i == 0 {
-				// The props struct's own field: the package checker
-				// supplies the precise unknown/unexported-field diagnostic;
-				// this guard only owns known renderer schema types.
-				return
-			}
-			l.errorf(n, "strict component %s cannot resolve %s.%s: struct %s declares no visible field %s; promoted, unexported, and unknown fields cannot cross the file renderer boundary", componentName, pathText, field, currentType, field)
-			return
+}
+
+// resolveStrictEachSourceType validates a strict <Each of> source's
+// loopable-type table (design spec section 2.3): the resolved field's
+// declared type must read exactly "[]T" where T is a same-file value
+// (non-pointer) struct. It returns T's bare name on success, or "" after
+// reporting exactly one diagnostic.
+//
+// This release resolves an of source one field deep only (a direct
+// props.Field, not a nested props.A.B): section 2.4 admits a nested of
+// source once every intermediate is a same-file value struct, but the file
+// renderer boundary (route/fileprogram.go's strictComponentAttrValue) only
+// dispatches a slice-typed check off a top-level props field name today.
+// Accepting a nested of source here without that boundary wiring would
+// type-check and transpile cleanly while leaving the loop's element type
+// unverified at the one place a caller-supplied value can diverge from what
+// the body assumes — exactly the class of gap this whole design exists to
+// close. No acceptance component needs a nested of source, so this widens
+// only alongside the boundary support, not ahead of it.
+func (l *lowerer) resolveStrictEachSourceType(n *gotreesitter.Node, componentName, propsType string, path []string) string {
+	if len(path) != 1 {
+		l.errorf(n, "strict component %s cannot loop over props.%s; <Each> resolves loop sources one field deep in this release, not a nested selector", componentName, strings.Join(path, "."))
+		return ""
+	}
+	res := l.walkStrictHops("props", propsBaseType(propsType), path)
+	switch res.failKind {
+	case strictHopUnknownField:
+		return ""
+	case strictHopOK:
+		elem, msg := admitStrictEachElemType(componentName, res.pathText, res.leafType, l.structTypes)
+		if msg != "" {
+			l.errorf(n, "%s", msg)
+			return ""
 		}
-		trimmed := strings.TrimSpace(fieldType)
-		pathText += "." + field
-		if i == len(path)-1 {
-			if !strictRendererScalarType(trimmed) {
-				l.errorf(n, "strict component %s cannot render %s of type %s; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins", componentName, pathText, trimmed)
-			}
-			return
+		return elem
+	default:
+		l.errorf(n, "%s", strictHopMessage(componentName, res))
+		return ""
+	}
+}
+
+// admitStrictEachElemType implements section 2.3's loopable-type table: the
+// final hop's declared type must read exactly "[]T", T a same-file value
+// struct. It returns T on success, or "" and a formatted message on any
+// other shape — a scalar-element slice, a pointer-element slice, a named
+// slice type, an array, a map, or a cross-file/undeclared element type
+// (Go's core-type generic inference would accept a named slice type such as
+// `type Rows []T`, so this exact-declared-text check is deliberately
+// stricter than the Go compiler alone would be here).
+func admitStrictEachElemType(componentName, pathText, leafType string, structTypes map[string]map[string]string) (elem string, message string) {
+	trimmed := strings.TrimSpace(leafType)
+	if strings.HasPrefix(trimmed, "[]") {
+		elemType := strings.TrimSpace(strings.TrimPrefix(trimmed, "[]"))
+		if strings.HasPrefix(elemType, "*") {
+			return "", fmt.Sprintf("strict component %s cannot loop over %s of type %s; pointer elements cannot preserve Go nil-pointer behavior in the file renderer", componentName, pathText, trimmed)
 		}
-		switch {
-		case strings.HasPrefix(trimmed, "*"):
-			l.errorf(n, "strict component %s cannot select through %s of pointer type %s; pointer fields cannot preserve Go nil-pointer behavior in the file renderer", componentName, pathText, trimmed)
-			return
-		case strictRendererScalarType(trimmed):
-			l.errorf(n, "strict component %s cannot select %q through %s of type %s; selector paths cross same-file struct fields only", componentName, path[i+1], pathText, trimmed)
-			return
-		default:
-			if _, isStruct := l.structTypes[trimmed]; isStruct {
-				currentType = trimmed
-				continue
+		if elemType != "" {
+			if _, ok := structTypes[elemType]; ok {
+				return elemType, ""
 			}
-			l.errorf(n, "strict component %s cannot resolve %s.%s: struct %s is not declared in this .gsx file; declare the renderer-visible struct beside the component", componentName, pathText, path[i+1], trimmed)
-			return
 		}
+		if strictRendererScalarType(elemType) {
+			return "", fmt.Sprintf("strict component %s cannot loop over %s of type %s; loop elements must be structs declared in this .gsx file", componentName, pathText, trimmed)
+		}
+	}
+	return "", fmt.Sprintf("strict component %s cannot loop over %s of type %s; <Each> sources must be []T slices of structs declared in this .gsx file", componentName, pathText, trimmed)
+}
+
+// resolveStrictSpreadForwardType validates an E2 spread source read (design
+// spec section 3.2, the "spread-forward" position class): the resolved
+// field's declared type must be a same-file declared struct — any struct
+// this .gsx file's schema knows, not necessarily one with further rendered
+// reads under it, since the callee (not this read-tracking pass) owns which
+// fields it actually needs. A pointer or scalar leaf fails closed with the
+// same "cannot forward" shape either way.
+func (l *lowerer) resolveStrictSpreadForwardType(n *gotreesitter.Node, componentName, propsType string, path []string) {
+	res := l.walkStrictHops("props", propsBaseType(propsType), path)
+	switch res.failKind {
+	case strictHopUnknownField:
+		return
+	case strictHopOK:
+		trimmed := strings.TrimSpace(res.leafType)
+		if _, isStruct := l.structTypes[trimmed]; !isStruct {
+			l.errorf(n, "strict component %s cannot forward %s of type %s; a spread source field must be a same-file declared struct", componentName, res.pathText, res.leafType)
+		}
+	default:
+		l.errorf(n, "%s", strictHopMessage(componentName, res))
 	}
 }
 
@@ -1218,39 +1573,30 @@ func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName,
 // would just duplicate that diagnostic, so those callers use this and skip
 // emitting anything when ok is false.
 func (l *lowerer) strictSelectorPathType(propsType string, path []string) (string, bool) {
-	if len(path) == 0 || len(path) > strictSelectorPathDepthLimit {
+	return l.resolveRootedFieldType(propsBaseType(propsType), path, true)
+}
+
+// resolveRootedFieldType generalizes strictSelectorPathType to an arbitrary
+// (rootType, path) pair — the same composition contract walkStrictHops
+// documents — for a caller that needs the leaf type with no component-span
+// diagnostic. scalarOnly=true keeps strictSelectorPathType's existing
+// exact-renderer-scalar gate (the concat and <If cond> exact-type passes,
+// generalized to a binding root in section 2.4); scalarOnly=false returns
+// the raw leaf type unfiltered — struct, slice, or scalar — for a caller
+// that applies its own admission rule, such as E2 tier 1's struct-identity
+// spread check.
+func (l *lowerer) resolveRootedFieldType(rootType string, path []string, scalarOnly bool) (string, bool) {
+	if len(path) == 0 {
 		return "", false
 	}
-	currentType := propsBaseType(propsType)
-	for i, field := range path {
-		fieldType, known := l.structTypes[currentType][field]
-		if !known {
-			// Unknown at hop 0 or later: both fail closed here (no leaf
-			// type, ok=false). Only resolveStrictSelectorPath's own copy of
-			// this check treats the two differently, since only it decides
-			// whether to emit a diagnostic.
-			return "", false
-		}
-		trimmed := strings.TrimSpace(fieldType)
-		if i == len(path)-1 {
-			if !strictRendererScalarType(trimmed) {
-				return "", false
-			}
-			return trimmed, true
-		}
-		if strings.HasPrefix(trimmed, "*") || strictRendererScalarType(trimmed) {
-			return "", false
-		}
-		if _, isStruct := l.structTypes[trimmed]; !isStruct {
-			return "", false
-		}
-		currentType = trimmed
+	res := l.walkStrictHops("", rootType, path)
+	if res.failKind != strictHopOK {
+		return "", false
 	}
-	// Unreachable: the top-of-function guard rejects an empty path, so the
-	// final iteration always has i == len(path)-1 and returns from the
-	// branch above. Go cannot prove that for a for-range loop, so this
-	// satisfies the compiler's return-statement requirement.
-	return "", false
+	if scalarOnly && !strictRendererScalarType(res.leafType) {
+		return "", false
+	}
+	return res.leafType, true
 }
 
 func lowerCamelInitialism(value string) string {
@@ -1312,11 +1658,18 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		return
 	}
 	if !l.strict && strictCallee {
-		l.errorf(n, "legacy component cannot call strict component %s; component styles may coexist but calls must stay within one style", tag)
+		l.validateLegacyToStrictCall(n, tag, attrs, children)
 		return
 	}
 	if l.strictServer && tag == "If" && !strictCallee {
 		l.validateStrictConditionalCall(n, attrs)
+		return
+	}
+	if l.strictServer && tag == "Each" && !strictCallee {
+		// Shape, binding, and type rules for a strict <Each> run in the
+		// second validation pass (validateStrictServerExpressions), which
+		// tracks the active binding scope while it walks the built IR tree
+		// — see section 2.2 of the design spec. Nothing to check here.
 		return
 	}
 	if l.strictServer && IsComponent(tag) && !strictCallee {
@@ -1326,10 +1679,9 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 	if !strictCallee {
 		return
 	}
-	for _, attr := range attrs {
-		if attr.Kind == AttrSpread {
-			l.errorf(n, "spread attributes are not supported for strict component %s", tag)
-		}
+	if attrHasSpread(attrs) {
+		l.validateStrictToStrictSpreadCall(n, tag, attrs, children)
+		return
 	}
 	if _, acceptsProps := l.strictProps[tag]; !acceptsProps && len(attrs) > 0 {
 		l.errorf(n, "strict component %s does not accept props", tag)
@@ -1385,6 +1737,100 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 	if len(children) > 0 {
 		l.errorf(n, "strict component %s does not accept positional children", tag)
 	}
+}
+
+// attrHasSpread reports whether attrs contains at least one spread
+// attribute — the trigger for validateStrictComponentCall's E2 branches.
+func attrHasSpread(attrs []Attr) bool {
+	for _, attr := range attrs {
+		if attr.Kind == AttrSpread {
+			return true
+		}
+	}
+	return false
+}
+
+// singleSpreadShape reports whether attrs is exactly one attribute, and
+// that attribute is a spread — the only call shape design spec section 3.1
+// admits at a strict callee: no named attributes beside the spread, no
+// second spread.
+func singleSpreadShape(attrs []Attr) (Attr, bool) {
+	if len(attrs) != 1 || attrs[0].Kind != AttrSpread {
+		return Attr{}, false
+	}
+	return attrs[0], true
+}
+
+// validateLegacyToStrictCall narrows the legacy-caller/strict-callee
+// cross-style ban (design spec section 3.3, E2 tier 2): a legacy body may
+// call a same-file strict component when the call is the single-spread
+// shape. The lowerer proves shape only here — a legacy expression has no
+// declared type — so the renderer boundary (strictSpreadProps,
+// route/fileprogram.go) re-proves the value structurally at run time. Every
+// other shape (no attributes, named attributes, multiple spreads, spread
+// plus named attributes) keeps the v0.39 cross-style ban, with an updated
+// message for the named-attributes case that names the supported spelling.
+func (l *lowerer) validateLegacyToStrictCall(n *gotreesitter.Node, tag string, attrs []Attr, children []NodeID) {
+	if len(attrs) == 0 {
+		l.errorf(n, "legacy component cannot call strict component %s; component styles may coexist but calls must stay within one style", tag)
+		return
+	}
+	if _, ok := singleSpreadShape(attrs); ok {
+		if len(children) > 0 {
+			l.errorf(n, "strict component %s does not accept positional children", tag)
+		}
+		return
+	}
+	l.errorf(n, "legacy component cannot call strict component %s with named attributes; pass one {...source} spread and the renderer will prove it at the boundary", tag)
+}
+
+// validateStrictToStrictSpreadCall validates E2 tier 1 (design spec section
+// 3.2): a strict caller may spread exactly one value into a same-file
+// strict callee when the source's declared type, resolved against the
+// caller's own schema, is exactly the callee's props type. Coverage is then
+// trivial: every rendered read is a field of the very struct the callee
+// declares, so no per-field proof is needed here — the emitted Go call is
+// verbatim (transpile.go), so the Go compiler proves the rest.
+func (l *lowerer) validateStrictToStrictSpreadCall(n *gotreesitter.Node, tag string, attrs []Attr, children []NodeID) {
+	spread, ok := singleSpreadShape(attrs)
+	if !ok {
+		l.errorf(n, "strict component call %s accepts at most one spread attribute and no other attributes", tag)
+		return
+	}
+	if len(children) > 0 {
+		l.errorf(n, "strict component %s does not accept positional children", tag)
+	}
+	calleeProps := l.strictProps[tag]
+	if strings.TrimSpace(calleeProps) == "" {
+		l.errorf(n, "strict component %s does not accept props", tag)
+		return
+	}
+	sourceType, ok := l.tierOneSpreadSourceType(spread.Expr)
+	if !ok {
+		l.errorf(n, "strict spread source %q is not renderable; spread sources are props or a props field selector", strings.TrimSpace(spread.Expr))
+		return
+	}
+	if propsBaseType(sourceType) != propsBaseType(calleeProps) {
+		l.errorf(n, "strict spread source %s has type %s, want exact %s; a strict caller spreads a value whose declared type is the callee props type", strings.TrimSpace(spread.Expr), sourceType, calleeProps)
+	}
+}
+
+// tierOneSpreadSourceType resolves a strict spread source's declared type
+// against l.currentStrictPropsType, the schema of the component whose body
+// is being lowered — validateStrictToStrictSpreadCall's caller-side half of
+// the tier-1 identity proof. It admits bare props (the whole props value)
+// and any props field selector the widened selector rule (section 2.4)
+// admits; every other expression shape returns ok=false, reported by the
+// caller with the "is not renderable" message (design spec section 4.4).
+func (l *lowerer) tierOneSpreadSourceType(expr string) (string, bool) {
+	if strings.TrimSpace(expr) == "props" {
+		return l.currentStrictPropsType, true
+	}
+	path, ok := strictcomponent.ServerPropPath(expr)
+	if !ok {
+		return "", false
+	}
+	return l.resolveRootedFieldType(propsBaseType(l.currentStrictPropsType), path, false)
 }
 
 // validateStrictConditionalCall enforces the shape of a strict <If cond={...}>
@@ -1603,11 +2049,17 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 
 	wasStrict := l.strict
 	wasStrictServer := l.strictServer
+	prevComponent := l.currentStrictComponent
+	prevPropsType := l.currentStrictPropsType
 	l.strict = true
 	l.strictServer = !isIsland && !isEngine
+	l.currentStrictComponent = componentName
+	l.currentStrictPropsType = propsType
 	rootID := l.lowerGSXNode(gsxRoot)
 	l.strict = wasStrict
 	l.strictServer = wasStrictServer
+	l.currentStrictComponent = prevComponent
+	l.currentStrictPropsType = prevPropsType
 	scope := l.analyzeBody(bodyNode)
 	propsFields, propsPaths := l.copyStrictPropTypes(propsType, l.strictReads[componentName])
 	comp := Component{
@@ -1632,21 +2084,28 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 	}
 
 	if !isIsland && !isEngine {
-		l.validateStrictServerExpressions(comp.Root, componentName, propsType)
+		comp.PropsSlices = l.validateStrictServerExpressions(comp.Root, componentName, propsType)
 	}
 	l.prog.Components = append(l.prog.Components, comp)
 }
 
 // copyStrictPropTypes builds the two IR maps the renderer boundary uses.
 // PropsFields records, for the root field of every registered read path,
-// that root's own declared type (a scalar builtin for a direct read, or a
-// same-file struct name for a nested read's root). PropsPaths records, for
-// every read path with at least one hop past its root, the leaf field's
-// declared type keyed by the full dot-joined path — populated only when the
-// path resolves cleanly; a broken path already has its own diagnostic from
-// validateStrictRenderedProps, so this silently omits it rather than
-// producing partial data for a component that is failing to compile anyway.
-func (l *lowerer) copyStrictPropTypes(propsType string, reads map[string]struct{}) (map[string]string, map[string]string) {
+// that root's own declared type (a scalar builtin for a direct read, a
+// same-file struct name for a nested read's root, or a "[]T" slice text for
+// an <Each of> loop-source read — section 2.6's back-compat rule: the
+// explicit-supply rule and the boundary dispatch see the field's raw
+// declared text unchanged, regardless of read class). PropsPaths records,
+// for every read path with at least one hop past its root, the leaf
+// field's declared type keyed by the full dot-joined path — populated only
+// when the path resolves cleanly; a broken path already has its own
+// diagnostic from validateStrictRenderedProps, so this silently omits it
+// rather than producing partial data for a component that is failing to
+// compile anyway. A loop-source read is always one field deep in this
+// release (resolveStrictEachSourceType), so it never reaches the
+// len(segments) > 1 branch below; its element schema lives in PropsSlices
+// instead, built by validateStrictServerExpressions.
+func (l *lowerer) copyStrictPropTypes(propsType string, reads map[string]strictReadClass) (map[string]string, map[string]string) {
 	fields := l.structTypes[propsBaseType(propsType)]
 	if len(fields) == 0 || len(reads) == 0 {
 		return nil, nil
@@ -1734,38 +2193,151 @@ func (l *lowerer) isSupportedStrictIslandDeclaration(n *gotreesitter.Node) bool 
 	return true
 }
 
-func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, propsType string) {
+// eachScope is one active <Each> binding the second validation pass has
+// pushed while it walks a strict component's IR tree — design spec section
+// 2.2's scoping rule and section 2.4's composition contract: a selector
+// chain may root at props or at any name in the active scope, resolved
+// through itemType (the element struct) instead of the props struct. It
+// forms a parent-linked chain the same shape as route/fileeval.go's
+// fileRenderScope, so nested loops shadow newest-first the same way at both
+// compile time and render time — with shadowing banned (section 2.2), the
+// two cannot disagree.
+type eachScope struct {
+	parent    *eachScope
+	itemName  string
+	itemType  string // same-file element struct name
+	indexName string
+	reads     map[string]string // binding-relative read paths -> leaf types; becomes this level's SlicePropSchema.Reads
+}
+
+func (s *eachScope) hasBinding(name string) bool {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.itemName == name || (cur.indexName != "" && cur.indexName == name) {
+			return true
+		}
+	}
+	return false
+}
+
+// resolve looks up name in the active scope chain, reporting whether it is
+// an item binding (with its element type) or an index binding.
+func (s *eachScope) resolve(name string) (itemType string, isIndex, ok bool) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.itemName == name {
+			return cur.itemType, false, true
+		}
+		if cur.indexName != "" && cur.indexName == name {
+			return "", true, true
+		}
+	}
+	return "", false, false
+}
+
+func (s *eachScope) items() []string {
+	var out []string
+	for cur := s; cur != nil; cur = cur.parent {
+		out = append(out, cur.itemName)
+	}
+	return out
+}
+
+func (s *eachScope) indices() []string {
+	var out []string
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.indexName != "" {
+			out = append(out, cur.indexName)
+		}
+	}
+	return out
+}
+
+func (s *eachScope) strictScope() strictcomponent.Scope {
+	return strictcomponent.Scope{Items: s.items(), Indices: s.indices()}
+}
+
+// recordRead registers a binding-rooted read's resolved leaf type into the
+// owning scope level's Reads accumulator (SlicePropSchema.Reads), walking
+// outward to find the level whose item name is root — a nested Each may
+// read an outer binding's field, and that read belongs to the outer
+// level's schema, not the innermost one.
+func (s *eachScope) recordRead(root string, path []string, leafType string) {
+	for cur := s; cur != nil; cur = cur.parent {
+		if cur.itemName == root {
+			if cur.reads != nil {
+				cur.reads[strings.Join(path, ".")] = leafType
+			}
+			return
+		}
+	}
+}
+
+// validateStrictServerExpressions walks a strict component's built IR tree,
+// validating every expression hole and expression/spread attribute, and
+// (design spec section 2.2) pushing an unshadowed <Each>'s declared
+// bindings onto the active scope before visiting its children. It returns
+// the component's PropsSlices — every depth-1 <Each of> loop-source read
+// this walk found, together with the binding-relative fields the loop body
+// actually reads (nil when the component has no strict <Each>).
+func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, propsType string) map[string]SlicePropSchema {
 	seen := make(map[NodeID]bool)
-	_, shadowedByStrict := l.strictNames["If"]
-	var visit func(NodeID)
-	visit = func(id NodeID) {
+	_, ifShadowed := l.strictNames["If"]
+	_, eachShadowed := l.strictNames["Each"]
+	slices := make(map[string]SlicePropSchema)
+	var visit func(NodeID, *eachScope)
+	visit = func(id NodeID, scope *eachScope) {
 		if seen[id] || int(id) >= len(l.prog.Nodes) {
 			return
 		}
 		seen[id] = true
 		node := &l.prog.Nodes[id]
 		if node.Kind == NodeExpr {
-			l.validateStrictServerExpression(node.Span, node.Text, componentName, propsType)
+			l.validateStrictServerExpression(node.Span, node.Text, componentName, propsType, scope)
 		}
-		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && !shadowedByStrict
+		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && !ifShadowed
+		isBuiltinEach := node.Kind == NodeComponent && node.Tag == "Each" && !eachShadowed
+		if isBuiltinEach {
+			childScope, ok := l.enterStrictEach(node, componentName, propsType, scope, slices)
+			if !ok {
+				return
+			}
+			for _, child := range node.Children {
+				visit(child, childScope)
+			}
+			return
+		}
 		for _, attr := range node.Attrs {
 			if isBuiltinIf && attr.Name == "cond" && attr.Kind == AttrExpr {
-				l.validateStrictConditionalExpression(node.Span, attr.Expr, componentName, propsType)
+				l.validateStrictConditionalExpression(node.Span, attr.Expr, componentName, propsType, scope)
 				continue
 			}
-			if attr.Kind == AttrExpr || attr.Kind == AttrSpread {
-				l.validateStrictServerExpression(node.Span, attr.Expr, componentName, propsType)
+			if attr.Kind == AttrExpr {
+				l.validateStrictServerExpression(node.Span, attr.Expr, componentName, propsType, scope)
 			}
+			// AttrSpread is not revalidated as an ordinary expression here:
+			// every spread position already has its own, more specific
+			// pass-1 validation (validateStrictToStrictSpreadCall for a
+			// strict callee's proven E2 tier-1 shape, whose admission rule
+			// legitimately differs from an ordinary expression position —
+			// bare props is a valid spread source but not a valid bare
+			// expression; validateStrictHTMLElement's unconditional ban for
+			// a strict HTML element; the "not renderable" rejection for any
+			// other unresolved component tag). Revalidating here would
+			// either duplicate a diagnostic or wrongly reject a proven
+			// spread with the bare-props message.
 		}
 		for _, child := range node.Children {
-			visit(child)
+			visit(child, scope)
 		}
 	}
-	visit(root)
+	visit(root, nil)
+	if len(slices) == 0 {
+		return nil
+	}
+	return slices
 }
 
-func (l *lowerer) validateStrictServerExpression(span Span, source, componentName, propsType string) {
-	if err := strictcomponent.ValidateServerExpression(source); err != nil {
+func (l *lowerer) validateStrictServerExpression(span Span, source, componentName, propsType string, scope *eachScope) {
+	if err := strictcomponent.ValidateServerExpressionScope(source, scope.strictScope()); err != nil {
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
 			Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(source), err),
@@ -1773,31 +2345,102 @@ func (l *lowerer) validateStrictServerExpression(span Span, source, componentNam
 		})
 		return
 	}
-	l.validateStrictExpressionTypes(span, source, componentName, propsType)
+	l.validateStrictBindingReadTypes(span, source, componentName, scope)
+	l.validateStrictExpressionTypes(span, source, componentName, propsType, scope)
+}
+
+// validateStrictBindingReadTypes is a props read's counterpart for a loop
+// binding: props reads get their scalar-ness checked once, early, by
+// validateStrictRenderedProps, before any <Each> scope even exists to
+// track; a binding read has no such early pass (the binding set is only
+// known once this second pass walks an <Each> node), so this scans source
+// for every binding-rooted path — bare, or nested inside a concat or cond
+// — and resolves+records each one here. A props-rooted path is skipped: it
+// already went through validateStrictRenderedProps, and restating it here
+// would just duplicate the diagnostic.
+func (l *lowerer) validateStrictBindingReadTypes(span Span, source, componentName string, scope *eachScope) {
+	for _, rp := range strictcomponent.ServerExpressionRootedPaths(source, scope.strictScope()) {
+		if rp.Root == "props" {
+			continue
+		}
+		l.validateEachBindingRead(span, componentName, scope, rp.Root, rp.Path)
+	}
+}
+
+// validateEachBindingRead resolves one binding-rooted read against its
+// owning <Each> element schema (walkStrictHops, generalized per design spec
+// section 2.4 to a binding root), reports exactly one diagnostic on
+// failure, and records a clean scalar resolution into the owning scope
+// level's SlicePropSchema.Reads.
+func (l *lowerer) validateEachBindingRead(span Span, componentName string, scope *eachScope, root string, path []string) {
+	itemType, isIndex, found := scope.resolve(root)
+	if !found {
+		return
+	}
+	if isIndex {
+		l.errs = append(l.errs, Diagnostic{Span: span, Message: fmt.Sprintf("strict component %s cannot use index binding %s in a selector; the index is an int value", componentName, root)})
+		return
+	}
+	res := l.walkStrictHops(root, itemType, path)
+	switch res.failKind {
+	case strictHopUnknownField:
+		return
+	case strictHopOK:
+		if !strictRendererScalarType(res.leafType) {
+			l.errs = append(l.errs, Diagnostic{Span: span, Message: fmt.Sprintf("strict component %s cannot render %s of type %s; loop selectors must reach an exact scalar field", componentName, res.pathText, res.leafType)})
+			return
+		}
+		scope.recordRead(root, path, res.leafType)
+	default:
+		l.errs = append(l.errs, Diagnostic{Span: span, Message: strictHopMessage(componentName, res)})
+	}
+}
+
+// resolveScopedFieldType resolves path's leaf type against root's schema —
+// the props struct when root is "props", or an active binding's element
+// struct otherwise (design spec section 2.4) — for the concat and cond
+// exact-type passes, which need the type regardless of which root supplied
+// it.
+func (l *lowerer) resolveScopedFieldType(propsType string, scope *eachScope, root string, path []string) (string, bool) {
+	if root == "props" {
+		return l.strictSelectorPathType(propsType, path)
+	}
+	itemType, isIndex, found := scope.resolve(root)
+	if !found || isIndex {
+		return "", false
+	}
+	return l.resolveRootedFieldType(itemType, path, true)
 }
 
 // validateStrictExpressionTypes runs the type-side gate for expression shapes
 // the syntactic validator accepts but cannot itself type-check: the
-// string-concatenation chain. Every props field operand — a direct field or
-// a nested path (props.A.B[.C]) — must resolve, through the same-file
-// struct schema, to declared type exactly string — not a named string type,
-// not []byte, not a struct. A path that fails to resolve at all is skipped
-// here; validateStrictRenderedProps already reports that root cause once,
-// and restating it would just duplicate the diagnostic.
-func (l *lowerer) validateStrictExpressionTypes(span Span, source, componentName, propsType string) {
-	paths, ok := strictcomponent.ServerConcatPropPaths(source)
+// string-concatenation chain. Every operand — a direct or nested props
+// field, or (section 2.4) a direct or nested binding field — must resolve,
+// through the same-file struct schema, to declared type exactly string —
+// not a named string type, not []byte, not a struct. A path that fails to
+// resolve at all is skipped here; a props path already got its own root
+// cause from validateStrictRenderedProps, and a binding path from
+// validateStrictBindingReadTypes above — restating either would just
+// duplicate the diagnostic.
+func (l *lowerer) validateStrictExpressionTypes(span Span, source, componentName, propsType string, scope *eachScope) {
+	rootedPaths, ok := strictcomponent.ServerConcatRootedPaths(source, scope.strictScope())
 	if !ok {
 		return
 	}
-	for _, path := range paths {
-		leafType, known := l.strictSelectorPathType(propsType, path)
+	for _, rp := range rootedPaths {
+		leafType, known := l.resolveScopedFieldType(propsType, scope, rp.Root, rp.Path)
 		if !known {
 			continue
 		}
 		if leafType != "string" {
+			suffix := "fields"
+			if rp.Root == "props" {
+				suffix = "props fields"
+			}
+			pathText := rp.Root + "." + strings.Join(rp.Path, ".")
 			l.errs = append(l.errs, Diagnostic{
 				Span:    span,
-				Message: fmt.Sprintf("strict component %s cannot concatenate props.%s of type %s; \"+\" operands must be exact string props fields", componentName, strings.Join(path, "."), leafType),
+				Message: fmt.Sprintf("strict component %s cannot concatenate %s of type %s; \"+\" operands must be exact string %s", componentName, pathText, leafType, suffix),
 			})
 		}
 	}
@@ -1805,13 +2448,13 @@ func (l *lowerer) validateStrictExpressionTypes(span Span, source, componentName
 
 // validateStrictConditionalExpression validates a strict <If cond={...}>
 // attribute's expression content: the syntactic shape (bare bool selector,
-// possibly a nested path, or that selector == false) through the dedicated
-// cond validator, then the exact bool type through the same-file struct
-// schema. General expression positions never reach this function — only the
-// cond attribute of an unshadowed <If> does, dispatched from
-// validateStrictServerExpressions.
-func (l *lowerer) validateStrictConditionalExpression(span Span, source, componentName, propsType string) {
-	path, _, err := strictcomponent.ValidateServerCondExpression(source)
+// possibly a nested path rooted at props or, section 2.4, at a binding, or
+// that selector == false) through the dedicated cond validator, then the
+// exact bool type through the same-file struct schema. General expression
+// positions never reach this function — only the cond attribute of an
+// unshadowed <If> does, dispatched from validateStrictServerExpressions.
+func (l *lowerer) validateStrictConditionalExpression(span Span, source, componentName, propsType string, scope *eachScope) {
+	root, path, _, err := strictcomponent.ValidateServerCondExpressionScope(source, scope.strictScope())
 	if err != nil {
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
@@ -1820,16 +2463,177 @@ func (l *lowerer) validateStrictConditionalExpression(span Span, source, compone
 		})
 		return
 	}
-	fieldType, known := l.strictSelectorPathType(propsType, path)
+	if root != "" && root != "props" {
+		l.validateEachBindingRead(span, componentName, scope, root, path)
+	}
+	fieldType, known := l.resolveScopedFieldType(propsType, scope, root, path)
 	if !known {
 		return
 	}
 	if fieldType != "bool" {
+		suffix := "field"
+		if root == "props" {
+			suffix = "props field"
+		}
+		pathText := root + "." + strings.Join(path, ".")
 		l.errs = append(l.errs, Diagnostic{
 			Span:    span,
-			Message: fmt.Sprintf("strict component %s cannot use props.%s of type %s in <If cond>; cond requires an exact bool props field", componentName, strings.Join(path, "."), fieldType),
+			Message: fmt.Sprintf("strict component %s cannot use %s of type %s in <If cond>; cond requires an exact bool %s", componentName, pathText, fieldType, suffix),
 		})
 	}
+}
+
+// strictBindingNamePattern is design spec section 2.2's binding-name rule:
+// lowercase-first, valid Go identifier characters. Lowercase-first keeps a
+// binding visually and lexically disjoint from component tags and type
+// names.
+var strictBindingNamePattern = regexp.MustCompile(`^[a-z][A-Za-z0-9]*$`)
+
+// goKeywords is the exhaustive Go keyword set; a binding may not use one,
+// since it is emitted verbatim as a Go func parameter name
+// (transpile.go's emitStrictEach).
+var goKeywords = map[string]bool{
+	"break": true, "default": true, "func": true, "interface": true, "select": true,
+	"case": true, "defer": true, "go": true, "map": true, "struct": true,
+	"chan": true, "else": true, "goto": true, "package": true, "switch": true,
+	"const": true, "fallthrough": true, "if": true, "range": true, "type": true,
+	"continue": true, "for": true, "import": true, "return": true, "var": true,
+}
+
+func invalidStrictBindingNameReason(name string) string {
+	if !strictBindingNamePattern.MatchString(name) || goKeywords[name] {
+		return "must start with a lowercase letter and be a valid Go identifier"
+	}
+	return ""
+}
+
+// enterStrictEach validates one strict <Each> node's own shape, binding
+// names, and of-source type, and returns the scope its children should
+// validate under. ok=false means the subtree should not be walked further:
+// a shape or type problem already reported its own diagnostic (or, for an
+// of source whose type already failed validateStrictRenderedProps' early
+// pass, was already reported there), and there is no well-defined binding
+// to check descendant expressions against.
+func (l *lowerer) enterStrictEach(node *Node, componentName, propsType string, scope *eachScope, slices map[string]SlicePropSchema) (*eachScope, bool) {
+	itemName, indexName, ofAttr, ok := l.strictEachShape(node, scope)
+	if !ok {
+		return nil, false
+	}
+	if err := strictcomponent.ValidateServerExpression(ofAttr.Expr); err != nil {
+		l.errs = append(l.errs, Diagnostic{
+			Span:    node.Span,
+			Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(ofAttr.Expr), err),
+			Hint:    "of must select a []T slice field on props",
+		})
+		return nil, false
+	}
+	path, sok := strictcomponent.ServerPropPath(ofAttr.Expr)
+	if !sok {
+		l.errs = append(l.errs, Diagnostic{
+			Span:    node.Span,
+			Message: fmt.Sprintf("strict <Each> of attribute %q must select a props field; of sources are props or a props field selector", strings.TrimSpace(ofAttr.Expr)),
+		})
+		return nil, false
+	}
+	dotted := strings.Join(path, ".")
+	elem, known := l.strictEachElems[componentName][dotted]
+	if !known {
+		// validateStrictRenderedProps (the early, component-span pass) has
+		// already reported this exact path's own diagnostic — see
+		// collectStrictPropReads' loop-source classification and
+		// resolveStrictEachSourceType. Stop walking this subtree without a
+		// duplicate.
+		return nil, false
+	}
+	reads := make(map[string]string)
+	if existing, exists := slices[dotted]; exists && existing.Reads != nil {
+		// Two <Each> loops over the same props path share one boundary
+		// schema — the union of fields either loop reads.
+		reads = existing.Reads
+	}
+	slices[dotted] = SlicePropSchema{Elem: elem, Reads: reads}
+	itemScope := &eachScope{parent: scope, itemName: itemName, itemType: elem, indexName: indexName, reads: reads}
+	return itemScope, true
+}
+
+// strictEachShape validates a strict <Each> node's own attributes (design
+// spec section 4.1): exactly one of attribute with an expression value, a
+// static as attribute, at most one static index attribute, and no others;
+// then the binding-name rules (section 2.2): valid Go identifier syntax,
+// not reserved (props/children), not shared between as and index, and not
+// already bound by an enclosing <Each>.
+func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, indexName string, ofAttr *Attr, ok bool) {
+	ok = true
+	var asAttr, indexAttrPtr *Attr
+	for i := range node.Attrs {
+		attr := &node.Attrs[i]
+		switch {
+		case attr.Kind == AttrSpread:
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> does not accept spread attributes; of, as, and index are the only supported attributes"})
+			ok = false
+		case attr.Name == "of":
+			if attr.Kind != AttrExpr {
+				l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one of attribute with an expression value"})
+				ok = false
+				continue
+			}
+			ofAttr = attr
+		case attr.Name == "as":
+			asAttr = attr
+		case attr.Name == "index":
+			indexAttrPtr = attr
+		default:
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> does not accept attribute %q; of, as, and index are the only supported attributes", attr.Name)})
+			ok = false
+		}
+	}
+	if ofAttr == nil {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires exactly one of attribute with an expression value"})
+		ok = false
+	}
+	if asAttr == nil || asAttr.Kind != AttrStatic || strings.TrimSpace(asAttr.Value) == "" {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires a static as attribute naming the loop binding"})
+		ok = false
+	}
+	if indexAttrPtr != nil && (indexAttrPtr.Kind != AttrStatic || strings.TrimSpace(indexAttrPtr.Value) == "") {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: "strict <Each> requires a static index attribute naming the index binding"})
+		ok = false
+	}
+	if !ok {
+		return "", "", nil, false
+	}
+	itemName = asAttr.Value
+	if indexAttrPtr != nil {
+		indexName = indexAttrPtr.Value
+	}
+	for _, binding := range []string{itemName, indexName} {
+		if binding == "" {
+			continue
+		}
+		if msg := invalidStrictBindingNameReason(binding); msg != "" {
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q %s", binding, msg)})
+			ok = false
+			continue
+		}
+		if binding == "props" || binding == "children" {
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is reserved; choose another name", binding)})
+			ok = false
+		}
+	}
+	if indexName != "" && indexName == itemName {
+		l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is already bound by this <Each>; as and index must name different bindings", itemName)})
+		ok = false
+	}
+	for _, binding := range []string{itemName, indexName} {
+		if binding != "" && scope.hasBinding(binding) {
+			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is already bound by an enclosing <Each>; loop bindings cannot shadow", binding)})
+			ok = false
+		}
+	}
+	if !ok {
+		return "", "", nil, false
+	}
+	return itemName, indexName, ofAttr, true
 }
 
 // surfaceAllowedHandlers is the exhaustive set of on* event names permitted on

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1463,11 +1463,41 @@ func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName,
 		return
 	case strictHopOK:
 		if !strictRendererScalarType(res.leafType) {
+			if l.isStrictEachLoopableSliceType(res.leafType) {
+				// A slice whose element is a same-file value struct has its
+				// own admitted rendering shape (design spec section 4.2's
+				// dedicated message) — the generic non-scalar-leaf message
+				// below would otherwise be technically true but misleading,
+				// naming builtins this slice could never satisfy instead of
+				// naming the one shape that does admit it. A slice this
+				// .gsx file's <Each of> would ALSO reject ([]string, a
+				// scalar-element slice) keeps the generic message — v0.42.2
+				// already rejected it that way, before <Each> existed.
+				l.errorf(n, "strict component %s cannot render %s of type %s here; slice props render only through <Each of>", componentName, res.pathText, res.leafType)
+				return
+			}
 			l.errorf(n, "strict component %s cannot render %s of type %s; renderer-visible props fields must use exact string, bool, integer, or floating-point builtins", componentName, res.pathText, res.leafType)
 		}
 	default:
 		l.errorf(n, "%s", strictHopMessage(componentName, res))
 	}
+}
+
+// isStrictEachLoopableSliceType reports whether typeName is a "[]T" whose T
+// is a same-file declared struct — the same admission admitStrictEachElemType
+// would give it inside a real <Each of>, checked here only to choose which
+// diagnostic a bare (non-loop) read of the same field gets.
+func (l *lowerer) isStrictEachLoopableSliceType(typeName string) bool {
+	trimmed := strings.TrimSpace(typeName)
+	if !strings.HasPrefix(trimmed, "[]") {
+		return false
+	}
+	elem := strings.TrimSpace(strings.TrimPrefix(trimmed, "[]"))
+	if elem == "" || strings.HasPrefix(elem, "*") {
+		return false
+	}
+	_, ok := l.structTypes[elem]
+	return ok
 }
 
 // resolveStrictEachSourceType validates a strict <Each of> source's

--- a/ir/propsslices_roundtrip_test.go
+++ b/ir/propsslices_roundtrip_test.go
@@ -1,0 +1,82 @@
+package ir
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestComponentPropsSlicesDecodesAbsentFromOlderPrograms proves the
+// compatibility rule PropsSlices' doc comment states, matching
+// ComponentSyntax's and PropsPaths' established zero-value convention: a
+// Component encoded before this field existed decodes into the current
+// type with PropsSlices absent (nil), not an error and not a
+// present-but-empty map that would compare unequal to the legacy zero
+// value. legacyComponentJSON is a hand-written encoding of a pre-#182/#184
+// Component — every field this change adds is absent, exactly as a program
+// serialized before PropsSlices existed would be.
+func TestComponentPropsSlicesDecodesAbsentFromOlderPrograms(t *testing.T) {
+	const legacyComponentJSON = `{
+		"Name": "Row",
+		"PropsType": "RowProps",
+		"PropsName": "props",
+		"PropsFields": {"Breakdown": "[]BreakdownRow"},
+		"Syntax": 1,
+		"Root": 3
+	}`
+	var comp Component
+	if err := json.Unmarshal([]byte(legacyComponentJSON), &comp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if comp.PropsSlices != nil {
+		t.Fatalf("PropsSlices = %#v, want nil (absent) for a program serialized before this field existed", comp.PropsSlices)
+	}
+	if comp.Name != "Row" || comp.PropsFields["Breakdown"] != "[]BreakdownRow" || comp.Syntax != ComponentSyntaxStrict {
+		t.Fatalf("legacy fields did not decode unchanged: %#v", comp)
+	}
+}
+
+// TestComponentPropsSlicesRoundTripsThroughJSON proves the new field
+// itself round-trips: a Component with a populated PropsSlices, including
+// a nested (dot-joined) Reads key, encodes and decodes back to an equal
+// value, alongside its PropsFields root-type entry.
+func TestComponentPropsSlicesRoundTripsThroughJSON(t *testing.T) {
+	comp := Component{
+		Name:      "Row",
+		PropsType: "RowProps",
+		PropsName: "props",
+		PropsFields: map[string]string{
+			"Breakdown": "[]BreakdownRow",
+		},
+		PropsSlices: map[string]SlicePropSchema{
+			"Breakdown": {
+				Elem: "BreakdownRow",
+				Reads: map[string]string{
+					"Label":      "string",
+					"Stat.Label": "string",
+				},
+			},
+		},
+		Syntax: ComponentSyntaxStrict,
+	}
+	data, err := json.Marshal(comp)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded Component
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	schema, ok := decoded.PropsSlices["Breakdown"]
+	if !ok {
+		t.Fatalf("PropsSlices did not round-trip: %#v", decoded.PropsSlices)
+	}
+	if schema.Elem != "BreakdownRow" {
+		t.Fatalf("PropsSlices[Breakdown].Elem = %q, want BreakdownRow", schema.Elem)
+	}
+	if schema.Reads["Label"] != "string" || schema.Reads["Stat.Label"] != "string" {
+		t.Fatalf("PropsSlices[Breakdown].Reads did not round-trip: %#v", schema.Reads)
+	}
+	if decoded.Name != comp.Name || decoded.PropsFields["Breakdown"] != "[]BreakdownRow" {
+		t.Fatalf("Component did not round-trip: %#v", decoded)
+	}
+}

--- a/route/fileeval.go
+++ b/route/fileeval.go
@@ -29,6 +29,30 @@ type fileRenderEnv struct {
 	renderEngine    func(engine.Config, gosx.Node) gosx.Node
 	renderIsland    func(*islandprogram.Program, any) gosx.Node
 	enableBootstrap func()
+	// strictSpreadSource is the raw, already-boundary-proved value that
+	// localComponentProps used to build the CURRENT strict component
+	// render frame's own "props" binding — set only when that frame came
+	// from the single-spread call shape (nil for an explicit-attrs call).
+	// writeLocalComponent resets it on every strict-component call, so it
+	// is never stale across an unrelated nested component, and it survives
+	// unchanged through any HTML/If/Each nodes in between, the same way
+	// the "props" scope binding itself does.
+	//
+	// It exists only to make a BARE {...props} spread forward, from
+	// inside a strict body, work at the map-backed file renderer boundary
+	// (gosx#182/#184 M-1): "props" in scope is always the reduced
+	// map[string]any localComponentProps builds for the current frame
+	// (never a real Go struct, even when every field it needs was proved
+	// from one), so re-spreading it verbatim into strictSpreadProps always
+	// fails the struct-kind check there — the same struct-kind check that
+	// correctly rejects an arbitrary map. Re-running that same proof
+	// against strictSpreadSource instead is sound unconditionally, not
+	// just for a statically-proven tier-1 chain: strictSpreadProps always
+	// re-proves every field the callee needs against the concrete runtime
+	// value, so a mismatched shape still fails closed, just against the
+	// right value instead of an artificially reduced map. See
+	// localComponentProps' single-spread branch.
+	strictSpreadSource any
 }
 
 // fileRenderScope is one copy-on-write binding in the render environment.

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1963,6 +1963,17 @@ func strictComponentSliceAttrValue(comp *ir.Component, attr ir.Attr, env fileRen
 // well-typed Go slice's elements all share one type, so proving the type
 // once proves every element's field access is total. A typed nil slice
 // passes (its Kind is still Slice) and iterates zero times, matching Go.
+//
+// Each hop rejects a promoted field the same way requireStrictStructValue
+// does (gosx#183's M2 fix, applied here to E1's own element walk):
+// reflect.Type.FieldByName also resolves embedded-field promotion, so a
+// bare found check alone would let a promoted field cross this boundary
+// even though the lowerer's walkStrictHops already refuses to compile a
+// loop-binding read through one (gosx#182/#184's generalized B1 fix). This
+// walk is type-level only (never Value.FieldByName), so there is no nil-
+// embedded-pointer panic vector here the way there was for
+// requireStrictStructValue's per-element instance would have had — but the
+// silent-promotion gap is the same, and closes the same way.
 func requireStrictSliceValue(value any, schema ir.SlicePropSchema) (any, error) {
 	if value == nil {
 		return nil, fmt.Errorf("value is nil")
@@ -1990,8 +2001,11 @@ func requireStrictSliceValue(value any, schema ir.SlicePropSchema) (any, error) 
 				return nil, fmt.Errorf("slice element %s: field %s is not a struct", schema.Elem, path)
 			}
 			field, found = ft.FieldByName(segment)
-			if !found {
+			if !found || !field.IsExported() {
 				return nil, fmt.Errorf("slice element %s has no field %s (%s) required by the renderer", schema.Elem, path, leafType)
+			}
+			if len(field.Index) != 1 {
+				return nil, fmt.Errorf("slice element %s field %s is a promoted (embedded) field; only fields declared directly on the struct resolve here", schema.Elem, path)
 			}
 			ft = field.Type
 		}
@@ -2043,10 +2057,25 @@ func strictSpreadProps(comp *ir.Component, value any) (map[string]any, error) {
 	props := make(map[string]any, len(fields)+4)
 	for _, field := range fields {
 		fieldType := comp.PropsFields[field]
-		fv := rv.FieldByName(field)
-		if !fv.IsValid() || !fv.CanInterface() {
+		// Resolve through the TYPE first, not Value.FieldByName: the latter
+		// also walks embedded-field promotion and indirects through any
+		// pointer along the way, which panics on a nil embedded pointer
+		// (gosx#183's M2 bug, reproduced here for a tier-2 spread source: a
+		// legacy caller's spread value has no declared type at compile
+		// time, so this render-time boundary is the only place a promoted
+		// field on the source struct is ever caught). sf.Index has length 1
+		// for a field declared directly on the struct and length >1 for a
+		// promoted field reached through one or more embeddings — reject
+		// before ever touching the value, the same way
+		// requireStrictStructValue does for a nested-selector root.
+		sf, found := rv.Type().FieldByName(field)
+		if !found || !sf.IsExported() {
 			return nil, fmt.Errorf("spread source %s has no field %s (%s); the renderer reads props.%s", rv.Type(), field, fieldType, field)
 		}
+		if len(sf.Index) != 1 {
+			return nil, fmt.Errorf("spread source %s field %s is a promoted (embedded) field; only fields declared directly on the struct resolve here", rv.Type(), field)
+		}
+		fv := rv.Field(sf.Index[0])
 		raw := fv.Interface()
 		var proved any
 		var err error

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1699,6 +1699,24 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 	if comp == nil || comp.Syntax != ir.ComponentSyntaxStrict || len(comp.PropsFields) == 0 {
 		return componentProps(attrs, env, children), nil
 	}
+	// The single-spread shape (design spec section 3.1) is the only spread
+	// shape validateStrictComponentCall admits at a strict callee, for
+	// both E2 tiers. strictSpreadProps re-proves it structurally at run
+	// time regardless of which tier produced it: a tier-1 spread's static
+	// proof only guarantees this re-proof can fail closed, not that it is
+	// skippable.
+	if len(attrs) == 1 && attrs[0].Kind == ir.AttrSpread {
+		source := evalFileExpr(attrs[0].Expr, env)
+		props, err := strictSpreadProps(comp, source)
+		if err != nil {
+			return nil, err
+		}
+		if !children.IsZero() {
+			setComponentProp(props, "children", children)
+			setComponentProp(props, "Children", children)
+		}
+		return props, nil
+	}
 	props := make(map[string]any, len(attrs)+4)
 	for _, attr := range attrs {
 		field, fieldType, rendered := resolvePropsFieldAlias(comp.PropsFields, attr.Name)
@@ -1725,6 +1743,14 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 
 func strictComponentAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
 	if !strictScalarFieldType(fieldType) {
+		if strings.HasPrefix(strings.TrimSpace(fieldType), "[]") {
+			// A rendered field whose declared type is "[]T" is an <Each of>
+			// loop source (ir.Component.PropsSlices, design spec section
+			// 2.7): T is a same-file element struct, provable at the
+			// boundary type-level (requireStrictSliceValue) without
+			// walking every element.
+			return strictComponentSliceAttrValue(comp, attr, env, fieldType)
+		}
 		// A rendered field whose declared type is not one of the renderer's
 		// exact scalar builtins is a nested-selector root (ir.Component.
 		// PropsPaths): a same-file struct, provable at every strict-call
@@ -1911,6 +1937,139 @@ func requireStrictStructValue(value any, typeName string, paths map[string]strin
 	return value, nil
 }
 
+// strictComponentSliceAttrValue handles a rendered prop whose declared type
+// is "[]T" (an <Each of> loop source, ir.Component.PropsSlices). A slice
+// value can only arrive through an AttrExpr — there is no static or
+// boolean spelling for one.
+func strictComponentSliceAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
+	if attr.Kind != ir.AttrExpr {
+		return nil, fmt.Errorf("value has no slice spelling, want exact %s", fieldType)
+	}
+	schema, ok := comp.PropsSlices[attr.Name]
+	if !ok {
+		return nil, fmt.Errorf("strict component %s has no loop schema for slice field %s", comp.Name, attr.Name)
+	}
+	value := evalFileExpr(attr.Expr, env)
+	return requireStrictSliceValue(value, schema)
+}
+
+// requireStrictSliceValue is E1's renderer-boundary check (design spec
+// section 2.7): value's runtime type must be a slice whose element type is
+// exactly the same-file struct schema.Elem — a declared struct type from
+// any package, never an anonymous struct and never a map element — and
+// every read path schema.Reads names must resolve, by FieldByName on the
+// element TYPE (not each element's value), to its exact declared leaf
+// type. The check is O(read paths) once per call, not O(elements): a
+// well-typed Go slice's elements all share one type, so proving the type
+// once proves every element's field access is total. A typed nil slice
+// passes (its Kind is still Slice) and iterates zero times, matching Go.
+func requireStrictSliceValue(value any, schema ir.SlicePropSchema) (any, error) {
+	if value == nil {
+		return nil, fmt.Errorf("value is nil")
+	}
+	rt := reflect.TypeOf(value)
+	if rt.Kind() != reflect.Slice {
+		return nil, fmt.Errorf("runtime value has type %s, want a slice of structs named %s", rt, schema.Elem)
+	}
+	elemType := rt.Elem()
+	if elemType.Kind() != reflect.Struct || elemType.PkgPath() == "" || elemType.Name() != schema.Elem {
+		return nil, fmt.Errorf("runtime value has type %s, want a slice of structs named %s", rt, schema.Elem)
+	}
+	paths := make([]string, 0, len(schema.Reads))
+	for path := range schema.Reads {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	for _, path := range paths {
+		leafType := schema.Reads[path]
+		ft := elemType
+		var field reflect.StructField
+		found := false
+		for _, segment := range strings.Split(path, ".") {
+			if ft.Kind() != reflect.Struct {
+				return nil, fmt.Errorf("slice element %s: field %s is not a struct", schema.Elem, path)
+			}
+			field, found = ft.FieldByName(segment)
+			if !found {
+				return nil, fmt.Errorf("slice element %s has no field %s (%s) required by the renderer", schema.Elem, path, leafType)
+			}
+			ft = field.Type
+		}
+		if want := strictScalarWantName(leafType); ft.PkgPath() != "" || ft.Name() != want {
+			return nil, fmt.Errorf("slice element field %s has type %s, want exact %s", path, ft, leafType)
+		}
+	}
+	return value, nil
+}
+
+// strictSpreadProps re-proves a single spread attribute's source at the
+// strict-callee boundary (design spec section 3.4). It is the render-time
+// authority for both E2 tiers: a tier-1 spread (a strict caller; the
+// lowerer already proved the source's declared type is exactly the
+// callee's props type) can only fail here on caller-side data corruption
+// between compile and render, and a tier-2 spread (a legacy caller,
+// unprovable at compile time because legacy expressions have no declared
+// type) is proved here for the first time. Failure order matches the spec:
+//  1. non-nil after pointer indirection;
+//  2. reflect kind is exactly Struct — map[string]any and every other map
+//     are rejected: a map can omit keys where the generated-Go twin
+//     synthesizes a typed zero value (the same divergence the
+//     explicit-supply rule exists to close); map keys have no canonical
+//     mapping to Go fields; a map has no field types to check ahead of the
+//     values; and no generated-Go call can be spelled from a map, so no
+//     twin exists to match;
+//  3. every rendered read (PropsFields' roots, dispatched by their own
+//     declared type — scalar, "[]T" loop source, or nested-selector
+//     struct) is present on the source with a matching value, never
+//     zero-filled;
+//  4. the proved values are written through setComponentProp, so body-side
+//     alias resolution behaves exactly as an explicit call does.
+func strictSpreadProps(comp *ir.Component, value any) (map[string]any, error) {
+	rv := reflect.ValueOf(value)
+	rv, ok := indirectReflectValue(rv)
+	if !ok {
+		return nil, fmt.Errorf("spread source is nil")
+	}
+	if rv.Kind() != reflect.Struct {
+		return nil, fmt.Errorf("spread source has type %s; the strict boundary proves struct values with declared fields, and maps cannot prove field coverage", rv.Type())
+	}
+
+	fields := make([]string, 0, len(comp.PropsFields))
+	for field := range comp.PropsFields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	props := make(map[string]any, len(fields)+4)
+	for _, field := range fields {
+		fieldType := comp.PropsFields[field]
+		fv := rv.FieldByName(field)
+		if !fv.IsValid() || !fv.CanInterface() {
+			return nil, fmt.Errorf("spread source %s has no field %s (%s); the renderer reads props.%s", rv.Type(), field, fieldType, field)
+		}
+		raw := fv.Interface()
+		var proved any
+		var err error
+		switch {
+		case strictScalarFieldType(fieldType):
+			proved, err = requireStrictScalarType(raw, fieldType)
+		case strings.HasPrefix(strings.TrimSpace(fieldType), "[]"):
+			if schema, hasSchema := comp.PropsSlices[field]; hasSchema {
+				proved, err = requireStrictSliceValue(raw, schema)
+			} else {
+				err = fmt.Errorf("strict component %s has no loop schema for slice field %s", comp.Name, field)
+			}
+		default:
+			proved, err = requireStrictStructValue(raw, fieldType, strictStructPropsPaths(comp, field))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("prop %s (%s): %w", field, fieldType, err)
+		}
+		setComponentProp(props, field, proved)
+	}
+	return props, nil
+}
+
 func strictGoConstant(source string) (constant.Value, bool) {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
@@ -2046,14 +2205,23 @@ func convertStrictConstant(value constant.Value, fieldType string) (any, error) 
 	}
 }
 
-func requireStrictScalarType(value any, fieldType string) (any, error) {
-	want := fieldType
-	switch want {
+// strictScalarWantName maps a declared field type to the reflect.Type.Name
+// the runtime value must match exactly: byte and rune are aliases (uint8,
+// int32), so a runtime value that alias-resolves to the same underlying
+// predeclared type must show that name, not the alias spelling.
+func strictScalarWantName(fieldType string) string {
+	switch fieldType {
 	case "byte":
-		want = "uint8"
+		return "uint8"
 	case "rune":
-		want = "int32"
+		return "int32"
+	default:
+		return fieldType
 	}
+}
+
+func requireStrictScalarType(value any, fieldType string) (any, error) {
+	want := strictScalarWantName(fieldType)
 	if value == nil {
 		return nil, fmt.Errorf("value is nil")
 	}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1095,13 +1095,18 @@ func (r *fileProgramRenderer) writeLocalComponent(b *strings.Builder, comp *ir.C
 	// Children render into their own string because the component body may
 	// reference them through the `children` binding.
 	childrenNode := gosx.RawHTML(r.renderChildren(node.Children, env))
-	props, err := localComponentProps(comp, node.Attrs, env, childrenNode)
+	props, rawSource, err := localComponentProps(comp, node.Attrs, env, childrenNode)
 	if err != nil {
 		r.err = fmt.Errorf("render strict component %s: %w", comp.Name, err)
 		return
 	}
 	scope := env.withValue("props", props)
 	scope = scope.withValue("children", childrenNode)
+	// Always overwrite, never inherit from env: rawSource is nil unless
+	// THIS call just proved it (single-spread shape), so an explicit-attrs
+	// call correctly clears whatever an enclosing strict frame left set,
+	// rather than leaking it into this unrelated component's own body.
+	scope.strictSpreadSource = rawSource
 	r.writeNode(b, comp.Root, scope)
 }
 
@@ -1120,7 +1125,7 @@ func (r *fileProgramRenderer) renderLocalIsland(name string, node *ir.Node, env 
 
 	props := r.componentAttrMap(node.Attrs, env)
 	if comp := r.components[name]; comp != nil && comp.Syntax == ir.ComponentSyntaxStrict {
-		converted, err := localComponentProps(comp, node.Attrs, env, gosx.Node{})
+		converted, _, err := localComponentProps(comp, node.Attrs, env, gosx.Node{})
 		if err != nil {
 			r.err = fmt.Errorf("render strict island %s: %w", name, err)
 			return ""
@@ -1695,27 +1700,65 @@ func componentProps(attrs []ir.Attr, env fileRenderEnv, children gosx.Node) map[
 	return props
 }
 
-func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv, children gosx.Node) (map[string]any, error) {
-	if comp == nil || comp.Syntax != ir.ComponentSyntaxStrict || len(comp.PropsFields) == 0 {
-		return componentProps(attrs, env, children), nil
+// localComponentProps builds a strict callee's render-time props map, and
+// also returns the raw source value a single-spread call proved it from —
+// nil for an explicit-attrs call, or when comp is not a strict component.
+// The caller (writeLocalComponent) threads that raw value into the render
+// env as strictSpreadSource, purely so a BARE {...props} forward inside
+// THIS callee's own body (if it has one) can reuse it — see
+// fileRenderEnv.strictSpreadSource's doc comment (gosx#182/#184 M-1).
+func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv, children gosx.Node) (map[string]any, any, error) {
+	if comp == nil || comp.Syntax != ir.ComponentSyntaxStrict {
+		return componentProps(attrs, env, children), nil, nil
 	}
 	// The single-spread shape (design spec section 3.1) is the only spread
 	// shape validateStrictComponentCall admits at a strict callee, for
 	// both E2 tiers. strictSpreadProps re-proves it structurally at run
 	// time regardless of which tier produced it: a tier-1 spread's static
 	// proof only guarantees this re-proof can fail closed, not that it is
-	// skippable.
+	// skippable. This branch runs even when comp.PropsFields is empty
+	// (gosx#182/#184 m-2): a strict callee that reads nothing of its own
+	// still declares a props type, and spec section 3.4 requires a nil,
+	// wrong-kind (e.g. a map or a scalar), or otherwise malformed source
+	// to fail closed here — an empty read set makes every per-field proof
+	// vacuous, not the nil/kind checks themselves.
 	if len(attrs) == 1 && attrs[0].Kind == ir.AttrSpread {
 		source := evalFileExpr(attrs[0].Expr, env)
+		if strings.TrimSpace(attrs[0].Expr) == "props" && env.strictSpreadSource != nil {
+			// A bare props forward: "props" in scope is always the reduced
+			// map[string]any this function built for the CURRENT frame,
+			// which strictSpreadProps below always rejects on the struct-
+			// kind check — even when every field this callee needs was
+			// itself proved into that map. Re-prove against the raw value
+			// that built the current frame's own props instead (see
+			// fileRenderEnv.strictSpreadSource); still fully re-checked by
+			// strictSpreadProps below, so this never skips a proof, only
+			// retargets it at the value that can actually satisfy it.
+			source = env.strictSpreadSource
+		}
 		props, err := strictSpreadProps(comp, source)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 		if !children.IsZero() {
 			setComponentProp(props, "children", children)
 			setComponentProp(props, "Children", children)
 		}
-		return props, nil
+		return props, source, nil
+	}
+	if len(comp.PropsFields) == 0 {
+		// A strict callee with nothing of its own to prove, called by name
+		// (not spread). Known, narrow residual gap: if this callee's own
+		// body bare-forwards {...props} to another same-typed strict
+		// component, strictSpreadSource is nil here (this frame's props
+		// came from N separate attr expressions, not one struct value), so
+		// that forward falls through to the pre-fix map-kind rejection
+		// instead of rendering. Closing it needs the callee's forwarded
+		// requirements folded back into ITS OWN required-props set at
+		// lowering time (cross-component, and potentially cyclic) — out of
+		// scope for this fix. It still fails closed (a clear boundary
+		// error), never silently wrong; no test exercises this shape.
+		return componentProps(attrs, env, children), nil, nil
 	}
 	props := make(map[string]any, len(attrs)+4)
 	for _, attr := range attrs {
@@ -1726,7 +1769,7 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 			resolved.Name = field
 			converted, err := strictComponentAttrValue(comp, resolved, env, fieldType)
 			if err != nil {
-				return nil, fmt.Errorf("prop %s (%s): %w", attr.Name, fieldType, err)
+				return nil, nil, fmt.Errorf("prop %s (%s): %w", attr.Name, fieldType, err)
 			}
 			value = converted
 		} else {
@@ -1738,7 +1781,7 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 		setComponentProp(props, "children", children)
 		setComponentProp(props, "Children", children)
 	}
-	return props, nil
+	return props, nil, nil
 }
 
 func strictComponentAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
@@ -1941,6 +1984,16 @@ func requireStrictStructValue(value any, typeName string, paths map[string]strin
 // is "[]T" (an <Each of> loop source, ir.Component.PropsSlices). A slice
 // value can only arrive through an AttrExpr — there is no static or
 // boolean spelling for one.
+//
+// Unreachable from any source the lowerer admits (gosx#182/#184 minor
+// m-1): a "[]T" PropsFields root is only ever the of source of a strict
+// <Each>, and that source is always consumed as a spread's or a same-
+// component <Each of> read, never as a NAMED attribute at a call site —
+// validateStrictComponentCall never routes a named attr into a slice-typed
+// field. This stays reachable only from a hand-built ir.Program (this
+// package's own boundary-defensive tests, and any other caller that
+// constructs IR directly instead of compiling .gsx source); kept for that
+// coverage, not deleted.
 func strictComponentSliceAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {
 	if attr.Kind != ir.AttrExpr {
 		return nil, fmt.Errorf("value has no slice spelling, want exact %s", fieldType)
@@ -1982,6 +2035,18 @@ func requireStrictSliceValue(value any, schema ir.SlicePropSchema) (any, error) 
 	if rt.Kind() != reflect.Slice {
 		return nil, fmt.Errorf("runtime value has type %s, want a slice of structs named %s", rt, schema.Elem)
 	}
+	// This checks Kind(), not Name(): a named slice type (type Rows
+	// []BreakdownRow) passes here exactly as the bare []BreakdownRow the
+	// .gsx source declares would (gosx#182/#184 minor m-5) — deliberate
+	// widening, checked below on the ELEMENT type only, never on the
+	// slice type itself. A tier-1 (strict-caller) source has no way to
+	// reach this with a named slice type at all: <Each of> only admits an
+	// exact "[]T" declared field text (admitStrictEachElemType), so a
+	// named slice type never gets this far from a compiled tier-1 call. A
+	// tier-2 (legacy) source has no compiled Go call to compare against —
+	// there is no "twin" a named slice type could diverge from — so this
+	// widening cannot desync the file renderer from generated Go the way
+	// an unchecked element type would; it is accepted, not tightened.
 	elemType := rt.Elem()
 	if elemType.Kind() != reflect.Struct || elemType.PkgPath() == "" || elemType.Name() != schema.Elem {
 		return nil, fmt.Errorf("runtime value has type %s, want a slice of structs named %s", rt, schema.Elem)

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -790,3 +790,392 @@ func TestLocalComponentPropsResolvesAliasBeforePropsFieldsLookup(t *testing.T) {
 		}
 	})
 }
+
+// routeTestBreakdownRow backs the E1 (#182) renderer-boundary tests below,
+// standing in for a same-file .gsx-declared element struct the same way
+// routeTestPlayer does for a nested-selector struct root.
+type routeTestBreakdownRow struct {
+	Scored bool
+	Label  string
+	Points string
+}
+
+// strictEachRowProgram builds the hand-written ir.Program every E1
+// renderer-boundary test below shares: a strict Row component with a
+// <Each of={props.Breakdown} as="row" index="i"> body, called from a
+// zero-props legacy Page that hands the Breakdown slice through
+// ProgramRenderEnv.Values — the same "generated-Go/typed caller" stand-in
+// TestStrictNestedSelectorRendersRealStructThroughRouteBoundary uses, since
+// the strict surface itself has no slice-literal spelling to construct one
+// (open question 1's reasoning, generalized to a slice source).
+func strictEachRowProgram() *ir.Program {
+	prog := &ir.Program{}
+	labelExprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "row.Label"})
+	pointsExprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "row.Points"})
+	indexExprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "i"})
+	rowDivID := prog.AddNode(ir.Node{
+		Kind: ir.NodeElement,
+		Tag:  "div",
+		Attrs: []ir.Attr{
+			{Name: "data-scored", Kind: ir.AttrExpr, Expr: "row.Scored"},
+		},
+		Children: []ir.NodeID{labelExprID, pointsExprID, indexExprID},
+	})
+	eachID := prog.AddNode(ir.Node{
+		Kind: ir.NodeComponent,
+		Tag:  "Each",
+		Attrs: []ir.Attr{
+			{Name: "of", Kind: ir.AttrExpr, Expr: "props.Breakdown"},
+			{Name: "as", Kind: ir.AttrStatic, Value: "row"},
+			{Name: "index", Kind: ir.AttrStatic, Value: "i"},
+		},
+		Children: []ir.NodeID{rowDivID},
+	})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "section", Children: []ir.NodeID{eachID}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:      "Row",
+		PropsName: "props",
+		PropsType: "RowProps",
+		PropsFields: map[string]string{
+			"Breakdown": "[]routeTestBreakdownRow",
+		},
+		PropsSlices: map[string]ir.SlicePropSchema{
+			"Breakdown": {
+				Elem: "routeTestBreakdownRow",
+				Reads: map[string]string{
+					"Scored": "bool",
+					"Label":  "string",
+					"Points": "string",
+				},
+			},
+		},
+		Syntax: ir.ComponentSyntaxStrict,
+		Root:   rowRoot,
+	})
+
+	rowCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Row",
+		Attrs: []ir.Attr{{Name: "Breakdown", Kind: ir.AttrExpr, Expr: "breakdownVar"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:   "Page",
+		Syntax: ir.ComponentSyntaxLegacy,
+		Root:   rowCall,
+	})
+	return prog
+}
+
+// TestStrictEachRendersSliceParityWithGeneratedGo is E1's render-parity
+// proof: a three-element slice renders byte-identically to the
+// hand-computed gosx.Map equivalent, including escaping, bool attr
+// rendering (data-scored), and index text.
+func TestStrictEachRendersSliceParityWithGeneratedGo(t *testing.T) {
+	rows := []routeTestBreakdownRow{
+		{Scored: true, Label: "Pass Yds", Points: "12.4"},
+		{Scored: false, Label: "Rush <TD>", Points: "0"},
+		{Scored: true, Label: "Rec", Points: "6"},
+	}
+	html, err := RenderProgramComponent(strictEachRowProgram(), "Page", ProgramRenderEnv{
+		Values: map[string]any{"breakdownVar": rows},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	var want strings.Builder
+	want.WriteString("<section>")
+	for i, row := range rows {
+		want.WriteString(gosx.RenderHTML(gosx.El("div", gosx.Attrs(gosx.Attr("data-scored", row.Scored)),
+			gosx.Expr(row.Label), gosx.Expr(row.Points), gosx.Expr(i),
+		)))
+	}
+	want.WriteString("</section>")
+	if html != want.String() {
+		t.Fatalf("file render = %q, generated-Go render = %q", html, want.String())
+	}
+}
+
+// TestStrictEachEmptyAndNilSliceRenderEmptyString covers section 2.5: the
+// strict form admits no fallback/empty attribute, so an empty or nil slice
+// renders zero iterations on both the file renderer and the generated
+// gosx.Map twin.
+func TestStrictEachEmptyAndNilSliceRenderEmptyString(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		rows []routeTestBreakdownRow
+	}{
+		{"empty", []routeTestBreakdownRow{}},
+		{"nil", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			html, err := RenderProgramComponent(strictEachRowProgram(), "Page", ProgramRenderEnv{
+				Values: map[string]any{"breakdownVar": tc.rows},
+			})
+			if err != nil {
+				t.Fatalf("RenderProgramComponent: %v", err)
+			}
+			if html != "<section></section>" {
+				t.Fatalf("html = %q, want %q", html, "<section></section>")
+			}
+		})
+	}
+}
+
+// TestStrictEachScopeIsolatesNestedBindings proves nested strict <Each>
+// loops keep their bindings separate — the render-time scope chain
+// (newest-first) matches the lexical shadow ban's guarantee, so the two
+// cannot disagree (design spec section 2.2). It mirrors
+// TestGSXEachScopeIsolatesItemBindings (route/gsxperf_test.go) for the
+// strict surface, and doubles as the implicit-key-binding-absent proof: the
+// strict Each path never binds an outer.rowKey-style name, so this
+// component reads only its own declared bindings, unlike the legacy Each
+// path this file's gsxperf_test.go exercises.
+func TestStrictEachScopeIsolatesNestedBindings(t *testing.T) {
+	prog := &ir.Program{}
+	innerLabelID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "inner.Label"})
+	innerSpanID := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "b", Children: []ir.NodeID{innerLabelID}})
+	innerEachID := prog.AddNode(ir.Node{
+		Kind: ir.NodeComponent,
+		Tag:  "Each",
+		Attrs: []ir.Attr{
+			{Name: "of", Kind: ir.AttrExpr, Expr: "row.Stats"},
+			{Name: "as", Kind: ir.AttrStatic, Value: "inner"},
+		},
+		Children: []ir.NodeID{innerSpanID},
+	})
+	outerLabelID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "row.Label"})
+	outerDivID := prog.AddNode(ir.Node{
+		Kind:     ir.NodeElement,
+		Tag:      "div",
+		Children: []ir.NodeID{outerLabelID, innerEachID},
+	})
+	outerEachID := prog.AddNode(ir.Node{
+		Kind: ir.NodeComponent,
+		Tag:  "Each",
+		Attrs: []ir.Attr{
+			{Name: "of", Kind: ir.AttrExpr, Expr: "props.Rows"},
+			{Name: "as", Kind: ir.AttrStatic, Value: "row"},
+		},
+		Children: []ir.NodeID{outerDivID},
+	})
+	rootID := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "section", Children: []ir.NodeID{outerEachID}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:      "Nested",
+		PropsName: "props",
+		PropsType: "NestedProps",
+		PropsFields: map[string]string{
+			"Rows": "[]routeTestOuterRow",
+		},
+		PropsSlices: map[string]ir.SlicePropSchema{
+			"Rows": {Elem: "routeTestOuterRow", Reads: map[string]string{"Label": "string"}},
+		},
+		Syntax: ir.ComponentSyntaxStrict,
+		Root:   rootID,
+	})
+	call := prog.AddNode(ir.Node{Kind: ir.NodeComponent, Tag: "Nested", Attrs: []ir.Attr{{Name: "Rows", Kind: ir.AttrExpr, Expr: "rowsVar"}}})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: call})
+
+	rows := []routeTestOuterRow{
+		{Label: "outer-1", Stats: []routeTestInnerStat{{Label: "a"}, {Label: "b"}}},
+		{Label: "outer-2", Stats: []routeTestInnerStat{{Label: "c"}}},
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"rowsVar": rows},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := "<section><div>outer-1<b>a</b><b>b</b></div><div>outer-2<b>c</b></div></section>"
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+type routeTestOuterRow struct {
+	Label string
+	Stats []routeTestInnerStat
+}
+
+type routeTestInnerStat struct {
+	Label string
+}
+
+// TestRequireStrictSliceValueDirectRejections exercises
+// requireStrictSliceValue directly, mirroring
+// TestRequireStrictStructValueRejectsBoundaryMismatches's pattern for the
+// slice boundary: []map[string]any (the wrong Kind of element), a wrong
+// element type name, a wrong leaf type, and pointer elements each fail
+// closed with a message naming what the renderer expected.
+func TestRequireStrictSliceValueDirectRejections(t *testing.T) {
+	schema := ir.SlicePropSchema{
+		Elem:  "routeTestBreakdownRow",
+		Reads: map[string]string{"Label": "string"},
+	}
+	type otherRow struct{ Label string }
+
+	for _, tc := range []struct {
+		name  string
+		value any
+	}{
+		{"nil value", nil},
+		{"not a slice", routeTestBreakdownRow{Label: "x"}},
+		{"slice of maps", []map[string]any{{"Label": "x"}}},
+		{"wrong element type name", []otherRow{{Label: "x"}}},
+		{"pointer elements", []*routeTestBreakdownRow{{Label: "x"}}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := requireStrictSliceValue(tc.value, schema); err == nil {
+				t.Fatalf("requireStrictSliceValue(%#v) unexpectedly accepted", tc.value)
+			}
+		})
+	}
+
+	t.Run("wrong leaf field type", func(t *testing.T) {
+		type wrongLeafRow struct{ Label int }
+		wrongSchema := ir.SlicePropSchema{Elem: "wrongLeafRow", Reads: map[string]string{"Label": "string"}}
+		if _, err := requireStrictSliceValue([]wrongLeafRow{{Label: 1}}, wrongSchema); err == nil {
+			t.Fatal("requireStrictSliceValue unexpectedly accepted a mismatched leaf field type")
+		}
+	})
+
+	t.Run("typed nil slice passes and iterates zero times", func(t *testing.T) {
+		var rows []routeTestBreakdownRow
+		got, err := requireStrictSliceValue(rows, schema)
+		if err != nil {
+			t.Fatalf("requireStrictSliceValue(nil slice): %v", err)
+		}
+		if got == nil {
+			t.Fatal("requireStrictSliceValue returned nil for a typed nil slice")
+		}
+	})
+}
+
+// --- E2 (#184): spread props at strict call sites -------------------------
+
+type routeTestMatchupTeam struct {
+	Tone         string
+	Abbreviation string
+}
+
+// strictSpreadTeamMarkProgram builds the shared TeamMark component both the
+// spread-parity test and the explicit-attr comparison call through, so the
+// two render paths exercise the identical strict body.
+func strictSpreadTeamMarkProgram(callAttrs []ir.Attr) *ir.Program {
+	prog := &ir.Program{}
+	toneExprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Tone"})
+	abbrExprID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Abbreviation"})
+	rootID := prog.AddNode(ir.Node{
+		Kind:     ir.NodeElement,
+		Tag:      "span",
+		Attrs:    []ir.Attr{{Name: "class", Kind: ir.AttrExpr, Expr: `"tone-" + props.Tone`}},
+		Children: []ir.NodeID{abbrExprID, toneExprID},
+	})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:      "TeamMark",
+		PropsName: "props",
+		PropsType: "TeamMarkProps",
+		PropsFields: map[string]string{
+			"Tone":         "string",
+			"Abbreviation": "string",
+		},
+		Syntax: ir.ComponentSyntaxStrict,
+		Root:   rootID,
+	})
+	call := prog.AddNode(ir.Node{Kind: ir.NodeComponent, Tag: "TeamMark", Attrs: callAttrs})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: call})
+	return prog
+}
+
+// TestStrictSpreadParityWithExplicitAttrCall proves a legacy caller
+// spreading a covering struct renders identically to the explicit-attr
+// call with the same values — the twin-equivalence E2's whole design rests
+// on (design spec section 3.1).
+func TestStrictSpreadParityWithExplicitAttrCall(t *testing.T) {
+	team := routeTestMatchupTeam{Tone: "red", Abbreviation: "NE"}
+
+	spreadHTML, err := RenderProgramComponent(
+		strictSpreadTeamMarkProgram([]ir.Attr{{Kind: ir.AttrSpread, Expr: "teamVar"}}),
+		"Page", ProgramRenderEnv{Values: map[string]any{"teamVar": team}},
+	)
+	if err != nil {
+		t.Fatalf("RenderProgramComponent (spread): %v", err)
+	}
+
+	explicitHTML, err := RenderProgramComponent(
+		strictSpreadTeamMarkProgram([]ir.Attr{
+			{Name: "Tone", Kind: ir.AttrExpr, Expr: "teamVar.Tone"},
+			{Name: "Abbreviation", Kind: ir.AttrExpr, Expr: "teamVar.Abbreviation"},
+		}),
+		"Page", ProgramRenderEnv{Values: map[string]any{"teamVar": team}},
+	)
+	if err != nil {
+		t.Fatalf("RenderProgramComponent (explicit): %v", err)
+	}
+
+	if spreadHTML != explicitHTML {
+		t.Fatalf("spread render = %q, explicit-attr render = %q", spreadHTML, explicitHTML)
+	}
+	if want := `<span class="tone-red">NEred</span>`; spreadHTML != want {
+		t.Fatalf("html = %q, want %q", spreadHTML, want)
+	}
+}
+
+// TestStrictSpreadProps exercises strictSpreadProps directly for every
+// design spec section 4.5 rejection shape: a nil source, a map source
+// (rejected unconditionally, never zero-filled), a struct missing a
+// rendered field, and a rendered field whose runtime type does not match
+// its declared scalar type.
+func TestStrictSpreadProps(t *testing.T) {
+	comp := &ir.Component{
+		Name: "TeamMark",
+		PropsFields: map[string]string{
+			"Tone":         "string",
+			"Abbreviation": "string",
+		},
+	}
+
+	t.Run("nil source", func(t *testing.T) {
+		if _, err := strictSpreadProps(comp, nil); err == nil {
+			t.Fatal("strictSpreadProps(nil) unexpectedly accepted")
+		}
+	})
+
+	t.Run("map source rejected unconditionally", func(t *testing.T) {
+		_, err := strictSpreadProps(comp, map[string]any{"Tone": "red", "Abbreviation": "NE"})
+		if err == nil {
+			t.Fatal("strictSpreadProps(map) unexpectedly accepted")
+		}
+		if !strings.Contains(err.Error(), "maps cannot prove field coverage") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("missing field", func(t *testing.T) {
+		type partialTeam struct{ Tone string }
+		_, err := strictSpreadProps(comp, partialTeam{Tone: "red"})
+		if err == nil || !strings.Contains(err.Error(), "no field Abbreviation") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("wrong field type", func(t *testing.T) {
+		type wrongTypeTeam struct {
+			Tone         string
+			Abbreviation int
+		}
+		_, err := strictSpreadProps(comp, wrongTypeTeam{Tone: "red", Abbreviation: 1})
+		if err == nil || !strings.Contains(err.Error(), "want exact string") {
+			t.Fatalf("error = %v", err)
+		}
+	})
+
+	t.Run("accepts a covering struct and proves values through setComponentProp aliases", func(t *testing.T) {
+		props, err := strictSpreadProps(comp, routeTestMatchupTeam{Tone: "red", Abbreviation: "NE"})
+		if err != nil {
+			t.Fatalf("strictSpreadProps: %v", err)
+		}
+		if props["Tone"] != "red" || props["tone"] != "red" {
+			t.Fatalf("props = %#v, want Tone/tone aliases set", props)
+		}
+	})
+}

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -1048,6 +1048,32 @@ func TestRequireStrictSliceValueDirectRejections(t *testing.T) {
 			t.Fatal("requireStrictSliceValue returned nil for a typed nil slice")
 		}
 	})
+
+	// "promoted element field" extends gosx#183's M2 fix (reject a
+	// promoted field by StructField.Index length before it can cross the
+	// boundary) to E1's own element walk: reflect.Type.FieldByName also
+	// resolves embedded-field promotion at the type level, so a bare
+	// found check alone would let a slice element whose read only
+	// resolves through embedding cross this boundary even though the
+	// lowerer's walkStrictHops already refuses to compile a loop-binding
+	// read through one (gosx#182/#184's generalized B1 fix).
+	t.Run("promoted element field required by the renderer", func(t *testing.T) {
+		type promotedElemInner struct{ City string }
+		type promotedElemRow struct {
+			promotedElemInner
+			Age int
+		}
+		promotedSchema := ir.SlicePropSchema{Elem: "promotedElemRow", Reads: map[string]string{"City": "string"}}
+		value := []promotedElemRow{{promotedElemInner: promotedElemInner{City: "Springfield"}, Age: 7}}
+		_, err := requireStrictSliceValue(value, promotedSchema)
+		if err == nil {
+			t.Fatal("requireStrictSliceValue unexpectedly accepted a promoted element field")
+		}
+		want := "field City is a promoted (embedded) field"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	})
 }
 
 // --- E2 (#184): spread props at strict call sites -------------------------
@@ -1176,6 +1202,39 @@ func TestStrictSpreadProps(t *testing.T) {
 		}
 		if props["Tone"] != "red" || props["tone"] != "red" {
 			t.Fatalf("props = %#v, want Tone/tone aliases set", props)
+		}
+	})
+
+	// TestStrictSpreadProps/promoted field on the spread source fails
+	// closed instead of zero-filling extends gosx#183's M2 fix (reject a
+	// promoted field before Value.FieldByName can panic or silently
+	// resolve one) to the E2 tier-2 spread boundary: a legacy caller's
+	// spread source has no declared type at compile time, so
+	// walkStrictHops' B1 rejection at lowering time never sees it — this
+	// render-time boundary is the only place a source whose Tone field is
+	// only reachable through embedding promotion is ever caught. Before
+	// the fix, Value.FieldByName resolved the promotion (a non-nil,
+	// non-pointer embed cannot panic the way M2's nil-embedded-pointer
+	// case does) and let the promoted value cross the boundary un-proven,
+	// the same silent-acceptance gap requireStrictStructValue's own M2 fix
+	// closed for a nested-selector struct root — never a Go zero value
+	// (strictSpreadProps' contract is to fail closed on any missing or
+	// unprovable field, never to synthesize one the way the generated-Go
+	// twin does for an explicit call's omitted attribute).
+	t.Run("promoted field on the spread source fails closed instead of zero-filling", func(t *testing.T) {
+		type toneHolder struct{ Tone string }
+		type promotedSpreadSource struct {
+			toneHolder
+			Abbreviation string
+		}
+		source := promotedSpreadSource{toneHolder: toneHolder{Tone: "red"}, Abbreviation: "NE"}
+		_, err := strictSpreadProps(comp, source)
+		if err == nil {
+			t.Fatal("strictSpreadProps unexpectedly accepted a promoted field on the spread source")
+		}
+		want := "field Tone is a promoted (embedded) field"
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
 		}
 	})
 }

--- a/route/strict_component_test.go
+++ b/route/strict_component_test.go
@@ -853,6 +853,15 @@ func strictEachRowProgram() *ir.Program {
 		Root:   rowRoot,
 	})
 
+	// This named "Breakdown" attribute (a "[]T" PropsFields root, supplied
+	// by name rather than through a spread or an <Each of>) is not a shape
+	// gosx#182/#184 minor m-1/m-4: real .gsx source never compiles a named
+	// attribute into a slice-typed field — validateStrictComponentCall
+	// never routes one there. This hand-built ir.Program exercises
+	// strictComponentSliceAttrValue's own boundary check directly, the
+	// same way this file's other hand-built-IR tests cover a route
+	// boundary function a compiler-admitted program cannot reach on its
+	// own; it is not a regression-of-compilability concern.
 	rowCall := prog.AddNode(ir.Node{
 		Kind:  ir.NodeComponent,
 		Tag:   "Row",
@@ -926,14 +935,35 @@ func TestStrictEachEmptyAndNilSliceRenderEmptyString(t *testing.T) {
 // (newest-first) matches the lexical shadow ban's guarantee, so the two
 // cannot disagree (design spec section 2.2). It mirrors
 // TestGSXEachScopeIsolatesItemBindings (route/gsxperf_test.go) for the
-// strict surface, and doubles as the implicit-key-binding-absent proof: the
-// strict Each path never binds an outer.rowKey-style name, so this
-// component reads only its own declared bindings, unlike the legacy Each
-// path this file's gsxperf_test.go exercises.
+// strict surface.
+//
+// It does NOT prove an implicit itemNameKey binding is absent — that
+// binding IS pushed: writeEach (this file's fileprogram.go) is the one
+// implementation both the legacy and the strict Each path render through,
+// and for a slice source (what strict <Each> requires) fileEachEntries
+// sets entry.Key equal to the index, so entry.Key != nil always holds and
+// "rowKey" lands in the render-time scope chain exactly as "row" does —
+// this is a documented spec drift from an earlier design that omitted it
+// for strict bodies. It is unobservable from a strict body only because
+// the COMPILE-TIME validator (strictcomponent.Scope) knows nothing but
+// props and the as/index names an <Each> actually declares — any
+// selector rooted at "rowKey" is rejected as an out-of-scope identifier
+// before this render-time scope chain is ever consulted, and for a slice
+// specifically, Key ties to Index, offering no field a rowKey selector
+// could reach even if one somehow compiled.
 func TestStrictEachScopeIsolatesNestedBindings(t *testing.T) {
 	prog := &ir.Program{}
 	innerLabelID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "inner.Label"})
 	innerSpanID := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "b", Children: []ir.NodeID{innerLabelID}})
+	// of={row.Stats} is a BINDING-rooted of source (gosx#182/#184 minor
+	// m-4): real .gsx source cannot compile this — enterStrictEach
+	// resolves an of source through strictcomponent.ServerPropPath, which
+	// requires a "props" root unconditionally, so a same-file <Each
+	// of={row.Stats}> is always rejected at compile time (this release
+	// only admits of={props.Field}, section 2.4). This hand-built
+	// ir.Program is boundary-defensive coverage of the render path a
+	// compiler-admitted program cannot reach, not a claim this shape
+	// compiles.
 	innerEachID := prog.AddNode(ir.Node{
 		Kind: ir.NodeComponent,
 		Tag:  "Each",
@@ -1235,6 +1265,153 @@ func TestStrictSpreadProps(t *testing.T) {
 		want := "field Tone is a promoted (embedded) field"
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	})
+}
+
+// TestTierOneBarePropsSpreadRenders and TestTierOneNestedFieldSpreadRenders
+// are gosx#182/#184 M-1's tier-1 render tests for both admitted E2 tier-1
+// spread source shapes: bare props (the whole props value) and a props
+// field selector. Before the fix, a strict body's "props" scope binding was
+// always the map[string]any localComponentProps built for the current
+// frame, and re-spreading that map into strictSpreadProps always failed
+// the struct-kind check there — so the admitted, documented bare-props
+// shape could compile but could never render. The props.Field shape
+// already worked (requireStrictStructValue preserves the real struct value
+// under its own map key), so it is here as the other half of the pair.
+func TestTierOneBarePropsSpreadRenders(t *testing.T) {
+	source := `package app
+type MarkProps struct {
+	Tone string
+}
+component Mark(props: MarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Panel(props: MarkProps) {
+	return <div class="panel"><Mark {...props}></Mark></div>
+}
+func Page() Node {
+	return <main><Panel {...src}></Panel></main>
+}
+`
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	type markPropsGo struct{ Tone string }
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"src": markPropsGo{Tone: "red"}},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := `<main><div class="panel"><span>red</span></div></main>`; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+func TestTierOneNestedFieldSpreadRenders(t *testing.T) {
+	source := `package app
+type MarkProps struct {
+	Tone string
+}
+component Mark(props: MarkProps) {
+	return <span>{props.Tone}</span>
+}
+type OuterProps struct {
+	Away MarkProps
+	Name string
+}
+component Outer(props: OuterProps) {
+	return <div><b>{props.Name}</b><Mark {...props.Away}></Mark></div>
+}
+func Page() Node {
+	return <main><Outer {...src}></Outer></main>
+}
+`
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	// requireStrictStructValue checks a nested struct-typed field's runtime
+	// Go type NAME against the .gsx-declared name exactly ("MarkProps"),
+	// unlike the outer Outer{...src} call itself (a tier-2 spread, proved
+	// field by field with no such nominal check on its own container
+	// type) — so this local type must be named MarkProps, not merely
+	// shaped like it.
+	type MarkProps struct{ Tone string }
+	type outerPropsGo struct {
+		Away MarkProps
+		Name string
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"src": outerPropsGo{Away: MarkProps{Tone: "blue"}, Name: "N"}},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := `<main><div><b>N</b><span>blue</span></div></main>`; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestZeroReadStrictCalleeSpreadBoundaryStillChecksKind covers minor m-2: a
+// strict callee with an empty read set (PropsFields nil) used to bypass
+// localComponentProps' strict spread branch entirely (the early
+// len(comp.PropsFields)==0 return fell to the generic, non-strict
+// componentProps builder), so a nil, map, or scalar spread source rendered
+// clean instead of failing closed the way design spec section 3.4
+// requires. A field-less but genuinely struct-typed source must still
+// pass — there is nothing to prove per field, but the nil/kind checks
+// still run.
+func TestZeroReadStrictCalleeSpreadBoundaryStillChecksKind(t *testing.T) {
+	source := `package app
+type EmptyProps struct {
+	Unused string
+}
+component Leaf(props: EmptyProps) {
+	return <span>leaf</span>
+}
+func Page() Node {
+	return <main><Leaf {...src}></Leaf></main>
+}
+`
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if fields := prog.Components[0].PropsFields; len(fields) != 0 {
+		t.Fatalf("Leaf.PropsFields = %#v, want empty", fields)
+	}
+
+	for _, tc := range []struct {
+		name string
+		src  any
+	}{
+		{"nil", nil},
+		{"map", map[string]any{"Unused": "x"}},
+		{"int", 42},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+				Values: map[string]any{"src": tc.src},
+			})
+			if err == nil {
+				t.Fatalf("%s source: want a boundary error, got a clean render", tc.name)
+			}
+		})
+	}
+
+	t.Run("struct still passes", func(t *testing.T) {
+		type emptyPropsGo struct{ Unused string }
+		html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+			Values: map[string]any{"src": emptyPropsGo{Unused: "x"}},
+		})
+		if err != nil {
+			t.Fatalf("RenderProgramComponent: %v", err)
+		}
+		if want := `<main><span>leaf</span></main>`; html != want {
+			t.Fatalf("html = %q, want %q", html, want)
 		}
 	})
 }

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1,6 +1,7 @@
 package gosx
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -562,7 +563,7 @@ func TestCompileStrictCalleeRejectsDynamicCallShape(t *testing.T) {
 		call    string
 		message string
 	}{
-		{name: "spread", call: `<Badge {...props} />`, message: "spread attributes are not supported"},
+		{name: "spread", call: `<Badge {...props} />`, message: "does not accept props"},
 		{name: "attribute", call: `<Badge bogus="x" />`, message: "does not accept props"},
 		{name: "children", call: `<Badge>child</Badge>`, message: "does not accept positional children"},
 	}
@@ -915,6 +916,552 @@ component Page() {
 `))
 	if err == nil || !strings.Contains(err.Error(), "requires prop Label") {
 		t.Fatalf("error = %v", err)
+	}
+}
+
+// --- E2 (#184): spread props at strict call sites -------------------------
+
+// TestCompileStrictTierOneSpreadAcceptsExactTypeSources covers design spec
+// section 3.2: bare props (the whole props value) and a props field
+// selector whose declared type is exactly the callee's props type.
+func TestCompileStrictTierOneSpreadAcceptsExactTypeSources(t *testing.T) {
+	t.Run("bare props", func(t *testing.T) {
+		_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Matchup(props: TeamMarkProps) {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+`))
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+	})
+	t.Run("props field", func(t *testing.T) {
+		_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+type MatchupProps struct {
+	Away TeamMarkProps
+}
+component Matchup(props: MatchupProps) {
+	return <div><TeamMark {...props.Away}></TeamMark></div>
+}
+`))
+		if err != nil {
+			t.Fatalf("Compile: %v", err)
+		}
+	})
+}
+
+func TestCompileStrictTierOneSpreadRejectsWrongType(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+type MatchupTeam struct {
+	Tone string
+}
+type MatchupProps struct {
+	Away MatchupTeam
+}
+component Matchup(props: MatchupProps) {
+	return <div><TeamMark {...props.Away}></TeamMark></div>
+}
+`))
+	want := "strict spread source props.Away has type MatchupTeam, want exact TeamMarkProps; a strict caller spreads a value whose declared type is the callee props type"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictTierOneSpreadRejectsNonSelectorSource(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Matchup(props: TeamMarkProps) {
+	return <div><TeamMark {...team()}></TeamMark></div>
+}
+`))
+	want := `strict spread source "team()" is not renderable; spread sources are props or a props field selector`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictTierOneSpreadRejectsSpreadPlusNamedAttr(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Matchup(props: TeamMarkProps) {
+	return <div><TeamMark {...props} tone="x"></TeamMark></div>
+}
+`))
+	want := "strict component call TeamMark accepts at most one spread attribute and no other attributes"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictTierOneSpreadRejectsTwoSpreads(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Matchup(props: TeamMarkProps) {
+	return <div><TeamMark {...props} {...props}></TeamMark></div>
+}
+`))
+	want := "strict component call TeamMark accepts at most one spread attribute and no other attributes"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictTierTwoSpreadAcceptsLegacySingleSpread covers section
+// 3.3: a legacy body's single spread into a same-file strict component
+// compiles — the shape is all the lowerer can prove; the renderer boundary
+// proves the value.
+func TestCompileStrictTierTwoSpreadAcceptsLegacySingleSpread(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+func Page() Node {
+	team := map[string]any{"Tone": "red"}
+	return <div><TeamMark {...team}></TeamMark></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+}
+
+// TestCompileStrictTierTwoSpreadRejectsNamedAttrs covers section 4.4's
+// updated cross-style message: a legacy body calling a strict component
+// with named attributes stays banned, now naming the supported spread
+// spelling instead of the flat v0.39 message.
+func TestCompileStrictTierTwoSpreadRejectsNamedAttrs(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+func Page() Node {
+	return <div><TeamMark tone="red"></TeamMark></div>
+}
+`))
+	want := "legacy component cannot call strict component TeamMark with named attributes; pass one {...source} spread and the renderer will prove it at the boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictTierTwoSpreadRejectsSpreadPlusAttr covers the shape rule
+// for tier 2 too: a spread plus a named attribute stays rejected by the
+// same message as the bare named-attrs case.
+func TestCompileStrictTierTwoSpreadRejectsSpreadPlusAttr(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+func Page() Node {
+	team := map[string]any{"Tone": "red"}
+	return <div><TeamMark {...team} tone="blue"></TeamMark></div>
+}
+`))
+	want := "legacy component cannot call strict component TeamMark with named attributes; pass one {...source} spread and the renderer will prove it at the boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileRejectsCrossStyleComponentCallsPolarityRegression re-runs
+// TestCompileRejectsCrossStyleComponentCalls' strict-to-legacy direction
+// (unaffected by E2, which only narrows the legacy-to-strict direction) and
+// the legacy-to-strict, no-attribute direction (which keeps its exact
+// v0.39 message).
+func TestCompileRejectsCrossStyleComponentCallsPolarityRegression(t *testing.T) {
+	_, err := Compile([]byte(`package app
+component Badge() {
+	return <span>badge</span>
+}
+func Page() Node {
+	return <Badge />
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "calls must stay within one style") {
+		t.Fatalf("error = %v", err)
+	}
+	_, err = Compile([]byte(`package app
+func Badge(attrs AttrList) Node {
+	return <span>badge</span>
+}
+component Page() {
+	return <Badge bogus="x">child</Badge>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "calls must stay within one style") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+// --- E1 (#182): strict <Each> ----------------------------------------------
+
+const breakdownRowFixturePrelude = `package app
+type BreakdownRow struct {
+	Scored bool
+	Label  string
+	Points string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+`
+
+func TestCompileStrictEachAcceptsSliceOfSameFileStruct(t *testing.T) {
+	prog, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row">
+			<div data-scored={row.Scored}><span>{row.Label}</span><b>{row.Points}</b></div>
+		</Each>
+	</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	row := prog.Components[0]
+	schema, ok := row.PropsSlices["Breakdown"]
+	if !ok {
+		t.Fatalf("PropsSlices missing Breakdown: %#v", row.PropsSlices)
+	}
+	if schema.Elem != "BreakdownRow" {
+		t.Fatalf("Elem = %q, want BreakdownRow", schema.Elem)
+	}
+	for _, field := range []string{"Scored", "Label", "Points"} {
+		if _, ok := schema.Reads[field]; !ok {
+			t.Fatalf("Reads missing %q: %#v", field, schema.Reads)
+		}
+	}
+	if row.PropsFields["Breakdown"] != "[]BreakdownRow" {
+		t.Fatalf("PropsFields[Breakdown] = %q, want []BreakdownRow", row.PropsFields["Breakdown"])
+	}
+}
+
+func TestCompileStrictEachRejectsLoopableTypeTable(t *testing.T) {
+	for _, tc := range []struct {
+		name   string
+		fields string
+		of     string
+		want   string
+	}{
+		{
+			name:   "map",
+			fields: "Breakdown map[string]BreakdownRow",
+			of:     "props.Breakdown",
+			want:   "<Each> sources must be []T slices of structs declared in this .gsx file",
+		},
+		{
+			name:   "pointer elements",
+			fields: "Breakdown []*BreakdownRow",
+			of:     "props.Breakdown",
+			want:   "pointer elements cannot preserve Go nil-pointer behavior in the file renderer",
+		},
+		{
+			name:   "scalar elements",
+			fields: "Names []string",
+			of:     "props.Names",
+			want:   "loop elements must be structs declared in this .gsx file",
+		},
+		{
+			name:   "array",
+			fields: "Breakdown [3]BreakdownRow",
+			of:     "props.Breakdown",
+			want:   "<Each> sources must be []T slices of structs declared in this .gsx file",
+		},
+		{
+			name:   "named slice type",
+			fields: "Breakdown Rows",
+			of:     "props.Breakdown",
+			want:   "<Each> sources must be []T slices of structs declared in this .gsx file",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			source := []byte(`package app
+type BreakdownRow struct {
+	Label string
+}
+type Rows []BreakdownRow
+type RowProps struct {
+	` + tc.fields + `
+}
+component Row(props: RowProps) {
+	return <div><Each of={` + tc.of + `} as="row"><span>{row.Label}</span></Each></div>
+}
+`)
+			_, err := Compile(source)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want to contain %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestCompileStrictEachRejectsMissingAs(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown}><span>x</span></Each></div>
+}
+`))
+	want := "strict <Each> requires a static as attribute naming the loop binding"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsFallbackAttr(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row" fallback="none"><span>{row.Label}</span></Each></div>
+}
+`))
+	want := `strict <Each> does not accept attribute "fallback"; of, as, and index are the only supported attributes`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsUppercaseBinding(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="Row"><span>x</span></Each></div>
+}
+`))
+	want := `strict <Each> binding "Row" must start with a lowercase letter and be a valid Go identifier`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsReservedPropsBinding(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="props"><span>x</span></Each></div>
+}
+`))
+	want := `strict <Each> binding "props" is reserved; choose another name`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsShadowedBinding(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Stat struct {
+	Label string
+}
+type BreakdownRow struct {
+	Stats []Stat
+	Label string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row">
+			<Each of={row.Stats} as="row"><span>{row.Label}</span></Each>
+		</Each>
+	</div>
+}
+`))
+	want := `strict <Each> binding "row" is already bound by an enclosing <Each>; loop bindings cannot shadow`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachRejectsCrossFileElement covers section 2.3's
+// cross-package/sibling-.go element row: this .gsx file's schema is blind
+// to any type it does not itself declare, including a scalar-looking
+// builtin-shaped name it never defines.
+func TestCompileStrictEachRejectsCrossFileElement(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type RowProps struct {
+	Breakdown []external.Row
+}
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>x</span></Each></div>
+}
+`))
+	if err == nil {
+		t.Fatal("Compile unexpectedly accepted a cross-package element type")
+	}
+}
+
+// TestCompileStrictEachShadowedByComponentStaysAComponentCall mirrors
+// TestCompileStrictServerIfShadowedBySameFileComponentStaysAComponentCall:
+// a same-file strict component literally named Each wins over the
+// builtin, and ordinary strict-call rules apply to it.
+func TestCompileStrictEachShadowedByComponentStaysAComponentCall(t *testing.T) {
+	prog, err := Compile([]byte(`package app
+type EachProps struct {
+	Label string
+}
+component Each(props: EachProps) {
+	return <em>{props.Label}</em>
+}
+component Page() {
+	return <Each label="shadowed" />
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	page := prog.Components[1]
+	call := prog.NodeAt(page.Root)
+	if call == nil || call.Tag != "Each" || len(call.Attrs) != 1 || call.Attrs[0].Name != "Label" {
+		t.Fatalf("shadowed Each call not lowered as a component call: %#v", call)
+	}
+}
+
+func TestCompileStrictEachRejectsSliceFieldRenderedAsScalar(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div>{props.Breakdown}</div>
+}
+`))
+	want := "renderer-visible props fields must use exact string, bool, integer, or floating-point builtins"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachAcceptsFieldBothLoopedAndNeverRenderedScalar proves
+// the same field looped (and never separately rendered as a bare scalar)
+// compiles cleanly.
+func TestCompileStrictEachAcceptsFieldBothLoopedAndNeverRenderedScalar(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{row.Label}</span></Each></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+}
+
+func TestCompileStrictEachBindingSelectorAcceptsScalarLeafRejectsStructLeaf(t *testing.T) {
+	source := []byte(`package app
+type Stat struct {
+	Label string
+}
+type BreakdownRow struct {
+	Stat Stat
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{row.Stat}</span></Each></div>
+}
+`)
+	_, err := Compile(source)
+	want := "strict component Row cannot render row.Stat of type Stat; loop selectors must reach an exact scalar field"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachBindingConcatAndCondBothPolarities(t *testing.T) {
+	// Accept: exact string/bool leaves.
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span class={"tone-" + row.Label}><If cond={row.Scored}>scored</If></span></Each></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile (accept): %v", err)
+	}
+
+	// Reject: concat of a non-string binding field.
+	_, err = Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{"scored-" + row.Scored}</span></Each></div>
+}
+`))
+	want := `strict component Row cannot concatenate row.Scored of type bool; "+" operands must be exact string fields`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+
+	// Reject: cond over a non-bool binding field.
+	_, err = Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><If cond={row.Label}>x</If></Each></div>
+}
+`))
+	want = "strict component Row cannot use row.Label of type string in <If cond>; cond requires an exact bool field"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsIndexBindingInSelector(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row" index="i"><span>{i.Label}</span></Each></div>
+}
+`))
+	want := "strict component Row cannot use index binding i in a selector; the index is an int value"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachSerializationRoundTrip covers the PropsSlices
+// round-trip half of section 5.2's list (paired with the dedicated absent-
+// field decode test in ir/propspaths_roundtrip_test.go-style coverage,
+// added under ir/).
+func TestCompileStrictEachSerializationRoundTrip(t *testing.T) {
+	prog, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{row.Label}</span></Each></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	data, err := json.Marshal(prog.Components[0])
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded ir.Component
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if decoded.PropsSlices["Breakdown"].Elem != "BreakdownRow" {
+		t.Fatalf("PropsSlices did not round-trip: %#v", decoded.PropsSlices)
 	}
 }
 

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1357,7 +1357,7 @@ func TestCompileStrictEachRejectsSliceFieldRenderedAsScalar(t *testing.T) {
 	return <div>{props.Breakdown}</div>
 }
 `))
-	want := "renderer-visible props fields must use exact string, bool, integer, or floating-point builtins"
+	want := "strict component Row cannot render props.Breakdown of type []BreakdownRow here; slice props render only through <Each of>"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("error = %v, want to contain %q", err, want)
 	}

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -3,6 +3,8 @@ package gosx
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
+	"sort"
 	"strings"
 	"testing"
 
@@ -921,6 +923,32 @@ component Page() {
 
 // --- E2 (#184): spread props at strict call sites -------------------------
 
+// TestCompileStrictTierOneSpreadIntoShadowedEachAccepts covers gosx#182/
+// #184 minor m-6: a same-file strict component literally named "Each"
+// (the section 2.1 shadow carve-out) is a valid E2 tier-1 spread callee
+// like any other. Before the fix, collectStrictElementReads excluded tag
+// "Each" from the spread-forward read class unconditionally, so the
+// struct-typed spread source fell through to the scalar-read walk and
+// validateStrictRenderedProps rejected it as a non-scalar prop — even
+// though validateStrictToStrictSpreadCall, a separate pass, proves this
+// exact call valid. This must now compile clean.
+func TestCompileStrictTierOneSpreadIntoShadowedEachAccepts(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type EachProps struct {
+	Label string
+}
+component Each(props: EachProps) {
+	return <em>{props.Label}</em>
+}
+component Page(props: EachProps) {
+	return <div><Each {...props}></Each></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+}
+
 // TestCompileStrictTierOneSpreadAcceptsExactTypeSources covers design spec
 // section 3.2: bare props (the whole props value) and a props field
 // selector whose declared type is exactly the callee's props type.
@@ -960,6 +988,96 @@ component Matchup(props: MatchupProps) {
 			t.Fatalf("Compile: %v", err)
 		}
 	})
+}
+
+// TestCompileStrictTierOneSpreadForwardReferencedCalleeCompiles covers
+// gosx#182/#184 M-3: collectStrictSchemas used to be one pass, populating
+// l.strictNames in file order while ALSO collecting each component's own
+// reads in that same pass — so isSpreadForwardTag (which needs
+// l.strictNames complete to classify a spread's read) saw a callee
+// declared LATER in the file as unknown, and a caller's {...props.Away}
+// spread into it fell through to the generic scalar-read walk, which
+// rejected the struct-typed props.Away as not a renderer scalar. Whether
+// this compiled depended only on which order Mark and Outer were declared
+// in, not on any real type-safety difference between the two orders. Both
+// orders must now compile, and produce byte-identical PropsFields and
+// PropsPaths for both components regardless of which pass order collected
+// them.
+func TestCompileStrictTierOneSpreadForwardReferencedCalleeCompiles(t *testing.T) {
+	calleeFirst := `package app
+type MarkProps struct {
+	Tone string
+}
+component Mark(props: MarkProps) {
+	return <span>{props.Tone}</span>
+}
+type OuterProps struct {
+	Away MarkProps
+}
+component Outer(props: OuterProps) {
+	return <div><Mark {...props.Away}></Mark></div>
+}
+`
+	calleeLast := `package app
+type OuterProps struct {
+	Away MarkProps
+}
+component Outer(props: OuterProps) {
+	return <div><Mark {...props.Away}></Mark></div>
+}
+type MarkProps struct {
+	Tone string
+}
+component Mark(props: MarkProps) {
+	return <span>{props.Tone}</span>
+}
+`
+	progFirst, err := Compile([]byte(calleeFirst))
+	if err != nil {
+		t.Fatalf("Compile (callee declared first): %v", err)
+	}
+	progLast, err := Compile([]byte(calleeLast))
+	if err != nil {
+		t.Fatalf("Compile (callee declared last, forward reference): %v", err)
+	}
+
+	fieldsByName := func(prog *ir.Program) map[string]ir.Component {
+		out := make(map[string]ir.Component, len(prog.Components))
+		for _, c := range prog.Components {
+			out[c.Name] = c
+		}
+		return out
+	}
+	first := fieldsByName(progFirst)
+	last := fieldsByName(progLast)
+	for _, name := range []string{"Outer", "Mark"} {
+		fc, lc := first[name], last[name]
+		if len(fc.PropsFields) == 0 {
+			t.Fatalf("%s: PropsFields empty in the callee-first order", name)
+		}
+		if fmtMap(fc.PropsFields) != fmtMap(lc.PropsFields) {
+			t.Fatalf("%s: PropsFields differ by declaration order: first=%#v last=%#v", name, fc.PropsFields, lc.PropsFields)
+		}
+		if fmtMap(fc.PropsPaths) != fmtMap(lc.PropsPaths) {
+			t.Fatalf("%s: PropsPaths differ by declaration order: first=%#v last=%#v", name, fc.PropsPaths, lc.PropsPaths)
+		}
+	}
+}
+
+// fmtMap gives two maps a deterministic, comparable string form for an
+// order-independence assertion — map equality via reflect.DeepEqual would
+// work too, but this reads directly in a failure message.
+func fmtMap(m map[string]string) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var b strings.Builder
+	for _, k := range keys {
+		fmt.Fprintf(&b, "%s=%s;", k, m[k])
+	}
+	return b.String()
 }
 
 func TestCompileStrictTierOneSpreadRejectsWrongType(t *testing.T) {
@@ -1249,6 +1367,83 @@ func TestCompileStrictEachRejectsMissingAs(t *testing.T) {
 	}
 }
 
+// TestCompileStrictEachRejectsDuplicateOf, TestCompileStrictEachRejectsDuplicateAs,
+// and TestCompileStrictEachRejectsDuplicateIndex cover gosx#182/#184 B-1:
+// strictEachShape used to count of, as, and index last-wins, with no
+// duplicate check — validateStrictConditionalCall already counted cond,
+// but <Each> lost that rule. route/fileprogram.go's attrValue binds the
+// FIRST matching attribute, while the transpiled Go call binds whichever
+// one the AST holds last, so `<Each of={props.Rows} as="row" as="alt">`
+// compiled clean and bound "alt" in generated Go but "row" in the file
+// renderer — a silent two-surface divergence with no compile error at
+// all. These prove the fix fails closed at compile time.
+func TestCompileStrictEachRejectsDuplicateOf(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} of={props.Breakdown} as="row"><span>{row.Label}</span></Each></div>
+}
+`))
+	want := "strict <Each> requires exactly one of attribute with an expression value"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachRejectsDuplicateAs reproduces the reviewer's exact
+// divergence shape verbatim: `<Each of={props.Rows} as="row" as="alt">`.
+// Before the fix this compiled; the file renderer bound "row" (attrValue's
+// first match) while the transpiled Go bound "alt" (the AST's last as),
+// so the SAME program rendered two different values depending on which
+// renderer executed it, with no diagnostic anywhere. It must now fail
+// closed at Compile, closing that divergence at the source.
+func TestCompileStrictEachRejectsDuplicateAs(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row" as="alt"><span>{alt.Label}</span></Each></div>
+}
+`))
+	want := "strict <Each> requires exactly one as attribute naming the loop binding"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsDuplicateIndex(t *testing.T) {
+	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row" index="i" index="j"><span>{j}</span><b>{row.Label}</b></Each></div>
+}
+`))
+	want := "strict <Each> requires exactly one index attribute naming the index binding"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachRejectsBindingNamedAfterImportAlias covers gosx#182/
+// #184 nit n-1: a binding named after an explicit same-file import alias
+// already failed closed in the strictcheck projection (the generated Go
+// shadows the package alias inside the loop body), just with a confusing
+// Go-compiler error far from the .gsx source instead of a clear lowerer
+// diagnostic at the binding itself.
+func TestCompileStrictEachRejectsBindingNamedAfterImportAlias(t *testing.T) {
+	_, err := Compile([]byte(`package app
+
+import strs "strings"
+
+type BreakdownRow struct {
+	Label string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="strs"><span>{strs.Label}</span></Each></div>
+}
+`))
+	want := `strict <Each> binding "strs" shadows this file's "strs" import; choose another name`
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
 func TestCompileStrictEachRejectsFallbackAttr(t *testing.T) {
 	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {
 	return <div><Each of={props.Breakdown} as="row" fallback="none"><span>{row.Label}</span></Each></div>
@@ -1438,6 +1633,47 @@ component Row(props: RowProps) {
 }
 `))
 	want := "strict component Row cannot resolve row.Stat.city: struct Team declares no visible field city; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachRejectsPromotedBindingHopZeroField and
+// TestCompileStrictEachRejectsUnexportedBindingHopZeroField cover gosx#182/
+// #184 M-2: a HOP-0 read on an <Each> BINDING root (the item's own
+// field, not a nested one) used to return the silent strictHopUnknownField
+// kind, on the claim that the package checker backstops it. That claim was
+// false here — the projection compiles in the SAME package as the .gsx
+// file's declarations, so Go resolves a promoted or unexported field on
+// the binding's element struct exactly as it resolves a declared one.
+// Before the fix this compiled clean, strictcheck accepted it, PropsSlices
+// omitted the field from Reads, and the boundary never proved it, so the
+// file renderer and the transpiled Go diverged on row.Label silently. Both
+// must now fail closed at compile time with the B1-style message.
+func TestCompileStrictEachRejectsPromotedBindingHopZeroField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Base struct { Label string }
+type Row struct { Base; Points string }
+type RowProps struct { Rows []Row }
+component C(props: RowProps) {
+	return <section><Each of={props.Rows} as="row"><span>{row.Label}</span></Each></section>
+}
+`))
+	want := "strict component C cannot resolve row.Label: struct Row declares no visible field Label; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictEachRejectsUnexportedBindingHopZeroField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Row struct { label string; Points string }
+type RowProps struct { Rows []Row }
+component C(props: RowProps) {
+	return <section><Each of={props.Rows} as="row"><span>{row.label}</span></Each></section>
+}
+`))
+	want := "strict component C cannot resolve row.label: struct Row declares no visible field label; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
 	if err == nil || !strings.Contains(err.Error(), want) {
 		t.Fatalf("error = %v, want to contain %q", err, want)
 	}

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1398,6 +1398,51 @@ component Row(props: RowProps) {
 	}
 }
 
+// TestCompileStrictEachRejectsBindingSelectorEmbeddedField extends gosx#183's
+// B1 fix (a promoted field at selector hop i>0 fails closed) to an <Each>
+// binding root: row.Stat.City crosses a promoted field the same way
+// props.Player.City did in TestCompileStrictServerRejectsNestedSelectorEmbeddedField.
+// TeamRef carries its own named sibling field (Note) so structTypes
+// registers TeamRef at all — with no named field of its own, TeamRef never
+// enters structTypes and the call fails on the separate "struct is not
+// declared" gate instead of the promoted-field gate this test means to
+// cover.
+func TestCompileStrictEachRejectsBindingSelectorEmbeddedField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Team struct { City string }
+type TeamRef struct { Team; Note string }
+type BreakdownRow struct { Stat TeamRef }
+type RowProps struct { Breakdown []BreakdownRow }
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{row.Stat.City}</span></Each></div>
+}
+`))
+	want := "strict component Row cannot resolve row.Stat.City: struct TeamRef declares no visible field City; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictEachRejectsBindingSelectorUnexportedLeaf covers the other
+// B1 shape for a binding root: an unexported leaf field on a same-file
+// declared struct (not promoted, just lowercase) hits the identical
+// hop-i>0 unknown-field gate, since collectStructSchemas never records an
+// unexported field at all.
+func TestCompileStrictEachRejectsBindingSelectorUnexportedLeaf(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Team struct { city string; Zone string }
+type BreakdownRow struct { Stat Team }
+type RowProps struct { Breakdown []BreakdownRow }
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row"><span>{row.Stat.city}</span></Each></div>
+}
+`))
+	want := "strict component Row cannot resolve row.Stat.city: struct Team declares no visible field city; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
 func TestCompileStrictEachBindingConcatAndCondBothPolarities(t *testing.T) {
 	// Accept: exact string/bool leaves.
 	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {

--- a/strict_each_spread_integration_test.go
+++ b/strict_each_spread_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	gosx "m31labs.dev/gosx"
@@ -245,4 +246,50 @@ func TestGridironAcceptanceTeamMarkCallSitesCompileAndCheck(t *testing.T) {
 		t.Fatalf("Compile: %v", err)
 	}
 	checkFixtureInRealModule(t, "teammarkcallsites", "teammark.gsx", teamMarkFixtureCallSitesSource)
+}
+
+// TestStrictcheckRejectsPromotedEachBindingHopZeroField is gosx#182/#184
+// M-2's real-Go-compiler-backed proof, alongside the lowerer-level
+// TestCompileStrictEachRejectsPromotedBindingHopZeroField: before the fix,
+// the projected check program compiled clean here — the promoted field
+// resolves fine in real Go, same package — which is exactly why the old
+// "the package checker backstops it" comment was false for this root.
+// strictcheck must reject it at the strict-syntax stage (the same
+// diagnostic gosx.Compile produces), never reach the Go compiler at all.
+func TestStrictcheckRejectsPromotedEachBindingHopZeroField(t *testing.T) {
+	source := `package app
+type Base struct { Label string }
+type Row struct { Base; Points string }
+type RowProps struct { Rows []Row }
+component C(props: RowProps) {
+	return <section><Each of={props.Rows} as="row"><span>{row.Label}</span></Each></section>
+}
+`
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module example.test/promotedhopzero\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSum, err := os.ReadFile("go.sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "promotedhopzero.gsx")
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"})
+	if err == nil {
+		t.Fatal("strictcheck unexpectedly accepted a promoted field read at an <Each> binding's hop 0")
+	}
+	if want := "declares no visible field Label"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
 }

--- a/strict_each_spread_integration_test.go
+++ b/strict_each_spread_integration_test.go
@@ -1,0 +1,248 @@
+package gosx_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	gosx "m31labs.dev/gosx"
+	"m31labs.dev/gosx/strictcheck"
+)
+
+// checkFixtureInRealModule runs source through strictcheck.CheckFileWithOptions
+// inside a throwaway module that replaces m31labs.dev/gosx with this
+// checkout — the same real-module, Go-compiler-backed harness
+// strict_surface_expansion_integration_test.go uses, reused here for the
+// #182/#184 gridiron acceptance table (design spec section 6).
+func checkFixtureInRealModule(t *testing.T, moduleName, fileName, source string) {
+	t.Helper()
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module example.test/" + moduleName + "\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSum, err := os.ReadFile("go.sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, fileName)
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"}); err != nil {
+		t.Fatalf("gosx check (strictcheck.CheckFileWithOptions): %v", err)
+	}
+}
+
+// rosterRowFixtureSource is the design spec's section 6 post-extension
+// RosterRow source (app/team/page.gsx), needing E1 (the Breakdown <Each>
+// body loop) and E2 (the legacy call site's {...player} spread), trimmed
+// to the fields the loop and its If siblings actually read. Loader structs
+// (BreakdownRow, RosterCard) stand in for internal/league types, per
+// section 5.7's fixture convention.
+const rosterRowFixtureSource = `package app
+
+type BreakdownRow struct {
+	Scored bool
+	Label  string
+	Calc   string
+	Points string
+}
+
+type RosterRowProps struct {
+	Name           string
+	HasBreakdown   bool
+	Breakdown      []BreakdownRow
+	BreakdownTotal string
+}
+
+component RosterRow(props: RosterRowProps) {
+	return <div class="roster-row">
+		<strong>{props.Name}</strong>
+		<If cond={props.HasBreakdown}>
+			<div class="stat-tip__rows">
+				<Each of={props.Breakdown} as="row">
+					<div class="stat-tip__row" data-scored={row.Scored}>
+						<span>{row.Label}</span>
+						<span class="mono">{row.Calc}</span>
+						<b class="mono">{row.Points}</b>
+					</div>
+				</Each>
+				<div class="stat-tip__total">
+					<span>League scoring</span>
+					<b class="mono">{props.BreakdownTotal}</b>
+				</div>
+			</div>
+		</If>
+		<If cond={props.HasBreakdown == false}>
+			<p class="stat-tip__empty">No projection detail for this position.</p>
+		</If>
+	</div>
+}
+
+type RosterCard struct {
+	Name           string
+	HasBreakdown   bool
+	Breakdown      []BreakdownRow
+	BreakdownTotal string
+}
+
+func Page() Node {
+	roster := []RosterCard{
+		{Name: "Ada Lovelace", HasBreakdown: true, BreakdownTotal: "12.4", Breakdown: []BreakdownRow{
+			{Scored: true, Label: "Pass Yds", Calc: "250/25", Points: "10.0"},
+			{Scored: false, Label: "INT", Calc: "0", Points: "0"},
+		}},
+	}
+	return <div>
+		<Each of={roster} as="player">
+			<RosterRow {...player}></RosterRow>
+		</Each>
+	</div>
+}
+`
+
+// draftTeamFixtureSource is the design spec's section 6 post-extension
+// DraftTeam source (app/draft/page.gsx): body qualifies since v0.42.0
+// (concat class, If pairs); needs only E2 at the call site.
+const draftTeamFixtureSource = `package app
+
+type DraftTeamProps struct {
+	OnClock      bool
+	Tone         string
+	Abbreviation string
+	Ready        bool
+	Autopick     bool
+}
+
+component DraftTeam(props: DraftTeamProps) {
+	return <div class="draft-team" data-on-clock={props.OnClock}>
+		<span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+		<If cond={props.Ready}><b class="ready-state is-ready">Ready</b></If>
+		<If cond={props.Ready == false}><b class="ready-state">Not ready</b></If>
+		<If cond={props.Autopick}><b class="autopick-badge mono">AUTO</b></If>
+	</div>
+}
+
+type DraftSeat struct {
+	OnClock      bool
+	Tone         string
+	Abbreviation string
+	Ready        bool
+	Autopick     bool
+}
+
+func Page() Node {
+	teams := []DraftSeat{
+		{OnClock: true, Tone: "red", Abbreviation: "NE", Ready: true, Autopick: false},
+	}
+	return <div>
+		<Each of={teams} as="team">
+			<DraftTeam {...team}></DraftTeam>
+		</Each>
+	</div>
+}
+`
+
+// teamMarkFixtureCallSitesSource is the design spec's section 6
+// post-extension TeamMark source (app/page.gsx): a concat-only strict
+// body, called with {...props.away}/{...props.home} from a legacy
+// MiniMatchup and {...props} from a legacy StandingRow — the two spread
+// shapes the gridiron TeamMark call sites need.
+const teamMarkFixtureCallSitesSource = `package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone} aria-hidden="true">{props.Abbreviation}</span>
+}
+
+type MatchupSide struct {
+	Tone         string
+	Abbreviation string
+	Name         string
+}
+
+type MiniMatchupProps struct {
+	Away MatchupSide
+	Home MatchupSide
+}
+
+func MiniMatchup(props MiniMatchupProps) Node {
+	return <div class="mini-matchup">
+		<TeamMark {...props.Away}></TeamMark>
+		<TeamMark {...props.Home}></TeamMark>
+	</div>
+}
+
+func StandingRow(props TeamMarkProps) Node {
+	return <div class="standing-row"><TeamMark {...props}></TeamMark></div>
+}
+
+func Page() Node {
+	return <div>
+		<MiniMatchup away={MatchupSide{Tone: "red", Abbreviation: "NE", Name: "Patriots"}} home={MatchupSide{Tone: "blue", Abbreviation: "BUF", Name: "Bills"}}></MiniMatchup>
+		<StandingRow tone="red" abbreviation="NE"></StandingRow>
+	</div>
+}
+`
+
+// TestGridironAcceptanceRosterRowCompilesChecksAndRenders is the E1+E2
+// acceptance fixture for design spec section 6's RosterRow row: it
+// compiles the post-extension source (proving PropsSlices for the
+// Breakdown loop) and checks it through the real Go-compiler-backed
+// strictcheck pipeline. It does not additionally render the legacy Page
+// entry: like the pre-existing BoardRow fixture (open question 1's
+// reasoning), Page's local roster slice is a Go composite literal, which
+// the file-interpreter render path does not execute — that is a full-
+// transpile/compiled-Go concern strictcheck's real `go list -export`
+// already covers, and render parity for the loop-plus-spread shape itself
+// is proved directly against a hand-built ir.Program in
+// route/strict_component_test.go's TestStrictEachRendersSliceParityWithGeneratedGo
+// and TestStrictSpreadParityWithExplicitAttrCall.
+func TestGridironAcceptanceRosterRowCompilesChecksAndRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(rosterRowFixtureSource))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	rosterRow := prog.Components[0]
+	if rosterRow.Name != "RosterRow" {
+		t.Fatalf("unexpected component order: %#v", prog.Components)
+	}
+	if rosterRow.PropsSlices["Breakdown"].Elem != "BreakdownRow" {
+		t.Fatalf("PropsSlices[Breakdown].Elem = %q, want BreakdownRow", rosterRow.PropsSlices["Breakdown"].Elem)
+	}
+
+	checkFixtureInRealModule(t, "rosterrow", "rosterrow.gsx", rosterRowFixtureSource)
+}
+
+// TestGridironAcceptanceDraftTeamCompilesAndChecks is the E2 acceptance
+// fixture for design spec section 6's DraftTeam row.
+func TestGridironAcceptanceDraftTeamCompilesAndChecks(t *testing.T) {
+	if _, err := gosx.Compile([]byte(draftTeamFixtureSource)); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	checkFixtureInRealModule(t, "draftteam", "draftteam.gsx", draftTeamFixtureSource)
+}
+
+// TestGridironAcceptanceTeamMarkCallSitesCompileAndCheck is the E2
+// acceptance fixture for design spec section 6's TeamMark row: both call
+// shapes gridiron needs (a spread over a nested field, and a spread over a
+// legacy body's own whole typed props parameter) compile and check clean.
+func TestGridironAcceptanceTeamMarkCallSitesCompileAndCheck(t *testing.T) {
+	if _, err := gosx.Compile([]byte(teamMarkFixtureCallSitesSource)); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	checkFixtureInRealModule(t, "teammarkcallsites", "teammark.gsx", teamMarkFixtureCallSitesSource)
+}

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -29,6 +29,7 @@ func Attrs(...AttrValue) any { return nil }
 func Props(values ...AttrValue) AttrList { return values }
 func Spread(any) AttrValue { return AttrValue{} }
 func If(cond bool, child Node) Node { return Node{} }
+func Map[T any](items []T, fn func(T, int) Node) Node { return Node{} }
 `)
 	mustWrite(t, filepath.Join(dir, "go.mod"), "module example.test/app\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => "+filepath.ToSlash(stub)+"\n")
 	return dir
@@ -697,5 +698,194 @@ func TestCommandEnvPreservesWorkspaceUnlessOverridden(t *testing.T) {
 	joined = strings.Join(got, "\n")
 	if strings.Contains(joined, "GOWORK=/workspace/go.work") || !strings.Contains(joined, "GOWORK=off") || !strings.Contains(joined, "GOFLAGS=-mod=readonly") {
 		t.Fatalf("environment not overridden: %v", got)
+	}
+}
+
+// TestCheckFileAcceptsTierOneSpreadCall covers design spec section 3.2
+// (#184 E2) through the full strictcheck pipeline: a strict caller's spread
+// source has exactly the callee's declared props type, so
+// emitStrictComponent/strictSpreadCallVerbatim emits the call verbatim and
+// the Go compiler proves it with zero synthesis.
+func TestCheckFileAcceptsTierOneSpreadCall(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+component Wrap(props: TeamMarkProps) {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsTierOneSpreadWrongType proves the lowerer's tier-1
+// identity check fails before the Go compiler ever sees a mismatched
+// spread — a strict caller spreading a value whose declared type is not
+// the callee's props type.
+func TestCheckFileRejectsTierOneSpreadWrongType(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+type WrapProps struct {
+	Tone string
+}
+component Wrap(props: WrapProps) {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "a strict caller spreads a value whose declared type is the callee props type") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileAcceptsStrictEachLoop is the check-program half of #182: a
+// same-file strict <Each> over a []T slice of a same-file struct emits
+// gosx.Map, and the Go compiler proves every binding-rooted read inside the
+// callback, including a concat operand and an <If cond>.
+func TestCheckFileAcceptsStrictEachLoop(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type BreakdownRow struct {
+	Scored bool
+	Label  string
+	Points string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row" index="i">
+			<div class={"row-" + row.Label} data-scored={row.Scored}><If cond={row.Scored}>{row.Points}</If>{i}</div>
+		</Each>
+	</div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsEachOverScalarSlice proves the lowerer's loopable-type
+// table (design spec section 2.3) fails at the IR gate, before the Go
+// compiler ever runs, with a message naming the field and its type.
+func TestCheckFileRejectsEachOverScalarSlice(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type RowProps struct {
+	Names []string
+}
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Names} as="name">
+			<span>{name}</span>
+		</Each>
+	</div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "loop elements must be structs declared in this .gsx file") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileRejectsEachIndexBindingMisusedAsOperand proves an index
+// binding's int-only contract fails at the IR gate: an index name used
+// where a string field is required (a concat operand here) is a shape the
+// syntactic validator's scope rules admit as a selector root candidate but
+// the lowerer's type resolution rejects, since an index binding is never a
+// struct.
+func TestCheckFileRejectsEachIndexBindingMisusedAsOperand(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type BreakdownRow struct {
+	Label string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row" index="i">
+			<span>{"row-" + i.Label}</span>
+		</Each>
+	</div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil || !strings.Contains(err.Error(), "index binding i in a selector") {
+		t.Fatalf("CheckFile error = %v", err)
+	}
+}
+
+// TestCheckFileAcceptsCombinedEachSpreadConcatCondAndNestedSelector proves
+// the full file combining E1, E2 tier 1, concat, <If>, and (b)'s nested
+// selectors passes — the acceptance bar section 5.4 sets for the combined
+// surface.
+func TestCheckFileAcceptsCombinedEachSpreadConcatCondAndNestedSelector(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type BreakdownRow struct {
+	Scored bool
+	Label  string
+}
+type Team struct {
+	City string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+	Team      Team
+}
+component Row(props: RowProps) {
+	return <div>
+		<span>{"in-" + props.Team.City}</span>
+		<Each of={props.Breakdown} as="row">
+			<div class={"tone-" + row.Label}><If cond={row.Scored}>scored</If></div>
+		</Each>
+	</div>
+}
+component Wrap(props: RowProps) {
+	return <div><Row {...props}></Row></div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
 	}
 }

--- a/transpile/strict_component_test.go
+++ b/transpile/strict_component_test.go
@@ -346,3 +346,205 @@ component Page() {
 		t.Fatalf("generated Go is missing %q:\n%s", want, out)
 	}
 }
+
+// --- E1 (#182): strict <Each> ----------------------------------------------
+
+// TestTranspileStrictEachEmitsGoSXMap covers design spec section 2.8: a
+// strict <Each of={...} as="row"> projects onto gosx.Map, with the row
+// element type named from the same-file struct schema and every
+// binding-rooted read emitted verbatim so the Go compiler proves it inside
+// the callback scope.
+func TestTranspileStrictEachEmitsGoSXMap(t *testing.T) {
+	source := []byte(`package app
+type BreakdownRow struct {
+	Scored bool
+	Label  string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div>
+		<Each of={props.Breakdown} as="row">
+			<div data-scored={row.Scored}>{row.Label}</div>
+		</Each>
+	</div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	for _, want := range []string{
+		`gosx.Map(props.Breakdown, func(row BreakdownRow, _ int) gosx.Node { return gosx.Fragment(`,
+		`gosx.Attr("data-scored", row.Scored)`,
+		`gosx.Expr(row.Label)`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTranspileStrictEachWithIndexNamesTheCallbackParam covers the index
+// binding: with index="i", the callback's second parameter is named i
+// instead of the placeholder _, so a bare {i} read compiles as an ordinary
+// int reference (compare the <If> emission tests above's alias-injection
+// pattern).
+func TestTranspileStrictEachWithIndexNamesTheCallbackParam(t *testing.T) {
+	source := []byte(`package app
+type BreakdownRow struct {
+	Label string
+}
+type RowProps struct {
+	Breakdown []BreakdownRow
+}
+component Row(props: RowProps) {
+	return <div><Each of={props.Breakdown} as="row" index="i">{row.Label}{i}</Each></div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `func(row BreakdownRow, i int) gosx.Node`; !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+	if want := `gosx.Expr(i)`; !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+}
+
+// TestTranspileStrictEachHonorsGoSXAliasInjection mirrors
+// TestTranspileStrictConditionalHonorsGoSXAliasInjection for the Map
+// emission: gosx.Map must reference whatever alias (or dot import) the
+// rest of the file's gosx emission uses.
+func TestTranspileStrictEachHonorsGoSXAliasInjection(t *testing.T) {
+	source := []byte(`package app
+import gx "m31labs.dev/gosx"
+type Row struct {
+	Label string
+}
+type Props struct {
+	Rows []Row
+}
+component Page(props: Props) {
+	return <div><Each of={props.Rows} as="row">{row.Label}</Each></div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `gx.Map(props.Rows, func(row Row, _ int) gx.Node { return gx.Fragment(`; !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+}
+
+// TestTranspileStrictEachShadowedByLocalComponentStaysAComponentCall mirrors
+// TestTranspileStrictConditionalShadowedByLocalComponentStaysAComponentCall:
+// a same-file strict component named Each keeps its ordinary typed-call
+// emission instead of the gosx.Map builtin projection.
+func TestTranspileStrictEachShadowedByLocalComponentStaysAComponentCall(t *testing.T) {
+	source := []byte(`package app
+type EachProps struct {
+	Label string
+}
+component Each(props: EachProps) {
+	return <em>{props.Label}</em>
+}
+component Page() {
+	return <Each label="shadowed" />
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `Each(EachProps{Label: "shadowed"})`; !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+	if strings.Contains(out, "gosx.Map") {
+		t.Fatalf("shadowed Each must not emit gosx.Map:\n%s", out)
+	}
+}
+
+// --- E2 (#184): spread props at strict call sites -------------------------
+
+// TestTranspileStrictTierOneSpreadEmitsVerbatimCall covers design spec
+// section 3.2's check-program encoding: a proven tier-1 spread emits the
+// call verbatim — Callee(<source>) — instead of a composite literal, so
+// the Go compiler proves type identity with zero synthesis.
+func TestTranspileStrictTierOneSpreadEmitsVerbatimCall(t *testing.T) {
+	source := []byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+component Wrap(props: TeamMarkProps) {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `TeamMark(props)`; !strings.Contains(out, want) {
+		t.Fatalf("missing verbatim spread call %q in:\n%s", want, out)
+	}
+	if strings.Contains(out, "TeamMarkProps{") {
+		t.Fatalf("tier-1 spread must not synthesize a composite literal:\n%s", out)
+	}
+}
+
+// TestTranspileStrictTierOneSpreadForwardsNestedFieldVerbatim covers a
+// props field selector source (not bare props): the spread source's exact
+// text is still emitted verbatim as the call argument.
+func TestTranspileStrictTierOneSpreadForwardsNestedFieldVerbatim(t *testing.T) {
+	source := []byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+type MatchupProps struct {
+	Away TeamMarkProps
+}
+component Matchup(props: MatchupProps) {
+	return <div><TeamMark {...props.Away}></TeamMark></div>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `TeamMark(props.Away)`; !strings.Contains(out, want) {
+		t.Fatalf("missing verbatim spread call %q in:\n%s", want, out)
+	}
+}
+
+// TestTranspileStrictLegacyTierTwoSpreadStillFailsFullTranspile covers
+// non-goal 3.5/open question 5: a legacy body's spread into a strict
+// callee is proved only at the file-renderer boundary, so full transpile
+// keeps failing, now with the updated message naming the supported path.
+func TestTranspileStrictLegacyTierTwoSpreadStillFailsFullTranspile(t *testing.T) {
+	source := []byte(`package app
+type TeamMarkProps struct {
+	Tone string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+func Page() Node {
+	team := map[string]any{"Tone": "red"}
+	return <div><TeamMark {...team}></TeamMark></div>
+}
+`)
+	_, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err == nil || !strings.Contains(err.Error(), "proven by the file renderer boundary, not by gosx transpile") {
+		t.Fatalf("error = %v", err)
+	}
+}

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -23,6 +23,7 @@ import (
 
 	gotreesitter "github.com/odvcencio/gotreesitter"
 	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/internal/strictcomponent"
 )
 
 // Options controls transpiler behavior.
@@ -83,13 +84,24 @@ func Transpile(source []byte, opts Options) (string, error) {
 }
 
 type transpiler struct {
-	src              []byte
-	lang             *gotreesitter.Language
-	sourceFile       string
-	imports          map[string]string // alias -> path
-	propsTypes       map[string]string
-	propsFields      map[string]map[string]string
+	src         []byte
+	lang        *gotreesitter.Language
+	sourceFile  string
+	imports     map[string]string // alias -> path
+	propsTypes  map[string]string
+	propsFields map[string]map[string]string
+	// structFieldTypes records, per same-file struct name, each field's raw
+	// declared type text — collectStructFields' companion map, populated
+	// alongside propsFields. emitStrictEach uses it to name a strict
+	// <Each>'s gosx.Map callback element type without re-deriving it from
+	// ir.Component (transpile.go works from the CST directly, not the IR).
+	structFieldTypes map[string]map[string]string
 	strictNames      map[string]struct{} // same-file gosx_component_declaration names, props or not
+	// currentPropsType is the props type of the strict component whose body
+	// is currently being emitted (empty outside strict emission) — needed
+	// to resolve a same-file <Each of> or spread source's element/struct
+	// type by walking structFieldTypes from the right root.
+	currentPropsType string
 	errs             []string
 	hasStrict        bool
 	strict           int
@@ -419,12 +431,17 @@ func (t *transpiler) collectStructFieldsFromTypeDecl(n *gotreesitter.Node) {
 			continue
 		}
 		fields := make(map[string]string)
+		fieldTypes := make(map[string]string)
 		var collect func(*gotreesitter.Node)
 		collect = func(node *gotreesitter.Node) {
 			if node == nil {
 				return
 			}
 			if t.nodeType(node) == "field_declaration" {
+				fieldType := ""
+				if fieldTypeNode := t.childByField(node, "type"); fieldTypeNode != nil {
+					fieldType = strings.TrimSpace(t.text(fieldTypeNode))
+				}
 				for i := 0; i < int(node.NamedChildCount()); i++ {
 					child := node.NamedChild(i)
 					if t.nodeType(child) != "field_identifier" {
@@ -436,6 +453,7 @@ func (t *transpiler) collectStructFieldsFromTypeDecl(n *gotreesitter.Node) {
 						continue
 					}
 					fields[field] = field
+					fieldTypes[field] = fieldType
 					alias := lowerCamelField(field)
 					if existing, ok := fields[alias]; ok && existing != field {
 						fields[alias] = ""
@@ -451,7 +469,12 @@ func (t *transpiler) collectStructFieldsFromTypeDecl(n *gotreesitter.Node) {
 		}
 		collect(typeNode)
 		if len(fields) > 0 {
-			t.propsFields[t.text(nameNode)] = fields
+			name := t.text(nameNode)
+			t.propsFields[name] = fields
+			if t.structFieldTypes == nil {
+				t.structFieldTypes = make(map[string]map[string]string)
+			}
+			t.structFieldTypes[name] = fieldTypes
 		}
 	}
 }
@@ -604,9 +627,12 @@ func (t *transpiler) emitStrictComponent(n *gotreesitter.Node) string {
 		}
 	}
 
+	prevPropsType := t.currentPropsType
+	t.currentPropsType = t.propsTypes[t.text(nameNode)]
 	t.strict++
 	body := t.emitDefault(bodyNode)
 	t.strict--
+	t.currentPropsType = prevPropsType
 	return "func " + t.text(nameNode) + "(" + params + ") " + t.gosxRef("Node") + " " + body
 }
 
@@ -673,12 +699,21 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 	}
 
 	tag := t.extractTagName(openNode)
+
+	if t.isStrictEachTag(tag) {
+		return t.emitStrictEach(openNode, n)
+	}
+
 	children := t.emitChildren(n)
 
 	if t.isStrictConditionalTag(tag) {
 		if cond, ok := t.strictConditionalCondExpr(openNode); ok {
 			return t.emitStrictConditional(cond, children)
 		}
+	}
+
+	if verbatim, ok := t.strictSpreadCallVerbatim(tag, openNode); ok {
+		return verbatim
 	}
 
 	if isComponent(tag) {
@@ -734,6 +769,167 @@ func (t *transpiler) strictConditionalCondExpr(openNode *gotreesitter.Node) (str
 // wrote zero, one, or many GSX children.
 func (t *transpiler) emitStrictConditional(cond string, children []string) string {
 	return fmt.Sprintf("%s(%s, %s(%s))", t.gosxRef("If"), cond, t.gosxRef("Fragment"), strings.Join(children, ", "))
+}
+
+// isStrictEachTag reports whether tag resolves to the strict <Each> builtin
+// rather than a same-file component named Each. It mirrors
+// isStrictConditionalTag's shadow rule and its reasoning: gosx.Compile
+// (run before any emission in Transpile) has already proven the file
+// compiles under ir/lower.go's identical carve-out, so by the time
+// emission runs, tag=="Each" outside t.strictNames can only be the
+// builtin.
+func (t *transpiler) isStrictEachTag(tag string) bool {
+	if t.strict == 0 || tag != "Each" {
+		return false
+	}
+	_, shadowed := t.strictNames[tag]
+	return !shadowed
+}
+
+// emitStrictEach projects a strict <Each of={...} as="x" [index="i"]> call
+// onto gosx.Map (design spec section 2.8): the of source, the item and
+// (optional) index binding names, and the Go compiler-provable element
+// type together produce
+//
+//	gosx.Map(<of>, func(<as> <ElemType>, <index or _> int) gosx.Node {
+//	    return gosx.Fragment(<children...>)
+//	})
+//
+// ir/lower.go's validateStrictEachCall has already proven the shape,
+// binding names, and loopable element type before transpile emission
+// runs, so this is extraction, not a second validation pass. elementNode
+// is nil for a self-closing <Each /> (no children).
+func (t *transpiler) emitStrictEach(openNode, elementNode *gotreesitter.Node) string {
+	var ofExpr, asName, indexName string
+	for i := 0; i < int(openNode.NamedChildCount()); i++ {
+		child := openNode.NamedChild(i)
+		if t.nodeType(child) != "jsx_attribute" {
+			continue
+		}
+		nameNode := t.childByField(child, "name")
+		if nameNode == nil {
+			continue
+		}
+		switch t.text(nameNode) {
+		case "of":
+			if value, boolAttr, ok := t.emitAttrValue(child); ok && !boolAttr {
+				ofExpr = value
+			}
+		case "as":
+			asName = trimGSXStringLiteral(child, t)
+		case "index":
+			indexName = trimGSXStringLiteral(child, t)
+		}
+	}
+
+	var children []string
+	if elementNode != nil {
+		children = t.emitChildren(elementNode)
+	}
+
+	elemType := t.strictEachElemType(ofExpr)
+	indexParam := "_"
+	if indexName != "" {
+		indexParam = indexName
+	}
+	body := fmt.Sprintf("%s(%s)", t.gosxRef("Fragment"), strings.Join(children, ", "))
+	return fmt.Sprintf("%s(%s, func(%s %s, %s int) %s { return %s })",
+		t.gosxRef("Map"), ofExpr, asName, elemType, indexParam, t.gosxRef("Node"), body)
+}
+
+// trimGSXStringLiteral reads a jsx_attribute's static string value (the
+// grammar's jsx_string_literal, quotes included) and strips the quotes —
+// used for as/index, which are always the static-string shape by the time
+// emission runs.
+func trimGSXStringLiteral(attr *gotreesitter.Node, t *transpiler) string {
+	valueNode := t.childByField(attr, "value")
+	if valueNode == nil {
+		return ""
+	}
+	raw := t.text(valueNode)
+	if len(raw) >= 2 && raw[0] == '"' && raw[len(raw)-1] == '"' {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}
+
+// strictEachElemType resolves a props-rooted <Each of> source to its
+// element struct name by walking t.structFieldTypes from
+// t.currentPropsType's base name — the transpiler's own re-derivation of
+// the same declared-text rule ir/lower.go's admitStrictEachElemType
+// enforces, needed here only to name the gosx.Map callback parameter. It
+// falls back to "any" for a shape the lowerer would already have rejected
+// (unreachable once gosx.Compile has run), so a transpiler bug fails as an
+// invalid-Go build error instead of a panic.
+func (t *transpiler) strictEachElemType(ofExpr string) string {
+	path, ok := strictcomponent.ServerPropPath(ofExpr)
+	if !ok || len(path) != 1 {
+		return "any"
+	}
+	fieldType := strings.TrimSpace(t.structFieldTypes[strictStructBaseName(t.currentPropsType)][path[0]])
+	if !strings.HasPrefix(fieldType, "[]") {
+		return "any"
+	}
+	elem := strings.TrimSpace(strings.TrimPrefix(fieldType, "[]"))
+	if elem == "" {
+		return "any"
+	}
+	return elem
+}
+
+// strictStructBaseName strips a declared type's pointer prefix, package
+// qualifier, and generic/array brackets down to the bare same-file struct
+// name t.structFieldTypes and t.propsFields key on — transpile.go's own
+// copy of ir/lower.go's propsBaseType, kept local since the two packages
+// share no such helper today.
+func strictStructBaseName(typeText string) string {
+	typeText = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(typeText), "*"))
+	if idx := strings.LastIndex(typeText, "."); idx >= 0 {
+		typeText = typeText[idx+1:]
+	}
+	if idx := strings.Index(typeText, "["); idx >= 0 {
+		typeText = typeText[:idx]
+	}
+	return typeText
+}
+
+// strictSpreadCallVerbatim recognizes E2 tier 1's proven call shape (design
+// spec section 3.2): inside a strict body, a call to a same-file strict
+// component with exactly one spread attribute and no other attributes.
+// ir/lower.go's validateStrictToStrictSpreadCall has already proven the
+// spread source's declared type is exactly the callee's props type before
+// transpile emission runs, so the call can be emitted verbatim —
+// Callee(<source>) — and the Go compiler proves the rest with zero
+// synthesis. This bypasses emitTypedAttrsForType's spread rejection only
+// for this proven shape; every other spread shape (a legacy caller's tier-2
+// spread, or any shape the lowerer did not prove) still reaches that
+// rejection with its own message.
+func (t *transpiler) strictSpreadCallVerbatim(tag string, n *gotreesitter.Node) (string, bool) {
+	if t.strict == 0 {
+		return "", false
+	}
+	if _, strictCallee := t.strictNames[tag]; !strictCallee {
+		return "", false
+	}
+	spreadCount := 0
+	otherCount := 0
+	var spreadExpr string
+	for i := 0; i < int(n.NamedChildCount()); i++ {
+		child := n.NamedChild(i)
+		switch t.nodeType(child) {
+		case "jsx_spread_attribute":
+			spreadCount++
+			if exprNode := t.childByField(child, "expression"); exprNode != nil {
+				spreadExpr = t.text(exprNode)
+			}
+		case "jsx_attribute":
+			otherCount++
+		}
+	}
+	if spreadCount != 1 || otherCount != 0 {
+		return "", false
+	}
+	return tag + "(" + spreadExpr + ")", true
 }
 
 // emitRawTextElement emits <script>/<style>. Their bodies are script or
@@ -795,10 +991,18 @@ func rawTextBody(raw string) string {
 func (t *transpiler) emitSelfClosing(n *gotreesitter.Node) string {
 	tag := t.extractTagName(n)
 
+	if t.isStrictEachTag(tag) {
+		return t.emitStrictEach(n, nil)
+	}
+
 	if t.isStrictConditionalTag(tag) {
 		if cond, ok := t.strictConditionalCondExpr(n); ok {
 			return t.emitStrictConditional(cond, nil)
 		}
+	}
+
+	if verbatim, ok := t.strictSpreadCallVerbatim(tag, n); ok {
+		return verbatim
 	}
 
 	if isComponent(tag) {
@@ -963,10 +1167,10 @@ func (t *transpiler) emitTypedAttrsForTag(tag string, n *gotreesitter.Node) []st
 	if t.isGoSXUITag(tag) {
 		return t.emitGoSXUIAttrs(tag, n)
 	}
-	return t.emitTypedAttrsForType(t.propsTypes[tag], n)
+	return t.emitTypedAttrsForType(tag, t.propsTypes[tag], n)
 }
 
-func (t *transpiler) emitTypedAttrsForType(propsType string, n *gotreesitter.Node) []string {
+func (t *transpiler) emitTypedAttrsForType(tag, propsType string, n *gotreesitter.Node) []string {
 	baseType, _ := typedPropsLiteralType(propsType)
 	if idx := strings.LastIndex(baseType, "."); idx >= 0 {
 		baseType = baseType[idx+1:]
@@ -980,6 +1184,17 @@ func (t *transpiler) emitTypedAttrsForType(propsType string, n *gotreesitter.Nod
 		child := n.NamedChild(i)
 		switch t.nodeType(child) {
 		case "jsx_spread_attribute":
+			if _, strictCallee := t.strictNames[tag]; strictCallee {
+				// E2 tier 2 (design spec section 3.3, non-goal 3.5): a
+				// legacy body's spread into a strict callee is proved only
+				// at the file-renderer boundary (strictSpreadProps,
+				// route/fileprogram.go); full transpile has no equivalent
+				// run-time re-proof, so it keeps failing here, with a
+				// message that names the supported path instead of the
+				// unproven one.
+				t.errorf(child, "spread attributes at a strict component call site are proven by the file renderer boundary, not by gosx transpile; render %s through gosx's file router, or call it with explicit typed attributes from a strict body", tag)
+				continue
+			}
 			t.errorf(child, "spread attributes are not supported for typed component props")
 		case "jsx_attribute":
 			nameNode := t.childByField(child, "name")


### PR DESCRIPTION
## Summary

Fixes strict component boundaries to correctly handle typed &lt;Each&gt; loops and single spread call sites at the render boundary. Extends the strict validator with scope-aware expressions so that loop binding selectors and bare index references resolve properly, and adds runtime type proofs for slice element types and spread sources — preventing mixed-type data from silently deserializing into the wrong Go struct.

## Changes

- Typed `<Each>` loop source validation.** Strict components may now loop over `[]T` where `T` is a same-file value struct; an `index` attribute binds a plain `int`. Elements must be named structs — scalar slices, maps, arrays, and named slice types all fail closed.
- Single spread call site provenance.** A strict caller may spread exactly one value whose declared type matches the callee's props type verbatim. A legacy caller's single spread is proved structurally at the renderer boundary (no map accepted, every field checked). Multiple spreads or spread plus named attributes stay rejected.
- Render-boundary type proofs.** Added `requireStrictSliceValue` and extended `strictSpreadProps` to verify element struct identity and per-read path leaf types via reflection. Both validate promoted-field exclusions the same way `requireStrictStructValue` does, closing a silent promotion gap.
- Scope-aware expression validator.** Generalized `ValidateServerExpression`, `ServerSelectorPath`, `ServerExpressionRootedPaths`, `ServerConcatRootedPaths`, and `ValidateServerCondExpression` to accept a `Scope` carrying `<Each>` item and index names. Empty-scope wrappers preserve byte-identical behavior for pre-existing callers.
- IR extension `Component.PropsSlices`.** Records per-loop-source element struct name and binding-relative read paths with leaf types. Decodes absent (nil) for older serialized programs matching existing zero-value conventions.
- Cross-style call ban narrowed.** Legacy bodies may now call same-file strict components through the single-spread shape; all other legacy-to-strict shapes and strict-to-legacy calls keep failing closed with updated diagnostics.
- Examples and tests.** Documentation page gains dedicated sections and runnable samples for loops and spread. Round-trip JSON tests prove backward-compatible serialization of the new `PropsSlices` field. Integration and check-test coverage exercises tier-1 spread, tier-2 spread, scalar slice rejection, and combined features end-to-end.

## Testing

- Run 'go test ./...' across ir, route, transpile, format, strictcheck, and internal/strictcomponent packages to validate the new PropSlices round-trip, scope-aware validators, and integration fixtures.
- Build the gosx-docs example and verify the Loops & Spread Props section renders without compilation errors.

## Related Issues

- Refs #182
- Refs #184

## Review Focus

Focus on the render-boundary proofs in route/fileprogram.go (requireStrictSliceValue, strictSpreadProps) and the Scope generalization in internal/strictcomponent/expression.go — ensure both respect the three-hop selector cap at lowering time and reject mixed-type data early.