### PR TITLE
add(strict components): allow strict components to accept children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,72 @@
 # Changelog
 
+## Unreleased
+
+### Added: a strict component accepts children
+
+- **A strict component can now place the markup its caller wrote.** Write
+  `{children}` in the body, and pass child content at the call site:
+
+  ```go
+  component Panel(props: PanelProps) {
+  	return <section class={"panel tone-" + props.Tone}>
+  		<h2 class="panel__title">{props.Title}</h2>
+  		<div class="panel__body">{children}</div>
+  	</section>
+  }
+
+  component Dashboard(props: DashboardProps) {
+  	return <Panel Title={props.Heading} Tone={props.Tone}>
+  		<p>{props.Summary}</p>
+  	</Panel>
+  }
+  ```
+
+  All three call shapes accept children: a strict caller's named attributes,
+  a strict caller's single spread, and a legacy caller's single spread. This
+  is a same-file capability. It needs no import and no shared directory.
+
+- **Children are not a prop, and this is exact.** They never enter
+  `PropsFields`, `PropsPaths`, or `PropsSlices`. No boundary proof reads
+  them, and the explicit-supply rule does not cover them. The renderer binds
+  them beside `props`, never inside it.
+
+- **Children arrive already rendered and already proved.** By the time the
+  callee sees them they are one opaque `gosx.Node`. The CALLER rendered
+  them, in the caller's scope, so every element and every props read inside
+  them already passed the caller's own compile, check, and render proofs.
+  Nothing is deferred across the call, because nothing is left to prove.
+
+- **The one operation on children is emission.** A body may write
+  `{children}` more than once, and each hole emits the markup again, exactly
+  as `gosx.Expr(children)` does in generated Go. Every other use stays
+  refused: `{children.Field}`, `{"prefix " + children}`,
+  `<If cond={children}>`, `<Each of={children}>`, `<Each as="children">`,
+  and `class={children}`. The last one matters most — an attribute value is
+  written inside quotes, so rendered markup there would produce broken HTML.
+  The attribute position uses a separate validator entry point and reports
+  "children renders as element content, not as an attribute value".
+
+- **A callee that renders no children rejects child content**, instead of
+  truncating it silently: "strict component Panel renders no children;
+  remove the child content or render `{children}` in Panel's body". The
+  predicate has one owner, `ir.Component.AcceptsChildren`, computed from the
+  body before any call site is checked, so the answer does not depend on
+  declaration order.
+
+### Changed: every strict component projects a variadic children parameter
+
+- **`emitStrictComponent` now emits
+  `func Name(props NameProps, children ...gosx.Node) gosx.Node`** for every
+  strict component, whether or not its body places children. A variadic
+  parameter accepts zero arguments, so every existing call site keeps
+  compiling and every existing render is byte-identical. Emitting it
+  conditionally would need `transpile` to decide "renders children" for
+  itself — it walks the CST with no `ir.Program` in hand — and two
+  implementations of one predicate drift. Arity stays a gosx-level rule with
+  a single owner and a diagnostic better than Go's "too many arguments".
+- A consumer that asserts on the projected signature text must update it.
+
 ## v0.48.0 (2026-08-18)
 
 ### Fixed: a strict spread from a non-strict component is rejected at compile time

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,16 +72,16 @@
 
   ```go
   component Panel(props: PanelProps) {
-  	return <section class={"panel tone-" + props.Tone}>
-  		<h2 class="panel__title">{props.Title}</h2>
-  		<div class="panel__body">{children}</div>
-  	</section>
+      return <section class={"panel tone-" + props.Tone}>
+          <h2 class="panel__title">{props.Title}</h2>
+          <div class="panel__body">{children}</div>
+      </section>
   }
 
   component Dashboard(props: DashboardProps) {
-  	return <Panel Title={props.Heading} Tone={props.Tone}>
-  		<p>{props.Summary}</p>
-  	</Panel>
+      return <Panel Title={props.Heading} Tone={props.Tone}>
+          <p>{props.Summary}</p>
+      </Panel>
   }
   ```
 

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -196,7 +196,30 @@ func Page() Node {
 		</p>
 		<CodeBlock lang="gosx" source={data.attributesSample} />
 		<p>
-			A strict component call is intentionally narrower than an HTML element: pass named attributes that match the props struct, or the single proven spread described above. Positional child content stays rejected either way; use a legacy caller-and-callee chain when component composition needs nested Node content.
+			A strict component call is intentionally narrower than an HTML element: pass named attributes that match the props struct, or the single proven spread described above.
+		</p>
+		<h2 id="children">Children</h2>
+		<p>
+			A strict component places the markup its caller wrote. Write
+			<span class="inline-code">{"{children}"}</span>
+			in the body, and pass child content at the call site. All three call shapes accept children: a strict caller's named attributes, a strict caller's single spread, and a legacy caller's single spread.
+		</p>
+		<p>
+			Children are not a prop. They never enter the props schema, no boundary proof reads them, and the explicit-supply rule does not cover them. They arrive as one already-rendered node: the caller rendered them, in the caller's scope, so every element and every props read inside them already passed the caller's own compile, check, and render proofs. Nothing is deferred across the call.
+		</p>
+		<p>
+			The one operation on children is emission. A body may write
+			<span class="inline-code">{"{children}"}</span>
+			more than once, and each hole emits the markup again. Every other use stays rejected: a field read, a concatenation operand, an
+			<span class="inline-code">If</span>
+			condition, an
+			<span class="inline-code">Each</span>
+			source, an
+			<span class="inline-code">Each</span>
+			binding named children, and an attribute value. An attribute value is written inside quotes, so rendered markup there would produce broken HTML.
+		</p>
+		<p>
+			A component that renders no children rejects child content with a diagnostic that names both remedies, rather than dropping the content silently.
 		</p>
 		<p>
 			Strict markup also accepts the familiar aliases

--- a/examples/gosx-docs/docs_truth_test.go
+++ b/examples/gosx-docs/docs_truth_test.go
@@ -117,8 +117,14 @@ func TestRuntimeDeploymentSceneAndRelayDocsUseCurrentContracts(t *testing.T) {
 		{
 			page: "components",
 			required: []string{
-				"Positional child content stays rejected either way",
+				"A strict component places the markup its caller wrote",
+				"Children are not a prop",
 				"gosx export .",
+			},
+			forbidden: []string{
+				// Children shipped. A doc that still says they are rejected
+				// would be worse than no doc at all.
+				"Positional child content stays rejected either way",
 			},
 		},
 		{

--- a/internal/strictcomponent/children_position_test.go
+++ b/internal/strictcomponent/children_position_test.go
@@ -1,0 +1,129 @@
+package strictcomponent
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestChildExpressionPositionAdmitsChildren proves B1: the bare children
+// identifier is renderable in a child expression hole. The renderer already
+// binds the name (writeLocalComponent, route/fileprogram.go); this removes
+// the validator rule that had nothing behind it.
+func TestChildExpressionPositionAdmitsChildren(t *testing.T) {
+	for _, source := range []string{"children", "(children)", "((children))"} {
+		if err := ValidateServerChildExpressionScope(source, Scope{}); err != nil {
+			t.Fatalf("ValidateServerChildExpressionScope(%q) = %v, want nil", source, err)
+		}
+	}
+}
+
+// TestAttributePositionRejectsChildren proves B5, the dangerous half of the
+// relaxation. An attribute value is written inside quotes, so a rendered node
+// there would splice markup into an HTML attribute. The attribute entry point
+// keeps refusing the identifier, and says why.
+func TestAttributePositionRejectsChildren(t *testing.T) {
+	const want = "children renders as element content, not as an attribute value"
+	for _, source := range []string{"children", "(children)"} {
+		err := ValidateServerExpressionScope(source, Scope{})
+		if err == nil {
+			t.Fatalf("ValidateServerExpressionScope(%q) = nil, want a refusal", source)
+		}
+		if err.Error() != want {
+			t.Fatalf("ValidateServerExpressionScope(%q) = %q, want %q", source, err, want)
+		}
+	}
+}
+
+// TestValidateServerExpressionKeepsAttributeDefault proves the fail-closed
+// default: the pre-children entry points are the attribute position, so any
+// caller that states no position keeps refusing children.
+func TestValidateServerExpressionKeepsAttributeDefault(t *testing.T) {
+	if err := ValidateServerExpression("children"); err == nil {
+		t.Fatal("ValidateServerExpression(children) = nil, want a refusal")
+	}
+}
+
+// TestChildPositionRejectsEveryOperationOnChildren proves the containment
+// that keeps children from becoming an escape hatch. The admission is one
+// identifier, in one position, with one operation: emission. Reading a field
+// of it, concatenating it, and branching on it all stay refused, in the child
+// position too, by rules this change does not touch.
+func TestChildPositionRejectsEveryOperationOnChildren(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   string
+	}{
+		{"field", "children.Something", "selector must be a field chain rooted at props"},
+		{"concat", `"prefix " + children`, "is not renderable; strict concatenation accepts string literals and props field selectors only"},
+		{"index", "children[0]", "index expressions are not supported"},
+		{"call", "children()", "calls are not supported"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := ValidateServerChildExpressionScope(test.source, Scope{})
+			if err == nil {
+				t.Fatalf("ValidateServerChildExpressionScope(%q) = nil, want a refusal", test.source)
+			}
+			if !strings.Contains(err.Error(), test.want) {
+				t.Fatalf("error = %q, want it to contain %q", err, test.want)
+			}
+		})
+	}
+}
+
+// TestCondPositionRejectsChildren proves W9's half of the containment: an
+// <If cond> needs a rooted selector, so children never reaches it. The
+// message is the cond validator's own, unchanged.
+func TestCondPositionRejectsChildren(t *testing.T) {
+	_, _, _, err := ValidateServerCondExpressionScope("children", Scope{})
+	if err == nil {
+		t.Fatal("ValidateServerCondExpressionScope(children) = nil, want a refusal")
+	}
+	if !strings.Contains(err.Error(), "strict cond must be a bool props field") {
+		t.Fatalf("error = %q, want the cond selector refusal", err)
+	}
+}
+
+// TestIsChildrenExpression pins the one spelling test the lowerer's
+// AcceptsChildren pass and this validator share, so the two can never
+// disagree about what children looks like.
+func TestIsChildrenExpression(t *testing.T) {
+	yes := []string{"children", "(children)", " children "}
+	no := []string{"props", "childrenList", "children.Field", "children()", `"children"`, "", "child ren"}
+	for _, source := range yes {
+		if !IsChildrenExpression(source) {
+			t.Fatalf("IsChildrenExpression(%q) = false, want true", source)
+		}
+	}
+	for _, source := range no {
+		if IsChildrenExpression(source) {
+			t.Fatalf("IsChildrenExpression(%q) = true, want false", source)
+		}
+	}
+}
+
+// TestChildPositionKeepsEveryOtherRule proves the child entry point differs
+// from the attribute one in exactly one identifier and nothing else.
+func TestChildPositionKeepsEveryOtherRule(t *testing.T) {
+	shared := []string{"props", "nil", "someLocal", "1 + 2", "-props.Count", `'a'`}
+	for _, source := range shared {
+		childErr := ValidateServerChildExpressionScope(source, Scope{})
+		attrErr := ValidateServerExpressionScope(source, Scope{})
+		if childErr == nil || attrErr == nil {
+			t.Fatalf("%q: child=%v attr=%v, want both refused", source, childErr, attrErr)
+		}
+		if childErr.Error() != attrErr.Error() {
+			t.Fatalf("%q: child=%q attr=%q, want identical messages", source, childErr, attrErr)
+		}
+	}
+	accepted := []string{`"text"`, "42", "true", "props.Label", `"a" + props.Label`}
+	for _, source := range accepted {
+		if err := ValidateServerChildExpressionScope(source, Scope{}); err != nil {
+			t.Fatalf("ValidateServerChildExpressionScope(%q) = %v, want nil", source, err)
+		}
+		if err := ValidateServerExpressionScope(source, Scope{}); err != nil {
+			t.Fatalf("ValidateServerExpressionScope(%q) = %v, want nil", source, err)
+		}
+	}
+}

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -60,6 +60,42 @@ func (s Scope) isBinding(name string) bool {
 	return s.isItem(name) || s.isIndex(name)
 }
 
+// ChildrenBinding is the one identifier a strict body may use to place the
+// markup its caller supplied. Four seams read this constant, so the spelling
+// cannot drift between them:
+//
+//   - the file renderer binds this exact name beside props
+//     (writeLocalComponent, route/fileprogram.go);
+//   - the lowerer reserves it against an <Each> binding, so no loop can
+//     shadow it (ir/lower.go);
+//   - the lowerer's AcceptsChildren pass looks for it, through
+//     IsChildrenExpression below;
+//   - the Go projection spells the variadic parameter of every strict
+//     component with it (emitStrictComponent, transpile/transpile.go).
+const ChildrenBinding = "children"
+
+// exprPosition names the syntactic slot an expression occupies. The strict
+// contract admits a different identifier set per slot, so the slot is an
+// explicit input to validation rather than a property of the source text.
+//
+// The two slots differ in exactly one identifier, children:
+//
+//   - positionChild is a whole child expression hole, {children}. Its value
+//     is written into element CONTENT, where markup is legal.
+//   - positionAttribute is an attribute value, class={children}. Its value is
+//     written into an HTML ATTRIBUTE, where markup is not legal — emitting a
+//     rendered node there would splice tags inside quotes and produce broken,
+//     unescapable output.
+//
+// positionAttribute is the zero value, so any caller that does not state a
+// position keeps the pre-children behavior and fails closed.
+type exprPosition uint8
+
+const (
+	positionAttribute exprPosition = iota
+	positionChild
+)
+
 // ValidateServerExpression accepts exactly the expression shapes implemented
 // by the file renderer for strict server components. The v0.39 contract is
 // intentionally small: literals and one direct props field (with parentheses).
@@ -87,18 +123,56 @@ func ValidateServerExpression(source string) error {
 // admit a selector chain rooted at any name in scope alongside props — the
 // #182 (`<Each>`) extension. See Scope's doc comment for the Items/Indices
 // distinction.
+//
+// This is the ATTRIBUTE-position entry point. It does not admit the children
+// identifier; use ValidateServerChildExpressionScope for a child expression
+// hole. Keeping the two apart is what stops class={children} from splicing
+// rendered markup into an HTML attribute value.
 func ValidateServerExpressionScope(source string, scope Scope) error {
+	return validateAt(source, scope, positionAttribute)
+}
+
+// ValidateServerChildExpressionScope is ValidateServerExpressionScope for a
+// whole child expression hole, {expr}, the one position that also admits the
+// bare identifier children.
+//
+// What the admission grants, exactly: emission. children is a single opaque
+// gosx.Node the caller already rendered. The callee cannot read a field of
+// it, index it, count it, concatenate it, or branch on it — every one of
+// those shapes is rejected by a rule this function does not touch
+// (rootedSelectorPath, classifyConcatOperand, ValidateServerCondExpression).
+// It is not a prop: it never enters PropsFields, PropsPaths, or PropsSlices,
+// and no boundary proof reads it.
+//
+// A body may write {children} more than once. Each occurrence emits the same
+// markup again, matching gosx.Expr(children) in the Go projection.
+func ValidateServerChildExpressionScope(source string, scope Scope) error {
+	return validateAt(source, scope, positionChild)
+}
+
+// IsChildrenExpression reports whether source is exactly the children
+// identifier, with parentheses transparent. It is the single spelling test
+// for "this expression hole places the caller's children", so the lowerer's
+// AcceptsChildren pass and this validator can never disagree about what
+// children looks like.
+func IsChildrenExpression(source string) bool {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return false
+	}
+	ident, ok := unwrapParens(expr).(*ast.Ident)
+	return ok && ident.Name == ChildrenBinding
+}
+
+func validateAt(source string, scope Scope, pos exprPosition) error {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
 		return fmt.Errorf("invalid Go expression: %w", err)
 	}
-	if err := validate(expr, source, scope); err != nil {
-		return err
-	}
-	return nil
+	return validate(expr, source, scope, pos)
 }
 
