### PR TITLE
update(examples): update basic example to use file-based routing

### DIFF
--- a/examples/basic/app/counter/page.gsx
+++ b/examples/basic/app/counter/page.gsx
@@ -4,7 +4,9 @@ func Page() Node {
 	return <div class="container">
 		<h1>Counter</h1>
 		<nav>
-			<a href="/">Home</a> | <a href="/counter">Counter</a>
+			<a href="/">Home</a>
+			|
+			<a href="/counter">Counter</a>
 		</nav>
 		<hr />
 		<div class="counter">

--- a/examples/basic/app/counter/page.gsx
+++ b/examples/basic/app/counter/page.gsx
@@ -1,0 +1,16 @@
+package counter
+
+func Page() Node {
+	return <div class="container">
+		<h1>Counter</h1>
+		<nav>
+			<a href="/">Home</a> | <a href="/counter">Counter</a>
+		</nav>
+		<hr />
+		<div class="counter">
+			<a href={data.prevHref}>[ - ]</a>
+			<span style="margin: 0 1em; font-size: 2em">{data.count}</span>
+			<a href={data.nextHref}>[ + ]</a>
+		</div>
+	</div>
+}

--- a/examples/basic/app/counter/page.server.go
+++ b/examples/basic/app/counter/page.server.go
@@ -1,0 +1,32 @@
+// Package counter renders /counter, a server-side counter demonstration.
+// Each button click does a full page navigation (server-first, no client
+// JS): the count lives in the "count" query parameter, and Load reads it
+// fresh on every request.
+package counter
+
+import (
+	"fmt"
+	"log"
+	"strconv"
+
+	"m31labs.dev/gosx/route"
+	"m31labs.dev/gosx/server"
+)
+
+func init() {
+	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			count, _ := strconv.Atoi(ctx.Query("count"))
+			return map[string]any{
+				"count":    count,
+				"prevHref": fmt.Sprintf("/counter?count=%d", count-1),
+				"nextHref": fmt.Sprintf("/counter?count=%d", count+1),
+			}, nil
+		},
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: server.Title{Default: "GoSX Example - Counter"}}, nil
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/basic/app/page.gsx
+++ b/examples/basic/app/page.gsx
@@ -1,0 +1,18 @@
+package app
+
+func Page() Node {
+	return <div class="container">
+		<h1>GoSX Example</h1>
+		<p>A Go-native web application platform.</p>
+		<nav>
+			<a href="/">Home</a>
+			|
+			<a href="/counter">Counter</a>
+		</nav>
+		<hr />
+		<p>
+			Server rendered at:
+			{data.serverTime}
+		</p>
+	</div>
+}

--- a/examples/basic/app/page.server.go
+++ b/examples/basic/app/page.server.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"log"
+	"time"
+
+	"m31labs.dev/gosx/route"
+	"m31labs.dev/gosx/server"
+)
+
+func init() {
+	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]any{
+				"serverTime": time.Now().Format(time.RFC3339),
+			}, nil
+		},
+		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
+			return server.Metadata{Title: server.Title{Default: "GoSX Example - Home"}}, nil
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/basic/main.go
+++ b/examples/basic/main.go
@@ -1,7 +1,9 @@
 // Example basic demonstrates a simple GoSX server application.
 //
-// This example uses the runtime Node API directly (rather than .gsx source files)
-// to build and render components on the server.
+// Pages are authored in .gsx source files (see app/page.gsx and
+// app/counter/page.gsx) and served through the file-based router — the
+// same app/page.gsx + page.server.go convention `gosx init` scaffolds for
+// a new application. main.go only wires the router to an HTTP server.
 //
 // Run: go run ./examples/basic
 // Visit: http://localhost:8080
