### PR TITLE
add(action,route,navigation): Add first-class file uploads and configurable action body cap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,33 @@
 # Changelog
 
+## Unreleased
+
+### Added: first-class file uploads through the action layer
+
+- **`ctx.Files(name)` and `ctx.File(name)` read uploaded files from an
+  action request.** Before this, an uploaded file sat in
+  `req.MultipartForm` behind `ctx.Request`, and every consumer wrote the
+  same lookup by hand. `Files` returns `[]*multipart.FileHeader` for a
+  form field name. `File` returns the first header, or nil. Both stay
+  nil-safe: a non-multipart request, a nil `Context`, or an absent field
+  name all return nil. Fixes #187.
+- **The 1 MiB action body cap is now configurable.** `ServeHandler`
+  keeps the 1 MiB default. A caller with a larger upload calls the new
+  `ServeHandlerWithOptions(w, req, handler, ServeHandlerOptions{MaxBodyBytes: n})`
+  instead. `route.FileModuleOptions.MaxActionBodyBytes` carries the same
+  cap through file-routed actions registered with
+  `route.RegisterFileModuleHere` and its sibling constructors, so a
+  consumer raises the limit per module without touching the action
+  package directly. An oversized request still fails with 413 through
+  `http.MaxBytesReader` semantics, never a silent truncation.
+- **A pinned test proves the navigation runtime's managed form
+  submission already carries a selected file.** `serializeForm()`
+  builds a real `FormData` from the form element and passes it straight
+  through to `fetch` as the request body, with no intermediate
+  stringification. The first consumer of this ask, gridiron-2000's team
+  avatar upload, needed the accessor and the raised cap. The runtime
+  half of the ask needed only this test.
+
 ## v0.43.0 (2026-08-16)
 
 The strict surface grows loops and spreads, and the runtime grows time. Seven

--- a/action/action.go
+++ b/action/action.go
@@ -10,6 +10,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime/multipart"
 	"net/http"
 	"strings"
 	"sync"
@@ -17,6 +18,11 @@ import (
 	"m31labs.dev/gosx/session"
 )
 
+// maxActionBodyBytes is the default request-body cap enforced by
+// [ServeHandler]. A caller that needs a larger cap (for example, an action
+// that accepts file uploads) calls [ServeHandlerWithOptions] with a
+// [ServeHandlerOptions.MaxBodyBytes] value instead; the default never
+// changes.
 const maxActionBodyBytes = 1024 * 1024
 
 const actionFlashKey = "__gosx_action_state"
@@ -127,6 +133,35 @@ type Context struct {
 
 	status int
 	result *Result
+}
+
+// Files returns the uploaded file headers submitted under the given
+// multipart form field name.
+//
+// [ServeHandler] and [ServeHandlerWithOptions] populate the backing form by
+// calling [http.Request.ParseMultipartForm] with the configured body-size
+// limit (1 MiB by default; see [ServeHandlerOptions.MaxBodyBytes]). Parts up
+// to that limit are held in memory; parts beyond it spill to temporary files
+// on disk for the life of the request, per the standard library's own
+// ParseMultipartForm behavior. Files is nil-safe: a non-multipart request, a
+// nil Context, or a field name absent from the form all return nil.
+func (c *Context) Files(name string) []*multipart.FileHeader {
+	if c == nil || c.Request == nil || c.Request.MultipartForm == nil {
+		return nil
+	}
+	return c.Request.MultipartForm.File[name]
+}
+
+// File returns the first uploaded file header submitted under the given
+// multipart form field name, or nil if the request carried none. It is a
+// singular convenience over [Context.Files]; see that method's doc comment
+// for the parse limit and memory/disk-spill behavior.
+func (c *Context) File(name string) *multipart.FileHeader {
+	files := c.Files(name)
+	if len(files) == 0 {
+		return nil
+	}
+	return files[0]
 }
 
 // View is the browser-facing action state surfaced back to HTML pages after a