-func validate(expr ast.Expr, source string, scope Scope) error {
+func validate(expr ast.Expr, source string, scope Scope, pos exprPosition) error {
 	switch node := expr.(type) {
 	case *ast.BasicLit:
 		return validateLiteral(node)
@@ -110,6 +184,11 @@ func validate(expr ast.Expr, source string, scope Scope) error {
 			return fmt.Errorf("nil is not supported because GoSX expression and file renderers serialize it differently")
 		case "props":
 			return fmt.Errorf("bare props is not supported; select a props field")
+		case ChildrenBinding:
+			if pos == positionChild {
+				return nil
+			}
+			return fmt.Errorf("children renders as element content, not as an attribute value")
 		default:
 			if scope.isIndex(node.Name) {
 				// An Each index binding is always a plain int — the same
@@ -124,7 +203,7 @@ func validate(expr ast.Expr, source string, scope Scope) error {
 			return fmt.Errorf("identifier %q is not available to the strict server renderer", node.Name)
 		}
 	case *ast.ParenExpr:
-		return validate(node.X, source, scope)
+		return validate(node.X, source, scope, pos)
 	case *ast.SelectorExpr:
 		if _, _, ok := rootedSelectorPath(node, scope); !ok {
 			return fmt.Errorf("selector must be a field chain rooted at props, with every step a plain field access; anything else cannot preserve Go nil-pointer behavior")
@@ -151,6 +230,11 @@ func validate(expr ast.Expr, source string, scope Scope) error {
 // of each. The renderer's applyFileBinaryOp takes the string branch whenever
 // either side of `+` is a Go string (route/exprlower.go), so this is the one
 // binary shape the file renderer and generated Go execute identically.
+//
+// It takes no exprPosition on purpose: children is never a concat operand,
+// in any position. A rendered node has no string value to add, so
+// {"prefix " + children} keeps falling into classifyConcatOperand's default
+// branch and its existing "not renderable" message.
 func validateConcatChain(node *ast.BinaryExpr, source string, scope Scope) error {
 	hasStringLiteral := false
 	hasPropsField := false

--- a/ir/acceptschildren_roundtrip_test.go
+++ b/ir/acceptschildren_roundtrip_test.go
@@ -1,0 +1,60 @@
+package ir
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// TestComponentAcceptsChildrenDecodesFalseFromOlderPrograms proves the
+// compatibility rule AcceptsChildren's doc comment states, matching
+// ComponentSyntax's, PropsPaths', and PropsSlices' zero-value convention: a
+// Component encoded before this field existed decodes with AcceptsChildren
+// false. False is not a fallback here, it is the correct historical answer —
+// children were rejected at every strict callee then, so such a program
+// accepted none.
+func TestComponentAcceptsChildrenDecodesFalseFromOlderPrograms(t *testing.T) {
+	const legacyComponentJSON = `{
+		"Name": "Panel",
+		"PropsType": "PanelProps",
+		"PropsName": "props",
+		"PropsFields": {"Title": "string"},
+		"Syntax": 1,
+		"Root": 4
+	}`
+	var comp Component
+	if err := json.Unmarshal([]byte(legacyComponentJSON), &comp); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if comp.AcceptsChildren {
+		t.Fatal("AcceptsChildren = true, want false for a program serialized before this field existed")
+	}
+	if comp.Name != "Panel" || comp.PropsFields["Title"] != "string" || comp.Syntax != ComponentSyntaxStrict {
+		t.Fatalf("legacy fields did not decode unchanged: %#v", comp)
+	}
+}
+
+// TestComponentAcceptsChildrenRoundTripsThroughJSON proves the new field
+// itself survives an encode and decode cycle.
+func TestComponentAcceptsChildrenRoundTripsThroughJSON(t *testing.T) {
+	comp := Component{
+		Name:            "Panel",
+		PropsType:       "PanelProps",
+		PropsName:       "props",
+		AcceptsChildren: true,
+		Syntax:          ComponentSyntaxStrict,
+	}
+	data, err := json.Marshal(comp)
+	if err != nil {
+		t.Fatalf("json.Marshal: %v", err)
+	}
+	var decoded Component
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if !decoded.AcceptsChildren {
+		t.Fatalf("AcceptsChildren did not round-trip: %#v", decoded)
+	}
+	if decoded.Name != comp.Name || decoded.Syntax != comp.Syntax {
+		t.Fatalf("Component did not round-trip: %#v", decoded)
+	}
+}

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -107,6 +107,34 @@ type Component struct {
 	// matching the ComponentSyntax zero-value convention above.
 	PropsSlices map[string]SlicePropSchema
 
+	// AcceptsChildren is true when this component's body places the caller's
+	// children, that is when it contains at least one {children} expression
+	// hole. It is the ONE owner of the "renders children" predicate: the
+	// lowerer computes it from the CST, the call-site rules read it, and the
+	// Go projection never recomputes it (transpile emits the variadic
+	// parameter unconditionally, so it needs no predicate of its own and the
+	// two can never drift).
+	//
+	// What it does NOT record: anything about the children's type, count, or
+	// contents. Children are not a prop. They never enter PropsFields,
+	// PropsPaths, or PropsSlices, no boundary proof reads them, and the
+	// explicit-supply rule does not cover them. They arrive as one opaque
+	// gosx.Node the CALLER already rendered and already proved.
+	//
+	// The zero value is false, which is exactly right for every program
+	// serialized before this field existed: children were rejected at every
+	// strict callee then, so such a program accepted none.
+	//
+	// It is a STRICT-component field. A legacy component leaves it false and
+	// no rule reads it there: a legacy body receives children through the
+	// runtime props map ("children" and "Children", localComponentProps),
+	// which is a separate, older contract this field does not touch. A
+	// strict body cannot reach that map — props.Children fails the field
+	// walk at lower time unless the author declares such a field, and a
+	// gosx.Node-typed props field is a separate feature. The two paths do
+	// not interact.
+	AcceptsChildren bool
+
 	// Syntax distinguishes legacy `func` components from strict
 	// `component Name(props: Type)` declarations.
 	Syntax ComponentSyntax

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -74,6 +74,19 @@ type lowerer struct {
 	structTypes   map[string]map[string]string
 	strictServer  bool
 
+	// strictChildren records, per same-file strict component name, whether
+	// that component's body places the caller's children — the single owner
+	// of the "renders children" predicate inside ir (see
+	// Component.AcceptsChildren). It is filled for the WHOLE file by
+	// collectStrictSchemas before any body is lowered, because
+	// validateStrictComponentCall must read a callee's flag from inside the
+	// CALLER's body walk, and a callee may be declared later in the file.
+	// Deriving it from the built IR instead would make a legal call fail or
+	// pass purely on declaration order — the same order-dependence bug
+	// collectStrictSchemas' two-pass split already fixed once for
+	// l.strictNames (gosx#182/#184 M-3).
+	strictChildren map[string]bool
+
 	// currentStrictComponent and currentStrictPropsType name the strict
 	// component whose body lowerGSXNode is currently walking (empty
 	// outside strict lowering). E2 tier 1 (validateStrictToStrictSpreadCall)
@@ -1023,6 +1036,7 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.strictReads = make(map[string]map[string]strictReadClass)
 	l.structFields = make(map[string]map[string]string)
 	l.structTypes = make(map[string]map[string]string)
+	l.strictChildren = make(map[string]bool)
 	// Pass 1: every same-file strict component's name and props type,
 	// every legacy (non-strict) top-level renderer function's name, and
 	// every declared struct's field schema — nothing here depends on
@@ -1044,6 +1058,13 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 				l.strictNames[componentName] = struct{}{}
 				if propsType != "" {
 					l.strictProps[componentName] = propsType
+				}
+				// Pass 1, not pass 2: the flag depends on nothing but this
+				// declaration's own body, and every caller's shape check
+				// needs it complete for the whole file regardless of
+				// declaration order.
+				if l.componentRendersChildren(child) {
+					l.strictChildren[componentName] = true
 				}
 			}
 		case "type_declaration":
@@ -1068,6 +1089,50 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 		}
 		l.strictReads[componentName] = l.collectStrictPropReads(child)
 	}
+}
+
+// componentRendersChildren reports whether decl's body contains at least one
+// {children} child expression hole — the whole of Component.AcceptsChildren's
+// definition, computed from the CST so it is available before any body is
+// lowered.
+//
+// It deliberately does NOT descend into an attribute. An attribute value can
+// itself be a jsx_expression_container (lowerAttr's third case), so a walk
+// that counted every container would read class={children} as a children
+// placement — and that expression is rejected, by
+// ValidateServerChildExpressionScope's attribute-position twin, precisely
+// because rendered markup cannot go inside an HTML attribute value. Counting
+// it would declare a component to accept children that can never place them.
+//
+// Multiple holes stay one flag. The flag answers "does this body place the
+// caller's children", not "how many times".
+func (l *lowerer) componentRendersChildren(decl *gotreesitter.Node) bool {
+	body := l.childByField(decl, "body")
+	if body == nil {
+		return false
+	}
+	found := false
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil || found {
+			return
+		}
+		switch l.nodeType(node) {
+		case "jsx_attribute", "jsx_spread_attribute":
+			return
+		case "jsx_expression_container":
+			exprNode := l.childByField(node, "expression")
+			if exprNode != nil && strictcomponent.IsChildrenExpression(l.text(exprNode)) {
+				found = true
+				return
+			}
+		}
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			walk(node.NamedChild(i))
+		}
+	}
+	walk(body)
+	return found
 }
 
 // collectStrictPropReads records every props field path (dot-joined, e.g.
@@ -1941,9 +2006,30 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 			}
 		}
 	}
-	if len(children) > 0 {
-		l.errorf(n, "strict component %s does not accept positional children", tag)
+	l.validateStrictCalleeChildren(n, tag, children)
+}
+
+// validateStrictCalleeChildren is the ONE arity rule for children at a strict
+// callee, shared by all three call shapes (named attributes, a strict
+// caller's single spread, a legacy caller's single spread). A callee that
+// places children accepts them; a callee that does not rejects them, with a
+// message that names both remedies instead of truncating the content
+// silently.
+//
+// The rule is arity only. It proves nothing about the children themselves and
+// has nothing to prove: they are markup the CALLER owns, rendered by the
+// caller's renderer, in the caller's env, against the caller's program,
+// before the callee is entered. Every read inside them already passed the
+// caller's own lower-time, check-time, and render-time proofs, so no
+// obligation crosses the call.
+func (l *lowerer) validateStrictCalleeChildren(n *gotreesitter.Node, tag string, children []NodeID) {
+	if len(children) == 0 {
+		return
 	}
+	if l.strictChildren[tag] {
+		return
+	}
+	l.errorf(n, "strict component %s renders no children; remove the child content or render {children} in %s's body", tag, tag)
 }
 
 // attrHasSpread reports whether attrs contains at least one spread
@@ -1988,9 +2074,7 @@ func (l *lowerer) validateLegacyToStrictCall(n *gotreesitter.Node, tag string, a
 		return
 	}
 	if spread, ok := singleSpreadShape(attrs); ok {
-		if len(children) > 0 {
-			l.errorf(n, "strict component %s does not accept positional children", tag)
-		}
+		l.validateStrictCalleeChildren(n, tag, children)
 		l.validateLegacyPropsSpread(n, tag, spread)
 		return
 	}
@@ -2054,9 +2138,7 @@ func (l *lowerer) validateStrictToStrictSpreadCall(n *gotreesitter.Node, tag str
 		l.errorf(n, "strict component call %s accepts at most one spread attribute and no other attributes", tag)
 		return
 	}
-	if len(children) > 0 {
-		l.errorf(n, "strict component %s does not accept positional children", tag)
-	}
+	l.validateStrictCalleeChildren(n, tag, children)
 	calleeProps := l.strictProps[tag]
 	if strings.TrimSpace(calleeProps) == "" {
 		l.errorf(n, "strict component %s does not accept props", tag)
@@ -2355,11 +2437,15 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 		PropsName:   propsName,
 		PropsFields: propsFields,
 		PropsPaths:  propsPaths,
-		Syntax:      ComponentSyntaxStrict,
-		Root:        rootID,
-		IsIsland:    isIsland,
-		Scope:       scope,
-		Span:        l.span(n),
+		// Read, never recomputed: collectStrictSchemas already decided this
+		// for every strict component in the file, and every call-site rule
+		// read the same map. One owner.
+		AcceptsChildren: l.strictChildren[componentName],
+		Syntax:          ComponentSyntaxStrict,
+		Root:            rootID,
+		IsIsland:        isIsland,
+		Scope:           scope,
+		Span:            l.span(n),
 	}
 	if isEngine {
 		comp.IsEngine = true
@@ -2578,7 +2664,12 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, pr
 		seen[id] = true
 		node := &l.prog.Nodes[id]
 		if node.Kind == NodeExpr {
-			l.validateStrictServerExpression(node.Span, node.Text, componentName, propsType, scope)
+			// CHILD position. A NodeExpr is only ever built from a
+			// jsx_expression_container in child position (lowerExprContainer);
+			// an attribute expression is stored on Attr.Expr instead and takes
+			// the attribute branch below. That split is what lets the two
+			// positions admit different identifier sets.
+			l.validateStrictServerChildExpression(node.Span, node.Text, componentName, propsType, scope)
 		}
 		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && !ifShadowed
 		isBuiltinEach := node.Kind == NodeComponent && node.Tag == "Each" && !eachShadowed
@@ -2598,6 +2689,11 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, pr
 				continue
 			}
 			if attr.Kind == AttrExpr {
+				// ATTRIBUTE position. This entry point does not admit
+				// children: an attribute value is written inside quotes, and
+				// splicing rendered markup there produces broken HTML that no
+				// escaping rule can repair. See
+				// ValidateServerChildExpressionScope's doc comment.
 				l.validateStrictServerExpression(node.Span, attr.Expr, componentName, propsType, scope)
 			}
 			// AttrSpread is not revalidated as an ordinary expression here:
@@ -2625,15 +2721,36 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, pr
 
 func (l *lowerer) validateStrictServerExpression(span Span, source, componentName, propsType string, scope *eachScope) {
 	if err := strictcomponent.ValidateServerExpressionScope(source, scope.strictScope()); err != nil {
-		l.errs = append(l.errs, Diagnostic{
-			Span:    span,
-			Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(source), err),
-			Hint:    "use literals or props field selection; compute, index, and call methods before rendering",
-		})
+		l.reportStrictServerExpression(span, source, err)
 		return
 	}
 	l.validateStrictBindingReadTypes(span, source, componentName, scope)
 	l.validateStrictExpressionTypes(span, source, componentName, propsType, scope)
+}
+
+// validateStrictServerChildExpression is validateStrictServerExpression for a
+// whole child expression hole. It differs in the validator entry point only,
+// so the two type passes below stay shared and no rule is duplicated.
+//
+// Both type passes are no-ops for a bare children: it holds no selector, so
+// ServerExpressionRootedPaths reports no path, and it is no `+` chain, so
+// ServerConcatRootedPaths reports none either. There is nothing to type-check
+// in an already-rendered node.
+func (l *lowerer) validateStrictServerChildExpression(span Span, source, componentName, propsType string, scope *eachScope) {
+	if err := strictcomponent.ValidateServerChildExpressionScope(source, scope.strictScope()); err != nil {
+		l.reportStrictServerExpression(span, source, err)
+		return
+	}
+	l.validateStrictBindingReadTypes(span, source, componentName, scope)
+	l.validateStrictExpressionTypes(span, source, componentName, propsType, scope)
+}
+
+func (l *lowerer) reportStrictServerExpression(span Span, source string, err error) {
+	l.errs = append(l.errs, Diagnostic{
+		Span:    span,
+		Message: fmt.Sprintf("strict server expression %q is not renderable: %v", strings.TrimSpace(source), err),
+		Hint:    "use literals or props field selection; compute, index, and call methods before rendering",
+	})
 }
 
 // validateStrictBindingReadTypes is a props read's counterpart for a loop
