### PR TITLE
update(props): Introduce typed legacy category for strict props spread checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,49 @@
 # Changelog
 
+## Unreleased
+
+### Added: a typed legacy component is treated as strict instead of flattened
+
+- **`func Name(props T) Node`, where `T` is a struct declared in the same
+  `.gsx` file, is now a TYPED legacy component** (gosx#240). It carries the
+  same `PropsFields` and `PropsPaths` schema a strict component carries, and
+  it takes part in strict spread boundaries in both directions: it may
+  forward its whole `props` into a strict callee, and a strict body may call
+  it, by one spread or by named attributes. Every one of those compositions
+  was a compile error before this release, so the change only widens what
+  compiles.
+- There are now three component categories, not two. A strict
+  `component Name(props: T)`, a typed legacy `func Name(props T) Node`, and
+  an UNTYPED legacy component — `props any`, an attribute list, a props type
+  declared in another file, a props parameter spelled something other than
+  `props`, or no parameter at all. The untyped category keeps every v0.48
+  rule, including gosx#229's rejection: there is no declared type to recover,
+  so nothing about its props can be proved.
+- **A whole-`props` forward is proved at the DECLARATION, not at the call
+  site.** The caller's props struct must declare every field the strict
+  callee renders, with the same declared type; the diagnostic names the
+  field, its type, and the read that needs it. Because the proof does not
+  depend on how any caller invokes the component, the same body renders from
+  every one of its call sites — a struct spread, a map spread, named
+  attributes, or named attributes with one omitted, where the boundary
+  supplies the Go zero value generated Go would supply.
+- **A typed legacy component keeps the legacy render frame's flattened map
+  binding.** Its body observes its props exactly as it did in v0.48:
+  `props.Children` still arrives, an attribute the struct does not name
+  still arrives, and a caller may still spread a map into it. Writing the
+  props type down widens what the component may compose with; it does not
+  change what the component sees. Binding the struct instead would have
+  broken all three.
+- gosx#229's diagnostic now reads `untyped legacy component X cannot spread
+  props into strict component Y`, because that is what it now means. Its
+  hint names the new remedy first: declare the props parameter with a struct
+  type declared in this file. The strict-calls-legacy ban reads `strict
+  component cannot call untyped legacy component X` for the same reason.
+- One residual gap, and it fails closed with a message that names the field
+  and the remedy: a typed legacy frame entered by named attributes cannot
+  synthesize a zero value for a forwarded field whose declared type is a
+  struct or a slice, only for a builtin scalar.
+
 ## v0.48.0 (2026-08-18)
 
 ### Fixed: a strict spread from a non-strict component is rejected at compile time

--- a/README.md
+++ b/README.md
@@ -54,9 +54,14 @@ func Counter(props CounterProps) Node {
 }
 ```
 
-Both component styles can live in the same file. In v0.39, component calls
-stay within their declaration style; this keeps legacy dynamic composition
-from bypassing strict prop checks. The strict
+Both component styles can live in the same file. A component call stays
+within its declaration style, with one exception: a **typed legacy**
+component — `func Name(props T) Node` whose `T` is a struct declared in the
+same `.gsx` file — declares the same prop contract a strict component does,
+so it takes part in strict calls in both directions. A component that
+declares no such type (`props any`, an attribute list, or a type from
+another file) is an **untyped legacy** component and keeps the cross-style
+ban, because nothing about its props can be checked. The strict
 `component Name(props: GoType) { ... }` form uses an ordinary Go type as its
 prop contract, so the package check catches unknown fields and incompatible
 values. `component` supplies the `Node` result type; it does not make returns
@@ -77,22 +82,41 @@ and server rendering observe the same zero values.
 ### Spreading a value into a strict component
 
 A strict component accepts one `{...source}` spread instead of named
-attributes. Two callers may write one:
+attributes. Three callers may write one, one per component category:
 
 - A **strict** caller spreads a value whose declared type is exactly the
   callee's props type. The compiler proves the type; the generated Go call
   is emitted verbatim.
-- A **legacy** caller spreads any expression. A legacy expression carries no
-  declared type, so the renderer proves the value at the boundary: the
-  source must be a struct, and every field the callee renders must be
-  present with a matching type.
+- A **typed legacy** caller — `func Name(props T) Node`, `T` a struct
+  declared in the same file — spreads its whole `props`, a field of it, or
+  any other expression. A whole-`props` forward is proved at the
+  declaration: `T` must declare every field the callee renders, with the
+  same declared type. Any other expression is proved at the renderer
+  boundary, as below.
+- An **untyped legacy** caller spreads any expression. That expression
+  carries no declared type, so the renderer proves the value at the
+  boundary: the source must be a struct, and every field the callee renders
+  must be present with a matching type.
 
-A legacy component **cannot** spread its own `props` into a strict
-component. A legacy render frame binds `props` to a `map[string]any` built
-from the call site's attributes, and the strict boundary proves struct
+An untyped legacy component **cannot** spread its own `props` into a strict
+component. An untyped legacy render frame binds `props` to a `map[string]any`
+built from the call site's attributes, and the strict boundary proves struct
 values only, so that composition fails on every render. The compiler rejects
-it and names both components and the spread site. Spread a struct-typed
-field of `props` instead, or declare the caller as a strict component.
+it and names both components and the spread site. Write the props struct
+down and the same code compiles as a typed legacy component; alternatively,
+spread a struct-typed field of `props`, or declare the caller as a strict
+component.
+
+A typed legacy component keeps the legacy render frame's flattened map
+binding, so its body observes its props exactly as it always has: children
+arrive under `props.Children`, an attribute the struct does not name still
+arrives, and a caller may spread a map into it. Writing the props type down
+widens what the component may compose with; it does not change what the
+component sees.
+
+A strict body may call a typed legacy component, by one spread or by named
+attributes, under the same rules a strict callee answers to. It may not call
+an untyped legacy component.
 
 A nested struct field inside a spread is proved **structurally**, by the
 fields the callee renders under it, not by the declared type's name. A

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -111,6 +111,29 @@ type Component struct {
 	// `component Name(props: Type)` declarations.
 	Syntax ComponentSyntax
 
+	// PropsTyped is true when PropsType names a struct declared in the
+	// same .gsx file. It is the third component category gosx#240 adds: a
+	// strict component, a TYPED legacy component (Syntax is
+	// ComponentSyntaxLegacy and PropsTyped is true), and an UNTYPED legacy
+	// component (PropsTyped is false — `props any`, an AttrList, a type
+	// from another file, or no props parameter at all).
+	//
+	// A typed legacy component declares the same schema a strict one does,
+	// so it carries PropsFields and PropsPaths and it takes part in strict
+	// spread boundaries in both directions. It keeps the legacy render
+	// frame's flattened map binding, because every existing legacy body
+	// reads props through that map — the retrofit widens which
+	// compositions compile, it does not change how a legacy body observes
+	// its props.
+	//
+	// A strict component leaves this false: Syntax already says its props
+	// are typed, and no consumer needs a second way to ask.
+	//
+	// The zero value (false) is the untyped legacy meaning, so a program
+	// serialized before this field existed decodes unchanged, matching the
+	// ComponentSyntax zero-value convention above.
+	PropsTyped bool
+
 	// Root is the index of the root node in Program.Nodes.
 	Root NodeID
 

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -74,6 +74,18 @@ type lowerer struct {
 	structTypes   map[string]map[string]string
 	strictServer  bool
 
+	// legacyProps records every legacy (func-spelled) renderer's declared
+	// props type text, and typedLegacyProps the subset whose base type is a
+	// struct declared in this same .gsx file (gosx#240). A name in
+	// typedLegacyProps is a TYPED legacy component: it carries the same
+	// schema a strict component does, so it participates in strict spread
+	// boundaries in both directions. A name in legacyProps but not in
+	// typedLegacyProps is an UNTYPED legacy component (`props any`, an
+	// AttrList, or a type declared elsewhere), which keeps every v0.48
+	// rule, including gosx#229's rejection.
+	legacyProps      map[string]string
+	typedLegacyProps map[string]string
+
 	// currentStrictComponent and currentStrictPropsType name the strict
 	// component whose body lowerGSXNode is currently walking (empty
 	// outside strict lowering). E2 tier 1 (validateStrictToStrictSpreadCall)
@@ -1023,10 +1035,12 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.strictReads = make(map[string]map[string]strictReadClass)
 	l.structFields = make(map[string]map[string]string)
 	l.structTypes = make(map[string]map[string]string)
+	l.legacyProps = make(map[string]string)
+	l.typedLegacyProps = make(map[string]string)
 	// Pass 1: every same-file strict component's name and props type,
-	// every legacy (non-strict) top-level renderer function's name, and
-	// every declared struct's field schema — nothing here depends on
-	// declaration order among components.
+	// every legacy (non-strict) top-level renderer function's name and
+	// declared props type, and every declared struct's field schema —
+	// nothing here depends on declaration order among components.
 	for i := 0; i < int(root.NamedChildCount()); i++ {
 		child := root.NamedChild(i)
 		switch l.nodeType(child) {
@@ -1034,7 +1048,16 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 			name := l.childByField(child, "name")
 			body := l.childByField(child, "body")
 			if name != nil && body != nil && l.findGSXReturn(body) != nil {
-				l.legacyNames[l.text(name)] = struct{}{}
+				componentName := l.text(name)
+				l.legacyNames[componentName] = struct{}{}
+				propsName, propsType := l.extractProps(child)
+				// The file renderer binds the identifier "props"
+				// literally, so a differently spelled parameter is not in
+				// scope at render time — such a component has no props
+				// schema this pass can honor.
+				if strings.TrimSpace(propsName) == "props" && strings.TrimSpace(propsType) != "" {
+					l.legacyProps[componentName] = propsType
+				}
 			}
 		case "gosx_component_declaration":
 			name := l.childByField(child, "name")
@@ -1050,20 +1073,46 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 			l.collectStructSchemas(child)
 		}
 	}
-	// Pass 2: each strict component's prop reads, now that l.strictNames
-	// holds every same-file strict component regardless of where in the
-	// file it is declared.
+	// Pass 1b (gosx#240): promote each legacy renderer whose declared props
+	// type is a struct declared in THIS file to a typed legacy component.
+	// It runs after the whole of pass 1 for the same reason pass 2 does:
+	// l.structTypes must hold every same-file struct before any component
+	// is classified, so a props struct declared below its own component
+	// classifies exactly as one declared above it. A props type declared in
+	// a sibling .go file stays untyped here, matching the same-file schema
+	// rule strict components already answer to
+	// (validateStrictRenderedProps).
+	for componentName, propsType := range l.legacyProps {
+		if _, declared := l.structTypes[propsBaseType(propsType)]; declared {
+			l.typedLegacyProps[componentName] = propsType
+		}
+	}
+	// Pass 2: each strict and each typed legacy component's prop reads, now
+	// that l.strictNames holds every same-file strict component regardless
+	// of where in the file it is declared.
 	for i := 0; i < int(root.NamedChildCount()); i++ {
 		child := root.NamedChild(i)
-		if l.nodeType(child) != "gosx_component_declaration" {
-			continue
-		}
-		name := l.childByField(child, "name")
-		if name == nil {
-			continue
-		}
-		componentName := l.text(name)
-		if _, hasProps := l.strictProps[componentName]; !hasProps {
+		var componentName string
+		switch l.nodeType(child) {
+		case "gosx_component_declaration":
+			name := l.childByField(child, "name")
+			if name == nil {
+				continue
+			}
+			componentName = l.text(name)
+			if _, hasProps := l.strictProps[componentName]; !hasProps {
+				continue
+			}
+		case "function_declaration":
+			name := l.childByField(child, "name")
+			if name == nil {
+				continue
+			}
+			componentName = l.text(name)
+			if _, typed := l.typedLegacyProps[componentName]; !typed {
+				continue
+			}
+		default:
 			continue
 		}
 		l.strictReads[componentName] = l.collectStrictPropReads(child)
@@ -1860,13 +1909,25 @@ func (l *lowerer) normalizeStrictComponentAttrs(tag string, attrs []Attr) {
 func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, attrs []Attr, children []NodeID) {
 	_, strictCallee := l.strictNames[tag]
 	_, legacyCallee := l.legacyNames[tag]
-	if l.strict && legacyCallee {
-		l.errorf(n, "strict component cannot call legacy component %s; component styles may coexist but calls must stay within one style", tag)
+	_, typedLegacyCallee := l.typedLegacyProps[tag]
+	if l.strict && legacyCallee && !typedLegacyCallee {
+		l.errorf(n, "strict component cannot call untyped legacy component %s; component styles may coexist but calls must stay within one style", tag)
+		l.hintLast("declare " + tag + "'s props parameter with a struct type declared in this file, or declare " + tag + " as a strict component")
 		return
 	}
 	if !l.strict && strictCallee {
 		l.validateLegacyToStrictCall(n, tag, attrs, children)
 		return
+	}
+	// gosx#240: inside a strict body a TYPED legacy callee answers to the
+	// callee-side rules a strict callee answers to — the explicit-supply
+	// rule, the single-spread shape, and the tier-1 identity proof. The
+	// widening is one-directional on purpose. Every shape below was an
+	// outright error before this release, so admitting some of them cannot
+	// change any program that compiles today, whereas imposing the same
+	// rules on a LEGACY caller would newly reject calls that work now.
+	if l.strict && typedLegacyCallee {
+		strictCallee = true
 	}
 	if l.strictServer && tag == "If" && !strictCallee {
 		l.validateStrictConditionalCall(n, attrs)
@@ -1890,12 +1951,13 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		l.validateStrictToStrictSpreadCall(n, tag, attrs, children)
 		return
 	}
-	if _, acceptsProps := l.strictProps[tag]; !acceptsProps && len(attrs) > 0 {
+	calleePropsType, acceptsProps := l.calleePropsType(tag)
+	if !acceptsProps && len(attrs) > 0 {
 		l.errorf(n, "strict component %s does not accept props", tag)
 	}
 	if required := l.strictReads[tag]; len(required) > 0 {
 		supplied := make(map[string]struct{}, len(attrs))
-		aliases := l.structFields[propsBaseType(l.strictProps[tag])]
+		aliases := l.structFields[propsBaseType(calleePropsType)]
 		hasUnknownSameFileAttr := false
 		for _, attr := range attrs {
 			name := attr.Name
@@ -1997,37 +2059,52 @@ func (l *lowerer) validateLegacyToStrictCall(n *gotreesitter.Node, tag string, a
 	l.errorf(n, "legacy component cannot call strict component %s with named attributes; pass one {...source} spread and the renderer will prove it at the boundary", tag)
 }
 
-// validateLegacyPropsSpread rejects gosx#229: a legacy body spreading its
-// OWN props identifier into a strict callee. Shape alone accepts that call
-// (validateLegacyToStrictCall above), and the source expression carries no
-// declared type a legacy body could be checked against, so before this rule
-// the composition compiled, checked, and transpiled clean, then failed at
-// every render — total, data-independent, and only on a code path that runs
-// once real data exists.
+// calleePropsType reports the declared props type of a same-file callee the
+// strict rules apply to — a strict component, or (gosx#240) a typed legacy
+// one. The two categories declare their schema the same way, so every
+// callee-side rule reads the type through this one lookup instead of
+// naming l.strictProps directly.
+func (l *lowerer) calleePropsType(tag string) (string, bool) {
+	if propsType, ok := l.strictProps[tag]; ok {
+		return propsType, true
+	}
+	propsType, ok := l.typedLegacyProps[tag]
+	return propsType, ok
+}
+
+// validateLegacyPropsSpread rules on gosx#229's shape: a legacy body
+// spreading its OWN props identifier into a strict callee. Shape alone
+// accepts that call (validateLegacyToStrictCall above), so this is where
+// the two legacy categories part.
 //
-// The failure is provable from three facts the lowerer already holds: the
-// callee is a same-file strict component (the caller checked
-// l.strictNames), the enclosing component is legacy (l.strict is false), and
-// the spread source is that component's own props parameter. A legacy render
-// frame binds props to the reduced map[string]any the file renderer builds
-// out of the call site's attributes (localComponentProps' non-strict branch,
-// route/fileprogram.go) — never a Go struct, even when a struct value
-// produced the attributes — and strictSpreadProps proves field coverage on
-// struct values only, because a map can omit a key where the generated-Go
-// twin would synthesize a typed zero. Full transpile refuses the same call
-// outright (emitTypedAttrsForType). So no execution path accepts this
-// composition, and rejecting it turns a guaranteed render-time failure into
-// a compile-time diagnostic with a source position.
+// An UNTYPED legacy component (`props any`, an AttrList, a props type from
+// another file, or a props parameter spelled something other than "props")
+// is rejected, unchanged from v0.48. The source expression carries no
+// declared type anything could be checked against, so before that rule the
+// composition compiled, checked, and transpiled clean, then failed at every
+// render — total, data-independent, and only on a code path that runs once
+// real data exists. An untyped legacy render frame binds props to the
+// reduced map[string]any the file renderer builds out of the call site's
+// attributes (localComponentProps, route/fileprogram.go) — never a Go
+// struct, even when a struct value produced the attributes — and
+// strictSpreadProps proves field coverage on struct values only, because a
+// map can omit a key where the generated-Go twin would synthesize a typed
+// zero.
 //
-// The rule is deliberately narrow. It fires only on the bare props
-// identifier, so the two shapes that DO render keep compiling: a struct-
-// typed FIELD of props ({...props.Away}) survives the shallow flatten with
-// its own type intact, and any other expression (a local, a loader value, a
-// page's data binding) is unconstrained by this rule. It says nothing about
-// a legacy component whose props parameter is spelled anything other than
-// "props" either: the file renderer binds the identifier "props" literally,
-// so a differently spelled parameter is not in scope at render time at all,
-// which is a separate defect with a separate cause.
+// A TYPED legacy component is retrofitted instead of rejected (gosx#240).
+// Its props type is a struct declared in this same file, so the lowerer can
+// prove the forward at the DECLARATION: validateTypedLegacyPropsForward
+// checks the caller's own struct declares every field the callee renders,
+// with the same declared type. That proof does not depend on how any caller
+// invokes the typed legacy component, so it holds identically at every one
+// of its call sites — the property that made this retrofit acceptable where
+// preserving a raw value beside the flattened map was not.
+//
+// The rule is deliberately narrow in both directions. It fires only on the
+// bare props identifier, so the shapes that already render keep compiling: a
+// struct-typed FIELD of props ({...props.Away}) survives the shallow flatten
+// with its own type intact, and any other expression (a local, a loader
+// value, a page's data binding) is unconstrained by this rule.
 func (l *lowerer) validateLegacyPropsSpread(n *gotreesitter.Node, tag string, spread Attr) {
 	propsName := strings.TrimSpace(l.currentLegacyPropsName)
 	if propsName != "props" || strings.TrimSpace(spread.Expr) != propsName {
@@ -2037,8 +2114,67 @@ func (l *lowerer) validateLegacyPropsSpread(n *gotreesitter.Node, tag string, sp
 	if caller == "" {
 		return
 	}
-	l.errorf(n, "legacy component %s cannot spread props into strict component %s; a legacy render frame binds props to map[string]any, and the strict spread boundary proves field coverage on struct values only", caller, tag)
-	l.hintLast("spread a struct-typed field instead (for example {...props.Team}), or declare " + caller + " as a strict component so props keeps its declared type")
+	if callerProps, typed := l.typedLegacyProps[caller]; typed {
+		l.validateTypedLegacyPropsForward(n, caller, callerProps, tag)
+		return
+	}
+	l.errorf(n, "untyped legacy component %s cannot spread props into strict component %s; an untyped legacy render frame binds props to map[string]any, and the strict spread boundary proves field coverage on struct values only", caller, tag)
+	l.hintLast("declare " + caller + "'s props parameter with a struct type declared in this file, or declare " + caller + " as a strict component so props keeps its declared type")
+}
+
+// validateTypedLegacyPropsForward is gosx#240's declaration-level proof for
+// a typed legacy body forwarding its whole props value into a strict
+// callee. Both schemas are structs declared in this one file, so the check
+// is exact: for every field the callee renders, the caller's props struct
+// must declare a field of the same name and the same declared type.
+//
+// Type identity, rather than the render boundary's structural rule for a
+// nested struct (gosx#230), is the right demand here for two reasons. The
+// caller forwards its WHOLE props value, so the callee reads the caller's
+// own fields by name and there is no converter type in between. And both
+// names resolve in the same file, so an identical spelling is an identical
+// type — the check costs an author nothing that is not already true.
+//
+// A callee whose props type is not declared in this file has no schema to
+// compare against. validateStrictRenderedProps already reports that on the
+// callee's own declaration, so this stays silent rather than reporting the
+// same defect a second time at every call site.
+func (l *lowerer) validateTypedLegacyPropsForward(n *gotreesitter.Node, caller, callerPropsType, tag string) {
+	reads := l.strictReads[tag]
+	if len(reads) == 0 {
+		return
+	}
+	calleePropsType := l.strictProps[tag]
+	calleeFields := l.structTypes[propsBaseType(calleePropsType)]
+	if len(calleeFields) == 0 {
+		return
+	}
+	callerFields := l.structTypes[propsBaseType(callerPropsType)]
+	roots := make(map[string]struct{}, len(reads))
+	for path := range reads {
+		root, _, _ := strings.Cut(path, ".")
+		roots[root] = struct{}{}
+	}
+	ordered := make([]string, 0, len(roots))
+	for root := range roots {
+		ordered = append(ordered, root)
+	}
+	sort.Strings(ordered)
+	for _, root := range ordered {
+		want, declared := calleeFields[root]
+		if !declared {
+			continue
+		}
+		got, present := callerFields[root]
+		if !present {
+			l.errorf(n, "typed legacy component %s cannot spread props into strict component %s: %s does not declare field %s (%s), which %s renders as props.%s", caller, tag, callerPropsType, root, want, tag, root)
+			l.hintLast("add " + root + " " + want + " to " + callerPropsType + ", or spread a struct-typed field of props instead (for example {...props.Team})")
+			continue
+		}
+		if got != want {
+			l.errorf(n, "typed legacy component %s cannot spread props into strict component %s: field %s is %s on %s and %s on %s; a whole-props forward needs the declared types to match", caller, tag, root, got, callerPropsType, want, calleePropsType)
+		}
+	}
 }
 
 // validateStrictToStrictSpreadCall validates E2 tier 1 (design spec section
@@ -2057,7 +2193,7 @@ func (l *lowerer) validateStrictToStrictSpreadCall(n *gotreesitter.Node, tag str
 	if len(children) > 0 {
 		l.errorf(n, "strict component %s does not accept positional children", tag)
 	}
-	calleeProps := l.strictProps[tag]
+	calleeProps, _ := l.calleePropsType(tag)
 	if strings.TrimSpace(calleeProps) == "" {
 		l.errorf(n, "strict component %s does not accept props", tag)
 		return
@@ -2270,15 +2406,30 @@ func (l *lowerer) lowerFunctionDecl(n *gotreesitter.Node) {
 	// itself rather than as a component that mysteriously is not an island.
 	l.checkDirectiveTypos(n)
 
+	// gosx#240: a legacy component whose props parameter names a struct
+	// declared in this same file carries the same schema a strict one does.
+	// PropsFields and PropsPaths are a declaration-level property here, the
+	// same as for a strict component: they describe what this body reads,
+	// never how a caller invokes it, so every call site of this component
+	// sees one answer.
+	_, propsTyped := l.typedLegacyProps[name]
+	var propsFields, propsPaths map[string]string
+	if propsTyped {
+		propsFields, propsPaths = l.copyStrictPropTypes(propsType, l.strictReads[name])
+	}
+
 	comp := Component{
-		Name:      name,
-		PropsType: propsType,
-		PropsName: propsName,
-		Syntax:    ComponentSyntaxLegacy,
-		Root:      rootID,
-		IsIsland:  l.hasIslandDirective(n),
-		Scope:     scope,
-		Span:      l.span(n),
+		Name:        name,
+		PropsType:   propsType,
+		PropsName:   propsName,
+		PropsFields: propsFields,
+		PropsPaths:  propsPaths,
+		PropsTyped:  propsTyped,
+		Syntax:      ComponentSyntaxLegacy,
+		Root:        rootID,
+		IsIsland:    l.hasIslandDirective(n),
+		Scope:       scope,
+		Span:        l.span(n),
 	}
 
 	// Check for engine directive

--- a/ir/typed_legacy_props_test.go
+++ b/ir/typed_legacy_props_test.go
@@ -1,0 +1,179 @@
+package ir_test
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+// --- gosx#240: the typed legacy component category --------------------------
+
+// lowerTypedLegacySource compiles source and returns its program, failing on
+// any diagnostic.
+func lowerTypedLegacySource(t *testing.T, source string) *ir.Program {
+	t.Helper()
+	prog, err := parse(t, []byte(source))
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	return prog
+}
+
+// componentByName returns the named component of prog, or fails.
+func componentByName(t *testing.T, prog *ir.Program, name string) ir.Component {
+	t.Helper()
+	for _, comp := range prog.Components {
+		if comp.Name == name {
+			return comp
+		}
+	}
+	t.Fatalf("component %s not found in %#v", name, prog.Components)
+	return ir.Component{}
+}
+
+// TestLowerRecordsTypedLegacyPropsSchema proves gosx#240's first claim:
+// PropsFields and PropsPaths population is no longer gated on the strict
+// spelling. A legacy component whose props parameter names a struct declared
+// in the same file now carries the same two maps a strict component carries,
+// built by the same collector from the same reads.
+func TestLowerRecordsTypedLegacyPropsSchema(t *testing.T) {
+	prog := lowerTypedLegacySource(t, `package app
+
+type Team struct {
+	Abbreviation string
+}
+
+type RowProps struct {
+	Team Team
+	Tone string
+}
+
+func Row(props RowProps) Node {
+	return <div class={"tone-" + props.Tone}>{props.Team.Abbreviation}</div>
+}
+`)
+	row := componentByName(t, prog, "Row")
+	if row.Syntax != ir.ComponentSyntaxLegacy {
+		t.Fatalf("Row.Syntax = %d, want %d", row.Syntax, ir.ComponentSyntaxLegacy)
+	}
+	if !row.PropsTyped {
+		t.Fatal("Row.PropsTyped = false, want true")
+	}
+	if row.PropsFields["Tone"] != "string" || row.PropsFields["Team"] != "Team" {
+		t.Fatalf("Row.PropsFields = %#v", row.PropsFields)
+	}
+	if row.PropsPaths["Team.Abbreviation"] != "string" {
+		t.Fatalf("Row.PropsPaths = %#v", row.PropsPaths)
+	}
+}
+
+// TestLowerClassifiesTypedLegacyRegardlessOfDeclarationOrder pins the
+// classification to the whole file rather than to file order, the same
+// property collectStrictSchemas' two passes give a strict component's own
+// reads (gosx#182/#184 M-3). A props struct declared BELOW its component
+// must classify exactly as one declared above it.
+func TestLowerClassifiesTypedLegacyRegardlessOfDeclarationOrder(t *testing.T) {
+	prog := lowerTypedLegacySource(t, `package app
+
+func Row(props RowProps) Node {
+	return <div>{props.Tone}</div>
+}
+
+type RowProps struct {
+	Tone string
+}
+`)
+	row := componentByName(t, prog, "Row")
+	if !row.PropsTyped {
+		t.Fatal("Row.PropsTyped = false, want true")
+	}
+	if row.PropsFields["Tone"] != "string" {
+		t.Fatalf("Row.PropsFields = %#v", row.PropsFields)
+	}
+}
+
+// TestLowerLeavesUntypedLegacyComponentsUntyped enumerates every shape that
+// is NOT retrofittable. Each keeps the v0.48 map binding and the gosx#229
+// diagnostic, because none of them names a struct this file declares.
+func TestLowerLeavesUntypedLegacyComponentsUntyped(t *testing.T) {
+	for _, tc := range []struct {
+		name        string
+		declaration string
+	}{
+		{
+			name: "props any",
+			declaration: `func Row(props any) Node {
+	return <div>row</div>
+}`,
+		},
+		{
+			name: "an attribute list",
+			declaration: `func Row(props AttrList) Node {
+	return <div>row</div>
+}`,
+		},
+		{
+			name: "a struct declared in another file",
+			declaration: `func Row(props ExternalProps) Node {
+	return <div>row</div>
+}`,
+		},
+		{
+			name: "an anonymous struct",
+			declaration: `func Row(props struct{ Tone string }) Node {
+	return <div>row</div>
+}`,
+		},
+		{
+			name: "a parameter the renderer never binds",
+			declaration: `type RowProps struct {
+	Tone string
+}
+
+func Row(attrs RowProps) Node {
+	return <div>row</div>
+}`,
+		},
+		{
+			name: "no parameter at all",
+			declaration: `func Row() Node {
+	return <div>row</div>
+}`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prog := lowerTypedLegacySource(t, "package app\n\n"+tc.declaration+"\n")
+			row := componentByName(t, prog, "Row")
+			if row.PropsTyped {
+				t.Fatalf("Row.PropsTyped = true, want false (%#v)", row)
+			}
+			if len(row.PropsFields) != 0 || len(row.PropsPaths) != 0 {
+				t.Fatalf("Row carries a schema it cannot have: fields=%#v paths=%#v", row.PropsFields, row.PropsPaths)
+			}
+		})
+	}
+}
+
+// TestLowerLeavesStrictComponentsPropsTypedFalse holds the field to its one
+// meaning. Syntax already reports that a strict component's props are typed,
+// so PropsTyped answers only the legacy question and no consumer has two
+// ways to ask the same thing.
+func TestLowerLeavesStrictComponentsPropsTypedFalse(t *testing.T) {
+	prog := lowerTypedLegacySource(t, `package app
+
+type RowProps struct {
+	Tone string
+}
+
+component Row(props: RowProps) {
+	return <div>{props.Tone}</div>
+}
+`)
+	row := componentByName(t, prog, "Row")
+	if row.Syntax != ir.ComponentSyntaxStrict {
+		t.Fatalf("Row.Syntax = %d, want %d", row.Syntax, ir.ComponentSyntaxStrict)
+	}
+	if row.PropsTyped {
+		t.Fatal("Row.PropsTyped = true, want false for a strict component")
+	}
+}

--- a/route/fileeval.go
+++ b/route/fileeval.go
@@ -53,7 +53,36 @@ type fileRenderEnv struct {
 	// right value instead of an artificially reduced map. See
 	// localComponentProps' single-spread branch.
 	strictSpreadSource any
+
+	// propsFrame records which component category owns the "props" binding
+	// currently in scope (gosx#240). strictSpreadSource alone no longer
+	// answers that: a typed legacy frame now carries a raw source too, and
+	// a nil source means "this frame came from named attributes" for both
+	// categories. writeLocalComponent overwrites it on every local
+	// component call, exactly as it overwrites strictSpreadSource, so it is
+	// never stale.
+	propsFrame propsFrameKind
 }
+
+// propsFrameKind names the component category that built the "props"
+// binding in scope. It exists so the strict spread boundary can tell a
+// typed legacy frame's flattened map (which its own declared schema makes
+// provable) from an untyped one (which nothing makes provable), and from a
+// strict frame's reduced map.
+type propsFrameKind uint8
+
+const (
+	// propsFrameNone is a page or layout entry, an untyped legacy frame, or
+	// any scope outside a local component call. Its props binding carries
+	// no declared schema.
+	propsFrameNone propsFrameKind = iota
+	// propsFrameStrict is a strict component's own render frame.
+	propsFrameStrict
+	// propsFrameTypedLegacy is a typed legacy component's render frame:
+	// a flattened map like every legacy frame, but backed by a props
+	// struct declared in the same .gsx file.
+	propsFrameTypedLegacy
+)
 
 // fileRenderScope is one copy-on-write binding in the render environment.
 //

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1154,8 +1154,10 @@ func (r *fileProgramRenderer) writeLocalComponent(b *strings.Builder, comp *ir.C
 	// Always overwrite, never inherit from env: rawSource is nil unless
 	// THIS call just proved it (single-spread shape), so an explicit-attrs
 	// call correctly clears whatever an enclosing strict frame left set,
-	// rather than leaking it into this unrelated component's own body.
+	// rather than leaking it into this unrelated component's own body. The
+	// frame kind is overwritten for the same reason.
 	scope.strictSpreadSource = rawSource
+	scope.propsFrame = componentPropsFrameKind(comp)
 	r.writeNode(b, comp.Root, scope)
 }
 
@@ -1772,16 +1774,95 @@ func componentProps(attrs []ir.Attr, env fileRenderEnv, children gosx.Node) map[
 	return props
 }
 
+// componentPropsFrameKind classifies the render frame a local component
+// call is about to open (gosx#240). See propsFrameKind.
+func componentPropsFrameKind(comp *ir.Component) propsFrameKind {
+	switch {
+	case comp == nil:
+		return propsFrameNone
+	case comp.Syntax == ir.ComponentSyntaxStrict:
+		return propsFrameStrict
+	case comp.PropsTyped:
+		return propsFrameTypedLegacy
+	default:
+		return propsFrameNone
+	}
+}
+
+// typedLegacyComponentProps builds a legacy callee's render-time props map.
+// The map itself is byte-for-byte what componentProps has always built, for
+// a typed and an untyped legacy callee alike: every legacy body reads its
+// props through that map, so gosx#240 widens which compositions compile
+// without changing how any legacy body observes its props.
+//
+// What a TYPED legacy callee gains is the second return value. A
+// single-spread call site hands the raw source value on, so a BARE
+// {...props} forward inside this callee's own body can be proved against
+// the value that built the frame instead of against the flattened map —
+// the same reuse a strict frame has had since gosx#182/#184 M-1. Before
+// this the lowerer rejected that forward outright (gosx#229), so nothing
+// that renders today reaches this.
+//
+// A bare {...props} spread that came from a STRICT caller is retargeted at
+// that caller's raw source, and fails closed when there is none. A strict
+// frame's own props map holds only the fields that frame renders
+// (strictSpreadProps), so forwarding the map itself would hand this callee
+// a value that is silently short of fields rather than one that is wrong in
+// a way anyone can see.
+func typedLegacyComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv, children gosx.Node) (map[string]any, any, error) {
+	if !comp.PropsTyped || len(attrs) != 1 || attrs[0].Kind != ir.AttrSpread {
+		return componentProps(attrs, env, children), nil, nil
+	}
+	source := evalFileExpr(attrs[0].Expr, env)
+	if strings.TrimSpace(attrs[0].Expr) == "props" && env.propsFrame == propsFrameStrict {
+		if env.strictSpreadSource == nil {
+			return nil, nil, fmt.Errorf("typed legacy component %s: the enclosing strict frame's props came from named attributes, so its whole props value is not available to forward; call the enclosing strict component with one {...source} spread", comp.Name)
+		}
+		source = env.strictSpreadSource
+	}
+	props := make(map[string]any, 8)
+	mergeComponentProps(props, source)
+	if !children.IsZero() {
+		setComponentProp(props, "children", children)
+		setComponentProp(props, "Children", children)
+	}
+	return props, structSpreadSource(source), nil
+}
+
+// structSpreadSource returns value when it indirects to a Go struct, and nil
+// otherwise. A legacy call site may spread a map, a slice, or a scalar —
+// none of which the strict boundary can prove — so only a struct is worth
+// carrying forward as this frame's raw source. Returning nil for the rest
+// sends a bare {...props} forward to strictSpreadPropsFromTypedFrame, which
+// proves the frame's own flattened map instead of failing on the kind check
+// with a value that was never going to satisfy it. A strict frame's raw
+// source is already always a struct, because strictSpreadProps rejects
+// every other kind before the frame opens.
+func structSpreadSource(value any) any {
+	if value == nil {
+		return nil
+	}
+	rv, ok := indirectReflectValue(reflect.ValueOf(value))
+	if !ok || rv.Kind() != reflect.Struct {
+		return nil
+	}
+	return value
+}
+
 // localComponentProps builds a strict callee's render-time props map, and
 // also returns the raw source value a single-spread call proved it from —
-// nil for an explicit-attrs call, or when comp is not a strict component.
-// The caller (writeLocalComponent) threads that raw value into the render
-// env as strictSpreadSource, purely so a BARE {...props} forward inside
-// THIS callee's own body (if it has one) can reuse it — see
-// fileRenderEnv.strictSpreadSource's doc comment (gosx#182/#184 M-1).
+// nil for an explicit-attrs call. The caller (writeLocalComponent) threads
+// that raw value into the render env as strictSpreadSource, purely so a
+// BARE {...props} forward inside THIS callee's own body (if it has one) can
+// reuse it — see fileRenderEnv.strictSpreadSource's doc comment
+// (gosx#182/#184 M-1). A legacy callee answers to
+// typedLegacyComponentProps instead.
 func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv, children gosx.Node) (map[string]any, any, error) {
-	if comp == nil || comp.Syntax != ir.ComponentSyntaxStrict {
+	if comp == nil {
 		return componentProps(attrs, env, children), nil, nil
+	}
+	if comp.Syntax != ir.ComponentSyntaxStrict {
+		return typedLegacyComponentProps(comp, attrs, env, children)
 	}
 	// The single-spread shape (design spec section 3.1) is the only spread
 	// shape validateStrictComponentCall admits at a strict callee, for
@@ -1795,8 +1876,31 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 	// to fail closed here — an empty read set makes every per-field proof
 	// vacuous, not the nil/kind checks themselves.
 	if len(attrs) == 1 && attrs[0].Kind == ir.AttrSpread {
+		bareProps := strings.TrimSpace(attrs[0].Expr) == "props"
+		if bareProps && env.strictSpreadSource == nil && env.propsFrame == propsFrameTypedLegacy {
+			// gosx#240: a TYPED legacy frame reached by named attributes
+			// has no raw source, but it does have a declared struct type,
+			// and the lowerer proved at that declaration that the type
+			// carries every field this callee renders
+			// (validateTypedLegacyPropsForward). The frame's own map is
+			// therefore a faithful reading of a value of that type, so it
+			// is proved key by key here instead of failing the struct-kind
+			// check. This is what keeps the retrofit unconditional: the
+			// same body renders whether its caller spread a struct into it
+			// or named its attributes one by one.
+			frame, _ := evalFileExpr("props", env).(map[string]any)
+			props, err := strictSpreadPropsFromTypedFrame(comp, frame)
+			if err != nil {
+				return nil, nil, err
+			}
+			if !children.IsZero() {
+				setComponentProp(props, "children", children)
+				setComponentProp(props, "Children", children)
+			}
+			return props, nil, nil
+		}
 		source := evalFileExpr(attrs[0].Expr, env)
-		if strings.TrimSpace(attrs[0].Expr) == "props" && env.strictSpreadSource != nil {
+		if bareProps && env.strictSpreadSource != nil {
 			// A bare props forward: "props" in scope is always the reduced
 			// map[string]any this function built for the CURRENT frame,
 			// which strictSpreadProps below always rejects on the struct-
@@ -2296,6 +2400,117 @@ func strictSpreadProps(comp *ir.Component, value any) (map[string]any, error) {
 		setComponentProp(props, field, proved)
 	}
 	return props, nil
+}
+
+// strictSpreadPropsFromTypedFrame is strictSpreadProps' counterpart for the
+// one map source the strict boundary accepts (gosx#240): the flattened
+// props map of an enclosing TYPED legacy frame, forwarded whole by a bare
+// {...props} spread.
+//
+// strictSpreadProps rejects every map because a map can omit a key where
+// the generated-Go twin synthesizes a typed zero, and because a map carries
+// no field types to check ahead of its values. Both objections are answered
+// here, and only here:
+//
+//   - The enclosing frame's props parameter has a struct type declared in
+//     the same .gsx file, and the lowerer proved at that declaration that
+//     the type declares every field this callee renders, with the callee's
+//     own declared type (ir/lower.go's validateTypedLegacyPropsForward). An
+//     absent key therefore means the frame's own caller omitted the
+//     attribute, which is exactly the case where Go supplies the zero
+//     value — so zero-filling a builtin scalar here reproduces the twin
+//     rather than diverging from it.
+//   - Every value present is proved against the callee's declared type by
+//     the same three dispatches strictSpreadProps uses.
+//
+// A field whose declared type is not a builtin scalar cannot be
+// zero-synthesized from a type name alone, so an absent one fails closed
+// with a message that names the field and the remedy. That is the single
+// residual gap, and it is narrower than the strict frame's own
+// (localComponentProps' PropsFields-empty branch): it needs a non-scalar
+// field AND an omitted attribute, not merely a named-attribute call.
+func strictSpreadPropsFromTypedFrame(comp *ir.Component, frame map[string]any) (map[string]any, error) {
+	fields := make([]string, 0, len(comp.PropsFields))
+	for field := range comp.PropsFields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+
+	props := make(map[string]any, len(fields)+4)
+	for _, field := range fields {
+		fieldType := comp.PropsFields[field]
+		raw, supplied := lookupTemplatePropValue(frame, field)
+		if !supplied {
+			zero, ok := strictScalarZeroValue(fieldType)
+			if !ok {
+				return nil, fmt.Errorf("prop %s (%s): the enclosing typed legacy frame did not receive this field, and only a builtin scalar has a zero value this boundary can synthesize; call the enclosing component with one {...source} spread, or pass %s explicitly", field, fieldType, field)
+			}
+			setComponentProp(props, field, zero)
+			continue
+		}
+		var proved any
+		var err error
+		switch {
+		case strictScalarFieldType(fieldType):
+			proved, err = requireStrictScalarType(raw, fieldType)
+		case strings.HasPrefix(strings.TrimSpace(fieldType), "[]"):
+			if schema, hasSchema := comp.PropsSlices[field]; hasSchema {
+				proved, err = requireStrictSliceValue(raw, schema)
+			} else {
+				err = fmt.Errorf("strict component %s has no loop schema for slice field %s", comp.Name, field)
+			}
+		default:
+			proved, err = requireStrictSpreadStructField(raw, fieldType, strictStructPropsPaths(comp, field))
+		}
+		if err != nil {
+			return nil, fmt.Errorf("prop %s (%s): %w", field, fieldType, err)
+		}
+		setComponentProp(props, field, proved)
+	}
+	return props, nil
+}
+
+// strictScalarZeroValue returns the Go zero value of one of the renderer's
+// exact scalar builtins, typed the way requireStrictScalarType demands it.
+// It reports false for every other type name, including a slice or a
+// same-file struct: those have a zero value in Go, but not one this
+// boundary can build from a type NAME, and guessing would be worse than
+// failing closed.
+func strictScalarZeroValue(fieldType string) (any, bool) {
+	switch strings.TrimSpace(fieldType) {
+	case "string":
+		return "", true
+	case "bool":
+		return false, true
+	case "int":
+		return int(0), true
+	case "int8":
+		return int8(0), true
+	case "int16":
+		return int16(0), true
+	case "int32", "rune":
+		return int32(0), true
+	case "int64":
+		return int64(0), true
+	case "uint":
+		return uint(0), true
+	case "uint8", "byte":
+		return uint8(0), true
+	case "uint16":
+		return uint16(0), true
+	case "uint32":
+		return uint32(0), true
+	case "uint64":
+		return uint64(0), true
+	case "uintptr":
+		return uintptr(0), true
+	case "float32":
+		return float32(0), true
+	case "float64":
+		return float64(0), true
+	default:
+		return nil, false
+	}
 }
 
 func strictGoConstant(source string) (constant.Value, bool) {

--- a/route/typed_legacy_props_test.go
+++ b/route/typed_legacy_props_test.go
@@ -1,0 +1,377 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	gosx "m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
+)
+
+// --- gosx#240: the typed legacy render boundary -----------------------------
+
+// routeTypedLegacySide stands in for the loader struct a sibling page.server.go
+// builds. Its name differs from the .gsx schema's on purpose, the same way
+// strictSpreadTestSide's does: a spread source is proved by the fields the
+// renderer reads, not by its type's name (gosx#230).
+type routeTypedLegacySide struct {
+	Tone         string
+	Abbreviation string
+}
+
+// typedLegacyMarkComponent is the strict callee every fixture below forwards
+// into: it renders two scalar props, so it needs both of them proved.
+func typedLegacyMarkComponent(prog *ir.Program) ir.Component {
+	tone := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Tone"})
+	abbr := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Abbreviation"})
+	root := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "span", Children: []ir.NodeID{tone, abbr}})
+	return ir.Component{
+		Name:        "Mark",
+		PropsName:   "props",
+		PropsType:   "MarkProps",
+		PropsFields: map[string]string{"Tone": "string", "Abbreviation": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        root,
+	}
+}
+
+// TestTypedLegacyFrameProvesItsOwnMapAtTheStrictBoundary is gosx#240's
+// unconditional-correctness proof at the render boundary. The typed legacy
+// Row frame is entered by NAMED attributes, so it holds no raw source at
+// all, yet its bare {...props} forward still renders: the frame's map is a
+// faithful reading of a value of its declared type, so the boundary proves
+// it key by key instead of rejecting it on the struct-kind check.
+func TestTypedLegacyFrameProvesItsOwnMapAtTheStrictBoundary(t *testing.T) {
+	prog := &ir.Program{}
+	prog.Components = append(prog.Components, typedLegacyMarkComponent(prog))
+
+	markCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Mark",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "props"}},
+	})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "div", Children: []ir.NodeID{markCall}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:       "Row",
+		PropsName:  "props",
+		PropsType:  "RowProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+		Root:       rowRoot,
+	})
+
+	rowCall := prog.AddNode(ir.Node{
+		Kind: ir.NodeComponent,
+		Tag:  "Row",
+		Attrs: []ir.Attr{
+			{Name: "tone", Kind: ir.AttrStatic, Value: "red"},
+			{Name: "abbreviation", Kind: ir.AttrStatic, Value: "NE"},
+		},
+	})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: rowCall})
+
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := "<div><span>redNE</span></div>"; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestTypedLegacyFrameZeroFillsAnOmittedScalar covers the case the map path
+// exists for. Row's caller omits abbreviation, so generated Go would supply
+// the empty string; the boundary supplies the same empty string rather than
+// observing a missing key, which is the divergence the struct-kind check
+// guards against everywhere else.
+func TestTypedLegacyFrameZeroFillsAnOmittedScalar(t *testing.T) {
+	prog := &ir.Program{}
+	prog.Components = append(prog.Components, typedLegacyMarkComponent(prog))
+
+	markCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Mark",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "props"}},
+	})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "div", Children: []ir.NodeID{markCall}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:       "Row",
+		PropsName:  "props",
+		PropsType:  "RowProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+		Root:       rowRoot,
+	})
+
+	rowCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Row",
+		Attrs: []ir.Attr{{Name: "tone", Kind: ir.AttrStatic, Value: "red"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: rowCall})
+
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := "<div><span>red</span></div>"; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestTypedLegacyFrameFailsClosedOnAnOmittedStructField documents the one
+// residual gap and proves it fails closed. A same-file struct has no zero
+// value this boundary can build from a type NAME, so an omitted one is an
+// error that names the field and the remedy, never a silently empty render.
+func TestTypedLegacyFrameFailsClosedOnAnOmittedStructField(t *testing.T) {
+	prog := &ir.Program{}
+	leaf := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Team.Abbreviation"})
+	markRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "span", Children: []ir.NodeID{leaf}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Mark",
+		PropsName:   "props",
+		PropsType:   "MarkProps",
+		PropsFields: map[string]string{"Team": "Team"},
+		PropsPaths:  map[string]string{"Team.Abbreviation": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        markRoot,
+	})
+
+	markCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Mark",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "props"}},
+	})
+	rowRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "div", Children: []ir.NodeID{markCall}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:       "Row",
+		PropsName:  "props",
+		PropsType:  "RowProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+		Root:       rowRoot,
+	})
+
+	rowCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Row",
+		Attrs: []ir.Attr{{Name: "tone", Kind: ir.AttrStatic, Value: "red"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: rowCall})
+
+	_, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly rendered an omitted struct field")
+	}
+	for _, want := range []string{
+		"prop Team (Team)",
+		"only a builtin scalar has a zero value this boundary can synthesize",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// TestStrictFrameForwardingIntoTypedLegacyFailsClosedWithoutARawSource
+// covers the new strict-caller edge. A strict frame's own props map holds
+// only the fields that frame renders, so forwarding the map itself would
+// hand the typed legacy callee a value that is silently short of fields.
+// The boundary refuses instead, and names the call shape that works.
+func TestStrictFrameForwardingIntoTypedLegacyFailsClosedWithoutARawSource(t *testing.T) {
+	prog := &ir.Program{}
+
+	scoreExpr := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Abbreviation"})
+	scoreRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "b", Children: []ir.NodeID{scoreExpr}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:       "Score",
+		PropsName:  "props",
+		PropsType:  "SideProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+		Root:       scoreRoot,
+	})
+
+	scoreCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Score",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "props"}},
+	})
+	shellRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "div", Children: []ir.NodeID{scoreCall}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Shell",
+		PropsName:   "props",
+		PropsType:   "SideProps",
+		PropsFields: map[string]string{"Tone": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        shellRoot,
+	})
+
+	shellCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Shell",
+		Attrs: []ir.Attr{{Name: "Tone", Kind: ir.AttrStatic, Value: "red"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: shellCall})
+
+	_, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err == nil {
+		t.Fatal("RenderProgramComponent unexpectedly forwarded a strict frame's reduced map")
+	}
+	want := "the enclosing strict frame's props came from named attributes"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want it to contain %q", err, want)
+	}
+}
+
+// TestStrictFrameForwardsItsRawSourceIntoTypedLegacy is the same edge with
+// the call shape that works: Shell is entered by one spread, so its raw
+// source is available and the typed legacy callee observes every field of
+// it, not just the ones Shell renders.
+func TestStrictFrameForwardsItsRawSourceIntoTypedLegacy(t *testing.T) {
+	prog := &ir.Program{}
+
+	scoreExpr := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "props.Abbreviation"})
+	scoreRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "b", Children: []ir.NodeID{scoreExpr}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:       "Score",
+		PropsName:  "props",
+		PropsType:  "SideProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+		Root:       scoreRoot,
+	})
+
+	scoreCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Score",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "props"}},
+	})
+	shellRoot := prog.AddNode(ir.Node{Kind: ir.NodeElement, Tag: "div", Children: []ir.NodeID{scoreCall}})
+	prog.Components = append(prog.Components, ir.Component{
+		Name:        "Shell",
+		PropsName:   "props",
+		PropsType:   "SideProps",
+		PropsFields: map[string]string{"Tone": "string"},
+		Syntax:      ir.ComponentSyntaxStrict,
+		Root:        shellRoot,
+	})
+
+	shellCall := prog.AddNode(ir.Node{
+		Kind:  ir.NodeComponent,
+		Tag:   "Shell",
+		Attrs: []ir.Attr{{Kind: ir.AttrSpread, Expr: "side"}},
+	})
+	prog.Components = append(prog.Components, ir.Component{Name: "Page", Syntax: ir.ComponentSyntaxLegacy, Root: shellCall})
+
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{"side": routeTypedLegacySide{Tone: "red", Abbreviation: "NE"}},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := "<div><b>NE</b></div>"; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestTypedLegacyComponentPropsKeepsTheMapBinding is the compatibility
+// guard at the unit the retrofit could most easily have broken. A typed
+// legacy callee still receives the flattened map componentProps has always
+// built, extra keys and children included, so no legacy body observes its
+// props differently than it did in v0.48.
+func TestTypedLegacyComponentPropsKeepsTheMapBinding(t *testing.T) {
+	comp := &ir.Component{
+		Name:        "Card",
+		PropsName:   "props",
+		PropsType:   "CardProps",
+		PropsTyped:  true,
+		PropsFields: map[string]string{"Title": "string"},
+		Syntax:      ir.ComponentSyntaxLegacy,
+	}
+	attrs := []ir.Attr{
+		{Name: "title", Kind: ir.AttrStatic, Value: "T"},
+		{Name: "kicker", Kind: ir.AttrStatic, Value: "K"},
+	}
+	props, rawSource, err := localComponentProps(comp, attrs, fileRenderEnv{}, gosx.RawHTML("<b>body</b>"))
+	if err != nil {
+		t.Fatalf("localComponentProps: %v", err)
+	}
+	if rawSource != nil {
+		t.Fatalf("rawSource = %#v, want nil for a named-attribute call", rawSource)
+	}
+	for key, want := range map[string]string{"Title": "T", "title": "T", "Kicker": "K", "kicker": "K"} {
+		if got, _ := props[key].(string); got != want {
+			t.Fatalf("props[%q] = %#v, want %q", key, props[key], want)
+		}
+	}
+	if _, ok := props["Children"]; !ok {
+		t.Fatalf("props has no Children key: %#v", props)
+	}
+}
+
+// TestTypedLegacyComponentPropsCarriesOnlyAStructRawSource pins
+// structSpreadSource. A legacy call site may spread a map, and no strict
+// boundary can prove one, so carrying it forward would only turn a
+// provable frame map into an unprovable raw value.
+func TestTypedLegacyComponentPropsCarriesOnlyAStructRawSource(t *testing.T) {
+	comp := &ir.Component{
+		Name:       "Card",
+		PropsName:  "props",
+		PropsType:  "CardProps",
+		PropsTyped: true,
+		Syntax:     ir.ComponentSyntaxLegacy,
+	}
+	env := fileRenderEnv{values: map[string]any{
+		"side": routeTypedLegacySide{Tone: "red", Abbreviation: "NE"},
+		"raw":  map[string]any{"Tone": "red"},
+	}}
+	for _, tc := range []struct {
+		name       string
+		expr       string
+		wantSource bool
+	}{
+		{name: "struct", expr: "side", wantSource: true},
+		{name: "map", expr: "raw", wantSource: false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			props, rawSource, err := localComponentProps(comp, []ir.Attr{{Kind: ir.AttrSpread, Expr: tc.expr}}, env, gosx.Node{})
+			if err != nil {
+				t.Fatalf("localComponentProps: %v", err)
+			}
+			if got := rawSource != nil; got != tc.wantSource {
+				t.Fatalf("rawSource != nil = %v, want %v (%#v)", got, tc.wantSource, rawSource)
+			}
+			if got, _ := props["Tone"].(string); got != "red" {
+				t.Fatalf("props[Tone] = %#v, want red", props["Tone"])
+			}
+		})
+	}
+}
+
+// TestStrictScalarZeroValueCoversTheRendererBuiltins holds the two lists to
+// one shape: every type strictScalarFieldType admits must have a zero value
+// the frame path can synthesize, or an omitted field of that type would
+// fail closed for no reason.
+func TestStrictScalarZeroValueCoversTheRendererBuiltins(t *testing.T) {
+	for _, fieldType := range []string{
+		"string", "bool",
+		"int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"byte", "rune", "float32", "float64",
+	} {
+		zero, ok := strictScalarZeroValue(fieldType)
+		if !ok {
+			t.Fatalf("strictScalarZeroValue(%q) reported no zero value", fieldType)
+		}
+		if _, err := requireStrictScalarType(zero, fieldType); err != nil {
+			t.Fatalf("requireStrictScalarType(zero of %s): %v", fieldType, err)
+		}
+	}
+	if _, ok := strictScalarZeroValue("Team"); ok {
+		t.Fatal("strictScalarZeroValue accepted a same-file struct name")
+	}
+	if _, ok := strictScalarZeroValue("[]Row"); ok {
+		t.Fatal("strictScalarZeroValue accepted a slice type")
+	}
+}

