### PR TITLE
add(image): add <Image> JSX builtin with check-time contract and picture output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,88 @@
 
 ## Unreleased
 
+### `<Image>`: a check-time contract and `<picture>` output (gosx#201)
+
+- **`strictcheck` gains a check-time `<Image>` contract, on top of the
+  #199/#200 pipeline.** `validateImageContract` runs beside
+  `validateStrictRenderEntries` in `runBuiltinChecks`, before the
+  `packageHasStrict` early return — the same placement, for the same
+  reason: the real consumer surface (gridiron-2000) compiles as legacy
+  syntax, so a check placed after that return would never run for it.
+  Four rules, each independently testable:
+  - Missing or empty `alt` errors.
+  - A local (root-relative) static `src` naming no readable image file
+    under `public/` errors. The check reads the file with
+    `imagepipe.Probe` (SVG is checked for existence only, since gosx never
+    optimizes SVG), the same way the renderer will at request time.
+  - An external (`http`/`https`, or protocol-relative `//`) or dynamic
+    (non-literal, or unresolvable through a spread) `src` missing an
+    explicit `width` or `height` errors. A local `src` needs neither: the
+    renderer injects intrinsic (or ladder-derived) dimensions
+    automatically — the one step next/image still asks an author to
+    perform, deleted for a local, build-time-known source.
+  - A `format` value outside the producible set errors, reusing
+    `server.ValidateProducibleImageFormat`'s exact allowlist and message
+    (newly exported for this purpose) so check-time and render-time can
+    never disagree.
+  - A node carrying a spread attribute (`{...props}`) is exempt from the
+    alt and dimension requirements by name: the spread might supply
+    either in a way this check cannot see (the real, already-tested
+    `route/filesystem_test.go` fixture pattern this exception exists to
+    keep passing).
+- **`route`'s file-router `<Image>` builtin now emits a manifest-backed
+  `<picture>` when gosx build has generated variants for its `src`.** A
+  new `route/image_picture.go` reads `buildmanifest.Manifest.Images`
+  through a new `server.LookupImageManifestAsset` (a process-global lookup
+  an `App` registers on `Build()`, mirroring the existing "local"
+  `ImageResolver` registry's convention) and, when variants exist, emits a
+  WebP `<source>` with `srcset`+`sizes` and an `<img>` fallback in the
+  source's own format with its own `srcset`, injected width/height
+  (intrinsic by default; an explicit `width` or `height` derives the
+  other proportionally; both explicit wins verbatim), `loading="lazy"
+  decoding="async"`, and priority flipping to `eager`+`fetchpriority="high"`
+  per #199's existing semantics. A WebP-native source (no redundant
+  same-format fallback ever exists for one) renders a plain `<img>`, no
+  `<picture>` wrapper. **This is new behavior for the `<Image>` JSX tag
+  only** — `server.Image`, the Go helper a `page.server.go` file calls
+  directly, keeps its existing single-`<img>` contract unchanged.
+  - **Fails open, never blocks a render.** No manifest registered (dev
+    mode with no prior `gosx build`), no entry for this `src`, or an
+    explicit `Format`/`Quality` prop naming an encode parameter a
+    pre-built variant cannot honor — every one of these falls straight
+    through, unmodified, to the existing #199-fixed `server.Image` path
+    (the runtime optimizer URL, or plain passthrough). A page under
+    active development always renders.
+- **`<Image>` is rejected inside island components, not silently
+  downgraded to a plain `<img>`.** `ir/island.go`'s `islandElementAlias`
+  no longer maps `"Image"` to `"img"`; `LowerIsland` now returns a
+  dedicated error, and `ir.Validate`'s
+  `unsupportedIslandComponentDiagnostic` reports the same message as a
+  `Diagnostic` — reachable from `gosx.Compile` itself (see `compile.go`),
+  so the rejection surfaces at check time, before `strictcheck` or any
+  other stage even sees the program. One tag name must not mean two
+  contracts: an island re-renders client-side from its own program and
+  cannot rebuild `<Image>`'s manifest-driven `<picture>` markup without
+  shipping the whole manifest to the client — out of scope this release.
+  The message points at the escape hatch: a plain `<img>` inside the
+  island, with `width` and `height` set explicitly.
+- **Docs.** The images docs page
+  (`examples/gosx-docs/app/docs/images/`) gains a `<Image>` builtin
+  section stating the local/external rule plainly: external images are
+  never proxied or resized this release, and require explicit `width` and
+  `height`. The page's own responsive example previously omitted
+  `Height`, leaving the emitted `<img>` with no `height` attribute at
+  all — a layout-shift-prone example this fix corrects, in both the code
+  sample and the live rendered image.
+- New tests: `strictcheck/image_test.go` (accept/reject tables covering
+  every rule and exact message, plus an island-nested `<Image>`
+  end-to-end through `CheckFile`), `route/image_picture_test.go`
+  (`<picture>` markup shape, the no-manifest and explicit-format/quality
+  fallbacks, priority semantics, external `src`, extra-attribute
+  placement), and `ir/island_test.go` /
+  `TestValidateIslandRejectsImage` (the island rejection, at both the
+  `ir.Validate` and `LowerIsland` layers).
+
 ### Strict components: `<Each of>` and tier-1 spread-forward hop-0 fields now fail closed (gosx#206)
 
 - **`resolveStrictEachSourceType` no longer defers a hop-0 unknown field

