### PR TITLE
fix(ir): Fail closed on promoted and unexported hop-0 props fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,43 @@
 # Changelog
 
+## Unreleased
+
+### Strict components: props-root hop-0 promoted and unexported fields now fail closed (gosx#195)
+
+- **`resolveStrictSelectorPath` no longer defers a hop-0 unknown field on
+  the props root.** The generated check program compiles in the same
+  package as the `.gsx` file, so Go resolved a promoted or unexported
+  props field there without complaint. The component compiled, checked
+  clean, and rendered differently between the map-backed file renderer
+  and the generated Go. The lowerer now reports the field with the same
+  B1-style message an `<Each>` binding root already used (gosx#182/#184):
+  `struct %s declares no visible field %s; promoted, unexported, and
+  unknown fields cannot cross the file renderer boundary`. Fixes #195.
+- **The old deferral covered two cases; only one still needs it.**
+  `validateStrictRenderedProps` already refuses a component when the
+  props struct's schema is not declared in the same file, before it calls
+  `resolveStrictSelectorPath` for any path. A genuinely absent field still
+  fails at the package checker, as before. A promoted or unexported field
+  on an already-known struct now fails at compile time, instead of
+  passing silently.
+- New tests cover both field shapes, plus an accept case for a legitimate
+  direct field and a mixed read set:
+  - `TestCompileStrictServerRejectsPromotedPropsHopZeroField`
+  - `TestCompileStrictServerRejectsUnexportedPropsHopZeroField`
+  - `TestCompileStrictServerAcceptsDirectScalarPropsHopZeroField`
+  - `TestCompileStrictServerRejectsMixedValidAndPromotedPropsReads`
+  - `TestStrictcheckRejectsPromotedPropsHopZeroField` and
+    `TestStrictcheckRejectsUnexportedPropsHopZeroField`
+    (real-Go-compiler-backed, mirroring
+    `TestStrictcheckRejectsPromotedEachBindingHopZeroField`)
+- **Scope note.** This fix covers a direct props read
+  (`resolveStrictSelectorPath`, including a concat or `<If cond>`
+  operand). `resolveStrictEachSourceType` (an `<Each of>` loop source) and
+  `resolveStrictSpreadForwardType` (an E2 spread source) still defer a
+  hop-0 unknown props field the same old way. They share the same guard
+  and the same latent gap; gosx#195 names only the direct-read case. A
+  follow-up issue should track the other two.
+
 ## v0.43.0 (2026-08-16)
 
 The strict surface grows loops and spreads, and the runtime grows time. Seven

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1359,22 +1359,30 @@ const (
 	strictHopThroughScalar
 	strictHopUndeclaredStruct
 	// strictHopUnknownField is only ever returned for hop 0 (the root's own
-	// field), and its two callers treat it differently:
+	// field). Every caller that reaches walkStrictHops with a fully known
+	// root schema reports it, reusing strictHopUnknownFieldDeep's wording
+	// with its own root substituted — there is no caller left that defers
+	// it to the package checker:
 	//   - An <Each> binding root (validateEachBindingRead): the binding's
 	//     element struct is fully known here, and the projection compiles
 	//     in the SAME package as its declaration, so Go resolves a
 	//     promoted or unexported field there exactly as it resolves a
-	//     declared one — there is no compiler backstop. This caller does
-	//     NOT skip this kind; it reports it, reusing
-	//     strictHopUnknownFieldDeep's wording with the binding root
-	//     substituted (gosx#182/#184).
-	//   - The props root (resolveStrictSelectorPath and its siblings):
-	//     still skips emitting anything for this kind, deferring to the
-	//     package checker. That deferral is sound only for a genuinely
-	//     absent field, which IS a compile error there; for a promoted or
-	//     unexported field it is not — Go resolves those too, same as for
-	//     an Each binding, so this is a known, inherited-from-main gap, not
-	//     a backstop, tracked in gosx#195.
+	//     declared one — there is no compiler backstop. This caller
+	//     reports it, reusing strictHopUnknownFieldDeep's wording with the
+	//     binding root substituted (gosx#182/#184).
+	//   - The props root (resolveStrictSelectorPath): reports it the same
+	//     way (gosx#195). validateStrictRenderedProps already refuses to
+	//     call resolveStrictSelectorPath at all unless the props struct's
+	//     schema is declared same-file (l.structTypes has it) — see its
+	//     own early "struct schema is not declared" gate — so the props
+	//     struct is always as fully known here as an <Each> element
+	//     struct is. Deferring an unknown field to the package checker was
+	//     sound only for a genuinely absent field, which IS a compile
+	//     error there; for a promoted or unexported field it was not — Go
+	//     resolves those too, same package, no backstop. That silent
+	//     deferral was gosx#195's bug: a promoted or unexported hop-0
+	//     props read compiled, checked clean, and rendered differently on
+	//     the map-backed file renderer and the generated Go.
 	strictHopUnknownField
 	// strictHopUnknownFieldDeep is gosx#183's B1 fix, generalized: an
 	// unknown field at hop i>0 gets no compiler backstop. Field promotion
@@ -1413,12 +1421,14 @@ type strictHopResult struct {
 // Each item binding read resolves with rootLabel the binding's name and
 // rootType its element struct — both are just a (rootLabel, rootType) pair
 // to this function, and it applies the identical pointer-ban,
-// scalar-cannot-be-selected-through, undeclared-struct, depth-cap, and
-// (gosx#183's B1 fix) hop-0-vs-later unknown-field rules to either root: an
-// unknown field at hop 0 is the root's own field, deferred to the package
-// checker; an unknown field at any later hop — promoted, unexported, or
-// genuinely absent — fails closed here, since no compiler backstop catches
-// it for either root shape (see strictHopUnknownFieldDeep).
+// scalar-cannot-be-selected-through, undeclared-struct, and depth-cap rules
+// to either root. Unknown-field handling splits by hop, not by root: an
+// unknown field at hop 0 is the root's own field (strictHopUnknownField —
+// see its doc comment for which callers report it and which still defer);
+// an unknown field at any later hop — promoted, unexported, or genuinely
+// absent — always fails closed here (gosx#183's B1 fix), since no compiler
+// backstop catches it for either root shape past hop 0 (see
+// strictHopUnknownFieldDeep).
 func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) strictHopResult {
 	if len(path) > strictSelectorPathDepthLimit {
 		return strictHopResult{pathText: rootLabel + "." + strings.Join(path, "."), failKind: strictHopTooDeep}
@@ -1431,10 +1441,9 @@ func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) stri
 			if i == 0 {
 				// The root's own field. failField/failType are populated
 				// the same way as the i>0 branch below so a caller that
-				// upgrades this kind to an error (an <Each> binding root —
-				// see strictHopUnknownField's doc comment) can format the
-				// identical message; a caller that defers instead (the
-				// props root) ignores both.
+				// reports this kind (an <Each> binding root, or, as of
+				// gosx#195, the props root — see strictHopUnknownField's
+				// doc comment) can format the identical message.
 				return strictHopResult{pathText: pathText, failKind: strictHopUnknownField, failField: field, failType: currentType}
 			}
 			// gosx#183's B1 fix, generalized to any root: a promoted,
@@ -1468,11 +1477,11 @@ func (l *lowerer) walkStrictHops(rootLabel, rootType string, path []string) stri
 // message text identical regardless of which selector position (a props
 // read, a loop-source read, an Each binding read) triggered it — the
 // failure is about the schema shape, not what the path is used for.
-// strictHopUnknownField (hop 0) is included here only for a caller that
-// has decided to upgrade it to an error (an <Each> binding root — see its
-// doc comment); a caller that instead defers hop 0 (the props root) keeps
-// its own early "case strictHopUnknownField: return" and never reaches
-// this function for that kind.
+// strictHopUnknownField (hop 0) reaches this function through every caller
+// that reports it instead of deferring — an <Each> binding root
+// (validateEachBindingRead, gosx#182/#184) and the props root
+// (resolveStrictSelectorPath, gosx#195) — see strictHopUnknownField's own
+// doc comment for the full list.
 //
 // strictHopUnknownFieldDeep and (when a caller reports it)
 // strictHopUnknownField both reuse gosx#183's B1 wording verbatim,
@@ -1504,33 +1513,35 @@ func strictHopMessage(componentName string, res strictHopResult) string {
 // selector semantics in the map-backed file renderer: too deep, a pointer
 // intermediate, an intermediate whose type is a renderer scalar (nothing to
 // select further through), an intermediate struct type this .gsx file does
-// not declare, an unknown field past the root, or a non-scalar leaf. The
-// props base type itself is assumed already declared in this file —
-// validateStrictRenderedProps checks that gate before calling this for any
-// path.
+// not declare, an unknown field at the root or past it, or a non-scalar
+// leaf. The props base type itself is assumed already declared in this
+// file — validateStrictRenderedProps checks that gate before calling this
+// for any path, and refuses the component entirely (its own "struct schema
+// is not declared in this .gsx file" diagnostic) when it is not, so this
+// function is never reached with an unknown props schema.
 //
-// An unknown field at hop 0 (a direct field of the props struct itself) is
-// left to the package checker. That deferral is a real backstop only for a
-// genuinely absent field — the check program's real props parameter is
-// exactly this same-file struct type, so a field this .gsx file never
-// declares anywhere is a compile error there regardless of what this
-// lowerer does. It is NOT a backstop for a promoted or unexported field:
-// the check program compiles those exactly as it compiles a directly
-// declared field, so this lowerer's silence here is a known, inherited
-// gap (tracked in gosx#195), not a guarantee. An unknown field at any
-// later hop gets no such backstop, for any field shape:
-// field promotion through an embedded type is legal Go, so the check
-// program compiles a promoted, unexported, or genuinely absent field the
-// same way — silently deferring here would let the component compile while
-// the map-backed file renderer and generated Go disagree on what the
-// selector resolves to (or panic trying). This function fails closed for
-// all three shapes at hop i>0, exactly mirroring the lowerer rule
-// strictSelectorPathType applies for its own, diagnostic-free callers.
+// An unknown field at hop 0 (a direct field of the props struct itself)
+// used to be left to the package checker (gosx#195). That deferral was a
+// real backstop only for a genuinely absent field — the check program's
+// real props parameter is exactly this same-file struct type, so a field
+// this .gsx file never declares anywhere is a compile error there
+// regardless of what this lowerer does. It was NOT a backstop for a
+// promoted or unexported field: the check program compiles those exactly
+// as it compiles a directly declared field, same package, so the
+// lowerer's silence let a promoted or unexported hop-0 props read compile,
+// check clean, and render differently between the map-backed file
+// renderer (whose schema never recorded the field) and the generated Go
+// (which resolved it fine). Since the props struct's schema is always
+// known here (see above), this now reports hop 0 the same way it always
+// reported every later hop, and the same way an <Each> binding root
+// reports its own hop 0 (validateEachBindingRead, gosx#182/#184): a
+// promoted, unexported, or genuinely absent field at any hop, including
+// the root's own, fails closed with strictHopMessage's B1-style wording.
+// This mirrors the lowerer rule strictSelectorPathType applies for its
+// own, diagnostic-free callers.
 func (l *lowerer) resolveStrictSelectorPath(n *gotreesitter.Node, componentName, propsType string, path []string) {
 	res := l.walkStrictHops("props", propsBaseType(propsType), path)
 	switch res.failKind {
-	case strictHopUnknownField:
-		return
 	case strictHopOK:
 		if !strictRendererScalarType(res.leafType) {
 			if l.isStrictEachLoopableSliceType(res.leafType) {
@@ -1660,18 +1671,18 @@ func (l *lowerer) resolveStrictSpreadForwardType(n *gotreesitter.Node, component
 
 // strictSelectorPathType is resolveStrictSelectorPath's silent counterpart:
 // it resolves path the same way but reports no diagnostic, returning
-// ok=false for any structural problem (too deep, an unknown field at hop 0
-// or later, a pointer or otherwise non-struct intermediate, an undeclared
+// ok=false for any structural problem (an unknown field at hop 0 or later,
+// too deep, a pointer or otherwise non-struct intermediate, an undeclared
 // intermediate struct) and also for a leaf that is not a renderer scalar at
-// all. It applies the same hop-0-vs-later distinction resolveStrictSelectorPath
-// documents for an unknown field, just without ever emitting a diagnostic
-// itself: validateStrictRenderedProps already reports each registered
-// read's own root cause once (an hop-0 unknown field by deferring to the
-// package checker, an hop-i>0 unknown field — promoted, unexported, or
-// absent — as its own error); a second caller (the concat exact-string
-// pass, the <If cond> exact-bool pass) restating either for the same path
-// would just duplicate that diagnostic, so those callers use this and skip
-// emitting anything when ok is false.
+// all. It treats an unknown field at hop 0 the same as at any later hop —
+// as of gosx#195, so does resolveStrictSelectorPath itself, so there is no
+// remaining hop-0-vs-later distinction for this caller to mirror — just
+// without ever emitting a diagnostic itself: validateStrictRenderedProps
+// already reports each registered read's own root cause once, whichever
+// hop it fails at; a second caller (the concat exact-string pass, the <If
+// cond> exact-bool pass) restating it for the same path would just
+// duplicate that diagnostic, so those callers use this and skip emitting
+// anything when ok is false.
 func (l *lowerer) strictSelectorPathType(propsType string, path []string) (string, bool) {
 	return l.resolveRootedFieldType(propsBaseType(propsType), path, true)
 }

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1679,6 +1679,86 @@ component C(props: RowProps) {
 	}
 }
 
+// TestCompileStrictServerRejectsPromotedPropsHopZeroField and
+// TestCompileStrictServerRejectsUnexportedPropsHopZeroField cover gosx#195:
+// a HOP-0 read on the PROPS root itself (a direct field of the props
+// struct, not a nested one) used to return the silent strictHopUnknownField
+// kind, deferring to the package checker. That deferral was false here too
+// — the generated check program compiles in the SAME package as the .gsx
+// file's declarations, so Go resolves a promoted or unexported props field
+// exactly as it resolves a declared one. Before the fix this compiled
+// clean, strictcheck accepted it, the boundary schema omitted the field,
+// and the file renderer and the transpiled Go diverged on props.Label
+// silently — the props-root mirror of gosx#182/#184's M-2 finding for an
+// <Each> binding root. Both must now fail closed at compile time with the
+// same B1-style message TestCompileStrictEachRejectsPromotedBindingHopZeroField
+// and TestCompileStrictEachRejectsUnexportedBindingHopZeroField prove for a
+// binding root.
+func TestCompileStrictServerRejectsPromotedPropsHopZeroField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Base struct { Label string }
+type Props struct { Base; Points string }
+component C(props: Props) {
+	return <section><span>{props.Label}</span></section>
+}
+`))
+	want := "strict component C cannot resolve props.Label: struct Props declares no visible field Label; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestCompileStrictServerRejectsUnexportedPropsHopZeroField(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Props struct { label string; Points string }
+component C(props: Props) {
+	return <section><span>{props.label}</span></section>
+}
+`))
+	want := "strict component C cannot resolve props.label: struct Props declares no visible field label; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+// TestCompileStrictServerAcceptsDirectScalarPropsHopZeroField is the accept
+// half of gosx#195's fix: Points is declared directly on Props (not
+// promoted through Base, not unexported), so a hop-0 read of it must keep
+// compiling clean — the fix rejects only a promoted or unexported hop-0
+// field, never a legitimately declared one.
+func TestCompileStrictServerAcceptsDirectScalarPropsHopZeroField(t *testing.T) {
+	source := []byte(`package app
+type Base struct { Label string }
+type Props struct { Base; Points string }
+component C(props: Props) {
+	return <section><span>{props.Points}</span></section>
+}
+`)
+	if _, err := Compile(source); err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+}
+
+// TestCompileStrictServerRejectsMixedValidAndPromotedPropsReads closes the
+// loop gosx#195's review probe opened: a read set that mixes one
+// legitimate direct scalar field with one promoted hop-0 field must still
+// fail closed on the promoted field, proving the fix fires per-path across
+// a component's whole read set, not only when the promoted field is the
+// sole read.
+func TestCompileStrictServerRejectsMixedValidAndPromotedPropsReads(t *testing.T) {
+	_, err := Compile([]byte(`package app
+type Base struct { Label string }
+type Props struct { Base; Points string }
+component C(props: Props) {
+	return <section><span>{props.Points}</span><b>{props.Label}</b></section>
+}
+`))
+	want := "strict component C cannot resolve props.Label: struct Props declares no visible field Label; promoted, unexported, and unknown fields cannot cross the file renderer boundary"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
 func TestCompileStrictEachBindingConcatAndCondBothPolarities(t *testing.T) {
 	// Accept: exact string/bool leaves.
 	_, err := Compile([]byte(breakdownRowFixturePrelude + `component Row(props: RowProps) {

--- a/strict_each_spread_integration_test.go
+++ b/strict_each_spread_integration_test.go
@@ -293,3 +293,86 @@ component C(props: RowProps) {
 		t.Fatalf("error = %v, want to contain %q", err, want)
 	}
 }
+
+// TestStrictcheckRejectsPromotedPropsHopZeroField and
+// TestStrictcheckRejectsUnexportedPropsHopZeroField are gosx#195's
+// real-Go-compiler-backed proof, mirroring
+// TestStrictcheckRejectsPromotedEachBindingHopZeroField for the PROPS root
+// instead of an <Each> binding root: before the fix, the projected check
+// program compiled clean here too — the promoted or unexported field
+// resolves fine in real Go, same package — which is exactly why the old
+// "the package checker backstops it" reasoning was false for this root as
+// well. strictcheck must reject both at the strict-syntax stage (the same
+// diagnostic gosx.Compile produces), never reach the Go compiler at all.
+func TestStrictcheckRejectsPromotedPropsHopZeroField(t *testing.T) {
+	source := `package app
+type Base struct { Label string }
+type Props struct { Base; Points string }
+component C(props: Props) {
+	return <section><span>{props.Label}</span></section>
+}
+`
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module example.test/promotedpropshopzero\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSum, err := os.ReadFile("go.sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "promotedpropshopzero.gsx")
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"})
+	if err == nil {
+		t.Fatal("strictcheck unexpectedly accepted a promoted field read at the props root's hop 0")
+	}
+	if want := "declares no visible field Label"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}
+
+func TestStrictcheckRejectsUnexportedPropsHopZeroField(t *testing.T) {
+	source := `package app
+type Props struct { label string; Points string }
+component C(props: Props) {
+	return <section><span>{props.label}</span></section>
+}
+`
+	root, err := filepath.Abs(".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	goMod := "module example.test/unexportedpropshopzero\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => " + filepath.ToSlash(root) + "\n"
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte(goMod), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	goSum, err := os.ReadFile("go.sum")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), goSum, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "unexportedpropshopzero.gsx")
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	err = strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{GOFLAGS: "-mod=mod"})
+	if err == nil {
+		t.Fatal("strictcheck unexpectedly accepted an unexported field read at the props root's hop 0")
+	}
+	if want := "declares no visible field label"; !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
+	}
+}


### PR DESCRIPTION
## Summary

Strict components previously compiled clean but rendered differently when accessing promoted or unexported fields on the props root. The IR lowerer incorrectly deferred these hop-0 checks to the package checker, which couldn't catch them since the check program runs in the same package. This updates `ir/lower.go` to fail closed at compile time for all three shapes (promoted, unexported, unknown), matching the existing behavior for `<Each>` binding roots and nested paths.

## Changes

- `walkStrictHops` and `resolveStrictSelectorPath` now fail closed on hop-0 props fields.** Previously, an unknown/promoted/unexported direct read of a props struct field silently deferred to the package checker. Since the generated check program compiles in the same package, Go resolves these fields exactly like declared ones, causing silent mismatches between the map-backed file renderer and generated Go. The lowerer now reports these as compile-time errors using the B1-style message previously reserved for `<Each>` binding roots.
- Updated internal documentation.** Rewrote doc comments in `ir/lower.go` to reflect that the props root no longer defers hop-0 unknown fields, and clarified that `strictHopUnknownField` is consistently reported across all callers.
- Added compile-time acceptance/rejection tests.** Added four new tests in `strict_component_test.go` covering promoted props, unexported props, legitimate direct scalars, and mixed read sets to ensure correct per-path evaluation.
- Added `strictcheck` integration tests.** Added two real-Go-compiler-backed tests in `strict_each_spread_integration_test.go` verifying that the validation pipeline rejects these invalid reads before compilation.

## Testing

- Run `go test -run TestCompileStrictServerRejectsPromotedPropsHopZeroField -v` to verify the new compile-time rejection logic.
- Run `go test -run TestStrictcheckRejectsPromotedPropsHopZeroField -v` to verify the full `strictcheck` pipeline rejects the case.
- Write a strict `.gsx` component reading a promoted props field and confirm it fails compilation with `declares no visible field ... promoted, unexported, and unknown fields cannot cross the file renderer boundary` instead of rendering silently.

## Related Issues

- Refs #195