@@ -2928,7 +3045,10 @@ func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, index
 			ok = false
 			continue
 		}
-		if binding == "props" || binding == "children" {
+		// The reservation predates the children feature and is what makes it
+		// safe: a loop binding may not shadow the identifier a body uses to
+		// place its caller's markup.
+		if binding == "props" || binding == strictcomponent.ChildrenBinding {
 			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is reserved; choose another name", binding)})
 			ok = false
 			continue

--- a/ir/strict_children_test.go
+++ b/ir/strict_children_test.go
@@ -1,0 +1,296 @@
+package ir_test
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+func componentByName(t *testing.T, prog *ir.Program, name string) *ir.Component {
+	t.Helper()
+	for i := range prog.Components {
+		if prog.Components[i].Name == name {
+			return &prog.Components[i]
+		}
+	}
+	t.Fatalf("component %s not found in %d components", name, len(prog.Components))
+	return nil
+}
+
+// TestAcceptsChildrenRecordsTheChildrenHole proves the IR field's whole
+// definition: a body that places {children} accepts children, and a body
+// that does not, does not.
+func TestAcceptsChildrenRecordsTheChildrenHole(t *testing.T) {
+	prog, err := parse(t, []byte(`package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2><div>{children}</div></section>
+}
+
+component Leaf(props: PanelProps) {
+	return <span>{props.Title}</span>
+}
+`))
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if !componentByName(t, prog, "Panel").AcceptsChildren {
+		t.Fatal("Panel.AcceptsChildren = false, want true")
+	}
+	if componentByName(t, prog, "Leaf").AcceptsChildren {
+		t.Fatal("Leaf.AcceptsChildren = true, want false")
+	}
+}
+
+// TestAcceptsChildrenIsIndependentOfDeclarationOrder proves the flag is
+// computed for the whole file before any body is lowered. A caller declared
+// BEFORE its callee must see the same answer as one declared after, or a
+// legal call would fail on file layout alone — the order-dependence class
+// collectStrictSchemas' two-pass split already fixed once for strictNames.
+func TestAcceptsChildrenIsIndependentOfDeclarationOrder(t *testing.T) {
+	const callerFirst = `package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><b>content</b></Panel>
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+`
+	const calleeFirst = `package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><b>content</b></Panel>
+}
+`
+	for name, source := range map[string]string{"caller first": callerFirst, "callee first": calleeFirst} {
+		t.Run(name, func(t *testing.T) {
+			prog, err := parse(t, []byte(source))
+			if err != nil {
+				t.Fatalf("Lower: %v", err)
+			}
+			if !componentByName(t, prog, "Panel").AcceptsChildren {
+				t.Fatal("Panel.AcceptsChildren = false, want true")
+			}
+		})
+	}
+}
+
+// TestChildrenInAnAttributeDoesNotDeclareAcceptance proves the attribute
+// walk exclusion in componentRendersChildren. An attribute value can itself
+// be an expression container, and class={children} is refused precisely
+// because rendered markup cannot go inside an attribute value. Counting it
+// would declare a component to accept children it can never place.
+func TestChildrenInAnAttributeDoesNotDeclareAcceptance(t *testing.T) {
+	_, err := parse(t, []byte(`package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section class={children}>{props.Title}</section>
+}
+`))
+	if err == nil {
+		t.Fatal("Lower accepted children in an attribute value")
+	}
+	if !strings.Contains(err.Error(), "children renders as element content, not as an attribute value") {
+		t.Fatalf("error = %v, want the attribute-position refusal", err)
+	}
+}
+
+// TestStrictCallSitesAcceptChildrenForAnAcceptingCallee covers all three
+// call shapes that reach a strict callee: a strict caller's named
+// attributes, a strict caller's single spread, and a legacy caller's single
+// spread.
+func TestStrictCallSitesAcceptChildrenForAnAcceptingCallee(t *testing.T) {
+	const preamble = `package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+`
+	tests := map[string]string{
+		"strict named attributes": `
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><b>x</b></Panel>
+}
+`,
+		"strict single spread": `
+component Page(props: PanelProps) {
+	return <Panel {...props}><b>x</b></Panel>
+}
+`,
+		"legacy single spread": `
+func Page(data PageData) Node {
+	return <Panel {...data.Panel}><b>x</b></Panel>
+}
+
+type PageData struct {
+	Panel PanelProps
+}
+`,
+	}
+	for name, caller := range tests {
+		t.Run(name, func(t *testing.T) {
+			if _, err := parse(t, []byte(preamble+caller)); err != nil {
+				t.Fatalf("Lower rejected children at an accepting callee: %v", err)
+			}
+		})
+	}
+}
+
+// TestStrictCallSitesRejectChildrenForANonAcceptingCallee proves the
+// unexpected-children diagnostic. Silent truncation is the failure this
+// replaces: without the rule, a caller writes child content and the callee
+// drops it with no signal at all.
+func TestStrictCallSitesRejectChildrenForANonAcceptingCallee(t *testing.T) {
+	const preamble = `package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2></section>
+}
+`
+	tests := map[string]string{
+		"strict named attributes": `
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><b>x</b></Panel>
+}
+`,
+		"strict single spread": `
+component Page(props: PanelProps) {
+	return <Panel {...props}><b>x</b></Panel>
+}
+`,
+		"legacy single spread": `
+type PageData struct {
+	Panel PanelProps
+}
+
+func Page(data PageData) Node {
+	return <Panel {...data.Panel}><b>x</b></Panel>
+}
+`,
+	}
+	const want = "strict component Panel renders no children; remove the child content or render {children} in Panel's body"
+	for name, caller := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := parse(t, []byte(preamble+caller))
+			if err == nil {
+				t.Fatal("Lower accepted children at a callee that renders none")
+			}
+			if !strings.Contains(err.Error(), want) {
+				t.Fatalf("error = %v, want it to contain %q", err, want)
+			}
+		})
+	}
+}
+
+// TestChildrenRenderedTwiceIsAccepted pins the documented semantics: each
+// {children} hole emits the children again, matching gosx.Expr(children) in
+// the Go projection. It is a feature of the emission model, not a defect.
+func TestChildrenRenderedTwiceIsAccepted(t *testing.T) {
+	prog, err := parse(t, []byte(`package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><div>{children}</div><div>{children}</div></section>
+}
+`))
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	if !componentByName(t, prog, "Panel").AcceptsChildren {
+		t.Fatal("Panel.AcceptsChildren = false, want true")
+	}
+}
+
+// TestChildrenIsNotAProp proves the boundary claim. Children never enter the
+// props schema, so no proof reads them and the explicit-supply rule does not
+// cover them.
+func TestChildrenIsNotAProp(t *testing.T) {
+	prog, err := parse(t, []byte(`package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+`))
+	if err != nil {
+		t.Fatalf("Lower: %v", err)
+	}
+	panel := componentByName(t, prog, "Panel")
+	for field := range panel.PropsFields {
+		if strings.EqualFold(field, "children") {
+			t.Fatalf("PropsFields carries %q; children must stay outside the props schema", field)
+		}
+	}
+	for path := range panel.PropsPaths {
+		if strings.HasPrefix(strings.ToLower(path), "children") {
+			t.Fatalf("PropsPaths carries %q; children must stay outside the props schema", path)
+		}
+	}
+	if _, ok := panel.PropsSlices["children"]; ok {
+		t.Fatal("PropsSlices carries children; children must stay outside the props schema")
+	}
+}
+
+// TestEachBindingNamedChildrenStaysReserved keeps W7 intact: the codebase
+// reserved the name against an <Each> binding before the feature existed,
+// and the reservation is what stops a loop binding from shadowing the one
+// identifier a body uses to place its caller's markup.
+func TestEachBindingNamedChildrenStaysReserved(t *testing.T) {
+	_, err := parse(t, []byte(`package app
+
+type Row struct {
+	Label string
+}
+
+type PanelProps struct {
+	Rows []Row
+}
+
+component Panel(props: PanelProps) {
+	return <section><Each of={props.Rows} as="children"><b>x</b></Each></section>
+}
+`))
+	if err == nil {
+		t.Fatal("Lower accepted an <Each> binding named children")
+	}
+	if !strings.Contains(err.Error(), `strict <Each> binding "children" is reserved`) {
+		t.Fatalf("error = %v, want the reserved-name refusal", err)
+	}
+}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1140,10 +1140,39 @@ func (r *fileProgramRenderer) renderBoundComponent(node *ir.Node, env fileRender
 	return true, defaultRenderedComponent(node.Tag, r.componentAttrMap(node.Attrs, env), childrenHTML)
 }
 
