### PR TITLE
fix(route): fix attribute determinism and spread name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,32 @@
 # Changelog
 
+## Unreleased
+
+### Fixes
+
+- **`route`: deterministic attribute order for an unresolved component
+  reference.** `defaultRenderedComponent` renders the
+  `<div data-gosx-component="Tag" ...>` fallback for a `<Component/>`
+  reference gosx does not resolve locally. It iterated its attribute map
+  in Go's randomized map order. Two renders of the same compiled program
+  could emit the same attributes in a different order. This broke
+  byte-identity goldens and churned HTTP caches and ETags on unchanged
+  content. Attribute names now sort before emission. Output is
+  byte-identical across repeated renders. Fixes #188.
+- **`route`: drop an attribute name smuggled through a `{...spread}` map
+  key.** `html.EscapeString` does not escape a space or an `=`. A spread
+  map key such as `x onmouseover=alert(1) y` rendered as three attributes —
+  `x`, `onmouseover=alert(1)`, and `y` — from one map entry, because
+  `normalizeFileAttrName` only trimmed whitespace and mapped `className`
+  to `class`. Every `{...spread}` call site now validates each key with
+  `validRenderAttrName`, the same helper #185's render-profile
+  `AttrWriter` path already uses, and drops an invalid key instead of
+  emitting it. This is inert, not fail-closed: the render-profile path
+  still fails closed on an invalid name, because a profile is trusted
+  code and a bad name there is a bug in it. A spread commonly carries
+  request or database data an author never wrote. One bad key must not
+  fail an otherwise-valid render. Fixes #189.
+
 ## v0.43.0 (2026-08-16)
 
 The strict surface grows loops and spreads, and the runtime grows time. Seven

