### PR TITLE
refactor(examples/dashboard): refactor dashboard to file-routed pages and extracted chrome

### DIFF
--- a/examples/dashboard/app/layout.gsx
+++ b/examples/dashboard/app/layout.gsx
@@ -1,21 +1,25 @@
 package app
 
+// Layout matches the sidebar/main shell main.go's Layout builds by hand for
+// the two island routes (/counter, /kitchen-sink), which need to inject
+// island preload hints and page-head scripts that this file-routed layout
+// has no hook for. Keep the two in step by hand when either one changes.
 func Layout() Node {
 	return <div class="layout">
 		<aside class="sidebar">
 			<h2>GoSX Dashboard</h2>
 			<nav>
-				<a href="/" data-gosx-link>Home</a>
-				<a href="/users" data-gosx-link>Users</a>
-				<a href="/users/new" data-gosx-link>New User</a>
-				<a href="/counter" data-gosx-link>Counter</a>
-				<a href="/kitchen-sink" data-gosx-link>Kitchen Sink</a>
-				<a href="/settings" data-gosx-link>Settings</a>
+				<a href="/">Home</a>
+				<a href="/users">Users</a>
+				<a href="/users/new">New User</a>
+				<a href="/counter">Counter</a>
+				<a href="/kitchen-sink">Kitchen Sink</a>
+				<a href="/settings">Settings</a>
 			</nav>
 		</aside>
 		<main class="main">
 			<Slot />
-			<div class="footer">GoSX — Server rendered</div>
+			<div class="footer">{dash.footer}</div>
 		</main>
 	</div>
 }