--- a/strict_props_spread_test.go
+++ b/strict_props_spread_test.go
@@ -55,7 +55,10 @@ func ScoreTeam(props any) Node {
 	</div>
 }
 `)
-	want := "legacy component ScoreTeam cannot spread props into strict component TeamMark; a legacy render frame binds props to map[string]any, and the strict spread boundary proves field coverage on struct values only"
+	// gosx#240 narrowed the rule to the case it is unavoidable for, so the
+	// message says "untyped legacy component" where it used to say "legacy
+	// component": a typed legacy component is retrofitted now, not rejected.
+	want := "untyped legacy component ScoreTeam cannot spread props into strict component TeamMark; an untyped legacy render frame binds props to map[string]any, and the strict spread boundary proves field coverage on struct values only"
 	if diag.Message != want {
 		t.Fatalf("message = %q, want %q", diag.Message, want)
 	}
@@ -69,13 +72,296 @@ func ScoreTeam(props any) Node {
 	}
 }
 
-// TestCompileRejectsTypedLegacyPropsSpreadIntoStrict covers the second
-// spelling of the same defect. A declared props struct changes nothing at
-// render time: the file renderer binds a legacy frame's props to the map it
-// builds from the call site's attributes, whatever the declaration says, so
-// this spelling failed exactly as the `props any` one did. It was an
-// accepted acceptance fixture before gosx#229.
-func TestCompileRejectsTypedLegacyPropsSpreadIntoStrict(t *testing.T) {
+// --- gosx#240: the typed legacy retrofit -----------------------------------
+
+// TestTypedLegacyPropsSpreadIntoStrictRenders is gosx#240's headline shape,
+// and the exact composition gosx#229 rejected under the name
+// TestCompileRejectsTypedLegacyPropsSpreadIntoStrict. A legacy component
+// that declares a props STRUCT declared in the same file now carries the
+// schema a strict component carries, so its whole-props forward is proved at
+// the declaration and renders. The test asserts HTML rather than a clean
+// compile: the rejection it replaces existed because the composition
+// compiled and then failed at every render.
+func TestTypedLegacyPropsSpreadIntoStrictRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+
+type ScoreTeamProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div class="score-team"><TeamMark {...props}></TeamMark></div>
+}
+
+func Page() Node {
+	return <div><ScoreTeam {...data.away}></ScoreTeam></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if comp := mustFindComponent(t, prog, "ScoreTeam"); !comp.PropsTyped {
+		t.Fatal("ScoreTeam.PropsTyped = false, want true")
+	}
+	html := mustRenderPage(t, prog, map[string]any{
+		"data": map[string]any{"away": strictSpreadTestSide{Tone: "red", Abbreviation: "NE"}},
+	})
+	want := `<div class="score-team"><span class="tone-red">NE</span></div>`
+	if !strings.Contains(html, want) {
+		t.Fatalf("rendered HTML %q does not contain %q", html, want)
+	}
+}
+
+// TestTypedLegacyPropsSpreadRendersFromEveryCallShape is the property that
+// made this retrofit acceptable where preserving a raw value beside the
+// flattened map was not (gosx#229's adjacent question): the proof is made at
+// the DECLARATION, so it does not turn on how any caller invokes the
+// component. The same ScoreTeam body renders whether its caller spreads one
+// struct into it or names its attributes one by one, including when the
+// caller omits an attribute and Go would supply the zero value.
+func TestTypedLegacyPropsSpreadRendersFromEveryCallShape(t *testing.T) {
+	const prelude = `package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+
+type ScoreTeamProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div class="score-team"><TeamMark {...props}></TeamMark></div>
+}
+`
+	for _, tc := range []struct {
+		name string
+		page string
+		want string
+	}{
+		{
+			name: "named attributes",
+			page: `<div><ScoreTeam tone="blue" abbreviation="BUF"></ScoreTeam></div>`,
+			want: `<div class="score-team"><span class="tone-blue">BUF</span></div>`,
+		},
+		{
+			name: "one omitted attribute takes the Go zero value",
+			page: `<div><ScoreTeam tone="blue"></ScoreTeam></div>`,
+			want: `<div class="score-team"><span class="tone-blue"></span></div>`,
+		},
+		{
+			name: "single struct spread",
+			page: `<div><ScoreTeam {...data.away}></ScoreTeam></div>`,
+			want: `<div class="score-team"><span class="tone-red">NE</span></div>`,
+		},
+		{
+			name: "single map spread",
+			page: `<div><ScoreTeam {...data.raw}></ScoreTeam></div>`,
+			want: `<div class="score-team"><span class="tone-gold">GB</span></div>`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := gosx.Compile([]byte(prelude + "\nfunc Page() Node {\n\treturn " + tc.page + "\n}\n"))
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			html := mustRenderPage(t, prog, map[string]any{
+				"data": map[string]any{
+					"away": strictSpreadTestSide{Tone: "red", Abbreviation: "NE"},
+					"raw":  map[string]any{"Tone": "gold", "Abbreviation": "GB"},
+				},
+			})
+			if !strings.Contains(html, tc.want) {
+				t.Fatalf("rendered HTML %q does not contain %q", html, tc.want)
+			}
+		})
+	}
+}
+
+// TestTypedLegacyComponentNestsInsideStrictComponent covers the other
+// direction of the same boundary: a strict body may now call a typed legacy
+// component, by one spread or by named attributes. Both shapes were an
+// outright cross-style error before gosx#240.
+func TestTypedLegacyComponentNestsInsideStrictComponent(t *testing.T) {
+	const prelude = `package app
+
+type SideProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+func ScoreTeam(props SideProps) Node {
+	return <b class={"tone-" + props.Tone}>{props.Abbreviation}</b>
+}
+`
+	for _, tc := range []struct {
+		name string
+		call string
+	}{
+		{name: "spread", call: `<ScoreTeam {...props}></ScoreTeam>`},
+		{name: "named attributes", call: `<ScoreTeam tone={props.Tone} abbreviation={props.Abbreviation}></ScoreTeam>`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			prog, err := gosx.Compile([]byte(prelude + `
+component Shell(props: SideProps) {
+	return <div class="shell">` + tc.call + `</div>
+}
+
+func Page() Node {
+	return <div><Shell {...data.away}></Shell></div>
+}
+`))
+			if err != nil {
+				t.Fatalf("Compile: %v", err)
+			}
+			html := mustRenderPage(t, prog, map[string]any{
+				"data": map[string]any{"away": strictSpreadTestSide{Tone: "red", Abbreviation: "NE"}},
+			})
+			want := `<div class="shell"><b class="tone-red">NE</b></div>`
+			if !strings.Contains(html, want) {
+				t.Fatalf("rendered HTML %q does not contain %q", html, want)
+			}
+		})
+	}
+}
+
+// TestTypedLegacyAndStrictNestBothWaysInOneTree renders one page whose tree
+// alternates the two spellings — strict, then typed legacy, then strict —
+// so the retrofit is proved as composition rather than as two separate one
+// hop cases.
+func TestTypedLegacyAndStrictNestBothWaysInOneTree(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+
+type SideProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: SideProps) {
+	return <span class={"tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+
+func ScoreTeam(props SideProps) Node {
+	return <b class="score-team"><TeamMark {...props}></TeamMark></b>
+}
+
+component Shell(props: SideProps) {
+	return <div class="shell"><ScoreTeam {...props}></ScoreTeam></div>
+}
+
+func Page() Node {
+	return <div><Shell {...data.away}></Shell></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html := mustRenderPage(t, prog, map[string]any{
+		"data": map[string]any{"away": strictSpreadTestSide{Tone: "red", Abbreviation: "NE"}},
+	})
+	want := `<div class="shell"><b class="score-team"><span class="tone-red">NE</span></b></div>`
+	if !strings.Contains(html, want) {
+		t.Fatalf("rendered HTML %q does not contain %q", html, want)
+	}
+}
+
+// TestTypedLegacyPropsSpreadInsideEachRenders is the shape both production
+// instances of gosx#229 actually had — the strict call sits inside a loop —
+// spelled with a declared props struct. It rejected at compile time before
+// gosx#240 and renders now.
+func TestTypedLegacyPropsSpreadInsideEachRenders(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+
+type TeamMarkProps struct {
+	Tone string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+
+type MatchupCardProps struct {
+	Tone string
+	Rows []int
+}
+
+func MatchupCard(props MatchupCardProps) Node {
+	return <div class="card">
+		<Each of={props.Rows} as="row">
+			<TeamMark {...props}></TeamMark>
+		</Each>
+	</div>
+}
+
+func Page() Node {
+	return <div><MatchupCard tone="red" rows={data.rows}></MatchupCard></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html := mustRenderPage(t, prog, map[string]any{
+		"data": map[string]any{"rows": []int{1, 2}},
+	})
+	if got := strings.Count(html, "<span>red</span>"); got != 2 {
+		t.Fatalf("rendered HTML %q has %d marks, want 2", html, got)
+	}
+}
+
+// TestCompileRejectsTypedLegacyForwardMissingField proves the retrofit is a
+// proof, not a waiver. A whole-props forward reads the CALLER's own fields,
+// so the caller's struct must declare every field the callee renders. The
+// diagnostic names the field, its type, and the read that needs it.
+func TestCompileRejectsTypedLegacyForwardMissingField(t *testing.T) {
+	diag := legacyPropsSpreadDiagnostic(t, `package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}{props.Abbreviation}</span>
+}
+
+type ScoreTeamProps struct {
+	Tone string
+}
+
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+`)
+	want := "typed legacy component ScoreTeam cannot spread props into strict component TeamMark: ScoreTeamProps does not declare field Abbreviation (string), which TeamMark renders as props.Abbreviation"
+	if diag.Message != want {
+		t.Fatalf("message = %q, want %q", diag.Message, want)
+	}
+	if !strings.Contains(diag.Hint, "add Abbreviation string to ScoreTeamProps") {
+		t.Fatalf("hint = %q, want the add-the-field remedy", diag.Hint)
+	}
+}
+
+// TestCompileRejectsTypedLegacyForwardTypeMismatch is the same proof for a
+// field that is declared but declared differently. Both names resolve in one
+// file, so an identical spelling is an identical type and the check costs an
+// author nothing that is not already true.
+func TestCompileRejectsTypedLegacyForwardTypeMismatch(t *testing.T) {
 	diag := legacyPropsSpreadDiagnostic(t, `package app
 
 type TeamMarkProps struct {
@@ -86,14 +372,110 @@ component TeamMark(props: TeamMarkProps) {
 	return <span>{props.Tone}</span>
 }
 
-func StandingRow(props TeamMarkProps) Node {
-	return <div class="standing-row"><TeamMark {...props}></TeamMark></div>
+type ScoreTeamProps struct {
+	Tone int
+}
+
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div><TeamMark {...props}></TeamMark></div>
 }
 `)
-	want := "legacy component StandingRow cannot spread props into strict component TeamMark"
-	if !strings.HasPrefix(diag.Message, want) {
-		t.Fatalf("message = %q, want prefix %q", diag.Message, want)
+	want := "typed legacy component ScoreTeam cannot spread props into strict component TeamMark: field Tone is int on ScoreTeamProps and string on TeamMarkProps; a whole-props forward needs the declared types to match"
+	if diag.Message != want {
+		t.Fatalf("message = %q, want %q", diag.Message, want)
 	}
+}
+
+// TestCompileRejectsPropsSpreadFromAnotherFilesPropsType pins the retrofit's
+// boundary. "Typed" means a struct declared in THIS .gsx file, the same
+// same-file schema rule a strict component answers to: a props type declared
+// in a sibling .go file has no schema the lowerer can prove against, so it
+// stays an untyped legacy component and keeps the gosx#229 rejection.
+func TestCompileRejectsPropsSpreadFromAnotherFilesPropsType(t *testing.T) {
+	diag := legacyPropsSpreadDiagnostic(t, `package app
+
+type TeamMarkProps struct {
+	Tone string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}</span>
+}
+
+func ScoreTeam(props ExternalProps) Node {
+	return <div><TeamMark {...props}></TeamMark></div>
+}
+`)
+	if !strings.HasPrefix(diag.Message, "untyped legacy component ScoreTeam cannot spread props into strict component TeamMark") {
+		t.Fatalf("message = %q", diag.Message)
+	}
+}
+
+// TestTypedLegacyComponentKeepsItsMapBinding is gosx#240's compatibility
+// guard, and the reason the retrofit changes what a typed legacy component
+// may COMPOSE with without changing how its body observes its props. A
+// legacy body reads props through the flattened map the file renderer
+// builds from the call site, and real programs depend on three properties
+// of that map that a struct binding would have taken away:
+//
+//  1. children arrive under props.Children, which no props struct declares
+//     (cmd/gosx/templates/docs/app/page.gsx does exactly this);
+//  2. an attribute the declared struct does not name still arrives;
+//  3. a spread source may be a map, not only a struct.
+//
+// All three keep working for a typed legacy component. The retrofit adds a
+// schema; it does not replace the binding.
+func TestTypedLegacyComponentKeepsItsMapBinding(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+
+type CardProps struct {
+	Title string
+}
+
+func Card(props CardProps) Node {
+	return <section class="card"><h3>{props.Title}</h3><em>{props.Kicker}</em>{props.Children}</section>
+}
+
+func Spread(props CardProps) Node {
+	return <p>{props.Title}|{props.Extra}</p>
+}
+
+func Page() Node {
+	return <div>
+		<Card title="T" kicker="K"><b>body</b></Card>
+		<Spread {...data.card}></Spread>
+	</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if comp := mustFindComponent(t, prog, "Card"); !comp.PropsTyped {
+		t.Fatal("Card.PropsTyped = false, want true")
+	}
+	html := mustRenderPage(t, prog, map[string]any{
+		"data": map[string]any{"card": map[string]any{"Title": "T2", "Extra": "E"}},
+	})
+	for _, want := range []string{
+		`<section class="card"><h3>T</h3><em>K</em><b>body</b></section>`,
+		`<p>T2|E</p>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered HTML %q does not contain %q", html, want)
+		}
+	}
+}
+
+// mustFindComponent returns the named component of prog, or fails.
+func mustFindComponent(t *testing.T, prog *ir.Program, name string) ir.Component {
+	t.Helper()
+	for _, comp := range prog.Components {
+		if comp.Name == name {
+			return comp
+		}
+	}
+	t.Fatalf("component %s not found in %#v", name, prog.Components)
+	return ir.Component{}
 }
 
 // TestCompileRejectsSelfClosingLegacyPropsSpreadIntoStrict pins the rule to