--- a/route/attr_determinism_test.go
+++ b/route/attr_determinism_test.go
@@ -1,0 +1,72 @@
+package route
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// TestDefaultRenderedComponentSortsAttrsDeterministically proves gosx#188:
+// defaultRenderedComponent used to iterate its attrs map in Go's randomized
+// map order, so two renders of the same input could emit the same
+// attributes in a different order. Sorting the names before emission makes
+// the output byte-identical across repeated calls, regardless of map
+// iteration order.
+func TestDefaultRenderedComponentSortsAttrsDeterministically(t *testing.T) {
+	attrs := map[string]any{
+		"lang":      "go",
+		"source":    "func main() {}",
+		"title":     "Example",
+		"line":      "12",
+		"theme":     "dark",
+		"copyable":  true,
+		"data-slot": "primary",
+	}
+	want := `<div data-gosx-component="CodeBlock" copyable data-slot="primary" lang="go" line="12" source="func main() {}" theme="dark" title="Example"></div>`
+
+	first := defaultRenderedComponent("CodeBlock", attrs, "")
+	if first != want {
+		t.Fatalf("attribute order not sorted alphabetically:\n got:  %s\n want: %s", first, want)
+	}
+
+	for i := 0; i < 20; i++ {
+		got := defaultRenderedComponent("CodeBlock", attrs, "")
+		if got != first {
+			t.Fatalf("render %d differs from render 0 (nondeterministic attribute order):\n render 0: %s\n render %d: %s", i, first, i, got)
+		}
+	}
+}
+
+// TestUnresolvedComponentReferenceRendersDeterministically proves gosx#188
+// end to end through the public render entry: a <CodeBlock/> reference with
+// six attributes that gosx does not resolve locally falls back to
+// defaultRenderedComponent (route/fileprogram.go's writeElement, the
+// data-gosx-component hydration marker). Twenty renders of the same
+// compiled program must produce byte-identical HTML.
+func TestUnresolvedComponentReferenceRendersDeterministically(t *testing.T) {
+	src := []byte(`package main
+
+func Page() Node {
+	return <CodeBlock lang="go" source="func main() {}" title="Example" line="12" theme="dark" copyable="true"/>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	first, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render 0: %v", err)
+	}
+
+	for i := 1; i < 20; i++ {
+		got, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+		if err != nil {
+			t.Fatalf("render %d: %v", i, err)
+		}
+		if got != first {
+			t.Fatalf("render %d differs from render 0 (nondeterministic attribute order):\n render 0: %s\n render %d: %s", i, first, i, got)
+		}
+	}
+}

--- a/route/corpus_determinism_test.go
+++ b/route/corpus_determinism_test.go
@@ -1,0 +1,81 @@
+package route
+
+import (
+	"crypto/sha256"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// TestRepositoryCorpusRendersDeterministically is the corpus-level proof for
+// gosx#188: it compiles every .gsx file under the repository root (72 at the
+// time of the fix, most of them under examples/gosx-docs) and renders every
+// component each one declares twice, byte-comparing the two renders.
+//
+// Before the fix, 12 of the rendered components (all docs pages, the same
+// class of file gosx#188 quoted) differed between the two renders because
+// defaultRenderedComponent iterated its attrs map in Go's randomized order.
+// After the fix, none differ. A file this test cannot compile, or a
+// component that errors on render (both expected for some of the corpus —
+// layout and error-boundary files are not meant to stand alone), is skipped
+// rather than failed: this test is about output determinism, not full
+// pipeline coverage.
+func TestRepositoryCorpusRendersDeterministically(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	root := filepath.Dir(wd) // route/ -> repository root
+
+	var files []string
+	err = filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.IsDir() && info.Name() == "node_modules" {
+			return filepath.SkipDir
+		}
+		if !info.IsDir() && filepath.Ext(path) == ".gsx" {
+			files = append(files, path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) == 0 {
+		t.Skip("no .gsx files found under repository root; skipping corpus determinism check")
+	}
+
+	rendered := 0
+	for _, f := range files {
+		src, err := os.ReadFile(f)
+		if err != nil {
+			t.Fatalf("read %s: %v", f, err)
+		}
+		prog, err := gosx.Compile(src)
+		if err != nil {
+			continue // not every .gsx file in the corpus is a standalone page
+		}
+		for _, comp := range prog.Components {
+			first, err := RenderProgramComponent(prog, comp.Name, ProgramRenderEnv{})
+			if err != nil {
+				continue // component needs props/env this bare render does not supply
+			}
+			rendered++
+			second, err := RenderProgramComponent(prog, comp.Name, ProgramRenderEnv{})
+			if err != nil {
+				t.Fatalf("%s :: %s: second render errored after the first succeeded: %v", f, comp.Name, err)
+			}
+			if sha256.Sum256([]byte(first)) != sha256.Sum256([]byte(second)) {
+				t.Errorf("%s :: %s renders nondeterministically:\n render 1: %s\n render 2: %s", f, comp.Name, first, second)
+			}
+		}
+	}
+	if rendered == 0 {
+		t.Skip("no component in the corpus rendered with a bare env; skipping corpus determinism check")
+	}
+	t.Logf("rendered %d components from %d .gsx files with matching bytes across two renders", rendered, len(files))
+}

--- a/route/filelayout.go
+++ b/route/filelayout.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -512,10 +513,26 @@ func injectHTMLTagAttr(tag, name, value string) string {
 	return out.String()
 }
 
+// defaultRenderedComponent emits the fallback markup for an unresolved
+// component reference: a <div data-gosx-component="Tag"> carrying every
+// attribute the reference supplied, so client-side hydration can find and
+// mount the real component.
+//
+// attrs iterates in sorted name order (gosx#188): Go's map iteration order
+// is randomized per run, so two renders of the same input previously
+// differed only in attribute order — byte-identity goldens, HTTP ETags, and
+// caches all churn on content that has not actually changed. Sorting names
+// before emission makes the output deterministic across runs and processes.
 func defaultRenderedComponent(tag string, attrs map[string]any, childrenHTML string) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, `<div data-gosx-component="%s"`, html.EscapeString(tag))
-	for name, value := range attrs {
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		value := attrs[name]
 		safeName := html.EscapeString(name)
 		switch v := value.(type) {
 		case bool:

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -390,7 +390,9 @@ func (r *fileProgramRenderer) renderLinkAttrs(b *strings.Builder, attrs []ir.Att
 				key := entry.Key
 				value := entry.Value
 				normalized := normalizeFileAttrName(key)
-				if normalized == "" || linkReservedAttr(normalized) {
+				// gosx#189: drop an invalid spread key inertly, same rule
+				// and same shared helper as renderFileSpreadAttrs.
+				if normalized == "" || linkReservedAttr(normalized) || !validRenderAttrName(normalized) {
 					continue
 				}
 				renderFileEvaluatedAttr(b, normalized, value)
@@ -1345,7 +1347,12 @@ func resolveFileAttrs(attrs []ir.Attr, env fileRenderEnv, excludeSpreadKey strin
 		case ir.AttrSpread:
 			for _, entry := range sortedSpreadProps(evalFileExpr(attr.Expr, env)) {
 				normalized := normalizeFileAttrName(entry.Key)
-				if normalized == "" || normalized == excludeSpreadKey {
+				// gosx#189: drop an invalid spread key here, before it ever
+				// reaches the render profile's AttrWriter, so spread data
+				// cannot trigger renderResolvedAttrs's fail-closed
+				// *RenderProfileError — that path is reserved for a name
+				// the profile itself introduces or mangles.
+				if normalized == "" || normalized == excludeSpreadKey || !validRenderAttrName(normalized) {
 					continue
 				}
 				out = appendResolvedAttr(out, normalized, entry.Value)
@@ -1397,12 +1404,16 @@ func appendResolvedAttr(out []RenderAttr, name string, value any) []RenderAttr {
 // tag and the offending Name, the same way a reported Validate diagnostic
 // does, instead of emitting whatever the parser would make of it.
 //
-// The identical hole in the {...spread} attribute-name path — normalizeFileAttrName
-// does not reject a name with these characters either — is gosx#189, out of
-// scope on this branch. A shared name-validation helper for both paths (this
-// one and normalizeFileAttrName's callers) is the natural follow-up once
-// #189 lands; validRenderAttrName is written so it can become that helper
-// without changing its signature.
+// The identical hole in the {...spread} attribute-name path —
+// normalizeFileAttrName does not reject a name with these characters
+// either — is gosx#189, fixed by sharing this function's validRenderAttrName
+// with every {...spread} call site (renderFileSpreadAttrs,
+// renderLinkAttrs's spread branch, and resolveFileAttrs). The two paths
+// disagree on purpose about what happens next: an invalid Name here is a bug
+// in trusted profile code, so this function still fails the render closed;
+// an invalid name from a spread is commonly untrusted request or database
+// data, so the spread call sites drop it inertly instead — one bad key does
+// not take out the rest of an otherwise-valid render.
 func (r *fileProgramRenderer) renderResolvedAttrs(b *strings.Builder, tag string, attrs []RenderAttr) {
 	for _, attr := range attrs {
 		if !validRenderAttrName(attr.Name) {
@@ -1509,10 +1520,24 @@ func renderFileAttr(b *strings.Builder, attr ir.Attr, env fileRenderEnv, exclude
 	}
 }
 
+// renderFileSpreadAttrs expands a {...spread} attribute's evaluated map into
+// HTML attribute text.
+//
+// Every key is validated with validRenderAttrName before it renders
+// (gosx#189): html.EscapeString does not escape a space or an "=", so a map
+// key like "x onmouseover=alert(1) y" would otherwise smuggle three
+// attributes past one map entry, the same hole gosx#185 M1 closed on the
+// render-profile hook path. A spread key fails INERT here — it is dropped
+// silently, with no attribute emitted and no logger call (nothing in this
+// render path holds a logger) — unlike the profile path's fail-closed
+// *RenderProfileError. The profile path treats an invalid Name as a bug in
+// trusted profile code, worth stopping the whole render over; a spread key
+// commonly carries request or database data an author never wrote down, so
+// one bad key must not take out an otherwise-valid render.
 func renderFileSpreadAttrs(b *strings.Builder, value any, excludeKey string) {
 	for _, entry := range sortedSpreadProps(value) {
 		normalized := normalizeFileAttrName(entry.Key)
-		if normalized == "" || normalized == excludeKey {
+		if normalized == "" || normalized == excludeKey || !validRenderAttrName(normalized) {
 			continue
 		}
 		renderFileEvaluatedAttr(b, normalized, entry.Value)

--- a/route/spread_attr_name_test.go
+++ b/route/spread_attr_name_test.go
@@ -1,0 +1,112 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+
+	"m31labs.dev/gosx"
+)
+
+// TestSpreadAttrNameSmugglingDropped is gosx#189's exact P7c probe shape
+// (found on the gosx#185 review, scratchpad/probes185/p7_htmlparse_test.go):
+// a {...spread} whose map key is `x onmouseover=alert(1) y`.
+// html.EscapeString does not escape a space or an "=", so before this fix
+// normalizeFileAttrName passed the key through unchanged and the renderer
+// wrote three attributes — x, onmouseover=alert(1), and y — from one map
+// entry. The fix drops an invalid spread key inertly: the render still
+// succeeds, but none of the smuggled attributes appear.
+func TestSpreadAttrNameSmugglingDropped(t *testing.T) {
+	prog, err := gosx.Compile([]byte("package main\n\nfunc Page() Node {\n\treturn <div {...extra}>x</div>\n}\n"))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	out, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"extra": map[string]any{`x onmouseover=alert(1) y`: "v"}},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(out, "onmouseover") {
+		t.Fatalf("smuggled onmouseover attribute reached output: %s", out)
+	}
+
+	doc, err := html.Parse(strings.NewReader("<!doctype html><html><body>" + out + "</body></html>"))
+	if err != nil {
+		t.Fatalf("parse rendered HTML: %v", err)
+	}
+	div := findHTMLNode(doc, "div")
+	if div == nil {
+		t.Fatalf("no <div> in rendered output: %s", out)
+	}
+	for _, a := range div.Attr {
+		if a.Key == "x" || a.Key == "onmouseover" || a.Key == "y" {
+			t.Fatalf("smuggled attribute %q survived as its own name: %s", a.Key, out)
+		}
+	}
+}
+
+// TestSpreadAttrNameValidNamesStillPass proves the drop in
+// TestSpreadAttrNameSmugglingDropped is name-specific, not a blanket spread
+// failure: a spread map with only valid attribute names renders every one
+// of them.
+func TestSpreadAttrNameValidNamesStillPass(t *testing.T) {
+	prog, err := gosx.Compile([]byte("package main\n\nfunc Page() Node {\n\treturn <div {...extra}>x</div>\n}\n"))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	out, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"extra": map[string]any{
+			"data-testid": "widget",
+			"aria-label":  "Widget",
+			"title":       "A widget",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, want := range []string{`data-testid="widget"`, `aria-label="Widget"`, `title="A widget"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("valid spread attribute %q missing from output: %s", want, out)
+		}
+	}
+}
+
+// TestSpreadAttrNameEmptyAndWhitespaceDropped proves an empty or
+// whitespace-only spread key is dropped rather than emitted as a bare or
+// malformed attribute (gosx#185 n4's rule, shared here by validRenderAttrName).
+func TestSpreadAttrNameEmptyAndWhitespaceDropped(t *testing.T) {
+	prog, err := gosx.Compile([]byte("package main\n\nfunc Page() Node {\n\treturn <div {...extra}>x</div>\n}\n"))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	out, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"extra": map[string]any{
+			"":      "v1",
+			"   ":   "v2",
+			"valid": "v3",
+		}},
+	})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if !strings.Contains(out, `valid="v3"`) {
+		t.Fatalf("valid spread attribute missing from output: %s", out)
+	}
+	if strings.Contains(out, "v1") || strings.Contains(out, "v2") {
+		t.Fatalf("empty or whitespace-only spread key was not dropped: %s", out)
+	}
+}
+
+func findHTMLNode(n *html.Node, tag string) *html.Node {
+	if n.Type == html.ElementNode && n.Data == tag {
+		return n
+	}
+	for c := n.FirstChild; c != nil; c = c.NextSibling {
+		if got := findHTMLNode(c, tag); got != nil {
+			return got
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

This PR resolves two routing bugs: non-deterministic attribute ordering on unresolved component fallbacks (which broke byte-identity goldens and churned HTTP caches/ETags), and unsafe attribute smuggling through {...spread} maps where keys containing spaces or '=' characters were incorrectly split into multiple attributes. Attribute names are now sorted before emission, and all spread call sites validate keys against validRenderAttrName, dropping invalid names inertly to block injection attempts without failing otherwise-valid renders.

## Changes

- Sort attribute names alphabetically in `defaultRenderedComponent` before HTML emission to guarantee byte-identical output across repeated renders, fixing golden mismatches and cache invalidation (#188).
- Validate every `{...spread}` map key in `renderLinkAttrs`, `resolveFileAttrs`, and `renderFileSpreadAttrs` using the shared `validRenderAttrName` helper; invalid keys are silently dropped instead of emitting malformed or dangerous attributes (#189).
- Add `route/attr_determinism_test.go` proving deterministic sorting at the unit level and end-to-end through the public render entry.
- Add `route/corpus_determinism_test.go` compiling and double-rendering every `.gsx` file in the repository to verify byte-identical output across the entire codebase.
- Add `route/spread_attr_name_test.go` verifying that smuggled keys (`x onmouseover=alert(1) y`) are dropped, valid keys still render correctly, and empty/whitespace keys are filtered out.
- Update CHANGELOG.md documenting both fixes and their impact on caches/goldens.

## Testing

- Run `go test ./route/ -run "TestDefaultRenderedComponentSortsAttrs|TestUnresolvedComponentReferenceRenders|TestRepositoryCorpusRenders|TestSpreadAttrName"`
- Verify previously failing golden tests now match by rerunning the full route test suite.
- Inspect rendered HTML from spreads containing spaces or '=' to confirm no extra attributes appear and normal spreads continue to work unchanged.

## Related Issues

- Refs #188
- Refs #189