--- a/examples/dashboard/app/layout.server.go
+++ b/examples/dashboard/app/layout.server.go
@@ -1,0 +1,29 @@
+package app
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+)
+
+func init() {
+	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
+		// footer is composed as one string, not joined from separate text and
+		// {dash.version}/{dash.renderedAt} holes in layout.gsx: gosx fmt wraps
+		// a long mix of literal text and expression holes onto separate
+		// lines, and each hole then renders with the line break and indent
+		// around it as literal text. A single hole has nothing to wrap.
+		Bindings: func(ctx *route.RouteContext, page route.FilePage, data any) route.FileTemplateBindings {
+			return route.FileTemplateBindings{Values: map[string]any{
+				"dash": map[string]string{
+					"footer": fmt.Sprintf("GoSX v%s — Server rendered at %s", gosx.Version, time.Now().Format("15:04:05")),
+				},
+			}}
+		},
+	}); err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/dashboard/app/page.gsx
+++ b/examples/dashboard/app/page.gsx
@@ -1,7 +1,7 @@
 package app
 
 func Page() Node {
-	return <div>
+	return <>
 		<h1>Dashboard</h1>
 		<div class="grid">
 			<div class="card">
@@ -60,5 +60,5 @@ func Page() Node {
 				</tbody>
 			</table>
 		</div>
-	</div>
+	</>
 }

--- a/examples/dashboard/app/settings/page.gsx
+++ b/examples/dashboard/app/settings/page.gsx
@@ -1,12 +1,11 @@
 package settings
 
 func Page() Node {
-	return <div>
+	return <>
 		<h1>Settings</h1>
 		<div class="card">
 			<h3>Application Settings</h3>
 			<form method="post" action={actionPath("saveSettings")}>
-				<input type="hidden" name="csrf_token" value={csrf.token}></input>
 				<div class="form-group">
 					<label>Site Name</label>
 					<input type="text" name="siteName" value="GoSX Dashboard"></input>
@@ -22,9 +21,11 @@ func Page() Node {
 					<label>Items per page</label>
 					<input type="number" name="pageSize" value="25" min="10" max="100"></input>
 				</div>
-				<p class="form-status">{action.message}</p>
+				<If cond={action.message != ""}>
+					<p class="form-status">{action.message}</p>
+				</If>
 				<button type="submit" class="btn btn-primary">Save Settings</button>
 			</form>
 		</div>
-	</div>
+	</>
 }

--- a/examples/dashboard/app/users/new/page.gsx
+++ b/examples/dashboard/app/users/new/page.gsx
@@ -1,15 +1,22 @@
 package new
 
 func Page() Node {
-	return <div>
+	return <>
 		<h1>New User</h1>
 		<div class="card">
 			<form method="post" action={actionPath("createUser")}>
-				<input type="hidden" name="csrf_token" value={csrf.token}></input>
 				<div class="form-group">
 					<label>Name</label>
-					<input type="text" name="name" placeholder="Full name" value={actions.createUser.values.name}></input>
-					<p class="form-error">{actions.createUser.fieldErrors.name}</p>
+					<input
+						type="text"
+						name="name"
+						placeholder="Full name"
+						required
+						value={actions.createUser.values.name}
+					></input>
+					<If cond={actions.createUser.fieldErrors.name != ""}>
+						<p class="form-error">{actions.createUser.fieldErrors.name}</p>
+					</If>
 				</div>
 				<div class="form-group">
 					<label>Email</label>
@@ -17,9 +24,12 @@ func Page() Node {
 						type="email"
 						name="email"
 						placeholder="email@example.com"
+						required
 						value={actions.createUser.values.email}
 					></input>
-					<p class="form-error">{actions.createUser.fieldErrors.email}</p>
+					<If cond={actions.createUser.fieldErrors.email != ""}>
+						<p class="form-error">{actions.createUser.fieldErrors.email}</p>
+					</If>
 				</div>
 				<div class="form-group">
 					<label>Role</label>
@@ -29,10 +39,12 @@ func Page() Node {
 						<option value="admin">Admin</option>
 					</select>
 				</div>
-				<p class="form-status">{action.message}</p>
+				<If cond={action.message != ""}>
+					<p class="form-status">{action.message}</p>
+				</If>
 				<button type="submit" class="btn btn-primary">Create User</button>
-				<a href="/users" data-gosx-link class="btn btn-cancel">Cancel</a>
+				<a href="/users" class="btn btn-cancel">Cancel</a>
 			</form>
 		</div>
-	</div>
+	</>
 }

--- a/examples/dashboard/app/users/new/page.server.go
+++ b/examples/dashboard/app/users/new/page.server.go
@@ -28,7 +28,8 @@ func init() {
 				if len(fieldErrors) > 0 {
 					return action.Validation("Please correct the highlighted fields.", fieldErrors, ctx.FormData)
 				}
-				return ctx.Success("User created.", nil)
+				ctx.Redirect("/users")
+				return nil
 			},
 		},
 	}); err != nil {

--- a/examples/dashboard/app/users/page.gsx
+++ b/examples/dashboard/app/users/page.gsx
@@ -1,11 +1,11 @@
 package users
 
 func Page() Node {
-	return <div>
+	return <>
 		<h1>Users</h1>
 		<div class="search-bar">
 			<form method="get" action="/users" class="search-form">
-				<input type="text" name="q" placeholder="Search users..." value={data.query}></input>
+				<input type="text" name="q" placeholder="Search users..." value={data.Query} />
 				<button type="submit" class="btn btn-primary">Search</button>
 			</form>
 			<a href="/users/new" class="btn btn-primary">+ New User</a>
@@ -22,74 +22,29 @@ func Page() Node {
 					</tr>
 				</thead>
 				<tbody>
-					<tr>
-						<td>Alice Johnson</td>
-						<td>alice@example.com</td>
-						<td>Admin</td>
-						<td>
-							<span class="badge badge-active">Active</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
-					<tr>
-						<td>Bob Smith</td>
-						<td>bob@example.com</td>
-						<td>Editor</td>
-						<td>
-							<span class="badge badge-active">Active</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
-					<tr>
-						<td>Carol Williams</td>
-						<td>carol@example.com</td>
-						<td>Viewer</td>
-						<td>
-							<span class="badge badge-inactive">Inactive</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
-					<tr>
-						<td>Dave Brown</td>
-						<td>dave@example.com</td>
-						<td>Editor</td>
-						<td>
-							<span class="badge badge-active">Active</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
-					<tr>
-						<td>Eve Davis</td>
-						<td>eve@example.com</td>
-						<td>Admin</td>
-						<td>
-							<span class="badge badge-active">Active</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
-					<tr>
-						<td>Frank Miller</td>
-						<td>frank@example.com</td>
-						<td>Viewer</td>
-						<td>
-							<span class="badge badge-inactive">Inactive</span>
-						</td>
-						<td>
-							<button class="btn btn-danger btn-sm">Delete</button>
-						</td>
-					</tr>
+					<Each of={data.Users} as="u">
+						<tr>
+							<td>{u.Name}</td>
+							<td>{u.Email}</td>
+							<td>{u.Role}</td>
+							<td>
+								<If cond={u.Active}>
+									<span class="badge badge-active">Active</span>
+								</If>
+								<If cond={!u.Active}>
+									<span class="badge badge-inactive">Inactive</span>
+								</If>
+							</td>
+							<td>
+								<button class="btn btn-danger btn-sm">Delete</button>
+							</td>
+						</tr>
+					</Each>
 				</tbody>
 			</table>
+			<If cond={data.Empty}>
+				<p class="empty-state">No users found matching your search.</p>
+			</If>
 		</div>
-	</div>
+	</>
 }

--- a/examples/dashboard/app/users/page.server.go
+++ b/examples/dashboard/app/users/page.server.go
@@ -2,17 +2,52 @@ package users
 
 import (
 	"log"
+	"strings"
 
 	"m31labs.dev/gosx/route"
 	"m31labs.dev/gosx/server"
 )
 
+// user is a display row for the users table. The loader below filters and
+// types this list; the page template only renders it.
+type user struct {
+	Name   string
+	Email  string
+	Role   string
+	Active bool
+}
+
+var allUsers = []user{
+	{"Alice Johnson", "alice@example.com", "Admin", true},
+	{"Bob Smith", "bob@example.com", "Editor", true},
+	{"Carol Williams", "carol@example.com", "Viewer", false},
+	{"Dave Brown", "dave@example.com", "Editor", true},
+	{"Eve Davis", "eve@example.com", "Admin", true},
+	{"Frank Miller", "frank@example.com", "Viewer", false},
+}
+
+type usersPageData struct {
+	Query string
+	Users []user
+	Empty bool
+}
+
 func init() {
 	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
 		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
-			return map[string]string{
-				"query": ctx.Query("q"),
-			}, nil
+			query := ctx.Query("q")
+			rows := allUsers
+			if query != "" {
+				q := strings.ToLower(query)
+				filtered := make([]user, 0, len(allUsers))
+				for _, u := range allUsers {
+					if strings.Contains(strings.ToLower(u.Name), q) || strings.Contains(strings.ToLower(u.Email), q) {
+						filtered = append(filtered, u)
+					}
+				}
+				rows = filtered
+			}
+			return usersPageData{Query: query, Users: rows, Empty: len(rows) == 0}, nil
 		},
 		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {
 			return server.Metadata{Title: server.Title{Absolute: "Users"}}, nil

--- a/examples/dashboard/chrome.go
+++ b/examples/dashboard/chrome.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"log"
+	"path/filepath"
+	"runtime"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/route"
+)
+
+// chromeProgram is chrome.gsx's compiled IR, loaded once at startup. Every
+// route.RenderProgramComponent call below reads through the same cached
+// program (route.LoadFileProgram caches by path and mtime), so an edit to
+// chrome.gsx invalidates it exactly the way an edit to a file-routed page
+// does — there is no second, independently-stale copy.
+var chromeProgram = mustLoadChromeProgram()
+
+func mustLoadChromeProgram() *ir.Program {
+	_, thisFile, _, _ := runtime.Caller(0)
+	path := filepath.Join(filepath.Dir(thisFile), "chrome.gsx")
+	prog, err := route.LoadFileProgram(path)
+	if err != nil {
+		log.Fatalf("load chrome.gsx: %v", err)
+	}
+	return prog
+}
+
+// chrome renders a zero-prop strict component from chrome.gsx as a Node the
+// caller splices next to Go-computed content (an island's rendered HTML,
+// primarily) that chrome.gsx itself has no way to accept — see the package
+// comment in chrome.gsx.
+func chrome(component string) gosx.Node {
+	html, err := route.RenderProgramComponent(chromeProgram, component, route.ProgramRenderEnv{})
+	if err != nil {
+		log.Fatalf("render chrome.gsx %s: %v", component, err)
+	}
+	return gosx.RawHTML(html)
+}

--- a/examples/dashboard/chrome.gsx
+++ b/examples/dashboard/chrome.gsx
@@ -1,0 +1,119 @@
+package main
+
+// chrome.gsx holds the static prose and card headings for the two island
+// routes (/counter, /kitchen-sink). Those routes stay hand-written Go — see
+// the comment on CounterPage and KitchenSinkPage in main.go for why — but
+// everything in this file is ordinary markup with no per-request data, so it
+// renders through route.RenderProgramComponent (gosx#226) instead of El.
+
+component CounterIntro() {
+	return <h1>Counter (Island Demo)</h1>
+}
+
+component CounterCardHeader() {
+	return <>
+		<h3>Interactive Island</h3>
+		<p>
+			This counter is compiled from counter.gsx and hydrated via WASM.
+		</p>
+		<br />
+	</>
+}
+
+component CounterHowItWorksCard() {
+	return <div class="card">
+		<h3>How It Works</h3>
+		<p>
+			1. counter.gsx is compiled to an IslandProgram at server startup
+		</p>
+		<p>
+			2. Server renders the counter HTML with data-gosx-handler attributes
+		</p>
+		<p>
+			3. Bootstrap loads the shared WASM runtime and fetches the IslandProgram
+		</p>
+		<p>
+			4. Event delegation catches clicks and dispatches to the VM
+		</p>
+		<p>
+			5. Signal updates trigger reconciliation and DOM patching
+		</p>
+	</div>
+}
+
+component KitchenSinkIntro() {
+	return <>
+		<h1>Kitchen Sink — SPA Patterns</h1>
+		<p>
+			Every pattern below is a GoSX island: server-rendered HTML hydrated with a shared WASM runtime. Click to interact — no page reloads.
+		</p>
+	</>
+}
+
+component KSCounterHeader() {
+	return <>
+		<h2>Counter</h2>
+		<p>Signal-driven increment/decrement.</p>
+	</>
+}
+
+component KSTabsHeader() {
+	return <>
+		<h2>Tabs</h2>
+		<p>
+			Conditional rendering via OpCond with dynamic CSS class toggling on active tab.
+		</p>
+	</>
+}
+
+component KSToggleHeader() {
+	return <>
+		<h2>Toggle</h2>
+		<p>
+			Boolean signal with show/hide. Click or press Enter to toggle (keyboard handler).
+		</p>
+	</>
+}
+
+component KSTodoHeader() {
+	return <>
+		<h2>Todo List</h2>
+		<p>String concatenation for list items.</p>
+	</>
+}
+
+component KSFormHeader() {
+	return <>
+		<h2>Form Validation</h2>
+		<p>
+			Two-way input binding via OpEventGet. Type in the input to see live updates.
+		</p>
+	</>
+}
+
+component KSPriceHeader() {
+	return <>
+		<h2>Price Calculator</h2>
+		<p>
+			Derived values: total = price x qty - discount.
+		</p>
+	</>
+}
+
+component KSListHeader() {
+	return <>
+		<h2>Dynamic List</h2>
+		<p>
+			Add/remove items from a list. Items stored as comma-separated string, count tracked separately.
+		</p>
+	</>
+}
+
+component KSEditorHeader() {
+	return <>
+		<h2>Code Editor</h2>
+		<p>
+			Overlay editor with WASM-powered Go syntax highlighting, line numbers, and live char count.
+		</p>
+	</>
+}

--- a/examples/dashboard/main.go
+++ b/examples/dashboard/main.go
@@ -23,7 +23,7 @@ import (
 	"time"
 
 	"m31labs.dev/gosx"
-	"m31labs.dev/gosx/action"
+	_ "m31labs.dev/gosx/examples/dashboard/modules"
 	"m31labs.dev/gosx/highlight"
 	"m31labs.dev/gosx/hydrate"
 	"m31labs.dev/gosx/island"
@@ -32,32 +32,6 @@ import (
 )
 
 func main() {
-	// Action registry for server-callable actions
-	actions := action.NewRegistry()
-	actions.Register("createUser", func(ctx *action.Context) error {
-		name := strings.TrimSpace(ctx.FormData["name"])
-		email := strings.TrimSpace(ctx.FormData["email"])
-		fieldErrors := map[string]string{}
-		if name == "" {
-			fieldErrors["name"] = "Name is required."
-		}
-		if email == "" {
-			fieldErrors["email"] = "Email is required."
-		}
-		if len(fieldErrors) > 0 {
-			ctx.ValidationFailure("Please correct the highlighted fields.", fieldErrors)
-			return nil
-		}
-		log.Printf("Creating user: %s <%s>", name, email)
-		ctx.Redirect("/users")
-		return nil
-	})
-	actions.Register("deleteUser", func(ctx *action.Context) error {
-		log.Printf("Deleting user from request")
-		ctx.Redirect("/users")
-		return nil
-	})
-
 	// Build the Counter island program.
 	// This uses the reference CounterProgram which has real signals, handlers,
 	// and expression opcodes the VM can execute. The .gsx compilation pipeline
@@ -114,36 +88,30 @@ func main() {
 		return r
 	}
 
+	// The default layout wraps only the document shell (doctype, head, css).
+	// The sidebar/main/footer chrome lives in app/layout.gsx and applies
+	// automatically to every page AddDir discovers below — /counter and
+	// /kitchen-sink keep their own Layout override (see below) because they
+	// inject island preload hints and page-head scripts this shell has no
+	// hook for; see the comment on app/layout.gsx's Layout entry.
 	router.SetLayout(func(ctx *route.RouteContext, content gosx.Node) gosx.Node {
-		return Layout("Dashboard", nil, content)
+		return gosx.RawHTML(fmt.Sprintf(`<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>%s</title>
+<link rel="stylesheet" href="/static/styles.css">
+</head>
+<body>
+`, ctx.Title("Dashboard")) + gosx.RenderHTML(content) + "\n\n</body>\n</html>")
 	})
 
+	if err := router.AddDir(filepath.Join(baseDir, "app"), route.FileRoutesOptions{}); err != nil {
+		log.Fatal(err)
+	}
+
 	router.Add(
-		route.Route{
-			Pattern: "/",
-			Handler: func(ctx *route.RouteContext) gosx.Node {
-				return HomePage()
-			},
-		},
-		route.Route{
-			Pattern: "/users",
-			Handler: func(ctx *route.RouteContext) gosx.Node {
-				q := ctx.Query("q")
-				return UsersPage(q)
-			},
-		},
-		route.Route{
-			Pattern: "/users/new",
-			Handler: func(ctx *route.RouteContext) gosx.Node {
-				return NewUserPage()
-			},
-		},
-		route.Route{
-			Pattern: "/settings",
-			Handler: func(ctx *route.RouteContext) gosx.Node {
-				return SettingsPage()
-			},
-		},
 		route.Route{
 			Pattern: "/counter",
 			Layout: func(ctx *route.RouteContext, content gosx.Node) gosx.Node {
@@ -169,7 +137,6 @@ func main() {
 	)
 
 	mux := http.NewServeMux()
-	mux.Handle("POST /gosx/action/{name}", actions)
 
 	// Resolve paths relative to this source file so it works from any working directory
 	exampleDir := baseDir
@@ -295,177 +262,6 @@ func Footer() gosx.Node {
 	)
 }
 
-// HomePage renders the dashboard home.
-func HomePage() gosx.Node {
-	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("Dashboard")),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "grid")),
-			StatCard("Users", "1,247"),
-			StatCard("Active", "892"),
-			StatCard("Revenue", "$48,290"),
-			StatCard("Growth", "+12.5%"),
-		),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h3", gosx.Text("Recent Activity")),
-			ActivityTable(),
-		),
-	)
-}
-
-// StatCard renders a statistics card.
-func StatCard(label, value string) gosx.Node {
-	return gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-		gosx.El("h3", gosx.Text(label)),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "stat")), gosx.Text(value)),
-	)
-}
-
-// ActivityTable renders recent activity.
-func ActivityTable() gosx.Node {
-	type activity struct {
-		user   string
-		action string
-		when   string
-	}
-	activities := []activity{
-		{"Alice", "Created account", "2 min ago"},
-		{"Bob", "Updated profile", "15 min ago"},
-		{"Carol", "Uploaded document", "1 hour ago"},
-		{"Dave", "Changed settings", "3 hours ago"},
-		{"Eve", "Logged in", "5 hours ago"},
-	}
-
-	return gosx.El("table",
-		gosx.El("thead",
-			gosx.El("tr",
-				gosx.El("th", gosx.Text("User")),
-				gosx.El("th", gosx.Text("Action")),
-				gosx.El("th", gosx.Text("When")),
-			),
-		),
-		gosx.El("tbody",
-			gosx.Map(activities, func(a activity, _ int) gosx.Node {
-				return gosx.El("tr",
-					gosx.El("td", gosx.Text(a.user)),
-					gosx.El("td", gosx.Text(a.action)),
-					gosx.El("td", gosx.Text(a.when)),
-				)
-			}),
-		),
-	)
-}
-
-// UsersPage renders the users list with search filtering.
-func UsersPage(query string) gosx.Node {
-	type user struct {
-		name   string
-		email  string
-		role   string
-		active bool
-	}
-	users := []user{
-		{"Alice Johnson", "alice@example.com", "Admin", true},
-		{"Bob Smith", "bob@example.com", "Editor", true},
-		{"Carol Williams", "carol@example.com", "Viewer", false},
-		{"Dave Brown", "dave@example.com", "Editor", true},
-		{"Eve Davis", "eve@example.com", "Admin", true},
-		{"Frank Miller", "frank@example.com", "Viewer", false},
-	}
-
-	// Filter by query
-	if query != "" {
-		var filtered []user
-		q := strings.ToLower(query)
-		for _, u := range users {
-			if strings.Contains(strings.ToLower(u.name), q) || strings.Contains(strings.ToLower(u.email), q) {
-				filtered = append(filtered, u)
-			}
-		}
-		users = filtered
-	}
-
-	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("Users")),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "search-bar")),
-			gosx.RawHTML(fmt.Sprintf(`<form method="get" action="/users" class="search-form">
-				<input type="text" name="q" placeholder="Search users..." value="%s" />
-				<button type="submit" class="btn btn-primary">Search</button>
-			</form>`, query)),
-			gosx.El("a", gosx.Attrs(gosx.Attr("href", "/users/new"), gosx.Attr("class", "btn btn-primary")), gosx.Text("+ New User")),
-		),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("table",
-				gosx.El("thead",
-					gosx.El("tr",
-						gosx.El("th", gosx.Text("Name")),
-						gosx.El("th", gosx.Text("Email")),
-						gosx.El("th", gosx.Text("Role")),
-						gosx.El("th", gosx.Text("Status")),
-						gosx.El("th", gosx.Text("Actions")),
-					),
-				),
-				gosx.El("tbody",
-					gosx.Map(users, func(u user, _ int) gosx.Node {
-						badgeClass := gosx.IfElse(u.active,
-							gosx.Text("badge badge-active"),
-							gosx.Text("badge badge-inactive"),
-						)
-						statusText := "Active"
-						if !u.active {
-							statusText = "Inactive"
-						}
-						return gosx.El("tr",
-							gosx.El("td", gosx.Text(u.name)),
-							gosx.El("td", gosx.Text(u.email)),
-							gosx.El("td", gosx.Text(u.role)),
-							gosx.El("td",
-								gosx.El("span", gosx.Attrs(gosx.Attr("class", gosx.RenderHTML(badgeClass))),
-									gosx.Text(statusText)),
-							),
-							gosx.El("td",
-								gosx.El("button", gosx.Attrs(gosx.Attr("class", "btn btn-danger btn-sm")), gosx.Text("Delete")),
-							),
-						)
-					}),
-				),
-			),
-			gosx.Show(len(users) == 0,
-				gosx.El("p", gosx.Attrs(gosx.Attr("class", "empty-state")),
-					gosx.Text("No users found matching your search.")),
-			),
-		),
-	)
-}
-
-// NewUserPage renders the user creation form.
-func NewUserPage() gosx.Node {
-	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("New User")),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.RawHTML(`<form method="post" action="/gosx/action/createUser">
-				<div class="form-group">
-					<label>Name</label>
-					<input type="text" name="name" placeholder="Full name" required />
-				</div>
-				<div class="form-group">
-					<label>Email</label>
-					<input type="email" name="email" placeholder="email@example.com" required />
-				</div>
-				<div class="form-group">
-					<label>Role</label>
-					<select name="role">
-						<option value="viewer">Viewer</option>
-						<option value="editor">Editor</option>
-						<option value="admin">Admin</option>
-					</select>
-				</div>
-				<button type="submit" class="btn btn-primary">Create User</button>
-				<a href="/users" class="btn btn-cancel">Cancel</a>
-			</form>`),
-		),
-	)
-}
-
 // CounterPage demonstrates an interactive island compiled from counter.gsx.
 //
 // The server-rendered HTML uses buttons with data-gosx-handler attributes that