--- a/examples/gosx-docs/app/docs/images/page.gsx
+++ b/examples/gosx-docs/app/docs/images/page.gsx
@@ -32,6 +32,74 @@ func Page() Node {
 				. The source is a checked-in PNG rendered by the GoSX native scene harness.
 			</p>
 		</div>
+		<h2 id="builtin">The &lt;Image&gt; builtin</h2>
+		<p>
+			<span class="inline-code">&lt;Image&gt;</span>
+			is the JSX tag form of the same helper, checked at build time instead of only at render time. Every
+			<span class="inline-code">&lt;Image&gt;</span>
+			requires a non-empty
+			<span class="inline-code">alt</span>
+			.
+		</p>
+		<CodeBlock lang="gsx" source={data.builtinLocalSample} />
+		<p>
+			A local source (a root-relative path such as
+			<span class="inline-code">/photos/harbor.jpg</span>
+			) needs no
+			<span class="inline-code">width</span>
+			or
+			<span class="inline-code">height</span>
+			:
+			<span class="inline-code">gosx check</span>
+			reads the file under
+			<span class="inline-code">public/</span>
+			and the renderer injects its intrinsic dimensions automatically. A local source naming no file under
+			<span class="inline-code">public/</span>
+			fails
+			<span class="inline-code">gosx check</span>
+			.
+		</p>
+		<CodeBlock lang="gsx" source={data.builtinExternalSample} />
+		<p>
+			An external source (an
+			<span class="inline-code">http://</span>
+			or
+			<span class="inline-code">https://</span>
+			URL) is never proxied or resized this release — it renders exactly as given. Because its dimensions cannot be probed at build time, an external (or otherwise dynamic) source requires an explicit
+			<span class="inline-code">width</span>
+			and
+			<span class="inline-code">height</span>
+			; omitting either fails
+			<span class="inline-code">gosx check</span>
+			too.
+		</p>
+		<p>
+			When
+			<span class="inline-code">gosx build</span>
+			has generated responsive variants for a local source (see
+			<a href="#formats">Formats &amp; Sizing</a>
+			), the rendered
+			<span class="inline-code">&lt;Image&gt;</span>
+			becomes a
+			<span class="inline-code">&lt;picture&gt;</span>
+			element: a WebP
+			<span class="inline-code">&lt;source&gt;</span>
+			plus an
+			<span class="inline-code">&lt;img&gt;</span>
+			fallback in the source's own format, both with a real srcset. Without a prior build — for example during
+			<span class="inline-code">gosx dev</span>
+			— it falls back to the request-time optimizer described above, so a page under active development always renders.
+		</p>
+		<p>
+			<span class="inline-code">&lt;Image&gt;</span>
+			is not supported inside an island component: an island re-renders on the client from its own program and cannot rebuild this server-rendered markup. Use a plain
+			<span class="inline-code">&lt;img&gt;</span>
+			element inside an island instead, with
+			<span class="inline-code">width</span>
+			and
+			<span class="inline-code">height</span>
+			set explicitly.
+		</p>
 		<h2 id="responsive">Responsive images</h2>
 		<CodeBlock lang="go" source={data.responsiveSample} />
 		<p>

--- a/examples/gosx-docs/app/docs/images/page.server.go
+++ b/examples/gosx-docs/app/docs/images/page.server.go
@@ -16,18 +16,27 @@ func init() {
 				"tags":        []string{"images", "resize", "responsive", "cache"},
 				"toc": []map[string]string{
 					{"href": "#helper", "label": "Image Helper"},
+					{"href": "#builtin", "label": "<Image> Builtin"},
 					{"href": "#responsive", "label": "Responsive Images"},
 					{"href": "#formats", "label": "Formats & Sizing"},
 					{"href": "#serving", "label": "Serving"},
 					{"href": "#caching", "label": "Caching"},
 				},
-				"imageSample":      "node := server.Image(server.ImageProps{\n\tSrc:      \"/photos/harbor.jpg\",\n\tAlt:      \"Harbor at dusk\",\n\tWidth:    1200,\n\tHeight:   800,\n\tQuality:  82,\n\tPriority: true,\n})",
-				"responsiveSample": "node := server.Image(server.ImageProps{\n\tSrc:        \"/photos/harbor.jpg\",\n\tAlt:        \"Harbor at dusk\",\n\tResponsive: true,\n\tWidth:      1200,\n\tWidths:     []int{320, 640, 960, 1200},\n\tSizes:      \"(max-width: 720px) 100vw, 720px\",\n})",
-				"urlSample":        "url := server.ImageURL(\"/photos/harbor.jpg\", server.ImageTransform{\n\tWidth:   640,\n\tQuality: 78,\n\tFormat:  \"jpeg\",\n})",
+				"imageSample": "node := server.Image(server.ImageProps{\n\tSrc:      \"/photos/harbor.jpg\",\n\tAlt:      \"Harbor at dusk\",\n\tWidth:    1200,\n\tHeight:   800,\n\tQuality:  82,\n\tPriority: true,\n})",
+				// Width and Height are both set, at the source's own 8:5
+				// aspect ratio (960x600) -- an example that omits Height
+				// leaves the emitted <img> with no height attribute at
+				// all, which reserves no layout box before the image
+				// loads (layout-shift-prone; flagged in review).
+				"responsiveSample":      "node := server.Image(server.ImageProps{\n\tSrc:        \"/photos/harbor.jpg\",\n\tAlt:        \"Harbor at dusk\",\n\tResponsive: true,\n\tWidth:      1200,\n\tHeight:     750,\n\tWidths:     []int{320, 640, 960, 1200},\n\tSizes:      \"(max-width: 720px) 100vw, 720px\",\n})",
+				"urlSample":             "url := server.ImageURL(\"/photos/harbor.jpg\", server.ImageTransform{\n\tWidth:   640,\n\tQuality: 78,\n\tFormat:  \"jpeg\",\n})",
+				"builtinLocalSample":    `<Image src="/photos/harbor.jpg" alt="Harbor at dusk" />`,
+				"builtinExternalSample": `<Image src="https://cdn.example.com/harbor.jpg" alt="Harbor at dusk" width={1200} height={800} />`,
 				"liveImage": server.Image(server.ImageProps{
 					Src:        "/checkers-native-preview.png",
 					Alt:        "Native GoSX Chinese Checkers renderer preview",
 					Width:      960,
+					Height:     600,
 					Responsive: true,
 					Widths:     []int{320, 640, 960},
 					Sizes:      "(max-width: 720px) 100vw, 720px",

--- a/ir/island.go
+++ b/ir/island.go
@@ -334,6 +334,9 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 			}
 			break
 		}
+		if srcNode.Tag == "Image" {
+			return 0, unsupportedIslandComponentImageError()
+		}
 		if tag, ok := islandElementAlias(srcNode.Tag); ok {
 			node.Kind = program.NodeElement
 			node.Tag = tag
@@ -600,15 +603,31 @@ func isConditionalComponent(tag string) bool {
 	}
 }
 
+// islandElementAlias no longer maps "Image" to "img" (gosx#201): see
+// unsupportedIslandComponentImageError below, and
+// unsupportedIslandComponentDiagnostic in ir/validate.go, for why <Image>
+// is rejected inside an island instead of silently downgraded to a plain
+// <img>.
 func islandElementAlias(tag string) (string, bool) {
 	switch tag {
 	case "Link":
 		return "a", true
-	case "Image":
-		return "img", true
 	default:
 		return "", false
 	}
+}
+
+// unsupportedIslandComponentImageError carries the same message text
+// unsupportedIslandComponentDiagnostic (ir/validate.go) uses for the same
+// rejection, formatted as a plain error instead of a Diagnostic: ir.Validate
+// gates every gosx.Compile call (see compile.go), so a program reaching
+// lowerNode below has almost always already failed there first. This
+// message exists for the paths that call LowerIsland directly against a
+// program Validate never ran over -- for example
+// route/fileprogram.go's dev-mode islandProgram lookup -- so <Image> still
+// fails closed even then, not just at compile time.
+func unsupportedIslandComponentImageError() error {
+	return fmt.Errorf("<Image> is not supported inside island components: an island cannot rebuild <Image>'s server-rendered <picture> markup on the client; use a plain <img> element inside the island instead, and set width and height explicitly to avoid layout shift")
 }
 
 func eachAttrSource(attrs []Attr, names ...string) string {

--- a/ir/island_test.go
+++ b/ir/island_test.go
@@ -335,6 +335,45 @@ func TestValidateIslandUnsupportedComponentRefRejected(t *testing.T) {
 	}
 }
 
+// TestValidateIslandRejectsImage covers gosx#201's check-time rule: an
+// <Image> reference inside an island component fails ir.Validate with a
+// dedicated message naming the plain <img> escape hatch, not the generic
+// "not supported inside island components yet" text
+// TestValidateIslandUnsupportedComponentRefRejected exercises for other
+// tags. ir.Validate runs inside gosx.Compile (see compile.go), so this is
+// the check-time surface that gates every real .gsx compile, including
+// strictcheck's own (transpile.LoadPackage -> gosx.Compile) and the
+// file-router's per-request dev-mode compile (route/filelayout.go).
+func TestValidateIslandRejectsImage(t *testing.T) {
+	prog := &Program{}
+	prog.Nodes = append(prog.Nodes, Node{
+		Kind: NodeComponent,
+		Tag:  "Image",
+		Attrs: []Attr{
+			{Kind: AttrStatic, Name: "src", Value: "/hero.png"},
+			{Kind: AttrStatic, Name: "alt", Value: "Hero"},
+		},
+	})
+	prog.Components = append(prog.Components, Component{Name: "Bad", Root: 0, IsIsland: true})
+
+	diags := Validate(prog)
+	found := false
+	for _, d := range diags {
+		if strings.Contains(d.Message, "<Image> is not supported inside island components") {
+			found = true
+			if !strings.Contains(d.Hint, "plain <img>") {
+				t.Fatalf("expected the plain <img> escape hatch named in the hint, got %q", d.Hint)
+			}
+		}
+		if strings.Contains(d.Message, "not supported inside island components yet") {
+			t.Fatalf("expected the dedicated <Image> message, not the generic one, got %q", d.Message)
+		}
+	}
+	if !found {
+		t.Fatal("expected a diagnostic rejecting <Image> inside an island component")
+	}
+}
+
 func TestValidateIslandAcceptsSignalAliasExprsFromComponentScope(t *testing.T) {
 	prog := &Program{}
 	prog.Nodes = append(prog.Nodes, Node{
@@ -466,16 +505,7 @@ func TestLowerIslandElementAliasComponents(t *testing.T) {
 			Children: []NodeID{1},
 		},
 		Node{Kind: NodeText, Text: "Docs"},
-		Node{
-			Kind: NodeComponent,
-			Tag:  "Image",
-			Attrs: []Attr{
-				{Kind: AttrStatic, Name: "src", Value: "/hero.png"},
-				{Kind: AttrStatic, Name: "alt", Value: "Hero"},
-			},
-		},
 	)
-	prog.Nodes[0].Children = append(prog.Nodes[0].Children, 2)
 	prog.Components = append(prog.Components, Component{Name: "Aliases", Root: 0, IsIsland: true})
 
 	island, err := LowerIsland(prog, 0)
@@ -486,9 +516,68 @@ func TestLowerIslandElementAliasComponents(t *testing.T) {
 	if root.Kind != program.NodeElement || root.Tag != "a" {
 		t.Fatalf("expected Link to lower to <a>, got kind=%s tag=%q", root.Kind, root.Tag)
 	}
-	image := island.Nodes[root.Children[1]]
-	if image.Kind != program.NodeElement || image.Tag != "img" {
-		t.Fatalf("expected Image to lower to <img>, got kind=%s tag=%q", image.Kind, image.Tag)
+}
+
+// TestLowerIslandRejectsImage covers gosx#201: <Image> inside an island
+// component is rejected outright, not silently downgraded to a plain <img>
+// the way islandElementAlias used to lower it (see
+// TestLowerIslandElementAliasComponents above, which no longer includes an
+// <Image> case). An island re-renders client-side from its own program and
+// cannot rebuild the manifest-driven <picture> markup <Image> emits on the
+// server, so one tag name must not mean two contracts.
+func TestLowerIslandRejectsImage(t *testing.T) {
+	prog := &Program{}
+	prog.Nodes = append(prog.Nodes,
+		Node{
+			Kind: NodeComponent,
+			Tag:  "Image",
+			Attrs: []Attr{
+				{Kind: AttrStatic, Name: "src", Value: "/hero.png"},
+				{Kind: AttrStatic, Name: "alt", Value: "Hero"},
+			},
+		},
+	)
+	prog.Components = append(prog.Components, Component{Name: "HasImage", Root: 0, IsIsland: true})
+
+	_, err := LowerIsland(prog, 0)
+	if err == nil {
+		t.Fatal("expected LowerIsland to reject <Image> inside an island component")
+	}
+	for _, snippet := range []string{"<Image>", "not supported inside island components", "plain <img>"} {
+		if !strings.Contains(err.Error(), snippet) {
+			t.Fatalf("expected %q in error, got %v", snippet, err)
+		}
+	}
+}
+
+// TestLowerIslandRejectsImageNestedInsideAnotherElement proves the
+// rejection fires for an <Image> anywhere in the island's node tree, not
+// only when it is the root node.
+func TestLowerIslandRejectsImageNestedInsideAnotherElement(t *testing.T) {
+	prog := &Program{}
+	prog.Nodes = append(prog.Nodes,
+		Node{
+			Kind:     NodeElement,
+			Tag:      "div",
+			Children: []NodeID{1},
+		},
+		Node{
+			Kind: NodeComponent,
+			Tag:  "Image",
+			Attrs: []Attr{
+				{Kind: AttrStatic, Name: "src", Value: "/hero.png"},
+				{Kind: AttrStatic, Name: "alt", Value: "Hero"},
+			},
+		},
+	)
+	prog.Components = append(prog.Components, Component{Name: "WrapsImage", Root: 0, IsIsland: true})
+
+	_, err := LowerIsland(prog, 0)
+	if err == nil {
+		t.Fatal("expected LowerIsland to reject a nested <Image> inside an island component")
+	}
+	if !strings.Contains(err.Error(), "<Image>") {
+		t.Fatalf("expected <Image> named in the error, got %v", err)
 	}
 }
 

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -474,7 +474,26 @@ func validateIslandNode(node *Node, scope *ExprScope) []Diagnostic {
 }
 
 func unsupportedIslandComponentDiagnostic(node *Node) (Diagnostic, bool) {
-	if node == nil || node.Kind != NodeComponent || !isUnsupportedIslandComponentRef(node.Tag) {
+	if node == nil || node.Kind != NodeComponent {
+		return Diagnostic{}, false
+	}
+	// <Image> gets its own message rather than falling through to the
+	// generic one below (gosx#201): an island re-renders client-side from
+	// its own program, which cannot rebuild the manifest-driven <picture>
+	// markup <Image> emits on the server (route/fileprogram.go) without
+	// shipping the whole buildmanifest.Manifest.Images bucket to the
+	// client -- out of scope for this release. One tag name must not mean
+	// two contracts, so <Image> is rejected inside an island outright, not
+	// silently downgraded to a plain <img> the way it used to be lowered
+	// (see islandElementAlias in ir/island.go, which no longer aliases it).
+	if node.Tag == "Image" {
+		return Diagnostic{
+			Span:    node.Span,
+			Message: "<Image> is not supported inside island components",
+			Hint:    "an island cannot rebuild <Image>'s server-rendered <picture> markup on the client; use a plain <img> element inside the island instead, and set width and height explicitly to avoid layout shift",
+		}, true
+	}
+	if !isUnsupportedIslandComponentRef(node.Tag) {
 		return Diagnostic{}, false
 	}
 	return Diagnostic{

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -566,6 +566,20 @@ func (r *fileProgramRenderer) writeManagedForm(b *strings.Builder, node *ir.Node
 	b.WriteString("</form>")
 }
 
+// renderImage renders the <Image> builtin tag. It emits a manifest-backed
+// <picture> (gosx#201) when gosx build's imagepipe stage (gosx#200)
+// recorded build-time variants for this src; otherwise it falls straight
+// through, unchanged, to the #199-fixed server.Image path — the runtime
+// optimizer URL, or a plain passthrough <img> for a source server.Image
+// does not optimize. Dev mode (no prior `gosx build`) always takes the
+// fallback: there is no manifest to read yet, so nothing here ever blocks
+// or changes dev-mode rendering.
+//
+// The format allowlist check runs once, here, before either path, so a bad
+// Format value panics identically regardless of which one a given src
+// would otherwise take (buildManifestImagePicture also declines a src that
+// names an explicit Format, but that decision must never depend on whether
+// the value was valid first).
 func (r *fileProgramRenderer) renderImage(node *ir.Node, env fileRenderEnv) string {
 	props := server.ImageProps{
 		Src:           stringValue(attrValue(node.Attrs, env, "src")),
@@ -582,11 +596,18 @@ func (r *fileProgramRenderer) renderImage(node *ir.Node, env fileRenderEnv) stri
 		Quality:       int(numericValue(attrValue(node.Attrs, env, "quality"))),
 		Format:        stringValue(attrValue(node.Attrs, env, "format")),
 	}
+	if err := server.ValidateProducibleImageFormat(props.Format); err != nil {
+		panic(err)
+	}
 
 	extra := imageExtraAttrs(node.Attrs, env)
 	args := make([]any, 0, len(extra))
 	if len(extra) > 0 {
 		args = append(args, gosx.Attrs(extra...))
+	}
+
+	if picture, ok := buildManifestImagePicture(props, args); ok {
+		return gosx.RenderHTML(picture)
 	}
 	return gosx.RenderHTML(server.Image(props, args...))
 }

--- a/route/image_picture.go
+++ b/route/image_picture.go
@@ -1,0 +1,233 @@
+package route
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/buildmanifest"
+	"m31labs.dev/gosx/server"
+)
+
+// buildManifestImagePicture builds a <picture> element from the build-time
+// image variants gosx build's imagepipe stage recorded in
+// buildmanifest.Manifest.Images (issue #200), for the file-router's
+// <Image> BUILTIN TAG specifically (gosx#201). server.Image, the Go helper
+// function a page.server.go file calls directly, keeps its existing
+// single-<img> contract unchanged — only the JSX tag gains this markup, so
+// one Go function does not silently start returning a different element
+// shape out from under an existing direct caller.
+//
+// It returns ok=false — and renderImage falls straight through to the
+// unmodified #199-fixed server.Image call — in every one of these cases,
+// so <Image> never fails a render just because a build-time variant is
+// unavailable:
+//
+//   - No App has registered a manifest lookup yet: an ordinary `gosx dev`
+//     run with no prior `gosx build`, or any process that never called
+//     App.Build() at all (for example RenderProgramComponent called
+//     directly, as cmd/gosx render and every route package test do).
+//   - src is external, a data: URI, or otherwise not a source gosx build's
+//     imagepipe stage ever records — see buildmanifest.ImageAsset.Source.
+//   - props.Format or props.Quality names an explicit encode parameter. A
+//     pre-built variant was encoded once, at build time, with neither; it
+//     cannot honor a caller's per-request override the way the runtime
+//     optimizer endpoint can, so a request naming either falls back to
+//     that endpoint instead of silently ignoring the override.
+func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node, bool) {
+	if strings.TrimSpace(props.Format) != "" || props.Quality != 0 {
+		return gosx.Node{}, false
+	}
+
+	asset, ok := server.LookupImageManifestAsset(server.AssetURL(props.Src))
+	if !ok || asset.Width <= 0 || asset.Height <= 0 || len(asset.Variants) == 0 {
+		return gosx.Node{}, false
+	}
+
+	webp := imageVariantsByFormat(asset.Variants, "webp")
+	native, _ := nativeImageVariants(asset.Variants)
+
+	width, height := manifestImageDisplaySize(props, asset)
+	base := manifestImageBaseAttrs(props, width, height)
+	sizes := manifestImageSizes(props.Sizes)
+
+	switch {
+	case len(webp) > 0 && len(native) > 0:
+		// The common case: a WebP <source> (smaller, modern) plus an <img>
+		// fallback in the source's own original format — every browser
+		// without WebP <picture> support still gets a real, correctly
+		// sized image via the <img> alone.
+		source := gosx.El("source", gosx.Attrs(
+			gosx.Attr("type", "image/webp"),
+			gosx.Attr("srcset", imageSrcsetValue(webp)),
+			gosx.Attr("sizes", sizes),
+		))
+		return gosx.El("picture", source, manifestImageOnly(base, sizes, native, extra)), true
+	case len(native) > 0:
+		// A source imagepipe could not also encode to WebP (none observed
+		// today — every raster extension it walks has a WebP encoder path
+		// — but a manifest is on-disk data a future build could vary).
+		// Its native-format variants alone already improve on the #199
+		// fallback: real hashed files, no per-request resize.
+		return manifestImageOnly(base, sizes, native, extra), true
+	case len(webp) > 0:
+		// A WebP-native source (imagepipe never generates a redundant
+		// same-format fallback for one — see cmd/gosx's
+		// imagePipeNativeFormat). Its own WebP variants already ARE the
+		// "original format", so they render on a plain <img> — the same
+		// top-level element shape a non-manifest render already produces
+		// — rather than a <picture> wrapping one <source type="image/webp">
+		// and an <img> naming the identical bytes twice.
+		return manifestImageOnly(base, sizes, webp, extra), true
+	default:
+		return gosx.Node{}, false
+	}
+}
+
+// manifestImageOnly renders one <img> whose src/srcset/sizes come from one
+// format's variant ladder — used directly for a single-format asset, and as
+// the fallback element inside buildManifestImagePicture's <picture>.
+func manifestImageOnly(base []any, sizes string, variants []buildmanifest.ImageVariantAsset, extra []any) gosx.Node {
+	attrs := append(append([]any{}, base...),
+		gosx.Attr("src", server.ImageManifestVariantURL(variants[len(variants)-1])),
+		gosx.Attr("srcset", imageSrcsetValue(variants)),
+		gosx.Attr("sizes", sizes),
+	)
+	args := append([]any{gosx.Attrs(attrs...)}, extra...)
+	return gosx.El("img", args...)
+}
+
+// manifestImageBaseAttrs returns the attributes shared by every manifest-
+// backed <img> regardless of format: alt, injected width/height, and the
+// loading/decoding/fetchpriority triad gosx#199 already defined for
+// server.Image. src/srcset/sizes are added by the caller once it knows
+// which format's variant ladder it is rendering.
+func manifestImageBaseAttrs(props server.ImageProps, width, height int) []any {
+	loading, decoding, fetchPriority := manifestImageLoadingAttrs(props)
+	attrs := []any{
+		gosx.Attr("alt", props.Alt),
+		gosx.Attr("width", width),
+		gosx.Attr("height", height),
+		gosx.Attr("loading", loading),
+		gosx.Attr("decoding", decoding),
+	}
+	if fetchPriority != "" {
+		attrs = append(attrs, gosx.Attr("fetchpriority", fetchPriority))
+	}
+	return attrs
+}
+
+// manifestImageLoadingAttrs mirrors server.Image's own loading/decoding/
+// fetchpriority defaulting (server/image.go) exactly, so a manifest-backed
+// <picture>/<img> and the #199 fallback path never disagree about priority
+// semantics: an explicit prop always wins; Priority flips the default to
+// eager+high; fetchPriority is empty (omitted) unless FetchPriority or
+// Priority asks for one.
+func manifestImageLoadingAttrs(props server.ImageProps) (loading, decoding, fetchPriority string) {
+	loading = strings.TrimSpace(props.Loading)
+	if loading == "" {
+		if props.Priority {
+			loading = "eager"
+		} else {
+			loading = "lazy"
+		}
+	}
+	decoding = strings.TrimSpace(props.Decoding)
+	if decoding == "" {
+		decoding = "async"
+	}
+	fetchPriority = strings.TrimSpace(props.FetchPriority)
+	if fetchPriority == "" && props.Priority {
+		fetchPriority = "high"
+	}
+	return loading, decoding, fetchPriority
+}
+
+// manifestImageDisplaySize resolves the <img> width/height HTML attributes
+// for a manifest-backed <Image>. An author-supplied width and height both
+// win verbatim (server.Image's existing "exact rectangle, can change aspect
+// ratio" contract); a single explicit dimension derives the other
+// proportionally from the source's own intrinsic ratio — capped
+// presentation via attrs. With neither set, the source's own intrinsic
+// Width/Height is injected automatically: gosx#201's whole point, the one
+// step next/image still asks an author to perform, deleted for a local,
+// build-time-known source.
+func manifestImageDisplaySize(props server.ImageProps, asset buildmanifest.ImageAsset) (int, int) {
+	switch {
+	case props.Width > 0 && props.Height > 0:
+		return props.Width, props.Height
+	case props.Width > 0:
+		height := int(float64(asset.Height) * (float64(props.Width) / float64(asset.Width)))
+		if height < 1 {
+			height = 1
+		}
+		return props.Width, height
+	case props.Height > 0:
+		width := int(float64(asset.Width) * (float64(props.Height) / float64(asset.Height)))
+		if width < 1 {
+			width = 1
+		}
+		return width, props.Height
+	default:
+		return asset.Width, asset.Height
+	}
+}
+
+// manifestImageSizes defaults sizes to "100vw" whenever the author leaves it
+// unset. Unlike server.Image's legacy responsive path (which defaults sizes
+// only when Responsive is explicitly set), a manifest-backed render always
+// carries a real, build-time-generated width ladder, so it is always worth
+// a sizes hint — there is no narrower "fixed, non-responsive" mode here to
+// distinguish it from.
+func manifestImageSizes(sizes string) string {
+	sizes = strings.TrimSpace(sizes)
+	if sizes == "" {
+		return "100vw"
+	}
+	return sizes
+}
+
+// imageVariantsByFormat returns every variant at format, sorted ascending
+// by width. The manifest itself already orders variants by the ladder gosx
+// build walked (ascending), but this does not assume that ordering.
+func imageVariantsByFormat(variants []buildmanifest.ImageVariantAsset, format string) []buildmanifest.ImageVariantAsset {
+	out := make([]buildmanifest.ImageVariantAsset, 0, len(variants))
+	for _, variant := range variants {
+		if variant.Format == format {
+			out = append(out, variant)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Width < out[j].Width })
+	return out
+}
+
+// nativeImageVariants returns the one non-WebP format rung asset.Variants
+// carries, if any, sorted ascending by width, plus that format's name.
+// cmd/gosx's stageImageVariants generates at most one non-WebP format per
+// source — the format matching the source's own extension (see
+// imagePipeNativeFormat) — so the first non-webp entry found names the
+// only such format present.
+func nativeImageVariants(variants []buildmanifest.ImageVariantAsset) ([]buildmanifest.ImageVariantAsset, string) {
+	format := ""
+	for _, variant := range variants {
+		if variant.Format != "webp" {
+			format = variant.Format
+			break
+		}
+	}
+	if format == "" {
+		return nil, ""
+	}
+	return imageVariantsByFormat(variants, format), format
+}
+
+// imageSrcsetValue joins one format's variant ladder into an HTML srcset
+// value ("<url> <width>w, <url> <width>w, ...").
+func imageSrcsetValue(variants []buildmanifest.ImageVariantAsset) string {
+	entries := make([]string, 0, len(variants))
+	for _, variant := range variants {
+		entries = append(entries, fmt.Sprintf("%s %dw", server.ImageManifestVariantURL(variant), variant.Width))
+	}
+	return strings.Join(entries, ", ")
+}

--- a/route/image_picture_test.go
+++ b/route/image_picture_test.go
@@ -1,0 +1,269 @@
+package route
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/server"
+)
+
+// manifestImageTestJSON is a build.json fixture carrying three
+// buildmanifest.Manifest.Images entries this file's tests exercise:
+//
+//   - /manifest-hero.jpg: a JPEG source with both webp and jpeg variants at
+//     three widths -- the common "full <picture>" case.
+//   - /manifest-only.webp: a WebP source with only webp variants -- imagepipe
+//     never generates a redundant same-format fallback for one.
+//
+// Every source path here is unique to this file (the "manifest-" prefix),
+// so registering it as the process-global App (server.registerImageManifestLookup,
+// the "last App built wins" convention every image_resolver.go test already
+// relies on) can never change what an unrelated test elsewhere in this
+// package observes for its own "/hero.png"-style fixture paths.
+const manifestImageTestJSON = `{
+  "runtime": {"wasm": {"file": "gosx-runtime.11111111.wasm", "hash": "11111111", "size": 10}},
+  "islands": [],
+  "css": [],
+  "images": [
+    {
+      "source": "/manifest-hero.jpg",
+      "width": 1200,
+      "height": 800,
+      "variants": [
+        {"width": 400, "format": "webp", "file": "hero-400w.aaaaaaaa.webp", "hash": "aaaaaaaa", "size": 1000},
+        {"width": 800, "format": "webp", "file": "hero-800w.bbbbbbbb.webp", "hash": "bbbbbbbb", "size": 2000},
+        {"width": 1200, "format": "webp", "file": "hero-1200w.cccccccc.webp", "hash": "cccccccc", "size": 3000},
+        {"width": 400, "format": "jpeg", "file": "hero-400w.dddddddd.jpg", "hash": "dddddddd", "size": 1500},
+        {"width": 800, "format": "jpeg", "file": "hero-800w.eeeeeeee.jpg", "hash": "eeeeeeee", "size": 2500},
+        {"width": 1200, "format": "jpeg", "file": "hero-1200w.ffffffff.jpg", "hash": "ffffffff", "size": 3500}
+      ]
+    },
+    {
+      "source": "/manifest-only.webp",
+      "width": 600,
+      "height": 300,
+      "variants": [
+        {"width": 300, "format": "webp", "file": "only-300w.11111112.webp", "hash": "11111112", "size": 700},
+        {"width": 600, "format": "webp", "file": "only-600w.11111113.webp", "hash": "11111113", "size": 1400}
+      ]
+    }
+  ]
+}`
+
+// buildManifestApp writes manifestImageTestJSON as build.json under a fresh
+// temp root, builds a *server.App pointed at that root, and registers it as
+// the process-global manifest lookup (via App.Build's call to
+// registerImageManifestLookup) so route's LookupImageManifestAsset calls
+// resolve against it.
+func buildManifestApp(t *testing.T) {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, "build.json"), []byte(manifestImageTestJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	app := server.New()
+	app.SetRuntimeRoot(root)
+	app.Build()
+}
+
+func TestFileRendererImageEmitsPictureWhenManifestHasBothFormats(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero"`)
+
+	if !strings.HasPrefix(html, "<picture>") || !strings.HasSuffix(html, "</picture>") {
+		t.Fatalf("expected a <picture> wrapper, got %q", html)
+	}
+	for _, snippet := range []string{
+		`<source type="image/webp" srcset="/gosx/assets/images/hero-400w.aaaaaaaa.webp 400w, /gosx/assets/images/hero-800w.bbbbbbbb.webp 800w, /gosx/assets/images/hero-1200w.cccccccc.webp 1200w" sizes="100vw" />`,
+		`src="/gosx/assets/images/hero-1200w.ffffffff.jpg"`,
+		`srcset="/gosx/assets/images/hero-400w.dddddddd.jpg 400w, /gosx/assets/images/hero-800w.eeeeeeee.jpg 800w, /gosx/assets/images/hero-1200w.ffffffff.jpg 1200w"`,
+		`sizes="100vw"`,
+		`alt="Hero"`,
+		// No explicit width/height: the source's own intrinsic dimensions
+		// are injected automatically (gosx#201's whole point).
+		`width="1200"`,
+		`height="800"`,
+		`loading="lazy"`,
+		`decoding="async"`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+	if strings.Contains(html, "fetchpriority") {
+		t.Fatalf("expected no fetchpriority without priority, got %q", html)
+	}
+}
+
+func TestFileRendererImagePictureInjectsProportionalHeightFromExplicitWidth(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" width={600}`)
+
+	// Intrinsic 1200x800 (3:2). An explicit width alone derives height
+	// proportionally: 800 * (600/1200) = 400.
+	for _, snippet := range []string{`width="600"`, `height="400"`} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+}
+
+func TestFileRendererImagePictureInjectsProportionalWidthFromExplicitHeight(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" height={200}`)
+
+	// Intrinsic 1200x800 (3:2). An explicit height alone derives width
+	// proportionally: 1200 * (200/800) = 300.
+	for _, snippet := range []string{`width="300"`, `height="200"`} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+}
+
+func TestFileRendererImagePictureKeepsBothExplicitDimensionsVerbatim(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" width={500} height={500}`)
+
+	// Both dimensions explicit: used verbatim, even off the source's own
+	// aspect ratio -- matching server.Image's existing "exact rectangle"
+	// contract for the non-manifest path.
+	for _, snippet := range []string{`width="500"`, `height="500"`} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+}
+
+func TestFileRendererImagePicturePriorityFlipsLoadingAndFetchPriority(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" priority`)
+
+	for _, snippet := range []string{`loading="eager"`, `fetchpriority="high"`} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+	if strings.Contains(html, `loading="lazy"`) {
+		t.Fatalf("expected eager to override the default lazy loading, got %q", html)
+	}
+}
+
+func TestFileRendererImagePictureExtraAttrsLandOnImgFallback(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" class="demo-image"`)
+
+	if !strings.Contains(html, `<img`) {
+		t.Fatalf("expected an <img> fallback, got %q", html)
+	}
+	imgStart := strings.Index(html, "<img")
+	imgEnd := strings.Index(html[imgStart:], ">")
+	imgTag := html[imgStart : imgStart+imgEnd]
+	if !strings.Contains(imgTag, `class="demo-image"`) {
+		t.Fatalf("expected class on the <img> fallback, got %q", imgTag)
+	}
+	sourceStart := strings.Index(html, "<source")
+	sourceEnd := strings.Index(html[sourceStart:], ">")
+	sourceTag := html[sourceStart : sourceStart+sourceEnd]
+	if strings.Contains(sourceTag, "demo-image") {
+		t.Fatalf("expected class not to leak onto <source>, got %q", sourceTag)
+	}
+}
+
+func TestFileRendererImageWebPSourceSkipsPictureWrapper(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-only.webp" alt="Only"`)
+
+	if strings.Contains(html, "<picture>") || strings.Contains(html, "<source") {
+		t.Fatalf("expected a plain <img>, no <picture>/<source> wrapper for a WebP-native source, got %q", html)
+	}
+	for _, snippet := range []string{
+		`<img`,
+		`src="/gosx/assets/images/only-600w.11111113.webp"`,
+		`srcset="/gosx/assets/images/only-300w.11111112.webp 300w, /gosx/assets/images/only-600w.11111113.webp 600w"`,
+		`width="600"`,
+		`height="300"`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+}
+
+func TestFileRendererImageFallsBackWhenSrcHasNoManifestEntry(t *testing.T) {
+	buildManifestApp(t)
+	// The App above only has entries for /manifest-hero.jpg and
+	// /manifest-only.webp; this src is absent even though a manifest lookup
+	// IS registered, proving the fallback decision is per-src, not a global
+	// "manifest present or not" switch. No transform prop is set, so
+	// server.Image's own #199 behavior leaves the src unmodified (see
+	// TestFileRendererImageWithoutResponsiveOmitsSrcset for the sibling
+	// case with a width set instead).
+	html := compileImageFixture(t, `src="/not-in-manifest.png" alt="Untracked"`)
+
+	if strings.Contains(html, "<picture>") {
+		t.Fatalf("expected the #199 fallback path, not a <picture>, got %q", html)
+	}
+	if !strings.Contains(html, `src="/not-in-manifest.png"`) {
+		t.Fatalf("expected the plain passthrough src, got %q", html)
+	}
+}
+
+func TestFileRendererImageExplicitFormatOptsOutOfManifestPicture(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" format="png"`)
+
+	if strings.Contains(html, "<picture>") {
+		t.Fatalf("expected an explicit format to opt out of manifest mode, got %q", html)
+	}
+	if !strings.Contains(html, "fmt=png") {
+		t.Fatalf("expected the runtime optimizer to receive the explicit format, got %q", html)
+	}
+}
+
+func TestFileRendererImageExplicitQualityOptsOutOfManifestPicture(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" quality={55}`)
+
+	if strings.Contains(html, "<picture>") {
+		t.Fatalf("expected an explicit quality to opt out of manifest mode, got %q", html)
+	}
+	if !strings.Contains(html, "q=55") {
+		t.Fatalf("expected the runtime optimizer to receive the explicit quality, got %q", html)
+	}
+}
+
+func TestFileRendererImageExternalSrcIgnoresRegisteredManifest(t *testing.T) {
+	buildManifestApp(t)
+	html := compileImageFixture(t, `src="https://cdn.example.com/manifest-hero.jpg" alt="External" width={400} height={300}`)
+
+	if strings.Contains(html, "<picture>") {
+		t.Fatalf("expected an external src never to resolve through the manifest, got %q", html)
+	}
+	if !strings.Contains(html, `src="https://cdn.example.com/manifest-hero.jpg"`) {
+		t.Fatalf("expected the external URL to pass through unchanged, got %q", html)
+	}
+}
+
+// TestFileRendererImageWithoutRegisteredAppStaysOnFallbackPath proves dev
+// mode (no App has ever called Build in this process) never takes the
+// <picture> path -- it exercises the same fixture path this file's own
+// manifest-backed tests use, through gosx.Compile + RenderProgramComponent
+// directly (no *server.App at all), the same shape cmd/gosx render and
+// every pre-existing image_attrs_test.go case already use.
+func TestFileRendererImageWithoutRegisteredAppStaysOnFallbackPath(t *testing.T) {
+	prog, err := gosx.Compile([]byte("package docs\n\nfunc Page() Node {\n\treturn <Image src=\"/never-built.png\" alt=\"Never built\" />\n}\n"))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(html, "<picture>") {
+		t.Fatalf("expected no <picture> with no manifest registered, got %q", html)
+	}
+}

--- a/server/image.go
+++ b/server/image.go
@@ -62,7 +62,7 @@ func Image(props ImageProps, args ...any) gosx.Node {
 	// Fail closed at render time: a format the handler cannot produce would
 	// otherwise ship as a fmt= URL that 400s only when a browser requests it
 	// (gosx#199). Check before any URL is built.
-	if err := validateProducibleImageFormat(props.Format); err != nil {
+	if err := ValidateProducibleImageFormat(props.Format); err != nil {
 		panic(err)
 	}
 	props.Src = AssetURL(props.Src)
@@ -516,10 +516,16 @@ func normalizeImageFormat(format string) string {
 // so nothing renders a fmt= value the handler would reject at request time.
 var producibleImageFormats = []string{"jpeg", "png", "gif"}
 
-// validateProducibleImageFormat rejects an Image format prop the optimizer
+// ValidateProducibleImageFormat rejects an Image format prop the optimizer
 // handler could never encode. An empty format defers to the source format
 // and always passes.
-func validateProducibleImageFormat(format string) error {
+//
+// Exported (gosx#201) so strictcheck's check-time <Image> contract can reject
+// the same unproducible format value before a render ever happens, using the
+// exact same allowlist and message this render-time check already uses —
+// one source of truth for both call sites, never two allowlists that could
+// drift apart.
+func ValidateProducibleImageFormat(format string) error {
 	format = strings.TrimSpace(format)
 	if format == "" {
 		return nil

--- a/server/image_manifest.go
+++ b/server/image_manifest.go
@@ -1,0 +1,95 @@
+package server
+
+import (
+	"strings"
+	"sync"
+
+	"m31labs.dev/gosx/buildmanifest"
+)
+
+// gosxAssetBaseURL is the public URL prefix serveRuntimeAsset (registered at
+// "GET /gosx/") answers dist/assets from — see runtimeManifestDirectAssetPath,
+// which strips this "gosx/" mount and resolves the remainder under
+// <root>/assets or <root>/dist/assets regardless of bucket ("islands",
+// "css", "runtime", or "images"). staticExportImageVariant already hardcoded
+// this same string; this constant gives image_manifest.go's own lookup the
+// identical base without a second, potentially divergent literal.
+const gosxAssetBaseURL = "/gosx/assets"
+
+// imageManifestLookupMu and imageManifestLookup mirror the "local"
+// ImageResolver registry in image_resolver.go: process-global, single-App-
+// per-process state that the most recently Build()-ed App owns (see
+// registerStaticExportImageResolver's doc comment for the accepted
+// convention this follows). A file-routed <Image> tag renders through
+// route.RenderProgramComponent, which has no *App of its own to read a
+// build manifest from -- server cannot import route (route already imports
+// server), so a registered function pointer, not a passed-in reference, is
+// the seam.
+var (
+	imageManifestLookupMu sync.RWMutex
+	imageManifestLookup   func(src string) (buildmanifest.ImageAsset, bool)
+)
+
+// LookupImageManifestAsset returns the build-time responsive/format variants
+// gosx build's imagepipe stage recorded for src (already normalized through
+// AssetURL) in the buildmanifest.Manifest.Images bucket, if any App
+// registered a manifest source by calling Build().
+//
+// It returns ok=false, always, in every one of these cases: no App has
+// called Build() yet in this process; that App has no build.json at its
+// resolved runtime root (an ordinary `gosx dev` run with no prior `gosx
+// build`); the loaded manifest predates issue #200 (Images is nil); or src
+// has no recorded ImageAsset. route's file-router <Image> renderer treats
+// every one of those, uniformly, as "fall back to the #199 runtime
+// optimizer/passthrough path" -- never a render failure.
+func LookupImageManifestAsset(src string) (buildmanifest.ImageAsset, bool) {
+	imageManifestLookupMu.RLock()
+	lookup := imageManifestLookup
+	imageManifestLookupMu.RUnlock()
+	if lookup == nil {
+		return buildmanifest.ImageAsset{}, false
+	}
+	return lookup(src)
+}
+
+// ImageManifestVariantURL returns the public URL for a build-time image
+// variant, through the same "/gosx/assets" base every other manifest-hashed
+// asset (runtime, islands, CSS) already resolves through.
+func ImageManifestVariantURL(variant buildmanifest.ImageVariantAsset) string {
+	return buildmanifest.AssetURL(gosxAssetBaseURL, "images", variant.File)
+}
+
+// registerImageManifestLookup installs a's own manifest lookup as the
+// process-global one, exactly mirroring registerStaticExportImageResolver's
+// "last App built wins" convention. Called unconditionally from
+// registerBuiltinRoutes on every Build(), not gated on GOSX_STATIC_EXPORT:
+// unlike the URL-rewriting resolver (whose whole job is answering the
+// static-export subprocess), a manifest-backed <picture> is a real,
+// permanent perf win for a normally served app too -- reading pre-built
+// hashed variants instead of paying a CPU-bound resize on every request the
+// runtime optimizer would otherwise serve.
+func registerImageManifestLookup(a *App) {
+	imageManifestLookupMu.Lock()
+	imageManifestLookup = a.lookupImageManifestAsset
+	imageManifestLookupMu.Unlock()
+}
+
+// lookupImageManifestAsset reads only the buildmanifest.Manifest.Images
+// bucket this App already loaded (via runtimeBuildManifest) for every other
+// hashed asset it serves. It never touches package imagepipe or its WebP
+// encoder -- both are cmd/gosx-only (and, as of gosx#201, strictcheck's own
+// check-time stage); see TestServerPackageTreeNeverImportsImagepipe.
+func (a *App) lookupImageManifestAsset(src string) (buildmanifest.ImageAsset, bool) {
+	if a == nil || strings.TrimSpace(src) == "" {
+		return buildmanifest.ImageAsset{}, false
+	}
+	root := a.effectiveRuntimeRoot()
+	if root == "" {
+		return buildmanifest.ImageAsset{}, false
+	}
+	manifest, ok := a.runtimeBuildManifest(root)
+	if !ok || manifest == nil {
+		return buildmanifest.ImageAsset{}, false
+	}
+	return manifest.ImageAssetBySource(src)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -532,6 +532,7 @@ func (a *App) registerBuiltinRoutes(mux *http.ServeMux) {
 		mux.Handle("GET /gosx/", http.HandlerFunc(a.serveRuntimeAsset))
 	}
 	registerStaticExportImageResolver(a)
+	registerImageManifestLookup(a)
 	if imageDir := a.effectiveImageDir(); imageDir != "" && !a.hasRoute(defaultImageEndpoint) {
 		mux.Handle("GET "+defaultImageEndpoint, ImageHandler(imageDir))
 	}

--- a/strictcheck/check.go
+++ b/strictcheck/check.go
@@ -66,7 +66,11 @@ func CheckFileWithOptions(ctx context.Context, path string, opts Options) error 
 	if err != nil {
 		return err
 	}
-	return checkPackage(ctx, files, opts)
+	// findProjectRoot's best-effort go.mod search (gosx#201) is the only way
+	// this entry point ever learns a project root: unlike CheckTreeWithOptions,
+	// a single-file/package check receives no root parameter of its own.
+	root := findProjectRoot(filepath.Dir(path))
+	return checkPackage(ctx, files, opts, root)
 }
 
 // CheckPackage checks every distinct .gsx package found directly in dir.
@@ -88,7 +92,8 @@ func CheckPackageWithOptions(ctx context.Context, dir string, opts Options) erro
 		}
 		paths = append(paths, filepath.Join(dir, entry.Name()))
 	}
-	return checkSourcePackages(ctx, paths, opts)
+	root := findProjectRoot(dir)
+	return checkSourcePackages(ctx, paths, opts, root)
 }
 
 // checkPackage runs every built-in strictcheck stage over files, then runs
@@ -110,8 +115,8 @@ func CheckPackageWithOptions(ctx context.Context, dir string, opts Options) erro
 // resolution, or transpilation still has a fully compiled *ir.Program for
 // every file a lint can check (see LintFile.Program). Their findings join
 // into every return path, including every one of those early-error paths.
-func checkPackage(ctx context.Context, files []transpile.PackageFile, opts Options) error {
-	builtinErr := runBuiltinChecks(ctx, files, opts)
+func checkPackage(ctx context.Context, files []transpile.PackageFile, opts Options, root string) error {
+	builtinErr := runBuiltinChecks(ctx, files, opts, root)
 	extraErr := runExtraLints(files, opts.ExtraLints)
 	switch {
 	case builtinErr != nil && extraErr != nil:
@@ -124,13 +129,24 @@ func checkPackage(ctx context.Context, files []transpile.PackageFile, opts Optio
 }
 
 // runBuiltinChecks runs every built-in strictcheck stage over files: strict
-// render-entry validation, import-name resolution, IR-to-Go projection, and
-// the Go compiler pass over that projection. It returns the first failing
-// stage's error, or nil once every stage passes (or is skipped because the
-// package has no strict syntax). No extra lint (Options.ExtraLints) runs
-// inside this function; see checkPackage for why that ordering matters.
-func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts Options) error {
+// render-entry validation, the check-time <Image> contract, import-name
+// resolution, IR-to-Go projection, and the Go compiler pass over that
+// projection. It returns the first failing stage's error, or nil once every
+// stage passes (or is skipped because the package has no strict syntax). No
+// extra lint (Options.ExtraLints) runs inside this function; see
+// checkPackage for why that ordering matters.
+func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts Options, root string) error {
 	if err := validateStrictRenderEntries(files); err != nil {
+		return err
+	}
+	// validateImageContract runs beside validateStrictRenderEntries, before
+	// the packageHasStrict early return below, and for the same reason
+	// (gosx#201): the real consumer surface (gridiron-2000) compiles as
+	// legacy syntax, so a check placed after that return would never run
+	// for it. <Image> is a builtin tag available to legacy and strict
+	// components alike; its contract must not depend on strict syntax being
+	// present anywhere in the package.
+	if err := validateImageContract(files, root); err != nil {
 		return err
 	}
 	if !packageHasStrict(files) {
@@ -354,6 +370,15 @@ func CheckTree(ctx context.Context, root string) error {
 // CheckTreeWithOptions checks a tree with an explicit Go command environment.
 // Generated/dependency/fixture/dot/nested-Git trees are skipped. Route segment
 // directories beginning with one or two underscores remain first-class.
+//
+// root doubles as the project root the check-time <Image> contract's local-
+// source rule (gosx#201) resolves public/ against — true for every real
+// caller today (cmd/gosx's checkStrictProject always passes the directory
+// holding go.mod, dist/, app/, and public/; see buildmanifest.Manifest.
+// SourceRoot's doc comment for the same convention). A caller that instead
+// names a subdirectory simply finds no public/ there, and that one rule
+// degrades to a no-op for the run — see validateImageContract — rather than
+// reporting a false positive.
 func CheckTreeWithOptions(ctx context.Context, root string, opts Options) error {
 	abs, err := filepath.Abs(root)
 	if err != nil {
@@ -378,7 +403,7 @@ func CheckTreeWithOptions(ctx context.Context, root string, opts Options) error 
 	if err != nil {
 		return err
 	}
-	return checkSourcePackages(ctx, sources, opts)
+	return checkSourcePackages(ctx, sources, opts, abs)
 }
 
 // checkSourcePackages checks every distinct package found among paths and
@@ -386,7 +411,7 @@ func CheckTreeWithOptions(ctx context.Context, root string, opts Options) error 
 // a lint finding is a package error like any other now, and CheckTree /
 // CheckPackage covering several offending packages must surface all of
 // them, not just whichever sorts first.
-func checkSourcePackages(ctx context.Context, paths []string, opts Options) error {
+func checkSourcePackages(ctx context.Context, paths []string, opts Options, root string) error {
 	sort.Strings(paths)
 	seen := make(map[string]struct{})
 	var errs []error
@@ -404,7 +429,7 @@ func checkSourcePackages(ctx context.Context, paths []string, opts Options) erro
 			continue
 		}
 		seen[key] = struct{}{}
-		if err := checkPackage(ctx, files, opts); err != nil {
+		if err := checkPackage(ctx, files, opts, root); err != nil {
 			errs = append(errs, err)
 		}
 	}
@@ -431,4 +456,40 @@ func shouldSkipDir(root, path, name string) bool {
 	}
 	_, err := os.Lstat(filepath.Join(path, ".git"))
 	return err == nil
+}
+
+// findProjectRoot returns the nearest ancestor of dir (dir included) that
+// contains a go.mod file, or "" if none is found before reaching the
+// filesystem root. This is the only project-root signal CheckFileWithOptions
+// and CheckPackageWithOptions have (gosx#201): unlike CheckTreeWithOptions,
+// neither receives an explicit project-root parameter of its own, and
+// go.mod is the standard, dependency-free marker every real gosx project
+// already has at its root (see buildmanifest.Manifest.SourceRoot's doc
+// comment for the same "directory holding dist/, app/, and go.mod"
+// convention CheckTreeWithOptions's own root parameter follows).
+//
+// A "" result is not an error: validateImageContract treats an unknown root
+// the same way it treats a root with no public/ directory under it -- the
+// local-source-must-exist rule degrades to a no-op rather than reporting a
+// false positive it cannot actually prove.
+func findProjectRoot(dir string) string {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return ""
+	}
+	for {
+		if isFileStrictcheck(filepath.Join(abs, "go.mod")) {
+			return abs
+		}
+		parent := filepath.Dir(abs)
+		if parent == abs {
+			return ""
+		}
+		abs = parent
+	}
+}
+
+func isFileStrictcheck(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
 }

--- a/strictcheck/image.go
+++ b/strictcheck/image.go
@@ -1,0 +1,343 @@
+package strictcheck
+
+import (
+	"fmt"
+	neturl "net/url"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"m31labs.dev/gosx/imagepipe"
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/server"
+	"m31labs.dev/gosx/transpile"
+)
+
+// validateImageContract is strictcheck's check-time <Image> contract
+// (gosx#201). It walks every file's compiled *ir.Program directly, the same
+// legacy-and-strict-alike shape validateStrictRenderEntries already uses,
+// so it runs whether or not the package has any strict syntax at all --
+// runBuiltinChecks calls it beside validateStrictRenderEntries, before the
+// packageHasStrict early return, for exactly that reason: the real
+// consumer surface (gridiron-2000) compiles as legacy syntax, so a check
+// placed after that return would never run for it.
+//
+// Four rules, each independently testable, mirroring the render-time
+// contract server.Image and route.renderImage already enforce (gosx#199,
+// gosx#201) so a check-time failure and a render-time failure never
+// disagree about what "valid" means:
+//
+//  1. alt is required and must not be empty.
+//  2. A local (root-relative) static src must name a real, readable image
+//     file under the project's public/ directory -- read with
+//     imagepipe.Probe, not just os.Stat, so a path that exists but is not
+//     a decodable image (or is not an image at all) still fails. SVG is
+//     exempt from the decode check: gosx never optimizes SVG (see
+//     shouldOptimizeImageSource in server/image.go), so existence alone is
+//     the whole contract for one.
+//  3. An external (http/https, or protocol-relative "//") or dynamic
+//     (non-literal, or unresolvable through a spread) src requires an
+//     explicit width and height -- a local src does not: the renderer
+//     probes the file and injects its intrinsic (or ladder-derived)
+//     dimensions automatically (gosx#201's whole point).
+//  4. format, if a static literal, must name a format the render-time
+//     optimizer can actually produce -- reusing
+//     server.ValidateProducibleImageFormat's exact allowlist and message,
+//     so the two checks can never drift apart.
+//
+// An island-nested <Image> is rejected earlier still, inside ir.Validate
+// (which gosx.Compile always runs -- see compile.go), before
+// transpile.LoadPackage can even hand this function a *ir.Program to walk;
+// see ir/validate.go's unsupportedIslandComponentDiagnostic.
+func validateImageContract(files []transpile.PackageFile, root string) error {
+	publicDir := publicImageDirFor(root)
+	var diags []ir.Diagnostic
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		for _, comp := range file.Program.Components {
+			for _, id := range collectImageContractNodeIDs(file.Program, comp.Root) {
+				node := &file.Program.Nodes[id]
+				if node.Kind != ir.NodeComponent || node.Tag != "Image" {
+					continue
+				}
+				diags = append(diags, imageNodeDiagnostics(node, publicDir, file.Path)...)
+			}
+		}
+	}
+	return ir.NewDiagnosticsError("image", diags)
+}
+
+// publicImageDirFor resolves root's public/ directory, or "" when root is
+// unknown or has no public/ directory. Either way, the local-file-exists
+// rule below degrades to a no-op for the whole run rather than reporting a
+// false positive it cannot actually prove -- see findProjectRoot's doc
+// comment for why a caller-supplied root might legitimately have no
+// public/ under it.
+func publicImageDirFor(root string) string {
+	root = strings.TrimSpace(root)
+	if root == "" {
+		return ""
+	}
+	dir := filepath.Join(root, "public")
+	info, err := os.Stat(dir)
+	if err != nil || !info.IsDir() {
+		return ""
+	}
+	return dir
+}
+
+// collectImageContractNodeIDs walks a component's node tree (Program.Nodes,
+// indexed by ir.NodeID) from root, depth-first, mirroring ir.Validate's own
+// unexported collectComponentNodeIDs -- strictcheck cannot reach that one
+// directly, so this is its own copy of the same, small, well-understood
+// shape.
+func collectImageContractNodeIDs(prog *ir.Program, root ir.NodeID) []ir.NodeID {
+	var ids []ir.NodeID
+	var walk func(id ir.NodeID)
+	walk = func(id ir.NodeID) {
+		if int(id) >= len(prog.Nodes) {
+			return
+		}
+		ids = append(ids, id)
+		for _, child := range prog.Nodes[id].Children {
+			walk(child)
+		}
+	}
+	walk(root)
+	return ids
+}
+
+// imageNodeDiagnostics runs every rule against one <Image> node and returns
+// every finding -- a node can fail more than one rule at once (for example
+// a bad format on a src that is also missing alt), and every failure is
+// reported in one check run rather than only the first (gosx#186 B3's same
+// "accumulate, do not stop at the first" posture, applied within one node
+// instead of across files).
+func imageNodeDiagnostics(node *ir.Node, publicDir, filePath string) []ir.Diagnostic {
+	span := node.Span
+	span.File = filePath
+
+	hasSpread := imageNodeHasSpreadAttr(node.Attrs)
+	class, src := classifyImageSrc(node)
+
+	var diags []ir.Diagnostic
+	if diag, ok := imageAltDiagnostic(node, span, hasSpread); ok {
+		diags = append(diags, diag)
+	}
+	if diag, ok := imageLocalFileDiagnostic(span, publicDir, class, src); ok {
+		diags = append(diags, diag)
+	}
+	if diag, ok := imageDimensionsDiagnostic(node, span, class, src, hasSpread); ok {
+		diags = append(diags, diag)
+	}
+	if diag, ok := imageFormatDiagnostic(node, span); ok {
+		diags = append(diags, diag)
+	}
+	return diags
+}
+
+func findImageAttr(attrs []ir.Attr, name string) (ir.Attr, bool) {
+	for _, attr := range attrs {
+		if attr.Name == name {
+			return attr, true
+		}
+	}
+	return ir.Attr{}, false
+}
+
+func imageNodeHasSpreadAttr(attrs []ir.Attr) bool {
+	for _, attr := range attrs {
+		if attr.Kind == ir.AttrSpread {
+			return true
+		}
+	}
+	return false
+}
+
+// imageAttrExplicit reports whether attrs names name with a non-empty
+// value: present and non-blank for a static literal, present at all for
+// any other kind (an expression's or bool attribute's value is not known
+// until render time, so presence is all a check-time rule can ask of it).
+func imageAttrExplicit(attrs []ir.Attr, name string) bool {
+	attr, found := findImageAttr(attrs, name)
+	if !found {
+		return false
+	}
+	if attr.Kind == ir.AttrStatic {
+		return strings.TrimSpace(attr.Value) != ""
+	}
+	return true
+}
+
+// Rule 1: alt is required and must not be empty. A spread attribute on the
+// node (`{...props}`) might supply alt at render time in a way this check
+// cannot see, so a missing (never an explicitly empty) alt is not flagged
+// when one is present -- see route/filesystem_test.go's
+// TestDefaultFileRendererSupportsImageBuiltin for the real, already-tested
+// shape (`{...data.image}` alone supplying src/width/height/widths) this
+// exception exists to keep passing.
+func imageAltDiagnostic(node *ir.Node, span ir.Span, hasSpread bool) (ir.Diagnostic, bool) {
+	attr, found := findImageAttr(node.Attrs, "alt")
+	switch {
+	case found && attr.Kind == ir.AttrStatic && strings.TrimSpace(attr.Value) == "":
+		// An explicitly empty alt is unambiguous even alongside a spread.
+	case found:
+		return ir.Diagnostic{}, false
+	case hasSpread:
+		return ir.Diagnostic{}, false
+	}
+	return ir.Diagnostic{
+		Span:    span,
+		Message: `gosx: Image requires a non-empty "alt" attribute`,
+		Hint:    `pass a descriptive alt, for example alt="Team photo"`,
+	}, true
+}
+
+// imageSrcClass classifies a <Image> src attribute for rules 2 and 3.
+type imageSrcClass int
+
+const (
+	// imageSrcUnresolved covers a data: URI and any src shape this checker
+	// does not recognize as local or external -- neither rule 2 nor rule 3
+	// applies to it.
+	imageSrcUnresolved imageSrcClass = iota
+	imageSrcLocal
+	imageSrcExternal
+	// imageSrcDynamic covers a non-literal src (an expression, or a spread
+	// that might supply one) and a missing src attribute entirely -- this
+	// checker cannot resolve either to a real file, so it is treated like
+	// an external src for rule 3's dimensions requirement.
+	imageSrcDynamic
+)
+
+func classifyImageSrc(node *ir.Node) (imageSrcClass, string) {
+	attr, found := findImageAttr(node.Attrs, "src")
+	if !found {
+		return imageSrcDynamic, ""
+	}
+	if attr.Kind != ir.AttrStatic {
+		return imageSrcDynamic, ""
+	}
+	value := strings.TrimSpace(attr.Value)
+	switch {
+	case value == "":
+		return imageSrcDynamic, ""
+	case strings.HasPrefix(value, "data:"):
+		return imageSrcUnresolved, value
+	case looksExternalImageSrc(value):
+		return imageSrcExternal, value
+	case looksLocalImageSrc(value):
+		return imageSrcLocal, value
+	default:
+		return imageSrcDynamic, value
+	}
+}
+
+func looksExternalImageSrc(value string) bool {
+	if strings.HasPrefix(value, "//") {
+		return true
+	}
+	parsed, err := neturl.Parse(value)
+	return err == nil && (parsed.Scheme != "" || parsed.Host != "")
+}
+
+func looksLocalImageSrc(value string) bool {
+	if !strings.HasPrefix(value, "/") || strings.HasPrefix(value, "//") {
+		return false
+	}
+	parsed, err := neturl.Parse(value)
+	return err == nil && parsed.Scheme == "" && parsed.Host == ""
+}
+
+// Rule 2: a local static src must name a real, readable image file under
+// public/.
+func imageLocalFileDiagnostic(span ir.Span, publicDir string, class imageSrcClass, src string) (ir.Diagnostic, bool) {
+	if class != imageSrcLocal || publicDir == "" {
+		return ir.Diagnostic{}, false
+	}
+	if imageLocalFileReadable(publicDir, src) {
+		return ir.Diagnostic{}, false
+	}
+	return ir.Diagnostic{
+		Span:    span,
+		Message: fmt.Sprintf("gosx: Image src %q does not name a readable image file under public/", src),
+		Hint:    "local <Image> sources must exist under the project's public/ directory as an SVG, JPEG, PNG, GIF, or WebP file",
+	}, true
+}
+
+// imageLocalFileReadable joins src onto publicDir the same way
+// server/image.go's own resolveImagePath cleans a request path (leading
+// slash, no ".." escape), then confirms it names a real file. SVG is
+// checked for existence only -- gosx never decodes or optimizes SVG (see
+// shouldOptimizeImageSource), so imagepipe.Probe (which cannot decode one
+// either) would otherwise reject a perfectly valid SVG source. Every other
+// extension is probed for real: existence alone is not enough when the
+// render-time renderer (and, at build time, imagepipe itself) must also
+// decode the file to resize it or read its intrinsic dimensions.
+func imageLocalFileReadable(publicDir, src string) bool {
+	parsed, err := neturl.Parse(src)
+	if err != nil {
+		return false
+	}
+	clean := path.Clean("/" + parsed.Path)
+	if clean == "/" {
+		return false
+	}
+	full := filepath.Join(publicDir, filepath.FromSlash(strings.TrimPrefix(clean, "/")))
+
+	if strings.EqualFold(filepath.Ext(full), ".svg") {
+		info, err := os.Stat(full)
+		return err == nil && info.Mode().IsRegular()
+	}
+	_, _, err = imagepipe.Probe(full)
+	return err == nil
+}
+
+// Rule 3: an external or dynamic src requires an explicit width and
+// height. A spread attribute on the node might supply either at render
+// time in a way this check cannot see, so neither is required (by name)
+// when one is present -- the same exception, and for the same reason, as
+// imageAltDiagnostic's.
+func imageDimensionsDiagnostic(node *ir.Node, span ir.Span, class imageSrcClass, src string, hasSpread bool) (ir.Diagnostic, bool) {
+	if class != imageSrcExternal && class != imageSrcDynamic {
+		return ir.Diagnostic{}, false
+	}
+	if hasSpread {
+		return ir.Diagnostic{}, false
+	}
+	if imageAttrExplicit(node.Attrs, "width") && imageAttrExplicit(node.Attrs, "height") {
+		return ir.Diagnostic{}, false
+	}
+	if class == imageSrcExternal {
+		return ir.Diagnostic{
+			Span:    span,
+			Message: fmt.Sprintf("gosx: Image src %q is external and requires explicit width and height", src),
+			Hint:    "local sources infer their intrinsic size automatically; an external source cannot, so set width and height explicitly to avoid layout shift",
+		}, true
+	}
+	return ir.Diagnostic{
+		Span:    span,
+		Message: "gosx: Image src is dynamic and requires explicit width and height",
+		Hint:    "a src computed at render time cannot be probed at check time, so set width and height explicitly to avoid layout shift",
+	}, true
+}
+
+// Rule 4: format, if a static literal, must be a producible output format.
+// A dynamic format ({expr}) is exempt at check time the same way an
+// external/dynamic src's rule stays scoped to what a literal proves -- an
+// unproducible dynamic format value still fails closed at render time
+// (server.Image / route.renderImage both call
+// server.ValidateProducibleImageFormat before building any URL).
+func imageFormatDiagnostic(node *ir.Node, span ir.Span) (ir.Diagnostic, bool) {
+	attr, found := findImageAttr(node.Attrs, "format")
+	if !found || attr.Kind != ir.AttrStatic {
+		return ir.Diagnostic{}, false
+	}
+	if err := server.ValidateProducibleImageFormat(attr.Value); err != nil {
+		return ir.Diagnostic{Span: span, Message: err.Error()}, true
+	}
+	return ir.Diagnostic{}, false
+}

--- a/strictcheck/image_test.go
+++ b/strictcheck/image_test.go
@@ -1,0 +1,311 @@
+package strictcheck
+
+import (
+	"bytes"
+	"context"
+	"image"
+	"image/color"
+	"image/png"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// imageFixture wraps tag in a LEGACY (func, not strict `component`) .gsx
+// page -- gosx#201's whole reason for placing validateImageContract before
+// the packageHasStrict early return: the real consumer surface
+// (gridiron-2000) compiles as legacy syntax, so every test here proves the
+// check runs without any strict syntax present anywhere in the package.
+func imageFixture(tag string) string {
+	return "package docs\n\nfunc Page() Node {\n\treturn " + tag + "\n}\n"
+}
+
+// writeTestPNG writes a real, decodable w x h PNG to path so
+// imagepipe.Probe (rule 2) succeeds against it, mirroring how a real
+// public/ asset would look.
+func writeTestPNG(t *testing.T, path string, w, h int) {
+	t.Helper()
+	img := image.NewRGBA(image.Rect(0, 0, w, h))
+	for y := 0; y < h; y++ {
+		for x := 0; x < w; x++ {
+			img.Set(x, y, color.RGBA{R: uint8(x), G: uint8(y), B: 0, A: 255})
+		}
+	}
+	var buf bytes.Buffer
+	if err := png.Encode(&buf, img); err != nil {
+		t.Fatalf("encode test png: %v", err)
+	}
+	mustWrite(t, path, buf.String())
+}
+
+func checkImageFixture(t *testing.T, dir, tag string) error {
+	t.Helper()
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, imageFixture(tag))
+	return CheckFile(context.Background(), path)
+}
+
+// --- Accepts ---------------------------------------------------------
+
+func TestImageContractAcceptsLocalSrcWithNoWidthOrHeight(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	if err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" />`); err != nil {
+		t.Fatalf("expected a local src to need no width/height, got %v", err)
+	}
+}
+
+func TestImageContractAcceptsLocalSVGWithNoWidthOrHeight(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "mark.svg"), `<svg xmlns="http://www.w3.org/2000/svg"></svg>`)
+
+	if err := checkImageFixture(t, dir, `<Image src="/mark.svg" alt="Mark" />`); err != nil {
+		t.Fatalf("expected a local SVG src to be accepted on existence alone, got %v", err)
+	}
+}
+
+func TestImageContractAcceptsExternalSrcWithExplicitWidthAndHeight(t *testing.T) {
+	dir := newTestModule(t)
+
+	if err := checkImageFixture(t, dir, `<Image src="https://cdn.example.com/hero.jpg" alt="Hero" width={800} height={600} />`); err != nil {
+		t.Fatalf("expected an external src with explicit dimensions to be accepted, got %v", err)
+	}
+}
+
+func TestImageContractAcceptsDynamicSrcWithExplicitWidthAndHeight(t *testing.T) {
+	dir := newTestModule(t)
+
+	if err := checkImageFixture(t, dir, `<Image src={data.heroURL} alt="Hero" width={800} height={600} />`); err != nil {
+		t.Fatalf("expected a dynamic src with explicit dimensions to be accepted, got %v", err)
+	}
+}
+
+func TestImageContractAcceptsDataURISrcWithNoWidthOrHeight(t *testing.T) {
+	dir := newTestModule(t)
+
+	if err := checkImageFixture(t, dir, `<Image src="data:image/png;base64,aaaa" alt="Inline" />`); err != nil {
+		t.Fatalf("expected a data: URI src to need no width/height, got %v", err)
+	}
+}
+
+func TestImageContractAcceptsExplicitProducibleFormat(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	for _, format := range []string{"jpeg", "jpg", "png", "gif"} {
+		t.Run(format, func(t *testing.T) {
+			tag := `<Image src="/hero.png" alt="Hero" format="` + format + `" />`
+			if err := checkImageFixture(t, dir, tag); err != nil {
+				t.Fatalf("expected format %q to be accepted, got %v", format, err)
+			}
+		})
+	}
+}
+
+func TestImageContractAcceptsDynamicFormat(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	if err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" format={data.format} />`); err != nil {
+		t.Fatalf("expected a dynamic format value to be exempt at check time, got %v", err)
+	}
+}
+
+// TestImageContractAcceptsSpreadSuppliedFieldsWithoutNamedAttrs proves the
+// real, already-tested fixture shape
+// (route/filesystem_test.go's TestDefaultFileRendererSupportsImageBuiltin:
+// `{...data.image}` alone supplying src/width/height/widths, no named src
+// or dimension attributes at all) keeps passing: a spread might supply
+// alt, width, and height in a way this check cannot see, so none of them
+// is required by name when a spread is present.
+func TestImageContractAcceptsSpreadSuppliedFieldsWithoutNamedAttrs(t *testing.T) {
+	dir := newTestModule(t)
+
+	if err := checkImageFixture(t, dir, `<Image sizes="100vw" {...data.image} />`); err != nil {
+		t.Fatalf("expected a spread-only <Image> to be accepted, got %v", err)
+	}
+}
+
+// --- Rejects: exact messages ------------------------------------------
+
+func TestImageContractRejectsMissingAlt(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" />`)
+	requireImageDiagnostic(t, err, `gosx: Image requires a non-empty "alt" attribute`)
+}
+
+func TestImageContractRejectsEmptyAlt(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="" />`)
+	requireImageDiagnostic(t, err, `gosx: Image requires a non-empty "alt" attribute`)
+}
+
+func TestImageContractRejectsLocalSrcNamingNoFile(t *testing.T) {
+	dir := newTestModule(t)
+	// public/ exists (so the rule is active) but hero.png does not.
+	mustMkdir(t, filepath.Join(dir, "public"))
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" />`)
+	requireImageDiagnostic(t, err, `gosx: Image src "/hero.png" does not name a readable image file under public/`)
+}
+
+func TestImageContractRejectsLocalSrcThatIsNotADecodableImage(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "hero.png"), "not a real png")
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" />`)
+	requireImageDiagnostic(t, err, `gosx: Image src "/hero.png" does not name a readable image file under public/`)
+}
+
+func TestImageContractRejectsExternalSrcMissingWidth(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image src="https://cdn.example.com/hero.jpg" alt="Hero" height={600} />`)
+	requireImageDiagnostic(t, err, `gosx: Image src "https://cdn.example.com/hero.jpg" is external and requires explicit width and height`)
+}
+
+func TestImageContractRejectsExternalSrcMissingHeight(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image src="https://cdn.example.com/hero.jpg" alt="Hero" width={800} />`)
+	requireImageDiagnostic(t, err, `gosx: Image src "https://cdn.example.com/hero.jpg" is external and requires explicit width and height`)
+}
+
+func TestImageContractRejectsProtocolRelativeSrcMissingDimensions(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image src="//cdn.example.com/hero.jpg" alt="Hero" />`)
+	requireImageDiagnostic(t, err, `is external and requires explicit width and height`)
+}
+
+func TestImageContractRejectsDynamicSrcMissingDimensions(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image src={data.heroURL} alt="Hero" />`)
+	requireImageDiagnostic(t, err, `gosx: Image src is dynamic and requires explicit width and height`)
+}
+
+func TestImageContractRejectsMissingSrcEntirely(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image alt="Hero" />`)
+	requireImageDiagnostic(t, err, `gosx: Image src is dynamic and requires explicit width and height`)
+}
+
+func TestImageContractRejectsUnproducibleFormat(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" format="avif" />`)
+	requireImageDiagnostic(t, err, `gosx: Image format "avif" is not a producible output format (want jpeg, png, or gif)`)
+}
+
+func TestImageContractRejectsUnproducibleFormatWebP(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+
+	err := checkImageFixture(t, dir, `<Image src="/hero.png" alt="Hero" format="webp" />`)
+	requireImageDiagnostic(t, err, `gosx: Image format "webp" is not a producible output format (want jpeg, png, or gif)`)
+}
+
+// TestImageContractAccumulatesMultipleViolationsOnOneNode proves every
+// rule a single <Image> node fails is reported in one check run, not just
+// the first.
+func TestImageContractAccumulatesMultipleViolationsOnOneNode(t *testing.T) {
+	dir := newTestModule(t)
+
+	err := checkImageFixture(t, dir, `<Image src="https://cdn.example.com/hero.jpg" format="avif" />`)
+	if err == nil {
+		t.Fatal("expected findings")
+	}
+	message := err.Error()
+	for _, want := range []string{
+		`gosx: Image requires a non-empty "alt" attribute`,
+		`gosx: Image src "https://cdn.example.com/hero.jpg" is external and requires explicit width and height`,
+		`gosx: Image format "avif" is not a producible output format`,
+	} {
+		if !strings.Contains(message, want) {
+			t.Fatalf("expected %q in accumulated message:\n%s", want, message)
+		}
+	}
+}
+
+// TestImageContractRunsWithoutAnyStrictSyntaxInThePackage is the
+// placement proof gosx#201 explains: the check must run for a package
+// with no `component` declaration anywhere, mirroring the real consumer
+// surface. imageFixture already builds a legacy `func` component; this
+// test only makes the intent explicit and pins it against regression if a
+// future change moves the call site back after packageHasStrict.
+func TestImageContractRunsWithoutAnyStrictSyntaxInThePackage(t *testing.T) {
+	dir := newTestModule(t)
+	src, err := os.ReadFile(filepath.Join(dir, "go.mod"))
+	if err != nil || len(src) == 0 {
+		t.Fatalf("test module fixture missing go.mod: %v", err)
+	}
+
+	err = checkImageFixture(t, dir, `<Image src="https://cdn.example.com/hero.jpg" alt="" />`)
+	requireImageDiagnostic(t, err, `gosx: Image requires a non-empty "alt" attribute`)
+}
+
+// TestImageContractCheckTreeResolvesPublicDirFromTreeRoot proves the
+// public/ resolution also works through CheckTree (the path
+// cmd/gosx's checkStrictProject uses), not only CheckFile's best-effort
+// go.mod search.
+func TestImageContractCheckTreeResolvesPublicDirFromTreeRoot(t *testing.T) {
+	dir := newTestModule(t)
+	writeTestPNG(t, filepath.Join(dir, "public", "hero.png"), 4, 4)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), imageFixture(`<Image src="/hero.png" alt="Hero" />`))
+
+	if err := CheckTree(context.Background(), dir); err != nil {
+		t.Fatalf("expected a real local file to be accepted through CheckTree, got %v", err)
+	}
+
+	mustWrite(t, filepath.Join(dir, "page.gsx"), imageFixture(`<Image src="/missing.png" alt="Hero" />`))
+	err := CheckTree(context.Background(), dir)
+	requireImageDiagnostic(t, err, `gosx: Image src "/missing.png" does not name a readable image file under public/`)
+}
+
+// TestImageContractRejectsImageInsideIsland proves the check-time island
+// rejection (gosx#201, ir/validate.go's unsupportedIslandComponentDiagnostic)
+// surfaces through strictcheck's own entry point: CheckFile loads the
+// package via transpile.LoadPackage, which compiles every file through
+// gosx.Compile -- the same call that runs ir.Validate and fails closed on
+// an island-nested <Image> before validateImageContract, or any other
+// strictcheck stage, ever sees the program.
+func TestImageContractRejectsImageInsideIsland(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package docs
+
+//gosx:island
+func Gallery() Node {
+	return <Image src="/hero.png" alt="Hero" width={800} height={600} />
+}
+`)
+
+	err := CheckFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("expected <Image> inside an island to fail check")
+	}
+	for _, snippet := range []string{"<Image>", "not supported inside island components", "plain <img>"} {
+		if !strings.Contains(err.Error(), snippet) {
+			t.Fatalf("expected %q in error, got %v", snippet, err)
+		}
+	}
+}
+
+func requireImageDiagnostic(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("expected an error containing %q, got nil", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("expected %q in error, got %v", want, err)
+	}
+}


### PR DESCRIPTION
## Summary

Introduces the `<Image>` JSX builtin tag, featuring a strict check-time contract for accessibility and dimension requirements, and automatic responsive `<picture>` rendering powered by pre-built image variants. Unavailable manifests or dynamic parameters fall back transparently to the existing `server.Image` runtime optimizer.

## Changes

- Implement check-time validation in `strictcheck/image.go`: enforces non-empty `alt`, verifies local static `src` exists under `public/`, requires explicit `width`/`height` for external/dynamic `src`, and validates `format` against the producible allowlist.
- Generate manifest-backed `<picture>` markup in `route/image_picture.go`: reads `buildmanifest.Manifest.Images` to emit WebP `<source>` tags with `srcset`/`sizes` and a native-format `<img>` fallback, automatically injecting intrinsic dimensions when unspecified. Falls back transparently to the existing `server.Image` runtime path when no manifest is registered or explicit `Format`/`Quality` props override pre-built variants.
- Export `server.ValidateProducibleImageFormat` and register `LookupImageManifestAsset` so both render-time and check-time stages share a single allowlist and process-global manifest lookup registry.
- Block `<Image>` inside island components: `ir/validate.go` and `ir/island.go` now return a dedicated diagnostic and lowering error instead of silently downgrading to `<img>`, guiding users to use a plain `<img>` with explicit dimensions inside islands.
- Update documentation and examples to reflect the new `<Image>` builtin rules, responsive behavior, and fix missing `Height` attributes in responsive code samples that previously caused layout shifts.
- Add comprehensive tests covering all validation rules, `<picture>` markup shapes, fallback paths, priority semantics, and island rejection scenarios.

## Testing

- Run `go test ./strictcheck/... ./route/... ./ir/... ./server/...` to verify validation, picture generation, and fallback behaviors.
- Execute `gosx check` on example projects containing `<Image>` tags to ensure check-time contract enforcement (missing alt, invalid local src, missing dimensions on external URLs).
- Verify `gosx dev` renders pages with `<Image>` without errors even when no prior `gosx build` has run (manifest fallback).
- Build the gosx-docs example app and inspect the rendered HTML for `/docs/images` to confirm `<picture>` emission and correct srcset/sizes attributes.