### PR TITLE
fix(server): Fix mount dispatcher to populate named path wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## Unreleased
+
+### Fixed
+
+- **`App.Mount` now populates named path wildcards.** A mounted pattern
+  with a wildcard segment, for example `GET /avatars/{teamID}`, dispatched
+  through `(*http.ServeMux).Handler(r)`, which the stdlib documents as
+  never populating `r.PathValue` — every wildcard silently read back as
+  the empty string. The dispatcher now serves a matched mount through
+  `mux.ServeHTTP`, which runs the same lookup internally and sets the
+  wildcard values on the request before the handler runs. Detecting a
+  non-match still uses `Handler(r)`, so an unmounted request falls through
+  to the page router exactly as before. Non-wildcard mounts, subtree
+  mounts, and the 404 fall-through keep their existing behavior. Refs
+  #194.
+
 ## v0.43.0 (2026-08-16)
 
 The strict surface grows loops and spreads, and the runtime grows time. Seven

--- a/server/server.go
+++ b/server/server.go
@@ -1496,11 +1496,18 @@ func routeHandled(mux *http.ServeMux, w http.ResponseWriter, r *http.Request) bo
 }
 
 func mountHandled(mux *http.ServeMux, w http.ResponseWriter, r *http.Request) bool {
-	handler, pattern := mux.Handler(r)
-	if pattern == "" || handler == nil {
+	if !muxMatched(mux, r) {
 		return false
 	}
-	handler.ServeHTTP(w, r)
+	// Dispatch through mux.ServeHTTP, not the handler pulled off mux.Handler:
+	// Handler's own doc comment says it "does not populate named path
+	// wildcards, so r.PathValue will always return the empty string." A
+	// mount pattern with a wildcard segment, e.g. "GET /avatars/{teamID}.png",
+	// needs ServeHTTP's internal findHandler call, which sets r.pat and
+	// r.matches before invoking the handler. muxMatched still does the
+	// match/no-match check via Handler(r), matching the no-match fall-through
+	// contract used by routeHandled, redirectHandled and rewriteHandled.
+	mux.ServeHTTP(w, r)
 	return true
 }
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -3112,6 +3112,100 @@ func TestMountAppIncludesRoutesRegisteredAfterMount(t *testing.T) {
 	}
 }
 
+func TestMountWildcardPatternPopulatesPathValue(t *testing.T) {
+	app := New()
+	var sawTeamID string
+	app.Mount("GET /avatars/{teamID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawTeamID = r.PathValue("teamID")
+		_, _ = w.Write([]byte("avatar-ok"))
+	}))
+
+	handler := app.Build()
+	req := httptest.NewRequest(http.MethodGet, "/avatars/broncos.png", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if sawTeamID != "broncos.png" {
+		t.Fatalf("expected PathValue(teamID) to be %q, got %q", "broncos.png", sawTeamID)
+	}
+}
+
+func TestMountPatternWithMultipleWildcardsPopulatesEach(t *testing.T) {
+	app := New()
+	var sawLeague, sawTeamID string
+	app.Mount("GET /leagues/{league}/teams/{teamID}", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawLeague = r.PathValue("league")
+		sawTeamID = r.PathValue("teamID")
+		_, _ = w.Write([]byte("team-ok"))
+	}))
+
+	handler := app.Build()
+	req := httptest.NewRequest(http.MethodGet, "/leagues/nfl/teams/broncos", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if sawLeague != "nfl" {
+		t.Fatalf("expected PathValue(league) to be %q, got %q", "nfl", sawLeague)
+	}
+	if sawTeamID != "broncos" {
+		t.Fatalf("expected PathValue(teamID) to be %q, got %q", "broncos", sawTeamID)
+	}
+}
+
+func TestMountUnmatchedRequestFallsThroughToPageRouter(t *testing.T) {
+	app := New()
+	app.Mount("GET /avatars/{teamID}/logo", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("avatar-ok"))
+	}))
+	app.SetNotFound(func(ctx *Context) gosx.Node {
+		return gosx.Text("custom-not-found")
+	})
+
+	handler := app.Build()
+	// One path segment short of the mounted pattern: no mount match, so
+	// dispatch must still fall through to the page router's 404 handler.
+	req := httptest.NewRequest(http.MethodGet, "/avatars/broncos", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "custom-not-found") {
+		t.Fatalf("expected custom-not-found body, got %q", body)
+	}
+}
+
+func TestMountSubtreePatternStillMatches(t *testing.T) {
+	app := New()
+	var sawPath string
+	app.Mount("/legacy/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawPath = r.URL.Path
+		_, _ = w.Write([]byte("legacy-ok"))
+	}))
+
+	handler := app.Build()
+	req := httptest.NewRequest(http.MethodGet, "/legacy/reports/2024.csv", nil)
+	w := httptest.NewRecorder()
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d (body=%q)", w.Code, w.Body.String())
+	}
+	if body := w.Body.String(); !strings.Contains(body, "legacy-ok") {
+		t.Fatalf("expected legacy-ok body, got %q", body)
+	}
+	if sawPath != "/legacy/reports/2024.csv" {
+		t.Fatalf("expected subtree handler to see full path, got %q", sawPath)
+	}
+}
+
 func TestAppServesBootstrapStubWhenNoBuildExists(t *testing.T) {
 	// Use a temp dir with no build artifacts at all — simulates `go run`
 	// without ever running `gosx build`.


### PR DESCRIPTION
## Summary

The standard library's `http.ServeMux.Handler` does not populate `r.PathValue`, causing mounted routes with wildcard segments to silently drop path parameters. This update switches the mount dispatcher to `mux.ServeHTTP` when a pattern matches, preserving existing fall-through logic while correctly setting wildcard values on the request.

## Changes

- Refactor `mountHandled` to check matches via `muxMatched` and delegate to `mux.ServeHTTP`, leveraging the stdlib's internal route lookup to set `r.PathValue` before invoking the handler.
- Add test coverage for single wildcards, multiple wildcards, subtree mounts, and unmatched request fallbacks to ensure parameters are captured and routing contracts remain intact.