--- a/strictcheck/legacy_props_spread_test.go
+++ b/strictcheck/legacy_props_spread_test.go
@@ -7,12 +7,14 @@ import (
 	"testing"
 )
 
-// TestCheckFileRejectsLegacyPropsSpreadIntoStrict proves gosx#229's rule
-// reaches the surface the two production instances went through. Both
+// TestCheckFileRejectsUntypedLegacyPropsSpreadIntoStrict proves gosx#229's
+// rule reaches the surface the two production instances went through. Both
 // shipped because `gosx check` passed; this is the run that now stops them.
 // The rule lives in the IR validation pass, so the same diagnostic reaches
 // the check CLI, the build gate, and the LSP without any per-surface work.
-func TestCheckFileRejectsLegacyPropsSpreadIntoStrict(t *testing.T) {
+// gosx#240 narrowed the rule to this untyped spelling, which is the one it
+// is unavoidable for.
+func TestCheckFileRejectsUntypedLegacyPropsSpreadIntoStrict(t *testing.T) {
 	dir := newTestModule(t)
 	path := filepath.Join(dir, "page.gsx")
 	mustWrite(t, path, `package main
@@ -35,13 +37,78 @@ component Page() {
 		t.Fatal("CheckFile unexpectedly accepted a strict spread from a legacy body's own props")
 	}
 	for _, want := range []string{
-		"legacy component ScoreTeam cannot spread props into strict component TeamMark",
+		"untyped legacy component ScoreTeam cannot spread props into strict component TeamMark",
 		"the strict spread boundary proves field coverage on struct values only",
 		"declare ScoreTeam as a strict component",
 	} {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("error = %v, want to contain %q", err, want)
 		}
+	}
+}
+
+// TestCheckFileAcceptsTypedLegacyPropsSpreadIntoStrict is gosx#240's run at
+// the same surface. `gosx check` compiles the .gsx, transpiles it, and type
+// checks the result with the real Go compiler, so this proves the retrofit
+// holds through the whole gate, not only through the lowerer.
+func TestCheckFileAcceptsTypedLegacyPropsSpreadIntoStrict(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+type ScoreTeamProps struct {
+	Tone         string
+	Abbreviation string
+}
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div class="score-team"><TeamMark {...props}></TeamMark></div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsTypedLegacyForwardMissingField proves the retrofit
+// stays a proof at this surface too: a caller struct short of a field the
+// strict callee renders is reported by `gosx check`, with the field named.
+func TestCheckFileRejectsTypedLegacyForwardMissingField(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+component TeamMark(props: TeamMarkProps) {
+	return <span>{props.Tone}{props.Abbreviation}</span>
+}
+type ScoreTeamProps struct {
+	Tone string
+}
+func ScoreTeam(props ScoreTeamProps) Node {
+	return <div class="score-team"><TeamMark {...props}></TeamMark></div>
+}
+component Page() {
+	return <main>ok</main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("CheckFile unexpectedly accepted a forward the caller struct cannot satisfy")
+	}
+	want := "typed legacy component ScoreTeam cannot spread props into strict component TeamMark: ScoreTeamProps does not declare field Abbreviation"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

Retrofit legacy components with strict schema proofs by introducing a typed legacy category. Components spelled `func Name(props T) Node` where `T` is a same-file struct now participate in strict spread boundaries in both directions, widening compilable compositions without altering how legacy bodies observe their props.

## Changes

- Define three component categories: strict, typed legacy, and untyped legacy.
- Track `PropsTyped` in the IR to distinguish legacy components whose props are same-file structs.
- Classify legacy props at the declaration level: a whole-`props` forward now proves coverage against the caller's struct schema rather than failing at the renderer boundary.
- Update runtime prop resolution (`route/fileprogram.go`) to thread a typed legacy frame's raw source through its flattened map, zero-filling omitted builtin scalars to match Go's generated twins.
- Refine diagnostics to explicitly name 'untyped legacy component' and suggest declaring a struct-typed props parameter or switching to a strict component.
- Expand tests covering classification regardless of declaration order, map-binding compatibility, nested composition trees, and edge cases like missing non-scalar fields.

## Testing

- Run `go test ./... -v -run 'TestTypedLegacy|TestLowerRecordsTypedLegacy|TestCompileRejectsTypedLegacy'`
- Compile a mixed file containing `component`, `func props T`, and `props any` declarations to verify strict propagation boundaries hold across all categories

## Review Focus

Focus on the backward compatibility guarantees in `route/fileprogram.go` (`typedLegacyComponentProps` and `strictSpreadPropsFromTypedFrame`). The retrofit intentionally preserves the legacy flattened-map binding while adding runtime checks for omitting struct/slice fields during named-attribute entry.