@@ -10,74 +12,36 @@ package main
 import (
 	"fmt"
 	"log"
-	"net/http"
-	"strconv"
-	"time"
+	"path/filepath"
+	"runtime"
 
 	"m31labs.dev/gosx"
+	_ "m31labs.dev/gosx/examples/basic/app"
+	_ "m31labs.dev/gosx/examples/basic/app/counter"
+	"m31labs.dev/gosx/route"
 	"m31labs.dev/gosx/server"
 )
 
 func main() {
+	_, thisFile, _, _ := runtime.Caller(0)
+	root := filepath.Dir(thisFile)
+
+	router := route.NewRouter()
+	router.SetLayout(func(ctx *route.RouteContext, body gosx.Node) gosx.Node {
+		return server.HTMLDocument(ctx.Title("GoSX Example"), gosx.Node{}, body)
+	})
+	if err := router.AddDir(filepath.Join(root, "app"), route.FileRoutesOptions{}); err != nil {
+		log.Fatal(err)
+	}
+
+	rootHandler, err := router.BuildChecked()
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	app := server.New()
-
-	app.SetLayout(func(title string, body gosx.Node) gosx.Node {
-		return server.HTMLDocument("GoSX Example - "+title, gosx.Node{}, body)
-	})
-
-	app.Route("/", func(r *http.Request) gosx.Node {
-		return HomePage()
-	})
-
-	app.Route("/counter", func(r *http.Request) gosx.Node {
-		countStr := r.URL.Query().Get("count")
-		count, _ := strconv.Atoi(countStr)
-		return CounterPage(count)
-	})
+	app.Mount("/", rootHandler)
 
 	fmt.Println("GoSX example server running at http://localhost:8080")
 	log.Fatal(app.ListenAndServe(":8080"))
-}
-
-// HomePage renders the home page.
-func HomePage() gosx.Node {
-	return gosx.El("div", gosx.Attrs(gosx.Attr("class", "container")),
-		gosx.El("h1", gosx.Text("GoSX Example")),
-		gosx.El("p", gosx.Text("A Go-native web application platform.")),
-		gosx.El("nav",
-			gosx.El("a", gosx.Attrs(gosx.Attr("href", "/")), gosx.Text("Home")),
-			gosx.Text(" | "),
-			gosx.El("a", gosx.Attrs(gosx.Attr("href", "/counter")), gosx.Text("Counter")),
-		),
-		gosx.El("hr"),
-		gosx.El("p", gosx.Text("Server rendered at: "+time.Now().Format(time.RFC3339))),
-	)
-}
-
-// CounterPage renders a server-side counter demonstration.
-// Each button click does a full page navigation (server-first, no client JS).
-func CounterPage(count int) gosx.Node {
-	return gosx.El("div", gosx.Attrs(gosx.Attr("class", "container")),
-		gosx.El("h1", gosx.Text("Counter")),
-		gosx.El("nav",
-			gosx.El("a", gosx.Attrs(gosx.Attr("href", "/")), gosx.Text("Home")),
-			gosx.Text(" | "),
-			gosx.El("a", gosx.Attrs(gosx.Attr("href", "/counter")), gosx.Text("Counter")),
-		),
-		gosx.El("hr"),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "counter")),
-			gosx.El("a",
-				gosx.Attrs(gosx.Attr("href", fmt.Sprintf("/counter?count=%d", count-1))),
-				gosx.Text("[ - ]"),
-			),
-			gosx.El("span",
-				gosx.Attrs(gosx.Attr("style", "margin: 0 1em; font-size: 2em")),
-				gosx.Expr(count),
-			),
-			gosx.El("a",
-				gosx.Attrs(gosx.Attr("href", fmt.Sprintf("/counter?count=%d", count+1))),
-				gosx.Text("[ + ]"),
-			),
-		),
-	)
 }

--- a/examples/gosx-docs/app/components.go
+++ b/examples/gosx-docs/app/components.go
@@ -1,3 +1,22 @@
+// Package docs implements the GoSX documentation site.
+//
+// This file holds the site's shared component library: CodeBlock,
+// StatCard, CapabilityTag, and Tooltip. Each one stays on the low-level
+// gosx.El/Attrs/Text API by necessity, not as a style example.
+//
+// modules.go binds each function, by compile-time Go identifier, into
+// every page's route.FileTemplateBindings.Funcs and .Components maps.
+// That binding lets other .gsx pages call these functions as tags, for
+// example `<CodeBlock lang="go" source={...} />`, or as plain calls, for
+// example `{CodeBlock("go", "...")}`.
+//
+// A Funcs or Components map entry must be a real, linkable Go function
+// value. The file router has no supported way to bind a .gsx-authored
+// component into that map by name. A component defined inside one
+// page.gsx file is visible only to that page, not to every page that
+// wants to reuse it. Until GoSX ships a shared, cross-page .gsx component
+// surface, this package stays Go, for the same reason server/page.go and
+// server/metadata_render.go stay Go.
 package docs
 
 import (

--- a/examples/gosx-docs/app/demos/water/page.server.go
+++ b/examples/gosx-docs/app/demos/water/page.server.go
@@ -33,6 +33,13 @@ func init() {
 	)
 }
 
