### PR TITLE
add(route): Add typed props support and LoadFileProgram helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## Unreleased
+
+### Added: render a page's own component from a Go handler
+
+- **`route.RenderProgramComponent` renders a strict component as the render
+  entry, with typed props** (gosx#226). A `component Foo(props: FooProps)`
+  declaration compiles to an `ir.Component` the file-program renderer only
+  reaches by name inside a compiled `*ir.Program` — not a linkable Go
+  symbol — so a hand-written `http.Handler` in the same package as a
+  `page.gsx` file had no supported way to render one of that page's own
+  components into a fragment. `ProgramRenderEnv.Props` now supplies the
+  typed props value; the renderer proves it at the exact boundary a nested
+  `<Foo {...props}/>` call already runs on every render (`strictSpreadProps`):
+  a `nil` Props value still fails closed with the original "no root props
+  binding" error, and a `map[string]any` — however it is shaped — still
+  cannot prove field coverage. Rendering a strict component this way
+  produces byte-for-byte the same markup a nested call to it produces.
+- **`route.LoadFileProgram` loads a `.gsx` file's compiled program through
+  the file router's own stat-keyed cache** (gosx#226), the same cache a
+  file-routed page or layout renders through. A fragment handler that
+  calls it renders through the identical cached program the page itself
+  uses — an edit to the `.gsx` file reaches both the same way, with no
+  second, independently-stale compile path to drift out of sync.
+- This closes the fragment-endpoint gap `data-gosx-region` needs: a
+  `data-gosx-region-url` handler can now render the page's own component
+  instead of hand-mirroring its markup with the low-level `El`/`Attrs`/
+  `Text` API. See the runtime docs' "Rendering a fragment from a Go
+  handler" section, beside `data-gosx-region`.
+
 ## v0.47.1 (2026-08-18)
 
 ### Fixed: the release version constant

--- a/examples/gosx-docs/app/docs/runtime/page.gsx
+++ b/examples/gosx-docs/app/docs/runtime/page.gsx
@@ -619,6 +619,75 @@ func Page() Node {
 				<span class="inline-code">data-gosx-live-bind</span>
 				rejects an empty or whitespace-containing key the same way.
 			</p>
+			<h3>Rendering a fragment from a Go handler</h3>
+			<p>
+				A
+				<span class="inline-code">data-gosx-region-url</span>
+				endpoint must render the same markup a page's own component already produces — otherwise the polled fragment and the page drift apart. Load the page's compiled program with
+				<span class="inline-code">route.LoadFileProgram</span>
+				and render one component from it with
+				<span class="inline-code">route.RenderProgramComponent</span>
+				, from a plain
+				<span class="inline-code">http.Handler</span>
+				in the same package as the page. This works for a component the page's own
+				<span class="inline-code">Page</span>
+				entry never renders directly, not only for
+				<span class="inline-code">Page</span>
+				itself.
+			</p>
+			{CodeBlock("gosx", `// page.gsx
+	type SignalCardProps struct {
+	    Label string
+	    Value string
+	}
+
+	component SignalCard(props: SignalCardProps) {
+	    return <li class="signal-card">{props.Label}: {props.Value}</li>
+	}
+
+	component Page() {
+	    return <ul data-gosx-region data-gosx-region-url="/wire/signal" data-gosx-region-interval="20s">
+	        <SignalCard label="Passing Yards" value="317" />
+	    </ul>
+	}`)}
+			{CodeBlock("go", `// page.server.go — same package as page.gsx
+	var pagePath = filepath.Join(thisDir, "page.gsx")
+
+	func ServeSignalFragment(w http.ResponseWriter, r *http.Request) {
+	    prog, err := route.LoadFileProgram(pagePath)
+	    if err != nil {
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	        return
+	    }
+	    html, err := route.RenderProgramComponent(prog, "SignalCard", route.ProgramRenderEnv{
+	        Props: SignalCardProps{Label: "Passing Yards", Value: currentValue()},
+	    })
+	    if err != nil {
+	        http.Error(w, err.Error(), http.StatusInternalServerError)
+	        return
+	    }
+	    w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	    w.Write([]byte(html))
+	}`)}
+			<p>
+				<span class="inline-code">route.LoadFileProgram</span>
+				reads through the same stat-keyed program cache a file-routed page renders through, so an edit to
+				<span class="inline-code">page.gsx</span>
+				reaches the fragment handler exactly the way it reaches the page's own hot reload — there is no second, independently-stale copy of the compiled component to fall behind.
+			</p>
+			<p>
+				A
+				<span class="inline-code">component</span>
+				declaration keeps its strict props boundary at this entry point: pass
+				<span class="inline-code">route.ProgramRenderEnv.Props</span>
+				a real
+				<span class="inline-code">SignalCardProps</span>
+				value, and the renderer proves every rendered field's presence and declared type before it renders — the same proof a nested strict-component call from inside another component's own body already runs on every render. A
+				<span class="inline-code">map[string]any</span>
+				never satisfies that proof, no matter how it is shaped, and a
+				<span class="inline-code">nil</span>
+				Props value fails closed with a named error instead of rendering.
+			</p>
 		</section>
 		<section id="declarative-filter">
 			<h2>Declarative list filter</h2>

--- a/route/filelayout.go
+++ b/route/filelayout.go
@@ -279,6 +279,15 @@ type fileRenderOptions struct {
 	// its own to set it from, so a file-routed page or layout cannot
 	// install a render profile today (gosx#185 m6).
 	Profile *RenderProfile
+	// EntryProps supplies the typed props value for a strict component
+	// rendered as the render entry (gosx#226). Only RenderProgramComponent
+	// sets this field, from ProgramRenderEnv.Props: renderFileNode, the
+	// entry point a file-routed page or layout renders through, has no
+	// Props field of its own to set it from, so a file-routed page or
+	// layout still cannot render with typed root props — a file-routed
+	// entry's data comes from ctx.Data and a DataLoader, not a Go-typed
+	// caller. See renderFileProgramHTML's strict-entry branch.
+	EntryProps any
 }
 
 func renderFileNode(path string, opts fileRenderOptions) (gosx.Node, error) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -61,8 +61,32 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 	if !ok {
 		return "", false, fmt.Errorf("component %q not found", component)
 	}
+	entryEnv := opts.EvalEnv
 	if comp.Syntax == ir.ComponentSyntaxStrict && strings.TrimSpace(comp.PropsType) != "" {
-		return "", false, fmt.Errorf("strict render entry %s accepts props %s, but the file renderer has no root props binding; use a zero-props Page/Layout entry", comp.Name, comp.PropsType)
+		// gosx#226: a strict component rendered as the render entry (not as a
+		// nested <Component/> call inside some other component's body) has no
+		// caller-side attribute list for localComponentProps to prove props
+		// from. opts.EntryProps is the only other place a typed value can
+		// come from — RenderProgramComponent sets it from
+		// ProgramRenderEnv.Props. A nil EntryProps reproduces the original,
+		// unconditional refusal byte-for-byte: this render entry always
+		// required a props binding, and until a caller supplies one there is
+		// still none to prove.
+		if opts.EntryProps == nil {
+			return "", false, fmt.Errorf("strict render entry %s accepts props %s, but the file renderer has no root props binding; use a zero-props Page/Layout entry", comp.Name, comp.PropsType)
+		}
+		// strictSpreadProps is the exact same boundary proof a nested
+		// <Component {...props}/> call re-runs on every render (see
+		// localComponentProps): reflect kind must be exactly Struct (a map
+		// is rejected — it cannot prove field coverage), and every rendered
+		// field is re-checked against its declared leaf type. Rendering a
+		// strict component as an entry point goes through this same proof,
+		// never around it.
+		props, err := strictSpreadProps(comp, opts.EntryProps)
+		if err != nil {
+			return "", false, fmt.Errorf("render strict entry %s: %w", comp.Name, err)
+		}
+		entryEnv = entryEnv.withValue("props", props)
 	}
 	// One builder carries the whole document. The renderer used to allocate a
 	// fresh strings.Builder per element and let the parent copy the child's
@@ -70,7 +94,7 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 	// allocated 1,085,241 B to emit 5,556 bytes.
 	var b strings.Builder
 	b.Grow(fileProgramRenderSizeHint(prog))
-	renderer.writeNode(&b, comp.Root, opts.EvalEnv)
+	renderer.writeNode(&b, comp.Root, entryEnv)
 	if renderer.err != nil {
 		return "", renderer.replaced, renderer.err
 	}

--- a/route/program_render.go
+++ b/route/program_render.go
@@ -1,6 +1,9 @@
 package route
 
 import (
+	"fmt"
+	"path/filepath"
+
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/ir"
 	islandprogram "m31labs.dev/gosx/island/program"
@@ -12,6 +15,23 @@ import (
 //   - Values / Funcs bind identifiers and functions referenced by {expr} (e.g.
 //     Funcs["strings"] = map[string]any{"ToUpper": strings.ToUpper}). Unresolved
 //     identifiers render empty rather than erroring, so missing bindings fail soft.
+//   - Props supplies the typed props value when component is a strict
+//     component (gosx#226): a `component Foo(props: FooProps)` declaration
+//     compiles to an ir.Component with a declared PropsType, and — same as
+//     a nested `<Foo {...props}/>` call inside another component's body —
+//     rendering it as the entry component must prove a real struct value,
+//     not a map. RenderProgramComponent proves Props at that identical
+//     boundary (see strictSpreadProps): a nil Props, any map[string]any
+//     (including one shaped exactly like FooProps — a map can omit keys
+//     and has no field types to check ahead of the values, so it never
+//     proves coverage), or a struct missing a rendered field or holding
+//     one of the wrong type all fail closed with a descriptive error
+//     instead of rendering. A same-shaped struct under a different Go type
+//     name is accepted, matching a generated-Go spread caller's own
+//     boundary (strictSpreadProps proves field coverage, not the source
+//     struct's own type identity — see TestStrictSpreadProps). Ignored for
+//     a legacy (non-strict) component, and for a strict component with no
+//     declared props.
 //   - RenderIsland turns a local //gosx:island child (referenced as <Name/>) into
 //     a hydrated server-rendered mount — pass server.PageRuntime.Island or
 //     island.(*Renderer).RenderIslandFromProgram. When nil, island children
@@ -24,6 +44,7 @@ import (
 type ProgramRenderEnv struct {
 	Values       map[string]any
 	Funcs        map[string]any
+	Props        any
 	RenderIsland func(*islandprogram.Program, any) gosx.Node
 	Profile      *RenderProfile
 }
@@ -34,10 +55,16 @@ type ProgramRenderEnv struct {
 //
 // It is the public entry to the file-program renderer that powers file-based
 // pages, for callers that compile and render components directly — e.g. a slide
-// deck that lowers each slide to a generated component — instead of from on-disk
-// page files. A single compiled source may declare the rendered component plus
-// any sibling components and islands it references; cross-references resolve here
-// at render time.
+// deck that lowers each slide to a generated component, or a plain http.Handler
+// in the same package as a page.gsx file rendering one of that page's own
+// components into a fragment (gosx#226, see LoadFileProgram) — instead of from
+// on-disk page files. A single compiled source may declare the rendered
+// component plus any sibling components and islands it references;
+// cross-references resolve here at render time.
+//
+// component is a strict component's own render entry exactly the same way a
+// nested call to it is: see ProgramRenderEnv.Props for the typed-props
+// contract this requires.
 //
 // When env.Profile is set and its Validate hook reports any diagnostic,
 // RenderProgramComponent returns a *RenderProfileError and an empty string;
@@ -49,7 +76,34 @@ func RenderProgramComponent(prog *ir.Program, component string, env ProgramRende
 			funcs:        env.Funcs,
 			renderIsland: env.RenderIsland,
 		},
-		Profile: env.Profile,
+		EntryProps: env.Props,
+		Profile:    env.Profile,
 	})
 	return html, err
+}
+
+// LoadFileProgram compiles the .gsx file at path and returns its IR program,
+// through the same stat-keyed cache (gosx#226) a file-routed page or layout
+// renders through (route/filelayout.go's gsxCompileCache): a request that
+// hits this file again before its next edit gets the cached *ir.Program back
+// without re-parsing, and an edit invalidates the cache exactly the way it
+// invalidates a running page's own hot reload — there is no second,
+// independently-stale cache for a caller of this function to fall behind.
+//
+// This is the other half of gosx#226's fix: a plain http.Handler in the same
+// package as a page.gsx file — for example, a fragment endpoint that data-
+// gosx-region polls — loads that file's compiled program with this function
+// and renders any component it declares, including one the page's own
+// Page/Layout entry never renders directly, with RenderProgramComponent.
+//
+// path resolves relative to the process's current working directory, same as
+// os.Open; pass an absolute path (for example, one built from the source
+// file's own directory: filepath.Join(filepath.Dir(sourceFile), "page.gsx"))
+// to make it independent of the working directory the binary starts in.
+func LoadFileProgram(path string) (*ir.Program, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve %s: %w", path, err)
+	}
+	return loadCachedGSXProgram(abs)
 }

--- a/route/render_component_test.go
+++ b/route/render_component_test.go
@@ -1,0 +1,246 @@
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// gosx#226: a hand-written Go http.Handler in the same package as a page.gsx
+// file must be able to render that page's own component with typed props
+// and get the exact markup the page itself produces — the pattern
+// data-gosx-region needs for a server-rendered, polled fragment. These tests
+// prove RenderProgramComponent's strict-entry support and LoadFileProgram
+// together close that gap, through the same strict-props boundary a nested
+// <Component/> call already goes through, never around it.
+
+const signalCardFixtureSource = `package app
+type SignalCardProps struct {
+	Label string
+	Value string
+}
+component SignalCard(props: SignalCardProps) {
+	return <li class="signal-card"><span class="signal-card__label">{props.Label}</span><strong class="signal-card__value">{props.Value}</strong></li>
+}
+component Page() {
+	return <SignalCard label="Passing Yards" value="317" />
+}
+`
+
+// SignalCardProps mirrors signalCardFixtureSource's declared props type by
+// name: the strict boundary matches a runtime value against the source's
+// declared struct name, so a Go caller must supply a type with this exact
+// identifier — the same rule a nested {...props} spread call already proves
+// against (see requireStrictStructValue / strictSpreadProps).
+type SignalCardProps struct {
+	Label string
+	Value string
+}
+
+// TestRenderProgramComponentStrictEntryMatchesNestedRenderByteForByte is the
+// required byte-for-byte proof: SignalCard renders identically whether it is
+// reached as Page's own nested call (named string attrs, the only shape a
+// .gsx caller can spell) or as the render entry itself (a typed Go value
+// through ProgramRenderEnv.Props).
+func TestRenderProgramComponentStrictEntryMatchesNestedRenderByteForByte(t *testing.T) {
+	prog, err := gosx.Compile([]byte(signalCardFixtureSource))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+
+	viaPage, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("render Page: %v", err)
+	}
+
+	viaEntry, err := RenderProgramComponent(prog, "SignalCard", ProgramRenderEnv{
+		Props: SignalCardProps{Label: "Passing Yards", Value: "317"},
+	})
+	if err != nil {
+		t.Fatalf("render SignalCard entry: %v", err)
+	}
+
+	const want = `<li class="signal-card"><span class="signal-card__label">Passing Yards</span><strong class="signal-card__value">317</strong></li>`
+	if viaPage != want {
+		t.Fatalf("Page render = %q, want %q", viaPage, want)
+	}
+	if viaEntry != viaPage {
+		t.Fatalf("strict entry render = %q, does not byte-match the page's own nested render %q", viaEntry, viaPage)
+	}
+}
+
+// TestRenderProgramComponentStrictEntryRejectsMapProps proves the strict
+// boundary still rejects a map at the entry point, the same way it rejects
+// one at a nested {...props} call site: a map cannot prove field coverage,
+// no matter how the render was reached.
+func TestRenderProgramComponentStrictEntryRejectsMapProps(t *testing.T) {
+	prog, err := gosx.Compile([]byte(signalCardFixtureSource))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = RenderProgramComponent(prog, "SignalCard", ProgramRenderEnv{
+		Props: map[string]any{"Label": "Passing Yards", "Value": "317"},
+	})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly accepted a map for strict typed props")
+	}
+	if !strings.Contains(err.Error(), "maps cannot prove field coverage") {
+		t.Fatalf("error = %v, want the strict map-rejection boundary message", err)
+	}
+}
+
+// TestRenderProgramComponentStrictEntryRejectsIncompleteStruct proves the
+// entry boundary proves every rendered field's presence and declared leaf
+// type, the same way a nested {...props} spread call's boundary does
+// (strictSpreadProps, see TestStrictSpreadProps): a struct missing a
+// rendered field fails closed instead of silently zero-filling it. (A
+// same-shaped struct under a different Go type name is accepted here, by
+// design — see ProgramRenderEnv.Props; strictSpreadProps proves field
+// coverage, not the source struct's own type identity.)
+func TestRenderProgramComponentStrictEntryRejectsIncompleteStruct(t *testing.T) {
+	type partialSignalCardProps struct {
+		Label string
+	}
+	prog, err := gosx.Compile([]byte(signalCardFixtureSource))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = RenderProgramComponent(prog, "SignalCard", ProgramRenderEnv{
+		Props: partialSignalCardProps{Label: "Passing Yards"},
+	})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly accepted a struct missing a rendered field")
+	}
+	if !strings.Contains(err.Error(), "no field Value") {
+		t.Fatalf("error = %v, want the missing-field boundary message", err)
+	}
+}
+
+// TestRenderProgramComponentStrictEntryRejectsNilProps proves the original,
+// unconditional refusal (gosx#185/#226: "the file renderer has no root
+// props binding") still fires byte-for-byte when a caller renders a strict
+// entry without supplying Props — the pre-existing
+// TestRenderProgramComponentRejectsStrictRootProps covers the same
+// contract; this one exercises it against a component with a real,
+// non-empty PropsFields set instead of a hand-built program.
+func TestRenderProgramComponentStrictEntryRejectsNilProps(t *testing.T) {
+	prog, err := gosx.Compile([]byte(signalCardFixtureSource))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	_, err = RenderProgramComponent(prog, "SignalCard", ProgramRenderEnv{})
+	if err == nil || !strings.Contains(err.Error(), "no root props binding") {
+		t.Fatalf("error = %v, want the no-props-supplied refusal", err)
+	}
+}
+
+// TestFragmentHandlerServesPageOwnComponentForLiveRegion is the gosx#226 end
+// to end proof. fragmentHandler stands in for a hand-written page.server.go
+// handler living in the same package as page.gsx: it loads the page's own
+// compiled program with LoadFileProgram and renders one of its strict
+// components directly, typed props and all, through RenderProgramComponent.
+// It never re-derives SignalCard's markup with the low-level
+// El/Attrs/Text API — the two-copies-that-drift workaround gosx#226
+// reports — it renders the SAME component the page itself declares. The
+// fragment it serves is byte-for-byte the same markup the page renders that
+// component as inside its own <ul data-gosx-region> list: the exact
+// swap-in fragment data-gosx-region-url polls for.
+func TestFragmentHandlerServesPageOwnComponentForLiveRegion(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", `package app
+type SignalCardProps struct {
+	Label string
+	Value string
+}
+component SignalCard(props: SignalCardProps) {
+	return <li class="signal-card">{props.Label}: {props.Value}</li>
+}
+component Page() {
+	return <ul data-gosx-region data-gosx-region-url="/wire/signal" data-gosx-region-interval="20s">
+		<SignalCard label="Passing Yards" value="317" />
+	</ul>
+}
+`)
+	gsxPath := filepath.Join(root, "page.gsx")
+
+	fragmentHandler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		prog, err := LoadFileProgram(gsxPath)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		html, err := RenderProgramComponent(prog, "SignalCard", ProgramRenderEnv{
+			Props: SignalCardProps{Label: "Passing Yards", Value: "317"},
+		})
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = w.Write([]byte(html))
+	})
+
+	router := NewRouter()
+	router.Handle("/wire/signal", fragmentHandler)
+	if err := router.AddDir(root, FileRoutesOptions{}); err != nil {
+		t.Fatalf("AddDir: %v", err)
+	}
+	handler := router.Build()
+
+	pageReq := httptest.NewRequest(http.MethodGet, "/", nil)
+	pageRec := httptest.NewRecorder()
+	handler.ServeHTTP(pageRec, pageReq)
+	if pageRec.Code != http.StatusOK {
+		t.Fatalf("GET / = %d, body: %s", pageRec.Code, pageRec.Body.String())
+	}
+	pageBody := pageRec.Body.String()
+	if !strings.Contains(pageBody, `data-gosx-region-url="/wire/signal"`) {
+		t.Fatalf("page is missing its data-gosx-region wiring: %s", pageBody)
+	}
+
+	fragmentReq := httptest.NewRequest(http.MethodGet, "/wire/signal", nil)
+	fragmentRec := httptest.NewRecorder()
+	handler.ServeHTTP(fragmentRec, fragmentReq)
+	if fragmentRec.Code != http.StatusOK {
+		t.Fatalf("GET /wire/signal = %d, body: %s", fragmentRec.Code, fragmentRec.Body.String())
+	}
+	fragmentBody := fragmentRec.Body.String()
+
+	const wantFragment = `<li class="signal-card">Passing Yards: 317</li>`
+	if fragmentBody != wantFragment {
+		t.Fatalf("fragment body = %q, want %q", fragmentBody, wantFragment)
+	}
+	if !strings.Contains(pageBody, wantFragment) {
+		t.Fatalf("page body does not embed the exact fragment markup %q: %s", wantFragment, pageBody)
+	}
+}
+
+// TestLoadFileProgramSharesFileRouterCache proves LoadFileProgram is not a
+// second, independently-stale compile path: it returns the identical
+// *ir.Program a file-routed page renders through (gsxCompileCache is keyed
+// by path plus mtime plus size), not a fresh parse of the same bytes.
+func TestLoadFileProgramSharesFileRouterCache(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", `package app
+component Page() {
+	return <main>hello</main>
+}
+`)
+	gsxPath := filepath.Join(root, "page.gsx")
+
+	viaHelper, err := LoadFileProgram(gsxPath)
+	if err != nil {
+		t.Fatalf("LoadFileProgram: %v", err)
+	}
+	viaFileRoute, err := loadCachedGSXProgram(gsxPath)
+	if err != nil {
+		t.Fatalf("loadCachedGSXProgram: %v", err)
+	}
+	if viaHelper != viaFileRoute {
+		t.Fatalf("LoadFileProgram returned a different *ir.Program than the file router's own cache")
+	}
+}


### PR DESCRIPTION
## Summary

Close the fragment-endpoint gap for `data-gosx-region-url` handlers by allowing Go handlers in the same package as a `.gsx` file to render its own strict component with typed props. Introduces `ProgramRenderEnv.Props` to validate field coverage at the entry point exactly as nested component calls do, plus `LoadFileProgram` to compile `.gsx` files through the file router's shared stat-keyed cache, ensuring hot-reload edits reach fragment handlers identically to the page itself.

## Changes

- Propagate `ProgramRenderEnv.Props` as `EntryProps` so `RenderProgramComponent` accepts typed props when a strict component is used as the render entry
- Enforce the same strict-spread boundary at the entry point as nested component calls: `nil` Props fails closed with the original missing-binding error, maps are rejected outright, and structs must cover every rendered field with matching declared leaf types
- Add `LoadFileProgram(path string)` to load a `.gsx` file's compiled IR program through the file router's existing stat-keyed cache, preventing independently-stale copies and aligning fragment hot-reloads with the page itself
- Update runtime documentation to demonstrate how a `page.server.go` `http.Handler` can use `LoadFileProgram` and `RenderProgramComponent` to serve the exact HTML fragment polled by `data-gosx-region`
- Add comprehensive tests covering byte-for-byte parity with nested renders, strict rejection rules for maps/incomplete structs, nil-props failure, end-to-end fragment routing, and cache-sharing verification

## Testing

- Run `go test ./route -run 'TestRenderProgramComponentStrict|TestFragmentHandlerServesPageOwnComponentForLiveRegion|TestLoadFileProgramSharesFileRouterCache'`
- Verify updated runtime docs render correctly by running `cd examples/gosx-docs && go run .`

## Related Issues

- Refs #226