@@ -504,22 +300,13 @@ func CounterPage(count int, islands *island.Renderer) gosx.Node {
 	noscriptFallback := gosx.RawHTML(fmt.Sprintf(`<noscript><div class="counter-display"><a href="/counter?count=%d">-</a> <span>%d</span> <a href="/counter?count=%d">+</a></div></noscript>`, count-1, count, count+1))
 
 	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("Counter (Island Demo)")),
+		chrome("CounterIntro"),
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h3", gosx.Text("Interactive Island")),
-			gosx.El("p", gosx.Text("This counter is compiled from counter.gsx and hydrated via WASM.")),
-			gosx.El("br"),
+			chrome("CounterCardHeader"),
 			islandNode,
 			noscriptFallback,
 		),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h3", gosx.Text("How It Works")),
-			gosx.El("p", gosx.Text("1. counter.gsx is compiled to an IslandProgram at server startup")),
-			gosx.El("p", gosx.Text("2. Server renders the counter HTML with data-gosx-handler attributes")),
-			gosx.El("p", gosx.Text("3. Bootstrap loads the shared WASM runtime and fetches the IslandProgram")),
-			gosx.El("p", gosx.Text("4. Event delegation catches clicks and dispatches to the VM")),
-			gosx.El("p", gosx.Text("5. Signal updates trigger reconciliation and DOM patching")),
-		),
+		chrome("CounterHowItWorksCard"),
 	)
 }
 