+// addWaterDemoPreloadHead builds one <link rel=preload> per cubemap face
+// and adds it to the response head. Load is a plain Go function, not a
+// .gsx page, so this loop cannot render markup declaratively. It reaches
+// for gosx.El because server has no cross-origin preload-link helper,
+// only the fixed server.ScenePosterPreload. A general
+// server.PreloadLink(href, as string, extra ...gosx.Attribute) helper
+// would remove this local El use.
 func addWaterDemoPreloadHead(ctx *route.RouteContext) {
 	if ctx == nil {
 		return

--- a/examples/gosx-docs/app/docs/engines/page.server.go
+++ b/examples/gosx-docs/app/docs/engines/page.server.go
@@ -21,6 +21,12 @@ func init() {
 					{"href": "#go-wasm", "label": "Go WASM"},
 					{"href": "#lifecycle", "label": "Lifecycle"},
 				},
+				// mountSample is teaching text, rendered through CodeBlock on the
+				// page. It shows a ctx.Engine call site, real Go code that would
+				// live in a Load function. Its fallback argument uses gosx.El on
+				// purpose: a one-node inline fallback is the idiom this same
+				// package already uses in Go glue code, for example in
+				// server.ScenePosterPreload.
 				"mountSample":      "raw, err := json.Marshal(ChartProps{Series: values})\nif err != nil {\n\treturn nil\n}\n\nreturn ctx.Engine(engine.Config{\n\tName:         \"Chart\",\n\tKind:         engine.KindSurface,\n\tMountID:      \"sales-chart\",\n\tProps:        raw,\n\tCapabilities: []engine.Capability{engine.CapCanvas, engine.CapPointer},\n\tMountAttrs: map[string]any{\n\t\t\"class\":      \"chart-surface\",\n\t\t\"aria-label\": \"Sales chart\",\n\t},\n}, gosx.El(\"p\", gosx.Text(\"Chart unavailable\")))",
 				"webgpuSample":     "required := engine.RequireWebGPU(\n\tengine.CapWebGPUTimestampQuery,\n\tengine.WebGPULimit(\"maxComputeWorkgroupsPerDimension\", 256),\n)\n\ncfg := engine.Config{\n\tName:                 \"ParticleLab\",\n\tKind:                 engine.KindSurface,\n\tMountID:              \"particles\",\n\tCapabilities:         []engine.Capability{engine.CapCanvas, engine.CapAnimation},\n\tRequiredCapabilities: required,\n}",
 				"wasmConfigSample": "cfg := engine.Config{\n\tName:     \"Chart\",\n\tKind:     engine.KindSurface,\n\tMountID:  \"chart\",\n\tRuntime:  engine.RuntimeGoWASM,\n\tWASMPath: \"/engines/chart.wasm\",\n}",

--- a/examples/gosx-docs/app/docs/streaming/page.server.go
+++ b/examples/gosx-docs/app/docs/streaming/page.server.go
@@ -24,6 +24,10 @@ func init() {
 					{"href": "#errors-and-csp", "label": "Errors & CSP"},
 					{"href": "#caching", "label": "Caching"},
 				},
+				// deferSample and optionsSample are teaching text, rendered
+				// through CodeBlock on the page. They show ctx.Defer/ctx.Suspense
+				// callers, so they show gosx.El on purpose: that is the real
+				// shape of a Defer callback body written in Go, not .gsx markup.
 				"deferSample":   "return gosx.El(\"main\",\n\tctx.Defer(\n\t\tgosx.El(\"p\", gosx.Text(\"Loading activity...\")),\n\t\tfunc() (gosx.Node, error) {\n\t\t\titems, err := loadActivity(ctx.Request.Context())\n\t\t\tif err != nil {\n\t\t\t\treturn nil, err\n\t\t\t}\n\t\t\treturn ActivityList(items), nil\n\t\t},\n\t),\n)",
 				"optionsSample": "ctx.SuspenseWithOptions(server.DeferredOptions{\n\tID:       \"account-summary\",\n\tTag:      \"section\",\n\tClass:    \"summary-shell\",\n\tBoundary: \"component\",\n}, fallback, resolve)",
 			}, nil
@@ -31,6 +35,13 @@ func init() {
 		Bindings: func(ctx *route.RouteContext, page route.FilePage, data any) route.FileTemplateBindings {
 			var demoRegion gosx.Node = gosx.Text("")
 			if ctx != nil {
+				// The fallback and resolved nodes below are plain gosx.El, not a
+				// .gsx-authored fragment. Bindings is a Go function, and .gsx
+				// content is reachable only from the file router's own page/layout
+				// scan, so a Go function such as this one cannot call into a .gsx
+				// file. ctx.DeferWithOptions also needs its fallback and resolve
+				// arguments as real gosx.Node/func values, computed here at
+				// request time, not as static page markup.
 				demoRegion = ctx.DeferWithOptions(server.DeferredOptions{
 					Class: "streaming-demo-region",
 				}, gosx.El("div", gosx.Attrs(gosx.Attr("class", "demo-well")),


### PR DESCRIPTION
## Summary

Migrates the basic example from manually wired runtime Node API calls to the standard file-based routing pattern (`app/page.gsx` + `page.server.go`). Also documents why `gosx-docs` intentionally relies on the lower-level `gosx.El` API for shared components, preload helpers, and sample code where `.gsx` compilation isn't supported yet.

## Changes

- Migrate `examples/basic/main.go` to use `route.NewRouter()` and `router.AddDir()`, replacing manual `app.Route()` registrations and inline page functions.
- Add `app/page.gsx`, `app/page.server.go`, `counter/page.gsx`, and `counter/page.server.go` to align with the `gosx init` scaffolding convention.
- Update `main.go` doc comment to reflect the new file-based authoring workflow.
- Add package and inline comments to `gosx-docs` examples clarifying why shared components, preload logic, and teaching samples use `gosx.El` instead of declarative `.gsx` markup.

## Testing

- Run `go run ./examples/basic` and navigate to http://localhost:8080 to verify the home page and /counter routes render correctly via file-based routing.
- Verify `go build ./...` succeeds for all updated examples to confirm no regressions in the docs site or core router usage.