@@ -314,15 +349,43 @@ func (r *Registry) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 	ServeHandler(w, req, handler)
 }
 
+// ServeHandlerOptions configures [ServeHandlerWithOptions].
+type ServeHandlerOptions struct {
+	// MaxBodyBytes caps the request body accepted for this action, enforced
+	// with [http.MaxBytesReader] semantics: a request over the cap fails
+	// with 413 Request Entity Too Large rather than being silently
+	// truncated. Zero or a negative value falls back to the package default
+	// of 1 MiB (the same default [ServeHandler] uses).
+	MaxBodyBytes int64
+}
+
 // ServeHandler handles a single action handler over HTTP using the same form,
-// JSON, redirect, and validation semantics as Registry.ServeHTTP.
+// JSON, redirect, and validation semantics as Registry.ServeHTTP. The request
+// body is capped at 1 MiB; call [ServeHandlerWithOptions] to raise that cap,
+// for example for an action that accepts file uploads.
 func ServeHandler(w http.ResponseWriter, req *http.Request, handler Handler) {
+	serveHandler(w, req, handler, maxActionBodyBytes)
+}
+
+// ServeHandlerWithOptions is [ServeHandler] with a configurable request-body
+// cap. It is the seam a file-routed app reaches through
+// `route.FileModuleOptions.MaxActionBodyBytes` to accept uploads larger than
+// the 1 MiB default.
+func ServeHandlerWithOptions(w http.ResponseWriter, req *http.Request, handler Handler, opts ServeHandlerOptions) {
+	maxBodyBytes := opts.MaxBodyBytes
+	if maxBodyBytes <= 0 {
+		maxBodyBytes = maxActionBodyBytes
+	}
+	serveHandler(w, req, handler, maxBodyBytes)
+}
+
+func serveHandler(w http.ResponseWriter, req *http.Request, handler Handler, maxBodyBytes int64) {
 	if handler == nil {
 		http.Error(w, "action handler required", http.StatusNotFound)
 		return
 	}
 
-	req.Body = http.MaxBytesReader(w, req.Body, maxActionBodyBytes)
+	req.Body = http.MaxBytesReader(w, req.Body, maxBodyBytes)
 	defer req.Body.Close()
 
 	ctx := &Context{
@@ -347,7 +410,7 @@ func ServeHandler(w http.ResponseWriter, req *http.Request, handler Handler) {
 	} else {
 		var err error
 		if strings.HasPrefix(contentType, "multipart/form-data") {
-			err = req.ParseMultipartForm(maxActionBodyBytes)
+			err = req.ParseMultipartForm(maxBodyBytes)
 		} else {
 			err = req.ParseForm()
 		}

--- a/action/action_test.go
+++ b/action/action_test.go
@@ -242,6 +242,184 @@ func TestRegistryHTTPMultipartFormData(t *testing.T) {
 	}
 }
 
+func TestContextFilesFromMultipartForm(t *testing.T) {
+	var gotFiles []*multipart.FileHeader
+	var gotFile *multipart.FileHeader
+	var gotMissing []*multipart.FileHeader
+
+	r := NewRegistry()
+	r.Register("upload", func(ctx *Context) error {
+		gotFiles = ctx.Files("avatar")
+		gotFile = ctx.File("avatar")
+		gotMissing = ctx.Files("does-not-exist")
+		return nil
+	})
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	if err := writer.WriteField("name", "Ada"); err != nil {
+		t.Fatalf("write name field: %v", err)
+	}
+	part, err := writer.CreateFormFile("avatar", "avatar.png")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := part.Write([]byte("fake-png-bytes")); err != nil {
+		t.Fatalf("write file bytes: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/gosx/action/upload", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.SetPathValue("name", "upload")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	if len(gotFiles) != 1 {
+		t.Fatalf("expected 1 file header, got %d", len(gotFiles))
+	}
+	if gotFiles[0].Filename != "avatar.png" {
+		t.Fatalf("expected avatar.png, got %q", gotFiles[0].Filename)
+	}
+	if gotFile == nil || gotFile.Filename != "avatar.png" {
+		t.Fatalf("expected File convenience accessor to return avatar.png, got %#v", gotFile)
+	}
+	if gotMissing != nil {
+		t.Fatalf("expected nil for an absent field name, got %#v", gotMissing)
+	}
+}
+
+func TestContextFilesNilOnNonMultipartRequest(t *testing.T) {
+	var gotFiles []*multipart.FileHeader
+	var gotFile *multipart.FileHeader
+
+	r := NewRegistry()
+	r.Register("submit", func(ctx *Context) error {
+		gotFiles = ctx.Files("avatar")
+		gotFile = ctx.File("avatar")
+		return nil
+	})
+
+	req := httptest.NewRequest("POST", "/gosx/action/submit", strings.NewReader("name=Ada"))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.SetPathValue("name", "submit")
+	w := httptest.NewRecorder()
+
+	r.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if gotFiles != nil {
+		t.Fatalf("expected nil Files on a non-multipart request, got %#v", gotFiles)
+	}
+	if gotFile != nil {
+		t.Fatalf("expected nil File on a non-multipart request, got %#v", gotFile)
+	}
+}
+
+func TestContextFilesNilSafeOnNilContext(t *testing.T) {
+	var ctx *Context
+	if got := ctx.Files("avatar"); got != nil {
+		t.Fatalf("expected nil, got %#v", got)
+	}
+	if got := ctx.File("avatar"); got != nil {
+		t.Fatalf("expected nil, got %#v", got)
+	}
+}
+
+func TestServeHandlerWithOptionsRejectsOversizedMultipartUpload(t *testing.T) {
+	called := false
+	handler := func(ctx *Context) error {
+		called = true
+		return nil
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("avatar", "avatar.png")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("a"), 4096)); err != nil {
+		t.Fatalf("write file bytes: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/gosx/action/upload", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	ServeHandlerWithOptions(w, req, handler, ServeHandlerOptions{MaxBodyBytes: 1024})
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413, got %d: %s", w.Code, w.Body.String())
+	}
+	if called {
+		t.Fatal("expected the handler not to run once the body exceeds the configured limit")
+	}
+}
+
+func TestServeHandlerWithOptionsAllowsUploadUnderConfiguredLimit(t *testing.T) {
+	var uploaded *multipart.FileHeader
+	handler := func(ctx *Context) error {
+		uploaded = ctx.File("avatar")
+		return ctx.Success("saved", nil)
+	}
+
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile("avatar", "avatar.png")
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	// The payload sits over the package's 1 MiB default cap and under the 2
+	// MiB cap configured below, so this proves the knob raises the ceiling
+	// rather than merely staying under an unrelated limit.
+	payload := bytes.Repeat([]byte("a"), maxActionBodyBytes+512*1024)
+	if _, err := part.Write(payload); err != nil {
+		t.Fatalf("write file bytes: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+
+	req := httptest.NewRequest("POST", "/gosx/action/upload", &body)
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	w := httptest.NewRecorder()
+
+	ServeHandlerWithOptions(w, req, handler, ServeHandlerOptions{MaxBodyBytes: 2 * 1024 * 1024})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if uploaded == nil || uploaded.Filename != "avatar.png" {
+		t.Fatalf("expected uploaded avatar.png, got %#v", uploaded)
+	}
+}
+
+func TestServeHandlerWithOptionsZeroFallsBackToPackageDefault(t *testing.T) {
+	handler := func(ctx *Context) error { return nil }
+
+	body := "name=" + strings.Repeat("a", maxActionBodyBytes+1)
+	req := httptest.NewRequest("POST", "/gosx/action/submit", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	w := httptest.NewRecorder()
+
+	ServeHandlerWithOptions(w, req, handler, ServeHandlerOptions{})
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 from the package default cap, got %d", w.Code)
+	}
+}
+
 func TestRegistryHTTPStructuredValidationError(t *testing.T) {
 	r := NewRegistry()
 	r.Register("submit", func(ctx *Context) error {

--- a/client/js/runtime-14-navigation.test.js
+++ b/client/js/runtime-14-navigation.test.js
@@ -23,6 +23,7 @@ const {
   scene3DCommandFetchRoutes,
   FakeElement,
   FakeFormData,
+  FakeFile,
   createContext,
   runScript,
   flushAsyncWork,
@@ -3904,6 +3905,67 @@ test("navigation runtime exposes programmatic managed action submission", async 
     ["csrf_token", "root-token"],
   ]);
   assert.equal(env.document.dispatchedEvents.at(-1).type, "gosx:form:result");
+});
+
+// Pins the field report behind gosx#187: the managed-form fetch submission
+// must carry an uploaded file straight through, since serializeForm() in
+// navigation.ts builds FormData from the live form element (new
+// FormData(form)) and passes that FormData object as the fetch body with no
+// intermediate stringification. A regression that read only text inputs, or
+// that stringified a File before sending it, must fail this test.
+test("managed form submission carries a selected file straight through to fetch", async () => {
+  const actionURL = "http://localhost:3000/team/__actions/avatar";
+  const form = new FakeElement("form", null);
+  form.setAttribute("action", actionURL);
+  form.setAttribute("method", "post");
+  form.setAttribute("data-gosx-form", "");
+
+  const nameField = new FakeElement("input", null);
+  nameField.setAttribute("name", "teamName");
+  nameField.value = "Falcons";
+  form.appendChild(nameField);
+
+  const fileField = new FakeElement("input", null);
+  fileField.setAttribute("type", "file");
+  fileField.setAttribute("name", "avatar");
+  const avatar = new FakeFile("avatar.png", "image/png", 2048);
+  fileField.files = [avatar];
+  form.appendChild(fileField);
+
+  const env = createContext({
+    elements: [form],
+    fetchRoutes: {
+      [actionURL]: { text: '{"ok":true}', url: actionURL },
+    },
+  });
+
+  runScript(navigationSource, env.context, "navigation_runtime.js");
+  env.document.eventListeners.get("submit")[0]({
+    type: "submit",
+    target: form,
+    defaultPrevented: false,
+    preventDefault() {},
+  });
+  await flushAsyncWork();
+
+  assert.equal(env.fetchCalls.length, 1);
+  assert.equal(env.fetchCalls[0].url, actionURL);
+
+  const body = env.fetchCalls[0].init.body;
+  assert.ok(
+    body instanceof FakeFormData,
+    "the managed form submission must send FormData as the fetch body",
+  );
+  assert.deepEqual(body.values, [
+    ["teamName", "Falcons"],
+    ["avatar", avatar],
+  ]);
+
+  const uploaded = body.get("avatar");
+  assert.equal(uploaded, avatar, "the file entry must remain the File object, not a stringified copy");
+  assert.equal(uploaded.name, "avatar.png");
+  assert.equal(uploaded.type, "image/png");
+  assert.equal(uploaded.size, 2048);
 });
 
 test("managed forms suppress duplicate submissions until their request settles", async () => {

--- a/client/js/runtime-test-harness.js
+++ b/client/js/runtime-test-harness.js
@@ -1965,6 +1965,20 @@ function buildSkinnedGLBBytes() {
   return Array.from(glb);
 }
 
+// FakeFile stands in for a browser File (a Blob subclass) inside the sandbox
+// DOM. It carries only the fields the runtime and its tests inspect — name,
+// MIME type, and byte size — never real bytes, since the fake fetch layer
+// never reads a request body.
+class FakeFile {
+  constructor(name, type, size) {
+    this.name = String(name || "");
+    this.type = String(type || "");
+    this.size = Number.isFinite(size) ? size : 0;
+    this.lastModified = Date.now();
+    this.__isFakeFile = true;
+  }
+}
+
 class FakeFormData {
   constructor(form) {
     this.values = [];
@@ -1974,6 +1988,10 @@ class FakeFormData {
   }
 
   append(name, value) {
+    if (value && typeof value === "object" && value.__isFakeFile) {
+      this.values.push([String(name), value]);
+      return;
+    }
     this.values.push([String(name), String(value == null ? "" : value)]);
   }
 
@@ -1997,7 +2015,12 @@ class FakeFormData {
       return;
     }
     const tag = node.tagName;
-    if ((tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") && node.hasAttribute("name")) {
+    if (tag === "INPUT" && node.getAttribute("type") === "file" && node.hasAttribute("name")) {
+      const files = Array.isArray(node.files) ? node.files : [];
+      for (const file of files) {
+        this.append(node.getAttribute("name"), file);
+      }
+    } else if ((tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") && node.hasAttribute("name")) {
       this.append(node.getAttribute("name"), node.value || node.getAttribute("value") || "");
     }
     for (const child of node.children) {
@@ -5523,6 +5546,7 @@ module.exports = {
   buildPointLineGLBBytes,
   buildSkinnedGLBBytes,
   FakeFormData,
+  FakeFile,
   createConsoleSpy,
   numberOr,
   createComputedStyleSnapshot,

--- a/route/filemodule.go
+++ b/route/filemodule.go
@@ -48,6 +48,13 @@ type FileModule struct {
 	Render   FileRenderDataFunc
 	Actions  FileActions
 	Bindings FileBindingsFunc
+
+	// MaxActionBodyBytes caps the request body accepted by this module's
+	// actions, enforced with http.MaxBytesReader semantics (an oversized
+	// request fails with 413 rather than being silently truncated). Zero
+	// keeps the action package default of 1 MiB. Set this to accept larger
+	// uploads, such as a file, through an action route.
+	MaxActionBodyBytes int64
 }
 
 // FileModuleOptions configures a file-routed server module.
@@ -57,17 +64,25 @@ type FileModuleOptions struct {
 	Render   FileRenderDataFunc
 	Actions  FileActions
 	Bindings FileBindingsFunc
+
+	// MaxActionBodyBytes caps the request body accepted by this module's
+	// actions, enforced with http.MaxBytesReader semantics (an oversized
+	// request fails with 413 rather than being silently truncated). Zero
+	// keeps the action package default of 1 MiB. Set this to accept larger
+	// uploads, such as a file, through an action route.
+	MaxActionBodyBytes int64
 }
 
 // FileModuleFor builds a file-routed server module definition.
 func FileModuleFor(source string, opts FileModuleOptions) FileModule {
 	return FileModule{
-		Source:   source,
-		Load:     opts.Load,
-		Metadata: opts.Metadata,
-		Render:   opts.Render,
-		Actions:  cloneFileActions(opts.Actions),
-		Bindings: opts.Bindings,
+		Source:             source,
+		Load:               opts.Load,
+		Metadata:           opts.Metadata,
+		Render:             opts.Render,
+		Actions:            cloneFileActions(opts.Actions),
+		Bindings:           opts.Bindings,
+		MaxActionBodyBytes: opts.MaxActionBodyBytes,
 	}
 }
 

--- a/route/filesystem.go
+++ b/route/filesystem.go
@@ -477,7 +477,7 @@ func (r *fileRouteRegistrar) buildRoute(page FilePage) (Route, error) {
 		}
 	}
 	if len(resolved.module.Actions) > 0 {
-		r.router.Handle(filePageActionPattern(resolved.page.Pattern), buildFileActionHandler(resolved.page, resolved.module.Actions), routeMiddleware...)
+		r.router.Handle(filePageActionPattern(resolved.page.Pattern), buildFileActionHandler(resolved.page, resolved.module.Actions, resolved.module.MaxActionBodyBytes), routeMiddleware...)
 	}
 	return Route{
 		Pattern:      resolved.page.Pattern,
@@ -633,7 +633,7 @@ func filePageActionPattern(pattern string) string {
 	return "POST " + strings.TrimSuffix(pattern, "/") + "/__actions/{__gosx_action}"
 }
 
-func buildFileActionHandler(page FilePage, handlers FileActions) http.Handler {
+func buildFileActionHandler(page FilePage, handlers FileActions, maxActionBodyBytes int64) http.Handler {
 	handlers = cloneFileActions(handlers)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		name := r.PathValue("__gosx_action")
@@ -646,7 +646,9 @@ func buildFileActionHandler(page FilePage, handlers FileActions) http.Handler {
 			http.Error(w, fmt.Sprintf("action %q not found for %s", name, page.Source), http.StatusNotFound)
 			return
 		}
-		action.ServeHandler(w, r, handler)
+		action.ServeHandlerWithOptions(w, r, handler, action.ServeHandlerOptions{
+			MaxBodyBytes: maxActionBodyBytes,
+		})
 	})
 }
 

--- a/route/filesystem_test.go
+++ b/route/filesystem_test.go
@@ -1,8 +1,10 @@
 package route
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"mime/multipart"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -3214,6 +3216,134 @@ func Page() Node {
 	}
 	if dataValue["slug"] != "hello-world" || dataValue["name"] != "GoSX" {
 		t.Fatalf("unexpected action data %#v", dataValue)
+	}
+}
+
+func buildMultipartUpload(t *testing.T, fieldName, filename string, size int) (*bytes.Buffer, string) {
+	t.Helper()
+	var body bytes.Buffer
+	writer := multipart.NewWriter(&body)
+	part, err := writer.CreateFormFile(fieldName, filename)
+	if err != nil {
+		t.Fatalf("create form file: %v", err)
+	}
+	if _, err := part.Write(bytes.Repeat([]byte("a"), size)); err != nil {
+		t.Fatalf("write file bytes: %v", err)
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatalf("close multipart writer: %v", err)
+	}
+	return &body, writer.FormDataContentType()
+}
+
+func registerUploadModule(t *testing.T, root string, opts FileModuleOptions) *FileModuleRegistry {
+	t.Helper()
+	writeRouteFile(t, root, "upload/page.gsx", `package docs
+
+func Page() Node {
+	return <main>Upload</main>
+}
+`)
+
+	opts.Actions = FileActions{
+		"upload": func(ctx *action.Context) error {
+			return ctx.Success("saved", nil)
+		},
+	}
+
+	modules := NewFileModuleRegistry()
+	if err := modules.Register(FileModuleFor("upload/page.gsx", opts)); err != nil {
+		t.Fatal(err)
+	}
+	return modules
+}
+
+func TestRouterAddDirFileModuleMaxActionBodyBytesRejectsOversizedUpload(t *testing.T) {
+	root := t.TempDir()
+	modules := registerUploadModule(t, root, FileModuleOptions{
+		MaxActionBodyBytes: 2048,
+	})
+
+	router := NewRouter()
+	if err := router.AddDir(root, FileRoutesOptions{Modules: modules}); err != nil {
+		t.Fatal(err)
+	}
+
+	body, contentType := buildMultipartUpload(t, "avatar", "avatar.png", 8*1024)
+	req := httptest.NewRequest(http.MethodPost, "/upload/__actions/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	router.Build().ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 for an upload over the configured module cap, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestRouterAddDirFileModuleMaxActionBodyBytesAllowsUploadUnderConfiguredLimit(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "upload/page.gsx", `package docs
+
+func Page() Node {
+	return <main>Upload</main>
+}
+`)
+
+	var uploaded *multipart.FileHeader
+	modules := NewFileModuleRegistry()
+	if err := modules.Register(FileModuleFor("upload/page.gsx", FileModuleOptions{
+		// The payload below sits over the 1 MiB package default and under
+		// this 2 MiB module cap, proving the knob raises the ceiling.
+		MaxActionBodyBytes: 2 * 1024 * 1024,
+		Actions: FileActions{
+			"upload": func(ctx *action.Context) error {
+				uploaded = ctx.File("avatar")
+				return ctx.Success("saved", nil)
+			},
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	router := NewRouter()
+	if err := router.AddDir(root, FileRoutesOptions{Modules: modules}); err != nil {
+		t.Fatal(err)
+	}
+
+	const oneMiB = 1024 * 1024
+	body, contentType := buildMultipartUpload(t, "avatar", "avatar.png", oneMiB+512*1024)
+	req := httptest.NewRequest(http.MethodPost, "/upload/__actions/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	req.Header.Set("Accept", "application/json")
+	w := httptest.NewRecorder()
+	router.Build().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for an upload under the configured module cap, got %d: %s", w.Code, w.Body.String())
+	}
+	if uploaded == nil || uploaded.Filename != "avatar.png" {
+		t.Fatalf("expected uploaded avatar.png, got %#v", uploaded)
+	}
+}
+
+func TestRouterAddDirFileModuleDefaultMaxActionBodyBytesRejectsOversizedUpload(t *testing.T) {
+	root := t.TempDir()
+	modules := registerUploadModule(t, root, FileModuleOptions{})
+
+	router := NewRouter()
+	if err := router.AddDir(root, FileRoutesOptions{Modules: modules}); err != nil {
+		t.Fatal(err)
+	}
+
+	const oneMiB = 1024 * 1024
+	body, contentType := buildMultipartUpload(t, "avatar", "avatar.png", oneMiB+512*1024)
+	req := httptest.NewRequest(http.MethodPost, "/upload/__actions/upload", body)
+	req.Header.Set("Content-Type", contentType)
+	w := httptest.NewRecorder()
+	router.Build().ServeHTTP(w, req)
+
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("expected 413 from the unchanged 1 MiB default, got %d: %s", w.Code, w.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

This branch introduces first-class support for file uploads through the action layer and makes the 1 MiB request-body cap configurable. Consumers can now read uploaded files via `ctx.Files()` and `ctx.File()`, and raise the body-cap limit per-route when larger uploads are needed. A pinned test confirms the navigation runtime already sends file fields through `FormData` to fetch without regression.

## Changes

- Add `ctx.Files(name)` and `ctx.File(name)` to action.Context** — reads uploaded file headers from multipart form fields. Nil-safe for non-multipart requests, nil context, or missing fields.
- Make the 1 MiB action body cap configurable** via new `ServeHandlerWithOptions(w, req, handler, ServeHandlerOptions{MaxBodyBytes: n})`. Zero or negative values fall back to the 1 MiB default. Oversized requests fail with 413 instead of silent truncation.
- Thread `MaxActionBodyBytes` through `FileModule` / `FileModuleOptions`** — file-routed actions honor a per-module cap set at registration time, so consumers adjust the limit without touching the action package directly.
- Pinned the navigation runtime file-upload path** — a new test verifies that `serializeForm()` builds real `FormData` from the live form element and passes it to `fetch` unchanged, ensuring file entries stay as `File` objects rather than being stringified.
- Wire `FakeFile` into the JS test harness** — supports the new navigation test and provides a minimal blob-substitute with `name`, `type`, and `size`.

## Testing

- Run `go test ./...` to execute the new Go tests for Context.Files, ServeHandlerWithOptions caps, and router-level MaxActionBodyBytes behavior. Run `npm test -- client/js/runtime-14-navigation.test.js` to verify the managed form submission carries a selected file straight through to fetch.

## Related Issues

- Refs #187

## Review Focus

Review the nil-safety guarantees on ctx.Files/File, the integration path from FileModuleOptions.MaxActionBodyBytes down through buildFileActionHandler to action.ServeHandlerWithOptions, and the FakeFile/FakeFormData plumbing in the JS test harness.