### PR TITLE
add: cross-directory shared component projection

### DIFF
--- a/transpile/package.go
+++ b/transpile/package.go
@@ -76,6 +76,85 @@ func LoadPackage(path string) ([]PackageFile, error) {
 	return files, nil
 }
 
+// SharedImport supplies a shared call's projection facts for one shared
+// (./ or ../ prefixed) import: the Go import path substituted for the
+// relative source text, and the props shape of every strict component the
+// target directory declares. gosx check (strictcheck, a later work
+// package) is the intended producer, built from the target directory's own
+// loaded programs (shared components design, section 5.2). See
+// Options.SharedImports and CollectSharedComponents.
+type SharedImport struct {
+	// GoImportPath replaces the shared import's relative path text in both
+	// the projected import declaration and every qualified call through
+	// its alias.
+	GoImportPath string
+	// Components resolves the props type and field-name aliases of every
+	// strict component the target directory exports, keyed by component
+	// name.
+	Components map[string]SharedComponent
+}
+
+// SharedComponent is one shared strict component's Go-facing call shape:
+// its props struct's bare type name, and the field-name aliases
+// (collectStructFieldsFromTypeDecl's own lower-camel rule) used to resolve
+// an attribute name to its exact exported Go field — the identical
+// resolution a same-file struct call already runs.
+type SharedComponent struct {
+	// PropsType is the props struct's bare (unqualified) type name, e.g.
+	// "TeamMarkProps". The caller's alias is prepended at the call site
+	// (transpiler.sharedPropsType), so this field never carries a package
+	// qualifier of its own.
+	PropsType string
+	// Fields maps an attribute spelling — exact or lower-camel — to its
+	// exact exported Go field name, matching t.propsFields' alias
+	// convention. An empty value marks an ambiguous lower-camel spelling,
+	// which projection rejects the same way a same-file call already does.
+	Fields map[string]string
+}
+
+// CollectSharedComponents builds a shared directory's component map from
+// its already-loaded package files, using the identical extraction a
+// same-file typed call already runs (collectComponentProps,
+// collectStructFieldsFromTypeDecl) so a shared call resolves through the
+// same rules as a same-file call and the two projections cannot drift
+// apart. A legacy component (a func, not a `component` declaration) is
+// omitted: shared components design section 4.3 admits only a strict
+// component as a shared call target.
+func CollectSharedComponents(files []PackageFile) map[string]SharedComponent {
+	components := make(map[string]SharedComponent)
+	for _, file := range files {
+		tree, lang, err := gosx.Parse(file.Source)
+		if err != nil {
+			continue
+		}
+		root := tree.RootNode()
+		if root.HasError() {
+			continue
+		}
+		ft := &transpiler{src: file.Source, lang: lang}
+		ft.collectStructFields(root)
+		ft.collectComponentProps(root)
+		for name := range ft.strictNames {
+			propsType := strings.TrimSpace(ft.propsTypes[name])
+			if propsType == "" {
+				continue
+			}
+			baseType := propsType
+			if idx := strings.LastIndex(baseType, "."); idx >= 0 {
+				baseType = baseType[idx+1:]
+			}
+			if idx := strings.Index(baseType, "["); idx >= 0 {
+				baseType = baseType[:idx]
+			}
+			components[name] = SharedComponent{
+				PropsType: propsType,
+				Fields:    ft.propsFields[baseType],
+			}
+		}
+	}
+	return components
+}
+
 func sourcePackageName(source []byte) (string, bool) {
 	tree, lang, err := gosx.Parse(source)
 	if err != nil {

--- a/transpile/shared_projection_test.go
+++ b/transpile/shared_projection_test.go
@@ -1,0 +1,476 @@
+package transpile
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// This file covers WP4 of the shared-.gsx-components design (see
+// gsx-shared-components-spec.md, section 11): the Go PROJECTION of a
+// cross-directory component call, taken from a supplied resolver map. The
+// resolver itself (a directory walk and a real `go list` call) belongs to
+// gosx check (strictcheck, WP5); these tests build the map by hand or with
+// CollectSharedComponents, exactly the shape gosx check will supply.
+
+// sharedTeamMarkSource is the shared directory's own .gsx source: a strict
+// component with props, and nothing else (design section 1.4).
+const sharedTeamMarkSource = `package ui
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+`
+
+// sharedTeamMarkPackageFile compiles sharedTeamMarkSource into a PackageFile,
+// the shape CollectSharedComponents (and gosx check's directory load) both
+// consume.
+func sharedTeamMarkPackageFile(t *testing.T) PackageFile {
+	t.Helper()
+	source := []byte(sharedTeamMarkSource)
+	prog, err := gosx.Compile(source)
+	if err != nil {
+		t.Fatalf("compile shared source: %v", err)
+	}
+	return PackageFile{Path: "ui/team_mark.gsx", Source: source, Program: prog}
+}
+
+func TestSharedCallProjectsQualifiedCompositeLiteral(t *testing.T) {
+	shared := CollectSharedComponents([]PackageFile{sharedTeamMarkPackageFile(t)})
+	if _, ok := shared["TeamMark"]; !ok {
+		t.Fatalf("CollectSharedComponents did not resolve TeamMark from shared source")
+	}
+
+	caller := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow(tone, abbreviation string) gosx.Node {
+	return <div><ui.TeamMark Tone={tone} Abbreviation={abbreviation}></ui.TeamMark></div>
+}
+`)
+	out, err := Transpile(caller, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: shared},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+
+	if want := `ui.TeamMark(ui.TeamMarkProps{Tone: tone, Abbreviation: abbreviation})`; !strings.Contains(out, want) {
+		t.Fatalf("missing shared call %q in:\n%s", want, out)
+	}
+	if want := `ui "example.test/app/ui"`; !strings.Contains(out, want) {
+		t.Fatalf("missing rewritten shared import %q in:\n%s", want, out)
+	}
+	if strings.Contains(out, `"./ui"`) {
+		t.Fatalf("relative import path leaked into projected Go:\n%s", out)
+	}
+}
+
+// TestSharedCallStructurallyMatchesSameFileShape is the parity guard the
+// task's discipline section asks for: a shared call and a same-file call
+// with an identical props shape and identical attributes must project to
+// the identical call shape, differing only by the "alias." qualifier a
+// shared call adds to both the function name and the composite literal
+// type. If a future change lets the two shapes drift apart, this test
+// catches it independent of any wording in either message.
+//
+// Both sides use a strict caller body — the spec's own headline example
+// (section 1.2) — projected with transpileProjectionOnly, which runs only
+// t.emit, skipping Transpile's gosx.Compile semantic gate. WP1 (the ir.Lower
+// relaxation that will let a strict body reach a shared call through the
+// full gosx.Compile pipeline) is a separate, independently dispatched work
+// package; exercising the projection layer directly is what proves WP4's
+// own scope without waiting on it, exactly as designed (spec section 1.3:
+// "type safety... is already proven today. Execution is not" — the same
+// split applies to this test rig: the shape is proven here, the semantic
+// gate is WP1's).
+func TestSharedCallStructurallyMatchesSameFileShape(t *testing.T) {
+	sameFile := []byte(`package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+
+type StandingRowProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component StandingRow(props: StandingRowProps) {
+	return <div><TeamMark Tone={props.Tone} Abbreviation={props.Abbreviation}></TeamMark></div>
+}
+`)
+	sameFileOut, err := transpileProjectionOnly(t, sameFile, Options{SourceFile: "same.gsx"})
+	if err != nil {
+		t.Fatalf("transpile same-file (projection only): %v", err)
+	}
+
+	shared := CollectSharedComponents([]PackageFile{sharedTeamMarkPackageFile(t)})
+	sharedCaller := []byte(`package app
+
+import ui "./ui"
+
+type StandingRowProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component StandingRow(props: StandingRowProps) {
+	return <div><ui.TeamMark Tone={props.Tone} Abbreviation={props.Abbreviation}></ui.TeamMark></div>
+}
+`)
+	sharedOut, err := transpileProjectionOnly(t, sharedCaller, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: shared},
+		},
+	})
+	if err != nil {
+		t.Fatalf("transpile shared (projection only): %v", err)
+	}
+
+	// Strip exactly the alias qualifier a shared call adds to the call and
+	// to the composite literal type; nothing else about the call shape may
+	// differ.
+	normalizedShared := strings.ReplaceAll(sharedOut, "ui.TeamMark", "TeamMark")
+	sameFileCall := extractCall(t, sameFileOut, "TeamMark(")
+	sharedCall := extractCall(t, normalizedShared, "TeamMark(")
+	if sameFileCall != sharedCall {
+		t.Fatalf("shared call shape drifted from same-file call shape:\nsame-file: %s\nshared (normalized): %s", sameFileCall, sharedCall)
+	}
+}
+
+// transpileProjectionOnly runs exactly the projection half of Transpile:
+// parse, then t.emit(root). It skips Transpile's gosx.Compile semantic
+// gate, which is how ir.Lower's pending WP1 relaxation (shared-call
+// admission for a strict caller body) would otherwise block this test from
+// exercising transpile's own, already-complete half of the feature.
+func transpileProjectionOnly(t *testing.T, source []byte, opts Options) (string, error) {
+	t.Helper()
+	tree, lang, err := gosx.Parse(source)
+	if err != nil {
+		return "", err
+	}
+	root := tree.RootNode()
+	if root.HasError() {
+		return "", gosx.DescribeParseError(root, source, lang)
+	}
+	tp := &transpiler{
+		src:              source,
+		lang:             lang,
+		sourceFile:       opts.SourceFile,
+		imports:          make(map[string]string),
+		strictProjection: opts.strictProjection,
+		importNames:      opts.importNames,
+		sharedImports:    opts.SharedImports,
+	}
+	result := tp.emit(root)
+	if len(tp.errs) > 0 {
+		return "", errors.New(strings.Join(tp.errs, "\n"))
+	}
+	return result, nil
+}
+
+// extractCall returns the balanced-parenthesis call expression starting at
+// the last occurrence of prefix in src — the call site, not the earlier
+// func TeamMark(props TeamMarkProps) declaration that also starts with
+// "TeamMark(".
+func extractCall(t *testing.T, src, prefix string) string {
+	t.Helper()
+	idx := strings.LastIndex(src, prefix)
+	if idx < 0 {
+		t.Fatalf("call prefix %q not found in:\n%s", prefix, src)
+	}
+	depth := 0
+	for i := idx; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[idx : i+1]
+			}
+		}
+	}
+	t.Fatalf("unbalanced call starting at %q in:\n%s", prefix, src)
+	return ""
+}
+
+// TestSharedSpreadCallKeepsExistingRefusal covers the task's explicit
+// requirement to keep transpile.go:1195's refusal unchanged: a spread
+// attribute at a shared strict callee is proven only at the file renderer
+// boundary in v1, never by gosx transpile.
+func TestSharedSpreadCallKeepsExistingRefusal(t *testing.T) {
+	shared := CollectSharedComponents([]PackageFile{sharedTeamMarkPackageFile(t)})
+	caller := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow(team map[string]any) gosx.Node {
+	return <div><ui.TeamMark {...team}></ui.TeamMark></div>
+}
+`)
+	_, err := Transpile(caller, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: shared},
+		},
+	})
+	if err == nil || !strings.Contains(err.Error(), "proven by the file renderer boundary, not by gosx transpile") {
+		t.Fatalf("error = %v, want the file-renderer-boundary refusal", err)
+	}
+}
+
+// TestSharedCallWithNoResolverNamesGosxCheck covers the task's explicit
+// exit gate: a file carrying a shared import, transpiled with no resolver
+// at all, must fail with a message naming gosx check rather than produce
+// broken Go.
+func TestSharedCallWithNoResolverNamesGosxCheck(t *testing.T) {
+	caller := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow(tone, abbreviation string) gosx.Node {
+	return <div><ui.TeamMark Tone={tone} Abbreviation={abbreviation}></ui.TeamMark></div>
+}
+`)
+	out, err := Transpile(caller, Options{SourceFile: "page.gsx"})
+	if err == nil {
+		t.Fatalf("Transpile succeeded with no resolver; got broken-Go output:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "gosx check") {
+		t.Fatalf("error = %v, want a message naming gosx check", err)
+	}
+	if strings.Contains(out, "ui.TeamMark(") {
+		t.Fatalf("unresolved shared call leaked a broken call into output:\n%s", out)
+	}
+}
+
+// TestSharedCallWithUnknownComponentNamesGosxCheck covers the "resolver
+// present but this component absent" half of the same discipline: a
+// resolved shared import that does not declare the called component must
+// not fall back to an untyped call (which would emit non-compiling Go);
+// it fails the same way as a wholly unresolved import.
+func TestSharedCallWithUnknownComponentNamesGosxCheck(t *testing.T) {
+	caller := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow() gosx.Node {
+	return <div><ui.Missing></ui.Missing></div>
+}
+`)
+	out, err := Transpile(caller, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: map[string]SharedComponent{}},
+		},
+	})
+	if err == nil {
+		t.Fatalf("Transpile succeeded for an undeclared shared component; got:\n%s", out)
+	}
+	if !strings.Contains(err.Error(), "gosx check") {
+		t.Fatalf("error = %v, want a message naming gosx check", err)
+	}
+}
+
+// TestStrictProjectionRetainsRewrittenSharedImport covers the task's
+// explicit exit-gate requirement: strictProjectionImports must retain a
+// shared import — with its path rewritten to the resolved Go import path —
+// because the alias is a selector root of the projected call.
+func TestStrictProjectionRetainsRewrittenSharedImport(t *testing.T) {
+	shared := CollectSharedComponents([]PackageFile{sharedTeamMarkPackageFile(t)})
+	caller := []byte(`package app
+
+import ui "./ui"
+
+type StandingRowProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component StandingRow(props: StandingRowProps) {
+	return <div><ui.TeamMark Tone={props.Tone} Abbreviation={props.Abbreviation}></ui.TeamMark></div>
+}
+`)
+	// Uses transpileProjectionOnly for the same reason as
+	// TestSharedCallStructurallyMatchesSameFileShape above: a strict
+	// caller's shared call does not yet clear Transpile's gosx.Compile gate
+	// (that relaxation is WP1's, not WP4's), so this test exercises
+	// strict-projection emission directly.
+	out, err := transpileProjectionOnly(t, caller, Options{
+		SourceFile:       "page.gsx",
+		strictProjection: true,
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: shared},
+		},
+	})
+	if err != nil {
+		t.Fatalf("transpile (strict projection): %v", err)
+	}
+	if want := `ui "example.test/app/ui"`; !strings.Contains(out, want) {
+		t.Fatalf("strict projection dropped the rewritten shared import; got:\n%s", out)
+	}
+	if want := `ui.TeamMark(ui.TeamMarkProps{`; !strings.Contains(out, want) {
+		t.Fatalf("strict projection missing shared call; got:\n%s", out)
+	}
+}
+
+// TestSharedCallResolvesLowerCamelAttribute proves CollectSharedComponents
+// genuinely resolves field aliases from the shared directory's own source
+// (design section 5.2's "resolve, do not constrain" — open question 3),
+// not merely the exact-spelling fallback: a lower-camel attribute name
+// resolves to its exact exported Go field the same way a same-file call
+// already resolves one.
+func TestSharedCallResolvesLowerCamelAttribute(t *testing.T) {
+	shared := CollectSharedComponents([]PackageFile{sharedTeamMarkPackageFile(t)})
+	caller := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow(tone, abbreviation string) gosx.Node {
+	return <div><ui.TeamMark tone={tone} abbreviation={abbreviation}></ui.TeamMark></div>
+}
+`)
+	out, err := Transpile(caller, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: shared},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if want := `ui.TeamMark(ui.TeamMarkProps{Tone: tone, Abbreviation: abbreviation})`; !strings.Contains(out, want) {
+		t.Fatalf("lower-camel attribute did not resolve to its exact field; got:\n%s", out)
+	}
+}
+
+// TestSharedCallProjectionCompiles is the golden end-to-end proof: the
+// projected Go for a cross-directory named-attribute call, written to a
+// real module alongside the shared package's own projected Go, compiles
+// with the real Go compiler. This is the exit gate's strongest form —
+// stronger than a string match, because it proves the composite literal's
+// field names and the props struct's field types actually line up.
+func TestSharedCallProjectionCompiles(t *testing.T) {
+	if _, err := exec.LookPath("go"); err != nil {
+		t.Skip("go toolchain not on PATH")
+	}
+
+	sharedFile := sharedTeamMarkPackageFile(t)
+	sharedGo, err := Transpile(sharedFile.Source, Options{SourceFile: sharedFile.Path})
+	if err != nil {
+		t.Fatalf("Transpile shared: %v", err)
+	}
+	sharedComponents := CollectSharedComponents([]PackageFile{sharedFile})
+
+	callerSource := []byte(`package app
+
+import (
+	"m31labs.dev/gosx"
+	ui "./ui"
+)
+
+func StandingRow(tone, abbreviation string) gosx.Node {
+	return <div><ui.TeamMark Tone={tone} Abbreviation={abbreviation}></ui.TeamMark></div>
+}
+`)
+	callerGo, err := Transpile(callerSource, Options{
+		SourceFile: "page.gsx",
+		SharedImports: map[string]SharedImport{
+			"./ui": {GoImportPath: "example.test/app/ui", Components: sharedComponents},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Transpile caller: %v", err)
+	}
+
+	dir := newGoBuildModule(t)
+	mustWriteGoFile(t, filepath.Join(dir, "ui", "team_mark.go"), sharedGo)
+	mustWriteGoFile(t, filepath.Join(dir, "app", "page.go"), callerGo)
+
+	cmd := exec.CommandContext(context.Background(), "go", "build", "./...")
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GOFLAGS=-buildvcs=false", "GOWORK=off")
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build failed: %v\n%s\n--- ui/team_mark.go ---\n%s\n--- app/page.go ---\n%s", err, out, sharedGo, callerGo)
+	}
+}
+
+// newGoBuildModule builds a temp Go module with a minimal m31labs.dev/gosx
+// stub (the same node-builder surface transpile targets), replaced in so a
+// generated file's "m31labs.dev/gosx" import resolves without network
+// access or the real module's much larger dependency graph.
+func newGoBuildModule(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "gosxstub")
+	mustWriteGoFile(t, filepath.Join(stub, "node.go"), `package gosx
+
+type Node struct{}
+type AttrValue struct{}
+type AttrList []AttrValue
+
+func El(string, ...any) Node       { return Node{} }
+func Text(string) Node             { return Node{} }
+func Expr(any) Node                { return Node{} }
+func RawHTML(string) Node          { return Node{} }
+func Fragment(...Node) Node        { return Node{} }
+func Attr(string, any) AttrValue   { return AttrValue{} }
+func Attrs(...AttrValue) any       { return nil }
+func Props(values ...AttrValue) AttrList { return values }
+func Spread(any) AttrValue         { return AttrValue{} }
+func If(cond bool, child Node) Node { return Node{} }
+func Map[T any](items []T, fn func(T, int) Node) Node { return Node{} }
+`)
+	mustWriteGoFile(t, filepath.Join(stub, "go.mod"), "module m31labs.dev/gosx\n\ngo 1.26\n")
+	mustWriteGoFile(t, filepath.Join(dir, "go.mod"),
+		"module example.test/app\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\nreplace m31labs.dev/gosx => "+filepath.ToSlash(stub)+"\n")
+	return dir
+}
+
+func mustWriteGoFile(t *testing.T, path, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -36,6 +36,18 @@ type Options struct {
 	// ordinary callers should transpile the complete source file.
 	strictProjection bool
 	importNames      map[string]string
+
+	// SharedImports resolves a shared (./ or ../ prefixed) import to its Go
+	// projection facts: the Go import path substituted for the relative
+	// source text, and the props shape of every strict component the
+	// target directory declares. gosx check (strictcheck) is the intended
+	// producer, built from the target directory's own loaded programs
+	// (shared components design, section 5.2); transpile never walks a
+	// directory to build this map itself (design rule 1: no file input or
+	// output). A shared import this map has no entry for still parses, but
+	// any call through it fails with a message naming gosx check rather
+	// than emitting Go that cannot type-check.
+	SharedImports map[string]SharedImport
 }
 
 // Transpile converts GoSX source into valid Go code that uses the gosx/node package.
@@ -63,6 +75,7 @@ func Transpile(source []byte, opts Options) (string, error) {
 		imports:          make(map[string]string),
 		strictProjection: opts.strictProjection,
 		importNames:      opts.importNames,
+		sharedImports:    opts.SharedImports,
 	}
 
 	result := t.emit(root)
@@ -109,6 +122,9 @@ type transpiler struct {
 	injectGosx       bool
 	strictProjection bool
 	importNames      map[string]string
+	// sharedImports resolves a shared import's raw source path text (e.g.
+	// "./ui") to its Go projection facts. See Options.SharedImports.
+	sharedImports map[string]SharedImport
 }
 
 func (t *transpiler) text(n *gotreesitter.Node) string {
@@ -134,6 +150,8 @@ func (t *transpiler) emit(n *gotreesitter.Node) string {
 	switch t.nodeType(n) {
 	case "source_file":
 		return t.emitSourceFile(n)
+	case "import_declaration":
+		return t.emitImportDeclaration(n)
 	case "gosx_component_declaration":
 		return t.emitStrictComponent(n)
 	case "jsx_element":
@@ -236,6 +254,67 @@ func (t *transpiler) emitStrictSourceFile(n *gotreesitter.Node) string {
 	return b.String()
 }
 
+// emitImportDeclaration re-emits an import declaration for the ordinary
+// (non-strict-projection) transpile output, rewriting every shared (./ or
+// ../ prefixed) spec that Options.SharedImports resolves to its Go import
+// path, with an explicit alias so the emitted meaning does not depend on
+// the resolved package's own declared identifier. transpile has no
+// filesystem access of its own (design rule 1), so a shared spec this
+// file's resolver has no entry for passes through unrewritten; any call
+// site that actually uses it fails separately with a message naming gosx
+// check (errUnresolvedSharedCall), so the unrewritten text never reaches a
+// caller as successful output. A declaration with no shared spec, or run
+// with no SharedImports at all, is untouched byte-for-byte.
+func (t *transpiler) emitImportDeclaration(n *gotreesitter.Node) string {
+	original := t.text(n)
+	if len(t.sharedImports) == 0 {
+		return original
+	}
+	file, err := parser.ParseFile(token.NewFileSet(), t.sourceFile, "package gosximportrewrite\n"+original, parser.ImportsOnly)
+	if err != nil {
+		return original
+	}
+	changed := false
+	specs := make([]string, 0, len(file.Imports))
+	for _, spec := range file.Imports {
+		importPath, err := strconv.Unquote(spec.Path.Value)
+		if err != nil {
+			continue
+		}
+		alias := ""
+		explicit := spec.Name != nil
+		if explicit {
+			alias = spec.Name.Name
+		}
+		emitPath := importPath
+		if target, ok := t.sharedImports[importPath]; ok && strings.TrimSpace(target.GoImportPath) != "" {
+			emitPath = target.GoImportPath
+			if !explicit {
+				alias = t.defaultImportName(importPath)
+			}
+			changed = true
+		}
+		if alias != "" {
+			specs = append(specs, alias+" "+strconv.Quote(emitPath))
+		} else {
+			specs = append(specs, strconv.Quote(emitPath))
+		}
+	}
+	if !changed {
+		return original
+	}
+	if len(specs) == 1 && !strings.Contains(original, "(") {
+		return "import " + specs[0]
+	}
+	var b strings.Builder
+	b.WriteString("import (\n")
+	for _, spec := range specs {
+		b.WriteString("\t" + spec + "\n")
+	}
+	b.WriteByte(')')
+	return b.String()
+}
+
 type projectionImport struct {
 	alias string
 	path  string
@@ -264,6 +343,17 @@ func (t *transpiler) strictProjectionImports(n *gotreesitter.Node, body string) 
 				alias = spec.Name.Name
 				explicit = true
 			}
+			// A shared (./ or ../ prefixed) spec projects to its resolved Go
+			// import path — the alias itself is unaffected, since it is
+			// derived (here and at the call site, via t.imports) from the
+			// same relative path text either way. Retaining the import below
+			// is what keeps the alias valid as the shared call's selector
+			// root (shared components design, section 5.2).
+			emitPath := importPath
+			if target, ok := t.sharedImports[importPath]; ok && strings.TrimSpace(target.GoImportPath) != "" {
+				emitPath = target.GoImportPath
+				explicit = true
+			}
 			switch alias {
 			case "_":
 				// Side-effect imports cannot affect structural type checking.
@@ -284,7 +374,7 @@ func (t *transpiler) strictProjectionImports(n *gotreesitter.Node, body string) 
 			if explicit || alias == "." {
 				emitAlias = alias
 			}
-			imports = append(imports, projectionImport{alias: emitAlias, path: importPath})
+			imports = append(imports, projectionImport{alias: emitAlias, path: emitPath})
 		}
 	}
 	return imports
@@ -720,9 +810,24 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 		if propsType, ok := t.typedPropsType(tag); ok {
 			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, openNode), children)
 		}
+		if rawPath, shared := t.sharedImportPath(memberTagAlias(tag)); shared {
+			t.errUnresolvedSharedCall(openNode, tag, rawPath)
+			return ""
+		}
 		return t.emitComponentCall(tag, t.emitAttrs(openNode), children)
 	}
 	return t.emitElementCall(tag, t.emitHTMLAttrs(openNode), children)
+}
+
+// memberTagAlias returns tag's alias segment for a dotted tag ("ui" for
+// "ui.TeamMark"), or "" for a bare tag. It is a thin wrapper over
+// splitMemberTag for call sites that only need the alias.
+func memberTagAlias(tag string) string {
+	alias, _, ok := splitMemberTag(tag)
+	if !ok {
+		return ""
+	}
+	return alias
 }
 
 // isStrictConditionalTag reports whether tag resolves to the strict <If>
@@ -1009,6 +1114,10 @@ func (t *transpiler) emitSelfClosing(n *gotreesitter.Node) string {
 		if propsType, ok := t.typedPropsType(tag); ok {
 			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, n), nil)
 		}
+		if rawPath, shared := t.sharedImportPath(memberTagAlias(tag)); shared {
+			t.errUnresolvedSharedCall(n, tag, rawPath)
+			return ""
+		}
 		return t.emitComponentCall(tag, t.emitAttrs(n), nil)
 	}
 	return t.emitElementCall(tag, t.emitHTMLAttrs(n), nil)
@@ -1097,9 +1206,95 @@ func (t *transpiler) emitComponentCall(tag string, attrs []string, children []st
 func (t *transpiler) typedPropsType(tag string) (string, bool) {
 	propsType := strings.TrimSpace(t.propsTypes[tag])
 	if propsType == "" || isAttrListPropsType(propsType) {
+		if sharedType, ok := t.sharedPropsType(tag); ok {
+			return sharedType, true
+		}
 		return t.gosxUIPropsType(tag)
 	}
 	return propsType, true
+}
+
+// isSharedImportPath reports whether path is a shared import per the shared
+// components design section 4.1: a "./"- or "../"-prefixed relative
+// directory reference, never a legal Go import path in module mode.
+func isSharedImportPath(path string) bool {
+	return strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../")
+}
+
+// sharedImportPath reports whether alias names a shared import in this
+// file and, if so, returns its raw (unrewritten) source path text — the key
+// Options.SharedImports resolves against.
+func (t *transpiler) sharedImportPath(alias string) (string, bool) {
+	raw, ok := t.imports[alias]
+	if !ok || !isSharedImportPath(raw) {
+		return "", false
+	}
+	return raw, true
+}
+
+// isSharedCallTag reports whether tag's alias names a shared import in this
+// file, regardless of whether Options.SharedImports resolves it. This is
+// the distinction that separates "this call needs gosx check" from "this
+// call is an ordinary dotted tag resolved through a Go binding" — the two
+// rows section 6.1 of the shared components design keeps apart.
+func (t *transpiler) isSharedCallTag(tag string) bool {
+	alias, _, ok := splitMemberTag(tag)
+	if !ok {
+		return false
+	}
+	_, shared := t.sharedImportPath(alias)
+	return shared
+}
+
+// sharedComponent resolves tag's callee component from
+// Options.SharedImports, which gosx check builds from the shared
+// directory's own loaded programs (design section 5.2). transpile has no
+// filesystem access of its own to try harder (design rule 1), so it
+// reports ok only when both the import path and the component name are
+// present in the supplied map.
+func (t *transpiler) sharedComponent(tag string) (SharedComponent, bool) {
+	alias, component, ok := splitMemberTag(tag)
+	if !ok {
+		return SharedComponent{}, false
+	}
+	rawPath, shared := t.sharedImportPath(alias)
+	if !shared {
+		return SharedComponent{}, false
+	}
+	target, ok := t.sharedImports[rawPath]
+	if !ok {
+		return SharedComponent{}, false
+	}
+	comp, ok := target.Components[component]
+	if !ok || strings.TrimSpace(comp.PropsType) == "" {
+		return SharedComponent{}, false
+	}
+	return comp, true
+}
+
+// sharedPropsType resolves tag's callee props type the same way
+// gosxUIPropsType resolves a m31labs.dev/gosx/ui call: alias qualified onto
+// the props type name, so emitTypedComponentCall's composite literal reads
+// as an ordinary qualified Go type, exactly like the call itself.
+func (t *transpiler) sharedPropsType(tag string) (string, bool) {
+	alias, _, ok := splitMemberTag(tag)
+	if !ok {
+		return "", false
+	}
+	comp, ok := t.sharedComponent(tag)
+	if !ok {
+		return "", false
+	}
+	return alias + "." + comp.PropsType, true
+}
+
+// errUnresolvedSharedCall reports the one outcome the shared components
+// design requires of gosx transpile with no resolver (or an incomplete
+// one): a message naming gosx check as the supported path, instead of
+// emitting Go that cannot type-check. rawPath is the shared import's own
+// source text (e.g. "./ui"), which names the resolver gap precisely.
+func (t *transpiler) errUnresolvedSharedCall(n *gotreesitter.Node, tag, rawPath string) {
+	t.errorf(n, "shared component %s cannot be projected without a resolved Go import for %q; gosx transpile does not resolve a ./ or ../ import on its own — run gosx check, which resolves and type-checks a shared .gsx import", tag, rawPath)
 }
 
 func (t *transpiler) gosxUIPropsType(tag string) (string, bool) {
@@ -1167,6 +1362,9 @@ func (t *transpiler) emitTypedAttrsForTag(tag string, n *gotreesitter.Node) []st
 	if t.isGoSXUITag(tag) {
 		return t.emitGoSXUIAttrs(tag, n)
 	}
+	if comp, ok := t.sharedComponent(tag); ok {
+		return t.emitTypedAttrsWithAliases(tag, comp.Fields, n)
+	}
 	return t.emitTypedAttrsForType(tag, t.propsTypes[tag], n)
 }
 
@@ -1178,20 +1376,34 @@ func (t *transpiler) emitTypedAttrsForType(tag, propsType string, n *gotreesitte
 	if idx := strings.Index(baseType, "["); idx >= 0 {
 		baseType = baseType[:idx]
 	}
-	aliases := t.propsFields[baseType]
+	return t.emitTypedAttrsWithAliases(tag, t.propsFields[baseType], n)
+}
+
+// emitTypedAttrsWithAliases projects a typed call's named attributes into
+// composite-literal fields against aliases, and applies the shared spread
+// refusal. A same-file struct call (emitTypedAttrsForType, aliases from
+// t.propsFields) and a shared cross-directory struct call
+// (emitTypedAttrsForTag, aliases from Options.SharedImports) both resolve
+// through this one function, so the two call shapes cannot drift apart —
+// there is exactly one boundary, matching how route/fileprogram.go's
+// localComponentProps already proves both call kinds through one function
+// at render time.
+func (t *transpiler) emitTypedAttrsWithAliases(tag string, aliases map[string]string, n *gotreesitter.Node) []string {
 	var attrs []string
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		child := n.NamedChild(i)
 		switch t.nodeType(child) {
 		case "jsx_spread_attribute":
-			if _, strictCallee := t.strictNames[tag]; strictCallee {
-				// E2 tier 2 (design spec section 3.3, non-goal 3.5): a
-				// legacy body's spread into a strict callee is proved only
-				// at the file-renderer boundary (strictSpreadProps,
-				// route/fileprogram.go); full transpile has no equivalent
-				// run-time re-proof, so it keeps failing here, with a
-				// message that names the supported path instead of the
-				// unproven one.
+			_, strictCallee := t.strictNames[tag]
+			if strictCallee || t.isSharedCallTag(tag) {
+				// E2 tier 2 (design spec section 3.3, non-goal 3.5), and its
+				// cross-directory counterpart (shared components design,
+				// section 5.1 R2): a spread into a strict callee — same-file
+				// or shared — is proved only at the file-renderer boundary
+				// (strictSpreadProps, route/fileprogram.go), never by
+				// transpile. Full transpile has no equivalent proof, so it
+				// keeps failing here, naming the supported path instead of
+				// the unproven one.
 				t.errorf(child, "spread attributes at a strict component call site are proven by the file renderer boundary, not by gosx transpile; render %s through gosx's file router, or call it with explicit typed attributes from a strict body", tag)
 				continue
 			}


### PR DESCRIPTION
## Summary

Enable the transpiler to project JSX elements originating from shared (./ or ../ prefixed) component directories by consuming pre-resolved import metadata supplied via Options.SharedImports. This allows cross-directory strict component calls to resolve props types and field-name aliases without the transpiler performing any filesystem access, deferring that responsibility to gosx check.

## Changes

- Add SharedImport and SharedComponent types carrying a resolved Go import path and each shared component's props type plus field-name alias map
- Add CollectSharedComponents to extract strict component definitions from a loaded set of PackageFiles using the same extraction logic as same-file calls
- Wire SharedImports through Options into the transpiler runtime
- Implement emitImportDeclaration to rewrite shared import specs to their resolved Go paths with explicit aliases so emitted meaning does not depend on the target's declared identifier
- Extend strictProjectionImports to substitute resolved Go paths for shared import entries while preserving the alias as the selector root
- Add shared-component lookup helpers (sharedImportPath, isSharedCallTag, sharedComponent, sharedPropsType) and error reporting (errUnresolvedSharedCall) that fail with a message directing users to run gosx check when no resolver is present
- Route typed-attrs projection through emitTypedAttrsForTag for shared components so both same-file and shared calls share emitTypedAttrsWithAliases, preventing future shape drift
- Extend the existing spread-attribute refusal to cover shared strict callees, keeping the same file-renderer-boundary guard
- Provide comprehensive tests verifying: qualified composite-literal projection, structural parity with same-file calls, spread refusal behavior, missing-resolver and unknown-component error messages naming gosx check, strict-projection import retention, lower-camel attribute resolution, and end-to-end compilation inside a temporary Go module

## Testing

- go test ./transpile/... -run TestSharedCall  # runs all shared-projection unit tests
- go test ./transpile/... -run TestSharedCallProjectionCompiles  # builds a real Go module and invokes the compiler