+// writeLocalComponent renders a strict component whose BODY and whose CALL
+// NODE both belong to r.prog — every same-file call today.
+//
+// It renders the children first, on r, and then hands the resulting node to
+// writeLocalComponentWithChildren. The split is not cosmetic. node.Children
+// are ir.NodeID values, and writeNode resolves each one through
+// r.prog.NodeAt: a node ID is an index into ONE program's Nodes slice and
+// means nothing in another. Any caller whose call node and callee body live
+// in different programs must therefore render the children on the renderer
+// that owns the CALL node, and pass the finished node across, rather than
+// hand the whole node to a renderer bound to the callee's program — that
+// would index the wrong slice and render unrelated markup, or panic on an
+// out-of-range index.
+//
+// Attribute expressions carry no such hazard: localComponentProps evaluates
+// them through env, which holds values, funcs, and a scope chain, and no node
+// IDs.
 func (r *fileProgramRenderer) writeLocalComponent(b *strings.Builder, comp *ir.Component, node *ir.Node, env fileRenderEnv) {
 	// Children render into their own string because the component body may
 	// reference them through the `children` binding.
 	childrenNode := gosx.RawHTML(r.renderChildren(node.Children, env))
+	r.writeLocalComponentWithChildren(b, comp, node, env, childrenNode)
+}
+
+// writeLocalComponentWithChildren renders comp's body with childrenNode
+// already rendered by whichever renderer owns the call node. r must own
+// comp's BODY, because writeNode resolves comp.Root against r.prog.
+//
+// childrenNode is one opaque gosx.Node. The callee places it and does nothing
+// else with it: it cannot read a field of it, count it, or branch on it.
+// Children are not a prop — they are bound beside props, never inside it, and
+// no boundary proof reads them.
+func (r *fileProgramRenderer) writeLocalComponentWithChildren(b *strings.Builder, comp *ir.Component, node *ir.Node, env fileRenderEnv, childrenNode gosx.Node) {
 	props, rawSource, err := localComponentProps(comp, node.Attrs, env, childrenNode)
 	if err != nil {
 		r.err = fmt.Errorf("render strict component %s: %w", comp.Name, err)
@@ -1812,10 +1841,7 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 		if err != nil {
 			return nil, nil, err
 		}
-		if !children.IsZero() {
-			setComponentProp(props, "children", children)
-			setComponentProp(props, "Children", children)
-		}
+		setStrictComponentChildren(comp, props, children)
 		return props, source, nil
 	}
 	if len(comp.PropsFields) == 0 {
@@ -1849,11 +1875,39 @@ func localComponentProps(comp *ir.Component, attrs []ir.Attr, env fileRenderEnv,
 		}
 		setComponentProp(props, attr.Name, value)
 	}
-	if !children.IsZero() {
-		setComponentProp(props, "children", children)
-		setComponentProp(props, "Children", children)
-	}
+	setStrictComponentChildren(comp, props, children)
 	return props, nil, nil
+}
+
+// setStrictComponentChildren writes the children node into a STRICT callee's
+// runtime props map, and refuses to overwrite a field that callee's schema
+// proves.
+//
+// Why the refusal. The "children"/"Children" map keys are the LEGACY
+// components' contract (componentProps). A strict body never reads them:
+// writeLocalComponent binds the node in the render SCOPE, beside props, and
+// {children} resolves there. So for a strict callee this write can never
+// serve the body — it can only collide.
+//
+// The collision is a real proof loss. A callee that declares and reads
+// `Children string` has that field proved against comp.PropsFields by the
+// loop above, and the unguarded write replaced the proved string with a
+// gosx.Node. The defect predates children (the write ran with an empty
+// RawHTML node even when the call passed none, so the field rendered empty),
+// but admitting children would upgrade it from "renders empty" to "renders
+// the caller's markup where a proved string belongs". Children are not a
+// prop, and this is what makes that statement true rather than nearly true.
+func setStrictComponentChildren(comp *ir.Component, props map[string]any, children gosx.Node) {
+	if children.IsZero() {
+		return
+	}
+	for _, name := range []string{"children", "Children"} {
+		if _, _, proved := resolvePropsFieldAlias(comp.PropsFields, name); proved {
+			return
+		}
+	}
+	setComponentProp(props, "children", children)
+	setComponentProp(props, "Children", children)
 }
 
 func strictComponentAttrValue(comp *ir.Component, attr ir.Attr, env fileRenderEnv, fieldType string) (any, error) {

--- a/route/strict_children_test.go
+++ b/route/strict_children_test.go
@@ -1,0 +1,349 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
+)
+
+// TestStrictComponentRendersCallerAuthoredChildren is the WP0 acceptance
+// render: a strict component wraps arbitrary caller-authored .gsx markup and
+// emits it in place.
+func TestStrictComponentRendersCallerAuthoredChildren(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type PanelProps struct {
+	Title string
+	Tone  string
+}
+component Panel(props: PanelProps) {
+	return <section class={"panel tone-" + props.Tone}><h2 class="panel__title">{props.Title}</h2><div class="panel__body">{children}</div></section>
+}
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title} Tone={props.Tone}><p class="lead">wrapped</p><b>markup</b></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Values: map[string]any{},
+		Props: struct {
+			Title string
+			Tone  string
+		}{Title: "Standings", Tone: "home"},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section class="panel tone-home"><h2 class="panel__title">Standings</h2><div class="panel__body"><p class="lead">wrapped</p><b>markup</b></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestStrictComponentRendersChildrenTwice pins the documented semantics of
+// two holes: each one emits the children again, matching gosx.Expr(children)
+// in the Go projection.
+func TestStrictComponentRendersChildrenTwice(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type PanelProps struct { Title string }
+component Panel(props: PanelProps) {
+	return <section><div class="a">{children}</div><div class="b">{children}</div></section>
+}
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><i>x</i></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Props: struct{ Title string }{Title: "t"},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section><div class="a"><i>x</i></div><div class="b"><i>x</i></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestStrictComponentChildrenAreEscapedByTheCaller proves the children reach
+// the callee as already-rendered, already-escaped markup. Text authored at
+// the call site is escaped by the caller's own renderer before the callee
+// ever sees it, so the callee adds no second escape pass and strips none.
+func TestStrictComponentChildrenAreEscapedByTheCaller(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type PanelProps struct { Title string }
+component Panel(props: PanelProps) {
+	return <section>{children}</section>
+}
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><p>{props.Title}</p></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Props: struct{ Title string }{Title: `<script>alert(1)</script>`},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if strings.Contains(html, "<script>") {
+		t.Fatalf("children were not escaped by the caller: %q", html)
+	}
+	want := `<section><p>&lt;script&gt;alert(1)&lt;/script&gt;</p></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// Row must carry this exact name: the strict boundary proves a loop source
+// by its element struct's DECLARED name (requireStrictSliceValue), so the Go
+// type the test supplies has to match the .gsx fixture's element struct.
+type Row struct{ Label string }
+
+type childrenEachPanelProps struct{ Rows []Row }
+
+// TestStrictComponentRendersChildrenInsideAnEachBody proves the children
+// binding survives into a loop scope: renderEach derives each item scope from
+// the enclosing frame, so the binding the component frame set is still in the
+// chain. Each iteration emits the children again, which is the same "one hole,
+// one emission" rule two holes follow.
+func TestStrictComponentRendersChildrenInsideAnEachBody(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type Row struct { Label string }
+type PanelProps struct { Rows []Row }
+type PageProps struct { Panel PanelProps }
+component Panel(props: PanelProps) {
+	return <ul><Each of={props.Rows} as="row"><li>{row.Label}{children}</li></Each></ul>
+}
+component Page(props: PageProps) {
+	return <Panel {...props.Panel}><b>C</b></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Props: struct{ Panel childrenEachPanelProps }{
+			Panel: childrenEachPanelProps{Rows: []Row{{Label: "a"}, {Label: "b"}}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<ul><li>a<b>C</b></li><li>b<b>C</b></li></ul>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestChildrenNeverOverwriteAProvedPropsField proves the boundary claim at
+// run time: children are not a prop, so they must not replace one.
+//
+// A callee that declares and reads `Children string` has that field proved
+// against its own schema. The children node is bound in the render scope
+// beside props, so both are readable and neither shadows the other.
+func TestChildrenNeverOverwriteAProvedPropsField(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type PanelProps struct {
+	Children string
+}
+component Panel(props: PanelProps) {
+	return <section><b>{props.Children}</b><div>{children}</div></section>
+}
+component Page(props: PanelProps) {
+	return <Panel Children={props.Children}><i>caller</i></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Props: struct{ Children string }{Children: "proved string"},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section><b>proved string</b><div><i>caller</i></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestSpreadChildrenNeverOverwriteAProvedPropsField is the same claim for
+// the single-spread call shape, which builds its props map through a
+// different function (strictSpreadProps).
+func TestSpreadChildrenNeverOverwriteAProvedPropsField(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type PanelProps struct {
+	Children string
+}
+type PageProps struct {
+	Panel PanelProps
+}
+component Panel(props: PanelProps) {
+	return <section><b>{props.Children}</b><div>{children}</div></section>
+}
+component Page(props: PageProps) {
+	return <Panel {...props.Panel}><i>caller</i></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	type panelProps struct{ Children string }
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{
+		Props: struct{ Panel panelProps }{Panel: panelProps{Children: "proved string"}},
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section><b>proved string</b><div><i>caller</i></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// childrenProgramPair builds two deliberately mismatched programs for the
+// cross-program regression test below.
+//
+// caller holds pad nodes so its children node IDs are large. callee is built
+// so that the SAME ID means something else entirely, which is what makes the
+// wrong-program bug observable rather than accidentally harmless.
+func childrenProgramPair(calleeFillers int) (caller *ir.Program, callee *ir.Program, callNode *ir.Node, comp *ir.Component) {
+	caller = &ir.Program{Package: "app"}
+	caller.AddNode(ir.Node{Kind: ir.NodeText, Text: "caller pad 0"})
+	caller.AddNode(ir.Node{Kind: ir.NodeText, Text: "caller pad 1"})
+	caller.AddNode(ir.Node{Kind: ir.NodeText, Text: "caller pad 2"})
+	childID := caller.AddNode(ir.Node{Kind: ir.NodeText, Text: "CALLER OWNS THIS"})
+	callID := caller.AddNode(ir.Node{
+		Kind:     ir.NodeComponent,
+		Tag:      "Panel",
+		Children: []ir.NodeID{childID},
+	})
+	callNode = caller.NodeAt(callID)
+
+	callee = &ir.Program{Package: "ui"}
+	for i := 0; i < calleeFillers; i++ {
+		callee.AddNode(ir.Node{Kind: ir.NodeText, Text: "CALLEE INTERNAL"})
+	}
+	holeID := callee.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "children"})
+	rootID := callee.AddNode(ir.Node{
+		Kind:     ir.NodeElement,
+		Tag:      "section",
+		Children: []ir.NodeID{holeID},
+	})
+	callee.Components = append(callee.Components, ir.Component{
+		Name:            "Panel",
+		Syntax:          ir.ComponentSyntaxStrict,
+		Root:            rootID,
+		AcceptsChildren: true,
+	})
+	comp = &callee.Components[0]
+	return caller, callee, callNode, comp
+}
+
+// TestChildrenResolveAgainstTheCallersProgram is the regression test for the
+// defect section 9.1.5 names. node.Children are ir.NodeID values, and a node
+// ID is an index into ONE program's Nodes slice. At a call site whose node
+// belongs to one program and whose callee body belongs to another, rendering
+// the children on the callee's renderer indexes the wrong slice.
+//
+// The two programs are built with deliberately different node counts, so the
+// bug cannot pass silently. Each sub-case first proves the WRONG path is
+// observably wrong, then proves the split renders correctly.
+func TestChildrenResolveAgainstTheCallersProgram(t *testing.T) {
+	t.Run("callee program is larger: wrong path renders unrelated markup", func(t *testing.T) {
+		caller, callee, callNode, comp := childrenProgramPair(6)
+		parent := newFileProgramRenderer(caller, fileRenderOptions{})
+		child := newFileProgramRenderer(callee, fileRenderOptions{})
+		env := fileRenderEnv{}
+
+		// The wrong path: hand the whole call node to the callee's renderer.
+		var wrong strings.Builder
+		child.writeLocalComponent(&wrong, comp, callNode, env)
+		if strings.Contains(wrong.String(), "CALLER OWNS THIS") {
+			t.Fatalf("the wrong-program path accidentally rendered the caller's markup: %q", wrong.String())
+		}
+		if !strings.Contains(wrong.String(), "CALLEE INTERNAL") {
+			t.Fatalf("the wrong-program path did not index the callee's slice, so this test proves nothing: %q", wrong.String())
+		}
+
+		// The required path: render children on the renderer that owns the
+		// call node, then hand the finished node across.
+		var right strings.Builder
+		childrenNode := gosx.RawHTML(parent.renderChildren(callNode.Children, env))
+		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode)
+		want := "<section>CALLER OWNS THIS</section>"
+		if right.String() != want {
+			t.Fatalf("html = %q, want %q", right.String(), want)
+		}
+	})
+
+	t.Run("callee program is smaller: wrong path panics out of range", func(t *testing.T) {
+		caller, callee, callNode, comp := childrenProgramPair(0)
+		parent := newFileProgramRenderer(caller, fileRenderOptions{})
+		child := newFileProgramRenderer(callee, fileRenderOptions{})
+		env := fileRenderEnv{}
+
+		func() {
+			defer func() {
+				if recover() == nil {
+					t.Fatal("the wrong-program path did not panic, so this test proves nothing")
+				}
+			}()
+			var wrong strings.Builder
+			child.writeLocalComponent(&wrong, comp, callNode, env)
+		}()
+
+		var right strings.Builder
+		childrenNode := gosx.RawHTML(parent.renderChildren(callNode.Children, env))
+		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode)
+		want := "<section>CALLER OWNS THIS</section>"
+		if right.String() != want {
+			t.Fatalf("html = %q, want %q", right.String(), want)
+		}
+	})
+}
+
+// TestSameFileChildrenPathStaysByteIdentical proves the split changed no
+// behavior for the only call kind that exists today: writeLocalComponent
+// renders the children itself, on its own renderer, exactly as before.
+func TestSameFileChildrenPathStaysByteIdentical(t *testing.T) {
+	caller, _, callNode, _ := childrenProgramPair(0)
+	comp := ir.Component{
+		Name:            "Panel",
+		Syntax:          ir.ComponentSyntaxStrict,
+		AcceptsChildren: true,
+	}
+	holeID := caller.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "children"})
+	comp.Root = caller.AddNode(ir.Node{
+		Kind:     ir.NodeElement,
+		Tag:      "section",
+		Children: []ir.NodeID{holeID},
+	})
+	caller.Components = append(caller.Components, comp)
+	r := newFileProgramRenderer(caller, fileRenderOptions{})
+	env := fileRenderEnv{}
+
+	var single strings.Builder
+	r.writeLocalComponent(&single, &caller.Components[0], callNode, env)
+
+	var split strings.Builder
+	childrenNode := gosx.RawHTML(r.renderChildren(callNode.Children, env))
+	r.writeLocalComponentWithChildren(&split, &caller.Components[0], callNode, env, childrenNode)
+
+	if single.String() != split.String() {
+		t.Fatalf("writeLocalComponent = %q, writeLocalComponentWithChildren = %q, want identical", single.String(), split.String())
+	}
+	if single.String() != "<section>CALLER OWNS THIS</section>" {
+		t.Fatalf("html = %q, want <section>CALLER OWNS THIS</section>", single.String())
+	}
+}

--- a/strict_children_integration_test.go
+++ b/strict_children_integration_test.go
@@ -1,0 +1,123 @@
+package gosx_test
+
+import (
+	"testing"
+
+	gosx "m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+)
+
+// childrenPanelFixtureSource is WP0's acceptance shape: a same-file strict
+// component that wraps arbitrary caller-authored .gsx markup. It uses no
+// import, no shared directory, and no file boundary — children are a
+// same-file gap that single-file pages have today.
+const childrenPanelFixtureSource = `package app
+
+type PanelProps struct {
+	Title string
+	Tone  string
+}
+
+component Panel(props: PanelProps) {
+	return <section class={"panel tone-" + props.Tone}><h2 class="panel__title">{props.Title}</h2><div class="panel__body">{children}</div></section>
+}
+
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title} Tone={props.Tone}><p class="lead">wrapped</p><b>markup</b></Panel>
+}
+`
+
+// panelPropsTwin mirrors the fixture's PanelProps struct for the render
+// entry and for the generated-Go twin below.
+type panelPropsTwin struct {
+	Title string
+	Tone  string
+}
+
+// panelTwin is the exact declaration emitTypedComponentCall and
+// emitStrictComponent project for the fixture's Panel, transcribed by hand:
+//
+//	func Panel(props PanelProps, children ...gosx.Node) gosx.Node
+//
+// Writing it out is the point. If the projected signature ever stops taking
+// children, this file stops compiling.
+func panelTwin(props panelPropsTwin, children ...gosx.Node) gosx.Node {
+	return gosx.El("section", gosx.Attrs(gosx.Attr("class", "panel tone-"+props.Tone)),
+		gosx.El("h2", gosx.Attrs(gosx.Attr("class", "panel__title")), gosx.Expr(props.Title)),
+		gosx.El("div", gosx.Attrs(gosx.Attr("class", "panel__body")), gosx.Expr(children)),
+	)
+}
+
+// pageTwin is the projection of the fixture's Page: a typed props literal
+// followed by the child arguments emitTypedComponentCall appends.
+func pageTwin(props panelPropsTwin, children ...gosx.Node) gosx.Node {
+	return panelTwin(panelPropsTwin{Title: props.Title, Tone: props.Tone},
+		gosx.El("p", gosx.Attrs(gosx.Attr("class", "lead")), gosx.Text("wrapped")),
+		gosx.El("b", gosx.Text("markup")),
+	)
+}
+
+// TestStrictChildrenFixtureCompilesChecksAndRendersAtParity is WP0's exit
+// gate, in three steps.
+//
+//  1. Compiles: the lowerer admits the {children} hole and the call site.
+//  2. Checks: the real Go-compiler-backed pipeline accepts the projection,
+//     which proves the always-variadic signature type-checks in a real
+//     module.
+//  3. Renders at parity: the file renderer emits byte-identical output to
+//     the generated-Go twin. Parity between the two renderers is the
+//     invariant the whole strict design rests on, so children must not be
+//     the one shape where they diverge.
+func TestStrictChildrenFixtureCompilesChecksAndRendersAtParity(t *testing.T) {
+	prog, err := gosx.Compile([]byte(childrenPanelFixtureSource))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	checkFixtureInRealModule(t, "children", "panel.gsx", childrenPanelFixtureSource)
+
+	props := panelPropsTwin{Title: "Standings", Tone: "home"}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{Props: props})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := gosx.RenderHTML(pageTwin(props))
+	if html != want {
+		t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+	}
+}
+
+// TestStrictChildrenEmptyCallRendersAtParity proves the variadic parameter's
+// zero-argument case. A component that places {children} and receives none
+// emits nothing there, in both renderers, so the always-variadic decision
+// costs no existing call site.
+func TestStrictChildrenEmptyCallRendersAtParity(t *testing.T) {
+	const source = `package app
+
+type PanelProps struct {
+	Title string
+	Tone  string
+}
+
+component Panel(props: PanelProps) {
+	return <section class={"panel tone-" + props.Tone}><h2 class="panel__title">{props.Title}</h2><div class="panel__body">{children}</div></section>
+}
+
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title} Tone={props.Tone}></Panel>
+}
+`
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	props := panelPropsTwin{Title: "Standings", Tone: "home"}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{Props: props})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := gosx.RenderHTML(panelTwin(props))
+	if html != want {
+		t.Fatalf("file render = %q, generated-Go render = %q", html, want)
+	}
+}

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -567,7 +567,10 @@ func TestCompileStrictCalleeRejectsDynamicCallShape(t *testing.T) {
 	}{
 		{name: "spread", call: `<Badge {...props} />`, message: "does not accept props"},
 		{name: "attribute", call: `<Badge bogus="x" />`, message: "does not accept props"},
-		{name: "children", call: `<Badge>child</Badge>`, message: "does not accept positional children"},
+		// Badge's body places no {children} hole, so its AcceptsChildren is
+		// false and the call is rejected — but now with a message that names
+		// both remedies instead of a flat refusal.
+		{name: "children", call: `<Badge>child</Badge>`, message: "renders no children; remove the child content or render {children} in Badge's body"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/transpile/package_test.go
+++ b/transpile/package_test.go
@@ -57,7 +57,7 @@ component Page() {
 	for _, want := range []string{
 		`clock "time"`,
 		`gx "m31labs.dev/gosx"`,
-		`func Badge(props BadgeProps) gx.Node`,
+		`func Badge(props BadgeProps, children ...gx.Node) gx.Node`,
 		`Badge(BadgeProps{Label: "ready", When: true})`,
 		`const BadgeLimit = 3`,
 	} {
@@ -83,7 +83,7 @@ component Page() {
 	if err != nil {
 		t.Fatalf("StrictProjection: %v", err)
 	}
-	if !strings.Contains(got, `. "m31labs.dev/gosx"`) || !strings.Contains(got, `func Page() Node`) {
+	if !strings.Contains(got, `. "m31labs.dev/gosx"`) || !strings.Contains(got, `func Page(children ...Node) Node`) {
 		t.Fatalf("dot import style lost:\n%s", got)
 	}
 }

--- a/transpile/strict_children_test.go
+++ b/transpile/strict_children_test.go
@@ -1,0 +1,97 @@
+package transpile
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestStrictComponentSignatureIsAlwaysVariadic pins B4's decision. transpile
+// walks the CST with no ir.Program in hand, so emitting the parameter only
+// for a body that renders children would need a second implementation of
+// ir.Component.AcceptsChildren's predicate, and two implementations of one
+// predicate drift. A variadic parameter accepts zero arguments, so every
+// call site that passes none keeps compiling.
+func TestStrictComponentSignatureIsAlwaysVariadic(t *testing.T) {
+	tests := map[string]struct {
+		source string
+		want   string
+	}{
+		"with props and children": {
+			source: `package app
+type PanelProps struct { Title string }
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+`,
+			want: `func Panel(props PanelProps, children ...gosx.Node) gosx.Node`,
+		},
+		"with props and no children": {
+			source: `package app
+type LeafProps struct { Title string }
+component Leaf(props: LeafProps) {
+	return <span>{props.Title}</span>
+}
+`,
+			want: `func Leaf(props LeafProps, children ...gosx.Node) gosx.Node`,
+		},
+		"without props": {
+			source: `package app
+component Bare() {
+	return <span>bare</span>
+}
+`,
+			want: `func Bare(children ...gosx.Node) gosx.Node`,
+		},
+	}
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			out, err := Transpile([]byte(test.source), Options{SourceFile: "page.gsx"})
+			if err != nil {
+				t.Fatalf("Transpile: %v", err)
+			}
+			if !strings.Contains(out, test.want) {
+				t.Fatalf("missing %q in:\n%s", test.want, out)
+			}
+		})
+	}
+}
+
+// TestStrictChildrenHoleProjectsToGosxExpr proves W4 and W5 stay unchanged:
+// the {children} hole emits gosx.Expr(children), and gosx.Expr fragments a
+// []Node, so the variadic parameter feeds it directly.
+func TestStrictChildrenHoleProjectsToGosxExpr(t *testing.T) {
+	out, err := Transpile([]byte(`package app
+type PanelProps struct { Title string }
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2><div class="body">{children}</div></section>
+}
+`), Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	if !strings.Contains(out, `gosx.Expr(children)`) {
+		t.Fatalf("missing gosx.Expr(children) in:\n%s", out)
+	}
+}
+
+// TestStrictCallWithChildrenProjectsChildArguments proves W6: the typed call
+// emitter already appends child arguments after the props literal, so a
+// children-bearing call needs no emitter change at all.
+func TestStrictCallWithChildrenProjectsChildArguments(t *testing.T) {
+	out, err := Transpile([]byte(`package app
+type PanelProps struct { Title string }
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2>{children}</section>
+}
+component Page(props: PanelProps) {
+	return <Panel Title={props.Title}><b>content</b></Panel>
+}
+`), Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	want := `Panel(PanelProps{Title: props.Title}, gosx.El("b", gosx.Text("content")))`
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+}

--- a/transpile/strict_component_test.go
+++ b/transpile/strict_component_test.go
@@ -24,10 +24,10 @@ component Page() {
 	}
 	for _, want := range []string{
 		`import gosx "m31labs.dev/gosx"`,
-		`func Card(props CardProps) gosx.Node`,
+		`func Card(props CardProps, children ...gosx.Node) gosx.Node`,
 		`gosx.Attr("class", "card")`,
 		`gosx.Attr("for", "field")`,
-		`func Page() gosx.Node`,
+		`func Page(children ...gosx.Node) gosx.Node`,
 		`Card(CardProps{Label: "Ready"})`,
 	} {
 		if !strings.Contains(out, want) {
@@ -64,7 +64,7 @@ func TestTranspileStrictComponentRespectsExistingGoSXImportStyle(t *testing.T) {
 			if err != nil {
 				t.Fatalf("Transpile: %v", err)
 			}
-			if !strings.Contains(out, "func Page() "+tc.result) || !strings.Contains(out, tc.el) {
+			if !strings.Contains(out, "func Page(children ..."+tc.result+") "+tc.result) || !strings.Contains(out, tc.el) {
 				t.Fatalf("import style not respected:\n%s", out)
 			}
 		})
@@ -82,7 +82,7 @@ component Page() {
 	if err != nil {
 		t.Fatalf("Transpile: %v", err)
 	}
-	if !strings.Contains(out, `import gosxgen1 "m31labs.dev/gosx"`) || !strings.Contains(out, `func Page() gosxgen1.Node`) {
+	if !strings.Contains(out, `import gosxgen1 "m31labs.dev/gosx"`) || !strings.Contains(out, `func Page(children ...gosxgen1.Node) gosxgen1.Node`) {
 		t.Fatalf("collision-safe alias missing:\n%s", out)
 	}
 }
@@ -283,7 +283,7 @@ component Row(props: RowProps) {
 		t.Fatalf("Transpile: %v", err)
 	}
 	for _, want := range []string{
-		`func Row(props RowProps) gosx.Node`,
+		`func Row(props RowProps, children ...gosx.Node) gosx.Node`,
 		`gosx.Attr("class", "player-" + props.Player.Name)`,
 		`gosx.If(props.Player.Ready, gosx.Fragment(gosx.Expr(props.Player.Team.City)))`,
 	} {
@@ -317,7 +317,7 @@ component Row(props: RowProps) {
 	if err != nil {
 		t.Fatalf("Transpile: %v", err)
 	}
-	if !strings.Contains(out, `func Row(props RowProps) gosx.Node`) {
+	if !strings.Contains(out, `func Row(props RowProps, children ...gosx.Node) gosx.Node`) {
 		t.Fatalf("missing typed func signature:\n%s", out)
 	}
 	if !strings.Contains(out, `gosx.Expr(props.Player.Name)`) {

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -627,6 +627,26 @@ func (t *transpiler) emitStrictComponent(n *gotreesitter.Node) string {
 		}
 	}
 
+	// Every strict component takes children, unconditionally.
+	//
+	// A variadic parameter accepts zero arguments, so every call site that
+	// passes none keeps compiling unchanged. The alternative — emit the
+	// parameter only for a body that renders children — would need transpile
+	// to decide "renders children" for itself, because transpile walks the
+	// CST with no ir.Program in hand. Two implementations of one predicate
+	// drift, and the drift would show up as a projected signature that does
+	// not match the checked contract. So arity stays a gosx-level rule with a
+	// single owner, ir.Component.AcceptsChildren, and it reports a message
+	// that names the remedy instead of Go's "too many arguments".
+	//
+	// The parameter is spelled children because the body's {children} hole
+	// projects to gosx.Expr(children) (emitExprContainer), and gosx.Expr
+	// fragments a []Node.
+	if params != "" {
+		params += ", "
+	}
+	params += strictcomponent.ChildrenBinding + " ..." + t.gosxRef("Node")
+
 	prevPropsType := t.currentPropsType
 	t.currentPropsType = t.propsTypes[t.text(nameNode)]
 	t.strict++


### PR DESCRIPTION
## Summary

Adds children support for strict server components. Bodies may now place caller-authored markup via `{children}`, which arrives as an opaque, already-rendered node bound beside `props` rather than injected into the props schema. Every strict component unconditionally projects a variadic `children ...gosx.Node` parameter to preserve backward compatibility with existing call sites, and a new call-site rule rejects unexpected children with a clear diagnostic naming both remedies.

## Changes

- Allow strict component bodies to render caller-provided markup via `{children}`, binding it beside props rather than mutating the props map or entering the props schema.
- Add `ir.Component.AcceptsChildren` flag computed during the two-pass schema collection to decouple the predicate evaluation from body-lowering order.
- Enforce arity-only validation at call sites; reject child content for callees that do not place `{children}`, replacing silent truncation with a diagnostic that names both fixes.
- Separate expression validators by syntactic slot to admit `{children}` exclusively in whole-child holes while refusing it in attribute values, preventing broken HTML markup splicing.
- Refactor the file renderer to emit children on the caller's program context before invoking the callee body, fixing a cross-program node-ID resolution hazard.
- Unconditionally project `func Name(props Type, children ...gosx.Node) gosx.Node` for all strict components so existing zero-argument calls compile unchanged.
- Expand internal validators, lowerer rules, and transpiler code generation to enforce the new contract, and update documentation examples accordingly.

## Testing

- Run `go test ./...` to validate updated compiler checks, IR serialization round-trips, renderer parity across same-file and cross-program boundaries, and transpiler output.
- Run the `examples/gosx-docs` integration test suite to ensure the updated component examples compile, check, and render correctly.


## Merge with main (cb1ace79)

This branch carries a merge commit. Its auto-generated message describes the
incoming work, not this branch's own change: the branch does NOT introduce
typed legacy components (#244) or `BodyAttrs` (#241). It introduces children,
and reconciles them with what landed.

Two textual conflicts, both in code #244 restructured:

- `ir/lower.go` — the lowerer field block, the `collectStrictSchemas`
  initializer, and `validateStrictToStrictSpreadCall`. Resolved as a union.
  The children arity rule now reads #244's `calleePropsType`.
- `CHANGELOG.md` — resolved as a union, incoming entries first.

Two semantic reconciliations the text conflicts did not show:

- **The children predicate now reads every component category.** #244 lets a
  strict body call a TYPED legacy component, so the children arity rule
  reaches a legacy callee. The predicate read only strict declarations, so it
  refused such a call and told the author to write `{children}` in a body that
  already had it. It now reads every same-file declaration, which makes the
  advice true and the rule strictly wider than `main`. A legacy caller
  invoking a legacy callee stays unconstrained.
- **#244 opened one new unguarded write over a schema-proved props map.**
  `strictSpreadPropsFromTypedFrame`'s branch wrote the children keys over a
  map built entirely from `PropsFields`. It now routes through
  `setStrictComponentChildren`, like the other two strict builders.
  `componentProps` and `typedLegacyComponentProps` are deliberately NOT
  guarded: for a LEGACY callee `props.Children` IS the children, by the older
  contract `TestTypedLegacyComponentKeepsItsMapBinding` pins.

Docs: the components page still stated the two-category rule #244 replaced.
It now names all three categories, mirroring `README.md`.

`main` then advanced again, to a63575de (#247), which edited the same
paragraph. Because this branch had already matched that wording byte for byte,
the second merge conflicted on one hunk only — this branch's extra paragraph —
and was resolved as a union, keeping both. #247's own `route/` changes are
untouched here.