@@ -724,54 +511,45 @@ func main() {
 </script>`)
 
 	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("Kitchen Sink — SPA Patterns")),
-		gosx.El("p", gosx.Text("Every pattern below is a GoSX island: server-rendered HTML hydrated with a shared WASM runtime. Click to interact — no page reloads.")),
+		chrome("KitchenSinkIntro"),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Counter")),
-			gosx.El("p", gosx.Text("Signal-driven increment/decrement.")),
+			chrome("KSCounterHeader"),
 			counterIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Tabs")),
-			gosx.El("p", gosx.Text("Conditional rendering via OpCond with dynamic CSS class toggling on active tab.")),
+			chrome("KSTabsHeader"),
 			tabsIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Toggle")),
-			gosx.El("p", gosx.Text("Boolean signal with show/hide. Click or press Enter to toggle (keyboard handler).")),
+			chrome("KSToggleHeader"),
 			toggleIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Todo List")),
-			gosx.El("p", gosx.Text("String concatenation for list items.")),
+			chrome("KSTodoHeader"),
 			todoIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Form Validation")),
-			gosx.El("p", gosx.Text("Two-way input binding via OpEventGet. Type in the input to see live updates.")),
+			chrome("KSFormHeader"),
 			formIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Price Calculator")),
-			gosx.El("p", gosx.Text("Derived values: total = price x qty - discount.")),
+			chrome("KSPriceHeader"),
 			derivedIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Dynamic List")),
-			gosx.El("p", gosx.Text("Add/remove items from a list. Items stored as comma-separated string, count tracked separately.")),
+			chrome("KSListHeader"),
 			listIsland,
 		),
 
 		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h2", gosx.Text("Code Editor")),
-			gosx.El("p", gosx.Text("Overlay editor with WASM-powered Go syntax highlighting, line numbers, and live char count.")),
+			chrome("KSEditorHeader"),
 			editorIsland,
 			editorScript,
 		),
@@ -786,32 +564,4 @@ func serverHighlight(source string) string {
 
 func lineNumbersHTML(count int) string {
 	return highlight.LineNumbers(count)
-}
-
-// SettingsPage renders application settings.
-func SettingsPage() gosx.Node {
-	return gosx.Fragment(
-		gosx.El("h1", gosx.Text("Settings")),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			gosx.El("h3", gosx.Text("Application Settings")),
-			gosx.RawHTML(`<form method="post" action="/gosx/action/saveSettings">
-				<div class="form-group">
-					<label>Site Name</label>
-					<input type="text" name="siteName" value="GoSX Dashboard" />
-				</div>
-				<div class="form-group">
-					<label>Theme</label>
-					<select name="theme">
-						<option value="light">Light</option>
-						<option value="dark">Dark</option>
-					</select>
-				</div>
-				<div class="form-group">
-					<label>Items per page</label>
-					<input type="number" name="pageSize" value="25" min="10" max="100" />
-				</div>
-				<button type="submit" class="btn btn-primary">Save Settings</button>
-			</form>`),
-		),
-	)
 }


### PR DESCRIPTION
## Summary

Refactors the dashboard example from hand-written Go handlers and inline templates to a file-routed structure with server-side data loaders. Extracts repetitive static markup for island demos into reusable components compiled from chrome.gsx.

## Changes

- Migrated all dashboard routes (/users, /users/new, /settings, /) to file-routed .gsx pages with dedicated .server.go data loaders.
- Replaced manual action.NewRegistry() and POST endpoint with declarative form handling, using conditional &lt;If&gt; blocks for field errors and status messages.
- Extracted static island headers and descriptions from main.go into chrome.gsx, rendered via route.RenderProgramComponent to keep them in sync with file routing.
- Centralized app shell layout in app/layout.gsx, computing footer strings through route.FileTemplateBindings to avoid formatter wrap artifacts.
- Simplified main.go by replacing explicit router.Add() calls with router.AddDir(), and dropped unused data-gosx-link attributes from navigation.

## Testing

- Run `go run main.go` inside `examples/dashboard/`
- Navigate to each page (Home, Users, New User, Settings, Counter, Kitchen Sink) to verify layout consistency and island hydration.
- Test the users search bar to confirm filtering works end-to-end.
- Submit the New User form with valid and invalid data to verify redirect behavior and conditional error display.

## Review Focus

Focus on file-routing migration patterns and verify island hydration still works correctly alongside the new layout system.