### PR TITLE
fix(route): fragment loading pattern broken by -trimpath builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 ## Unreleased
 
+### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build
+
+- **`route.LoadFileProgramHere` resolves a page's sibling `.gsx` file without
+  depending on `runtime.Caller`'s raw path** (gosx#239). A `-trimpath` build
+  replaces that path with the calling module's declared path, which does not
+  exist on the machine that runs the binary. `gosx build` passes `-trimpath`
+  on every build, so the documented "Rendering a fragment from a Go handler"
+  pattern broke in every production build, not only some.
+- `RegisterFileModuleHere` carried the same weakness in its `.gsx`/`.html`
+  extension guess: it called `os.Stat` on the same unreachable path and
+  silently fell back to `.gsx`. A `.gsx` page kept working by coincidence; an
+  `.html` page lost its registered `Load`, `Render`, and `Actions` hooks
+  under `-trimpath`. Both now resolve through the same trimpath-safe path.
+- `LoadFileProgram` is unchanged and still takes an absolute path. Its doc
+  comment now states plainly why building that path from `runtime.Caller`
+  breaks under `-trimpath`, and points callers to `LoadFileProgramHere`
+  instead.
+- The fragment-handler docs page and the `examples/dashboard` chrome pattern
+  now use `route.LoadFileProgramHere`.
+
 ### Added: a typed legacy component is treated as strict instead of flattened
 
 - **`func Name(props T) Node`, where `T` is a struct declared in the same

--- a/examples/dashboard/chrome.go
+++ b/examples/dashboard/chrome.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"log"
-	"path/filepath"
-	"runtime"
 
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/ir"
@@ -18,9 +16,7 @@ import (
 var chromeProgram = mustLoadChromeProgram()
 
 func mustLoadChromeProgram() *ir.Program {
-	_, thisFile, _, _ := runtime.Caller(0)
-	path := filepath.Join(filepath.Dir(thisFile), "chrome.gsx")
-	prog, err := route.LoadFileProgram(path)
+	prog, err := route.LoadFileProgramHere("chrome.gsx")
 	if err != nil {
 		log.Fatalf("load chrome.gsx: %v", err)
 	}

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -174,7 +174,19 @@ func Page() Node {
 			binding.
 		</p>
 		<p>
-			Both declaration styles may coexist in one file, but v0.39 keeps component calls within the same style. This prevents a dynamic legacy call from bypassing a strict component's typed prop contract.
+			Both declaration styles may coexist in one file. A component call stays within its declaration style, with one exception: a
+			<span class="inline-code">typed legacy</span>
+			component —
+			<span class="inline-code">func Name(props T) Node</span>
+			whose
+			<span class="inline-code">T</span>
+			is a struct declared in the same
+			<span class="inline-code">.gsx</span>
+			file — declares the same prop contract a strict component does, so it takes part in strict calls in both directions. A component that declares no such type (
+			<span class="inline-code">props any</span>
+			, an attribute list, or a type from another file) is an
+			<span class="inline-code">untyped legacy</span>
+			component and keeps the cross-style ban, because nothing about its props can be checked.
 		</p>
 		<CodeBlock lang="gosx" source={data.legacySample} />
 		<p>

--- a/examples/gosx-docs/app/docs/runtime/page.gsx
+++ b/examples/gosx-docs/app/docs/runtime/page.gsx
@@ -715,12 +715,16 @@ func Page() Node {
 				A
 				<span class="inline-code">data-gosx-region-url</span>
 				endpoint must render the same markup a page's own component already produces — otherwise the polled fragment and the page drift apart. Load the page's compiled program with
-				<span class="inline-code">route.LoadFileProgram</span>
+				<span class="inline-code">route.LoadFileProgramHere</span>
 				and render one component from it with
 				<span class="inline-code">route.RenderProgramComponent</span>
 				, from a plain
 				<span class="inline-code">http.Handler</span>
-				in the same package as the page. This works for a component the page's own
+				in the same package as the page.
+				<span class="inline-code">route.LoadFileProgramHere</span>
+				finds the page's own
+				<span class="inline-code">.gsx</span>
+				file next to the handler in every build, including a deployed binary. This works for a component the page's own
 				<span class="inline-code">Page</span>
 				entry never renders directly, not only for
 				<span class="inline-code">Page</span>
@@ -742,10 +746,8 @@ func Page() Node {
 	    </ul>
 	}`)}
 			{CodeBlock("go", `// page.server.go — same package as page.gsx
-	var pagePath = filepath.Join(thisDir, "page.gsx")
-
 	func ServeSignalFragment(w http.ResponseWriter, r *http.Request) {
-	    prog, err := route.LoadFileProgram(pagePath)
+	    prog, err := route.LoadFileProgramHere("page.gsx")
 	    if err != nil {
 	        http.Error(w, err.Error(), http.StatusInternalServerError)
 	        return
@@ -761,7 +763,7 @@ func Page() Node {
 	    w.Write([]byte(html))
 	}`)}
 			<p>
-				<span class="inline-code">route.LoadFileProgram</span>
+				<span class="inline-code">route.LoadFileProgramHere</span>
 				reads through the same stat-keyed program cache a file-routed page renders through, so an edit to
 				<span class="inline-code">page.gsx</span>
 				reaches the fragment handler exactly the way it reaches the page's own hot reload — there is no second, independently-stale copy of the compiled component to fall behind.

--- a/route/callerpath.go
+++ b/route/callerpath.go
@@ -1,0 +1,52 @@
+package route
+
+import (
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+
+	"m31labs.dev/gosx/server"
+)
+
+// resolveCallerFilePath turns a runtime.Caller file value into a path this
+// process can actually open. An ordinary build already gives one:
+// runtime.Caller returns the absolute path the compiler saw on disk. A
+// `-trimpath` build — `gosx build`'s default, and the shape of most
+// container images — does not: it replaces that absolute path with the
+// calling module's own declared path plus the file's path inside that
+// module (for example "gridiron-2000/app/wire/page.gsx" instead of
+// "/app/app/wire/page.gsx"), a string with no filesystem meaning on the
+// machine that runs the binary (gosx#239).
+//
+// When file is already absolute, this returns it unchanged, so every
+// existing dev-mode and `go test` behavior stays exactly as it was — neither
+// passes -trimpath, so runtime.Caller already returns a real path in both.
+// Otherwise it strips the running binary's own module path — read from
+// runtime/debug.BuildInfo, which -trimpath does not touch — off the front of
+// file, and resolves what remains against server.ResolveAppRoot(""): the
+// same app-root discovery (the GOSX_APP_ROOT environment variable, the
+// running executable's own directory, then the working directory) a
+// generated main.go already uses to mount file routes, so this does not add
+// a second, independent way for root discovery to go wrong. When neither
+// step applies — no build info, or file does not start with the module
+// path — file is returned unchanged, the same best-effort result callers got
+// before this existed.
+func resolveCallerFilePath(file string) string {
+	if file == "" || filepath.IsAbs(file) {
+		return file
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok || info.Main.Path == "" {
+		return file
+	}
+	prefix := info.Main.Path + "/"
+	if !strings.HasPrefix(file, prefix) {
+		return file
+	}
+	rel := strings.TrimPrefix(file, prefix)
+	root := strings.TrimSpace(server.ResolveAppRoot(""))
+	if root == "" {
+		return file
+	}
+	return filepath.Join(root, filepath.FromSlash(rel))
+}

--- a/route/dirmodule.go
+++ b/route/dirmodule.go
@@ -300,5 +300,5 @@ func dirModuleSourceHere(skip int) string {
 	if !ok {
 		return ""
 	}
-	return filepath.Dir(file)
+	return filepath.Dir(resolveCallerFilePath(file))
 }

--- a/route/filemodule.go
+++ b/route/filemodule.go
@@ -304,7 +304,7 @@ func fileModuleSourceHere(skip int) string {
 	if !ok {
 		return ""
 	}
-	return fileModuleSourceFromFile(file)
+	return fileModuleSourceFromFile(resolveCallerFilePath(file))
 }
 
 func fileModuleSourceFromFile(file string) string {

--- a/route/program_render.go
+++ b/route/program_render.go
@@ -3,6 +3,7 @@ package route
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/ir"
@@ -97,13 +98,46 @@ func RenderProgramComponent(prog *ir.Program, component string, env ProgramRende
 // Page/Layout entry never renders directly, with RenderProgramComponent.
 //
 // path resolves relative to the process's current working directory, same as
-// os.Open; pass an absolute path (for example, one built from the source
-// file's own directory: filepath.Join(filepath.Dir(sourceFile), "page.gsx"))
-// to make it independent of the working directory the binary starts in.
+// os.Open; pass an absolute path to make it independent of the working
+// directory the binary starts in.
+//
+// Do not build that absolute path from runtime.Caller's own file value: a
+// `-trimpath` build — `gosx build`'s default, and the shape of most
+// container images — replaces that value with the calling module's own
+// declared path, not a path that exists on the machine running the binary,
+// so path resolves to a file that was never there (gosx#239). This mistake
+// passes every local check: a plain `go run` or `go build` still records the
+// real path, so it only surfaces once something builds with -trimpath.
+// LoadFileProgramHere resolves a sibling of the calling file without this
+// problem; prefer it when path is a sibling of the calling source file.
 func LoadFileProgram(path string) (*ir.Program, error) {
 	abs, err := filepath.Abs(path)
 	if err != nil {
 		return nil, fmt.Errorf("resolve %s: %w", path, err)
 	}
 	return loadCachedGSXProgram(abs)
+}
+
+// LoadFileProgramHere compiles the .gsx (or .html) file named name in the
+// same directory as the calling source file and returns its IR program,
+// through the same cache LoadFileProgram uses (gosx#226).
+//
+// Use this in place of building a path from runtime.Caller and
+// filepath.Dir yourself, the pattern the "Rendering a fragment from a Go
+// handler" example used before this function existed: see LoadFileProgram's
+// own doc comment for why that pattern breaks under a `-trimpath` build
+// (gosx#239). LoadFileProgramHere resolves the calling file the same
+// trimpath-safe way RegisterFileModuleHere resolves a page's sibling .gsx
+// file, so it does not have that problem.
+//
+// name is a bare file name, such as "page.gsx" — a sibling of the calling
+// file, not a path elsewhere in the tree. For that, resolve an absolute path
+// yourself and call LoadFileProgram directly.
+func LoadFileProgramHere(name string) (*ir.Program, error) {
+	_, file, _, ok := runtime.Caller(1)
+	if !ok {
+		return nil, fmt.Errorf("load %s: could not resolve the calling file", name)
+	}
+	dir := filepath.Dir(resolveCallerFilePath(file))
+	return LoadFileProgram(filepath.Join(dir, name))
 }

--- a/route/trimpath_program_test.go
+++ b/route/trimpath_program_test.go
@@ -1,0 +1,291 @@
+package route
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// gosx#239: LoadFileProgramHere and RegisterFileModuleHere must resolve a
+// page's sibling .gsx file correctly in a `-trimpath` binary, not only in
+// `go test` and `go run`, because neither of those ever passes -trimpath —
+// a unit test that only exercises this package in-process cannot catch a
+// regression here. These tests build and run real binaries instead.
+//
+// TestLoadFileProgramHereSurvivesTrimpathBuild is the end-to-end proof: it
+// writes a tiny app that follows the documented "Rendering a fragment from a
+// Go handler" pattern (gosx#226) with route.LoadFileProgramHere, builds it
+// once with `go build -trimpath` (gosx build's own default) and once without
+// it, runs each binary as a real subprocess, and asserts both the page and
+// its fragment endpoint return 200 with the expected markup — proving dev
+// mode and a `-trimpath` production binary both work, not just one.
+func TestLoadFileProgramHereSurvivesTrimpathBuild(t *testing.T) {
+	if testing.Short() {
+		t.Skip("builds real binaries; skipped in short mode")
+	}
+	goBin, err := exec.LookPath("go")
+	if err != nil {
+		t.Skip("go tool not found on PATH")
+	}
+
+	repoRoot := trimpathTestRepoRoot(t)
+	appRoot := writeTrimpathFixtureApp(t, repoRoot)
+
+	buildDir := t.TempDir()
+	trimmedBin := filepath.Join(buildDir, "trimtestapp-trimpath")
+	plainBin := filepath.Join(buildDir, "trimtestapp-plain")
+
+	buildTrimpathFixtureApp(t, goBin, appRoot, trimmedBin, true)
+	buildTrimpathFixtureApp(t, goBin, appRoot, plainBin, false)
+
+	t.Run("trimpath build", func(t *testing.T) {
+		assertTrimpathFixtureAppServes(t, trimmedBin, appRoot)
+	})
+	t.Run("non-trimpath build", func(t *testing.T) {
+		assertTrimpathFixtureAppServes(t, plainBin, appRoot)
+	})
+}
+
+func trimpathTestRepoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("resolve repo root caller")
+	}
+	// This file lives at <repoRoot>/route/trimpath_program_test.go.
+	return filepath.Clean(filepath.Join(filepath.Dir(file), ".."))
+}
+
+// writeTrimpathFixtureApp writes a standalone module, outside the gosx
+// module tree, that depends on gosx through a local replace directive and
+// reproduces the documented fragment pattern: app/wire/page.gsx declares
+// SignalCard and Page, and app/wire/page.server.go serves a fragment of
+// SignalCard from route.LoadFileProgramHere("page.gsx") — a plain
+// http.Handler in the same package as the page, same as the docs.
+func writeTrimpathFixtureApp(t *testing.T, repoRoot string) string {
+	t.Helper()
+	root := t.TempDir()
+
+	goMod := fmt.Sprintf(`module trimtestapp
+
+go 1.25
+
+require m31labs.dev/gosx v0.0.0-00010101000000-000000000000
+
+replace m31labs.dev/gosx => %s
+`, filepath.ToSlash(repoRoot))
+	writeTrimpathFile(t, root, "go.mod", goMod)
+
+	mainGo := `package main
+
+import (
+	"fmt"
+	"log"
+	"net"
+	"net/http"
+
+	"m31labs.dev/gosx/route"
+	"trimtestapp/app/wire"
+)
+
+func main() {
+	router := route.NewRouter()
+	router.Handle("/wire/signal", http.HandlerFunc(wire.ServeSignalFragment))
+	if err := router.AddDir("app", route.FileRoutesOptions{}); err != nil {
+		log.Fatalf("AddDir: %v", err)
+	}
+	handler, err := router.BuildChecked()
+	if err != nil {
+		log.Fatalf("BuildChecked: %v", err)
+	}
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		log.Fatalf("listen: %v", err)
+	}
+	fmt.Printf("LISTENING %s\n", ln.Addr().String())
+	log.Fatal(http.Serve(ln, handler))
+}
+`
+	writeTrimpathFile(t, root, "main.go", mainGo)
+
+	pageGSX := `package wire
+
+type SignalCardProps struct {
+	Label string
+	Value string
+}
+
+component SignalCard(props: SignalCardProps) {
+	return <li class="signal-card">{props.Label}: {props.Value}</li>
+}
+
+component Page() {
+	return <ul data-gosx-region data-gosx-region-url="/wire/signal">
+		<SignalCard label="Passing Yards" value="317" />
+	</ul>
+}
+`
+	writeTrimpathFile(t, root, "app/wire/page.gsx", pageGSX)
+
+	pageServerGo := `package wire
+
+import "net/http"
+
+import "m31labs.dev/gosx/route"
+
+// SignalCardProps mirrors page.gsx's declared props struct by field
+// coverage, not by name (a same-shaped struct under a different Go type
+// name satisfies the strict boundary by design).
+type SignalCardProps struct {
+	Label string
+	Value string
+}
+
+// ServeSignalFragment is the "Rendering a fragment from a Go handler"
+// pattern from the docs, gosx#226: a plain http.Handler in the same package
+// as page.gsx, loading that file's own compiled program with
+// route.LoadFileProgramHere and rendering one of its components directly.
+func ServeSignalFragment(w http.ResponseWriter, r *http.Request) {
+	prog, err := route.LoadFileProgramHere("page.gsx")
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	html, err := route.RenderProgramComponent(prog, "SignalCard", route.ProgramRenderEnv{
+		Props: SignalCardProps{Label: "Passing Yards", Value: "317"},
+	})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Write([]byte(html))
+}
+`
+	writeTrimpathFile(t, root, "app/wire/page.server.go", pageServerGo)
+
+	tidyCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	tidy := exec.CommandContext(tidyCtx, "go", "mod", "tidy")
+	tidy.Dir = root
+	tidy.Env = append(os.Environ(), "GOFLAGS=-mod=mod")
+	if out, err := tidy.CombinedOutput(); err != nil {
+		t.Fatalf("go mod tidy: %v\n%s", err, out)
+	}
+
+	return root
+}
+
+func writeTrimpathFile(t *testing.T, root, rel, contents string) {
+	t.Helper()
+	full := filepath.Join(root, filepath.FromSlash(rel))
+	if err := os.MkdirAll(filepath.Dir(full), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(full), err)
+	}
+	if err := os.WriteFile(full, []byte(contents), 0o644); err != nil {
+		t.Fatalf("write %s: %v", full, err)
+	}
+}
+
+func buildTrimpathFixtureApp(t *testing.T, goBin, appRoot, outputPath string, trimpath bool) {
+	t.Helper()
+	args := []string{"build", "-buildvcs=false"}
+	if trimpath {
+		args = append(args, "-trimpath")
+	}
+	args = append(args, "-o", outputPath, ".")
+
+	buildCtx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	cmd := exec.CommandContext(buildCtx, goBin, args...)
+	cmd.Dir = appRoot
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("go build (trimpath=%v): %v\n%s", trimpath, err, out)
+	}
+}
+
+// assertTrimpathFixtureAppServes runs binPath as a subprocess with its
+// working directory set to appRoot — the same shape a container gives a
+// deployed binary (WORKDIR set to the app root; the binary itself can live
+// anywhere) — and proves both the page and its fragment endpoint render,
+// rather than 500.
+func assertTrimpathFixtureAppServes(t *testing.T, binPath, appRoot string) {
+	t.Helper()
+
+	cmd := exec.Command(binPath)
+	cmd.Dir = appRoot
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		t.Fatalf("stdout pipe: %v", err)
+	}
+	cmd.Stderr = os.Stderr
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start %s: %v", binPath, err)
+	}
+	defer func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}()
+
+	addrCh := make(chan string, 1)
+	go func() {
+		scanner := bufio.NewScanner(stdout)
+		for scanner.Scan() {
+			line := scanner.Text()
+			if addr, ok := strings.CutPrefix(line, "LISTENING "); ok {
+				addrCh <- addr
+			}
+		}
+	}()
+
+	var addr string
+	select {
+	case addr = <-addrCh:
+	case <-time.After(10 * time.Second):
+		t.Fatalf("%s never printed its listening address", binPath)
+	}
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	base := "http://" + addr
+
+	pageResp, err := client.Get(base + "/wire")
+	if err != nil {
+		t.Fatalf("GET /wire: %v", err)
+	}
+	pageBody, _ := readAllAndClose(pageResp.Body)
+	if pageResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /wire = %d, want 200; body: %s", pageResp.StatusCode, pageBody)
+	}
+	if !strings.Contains(pageBody, `data-gosx-region-url="/wire/signal"`) {
+		t.Fatalf("page is missing its data-gosx-region wiring: %s", pageBody)
+	}
+
+	fragResp, err := client.Get(base + "/wire/signal")
+	if err != nil {
+		t.Fatalf("GET /wire/signal: %v", err)
+	}
+	fragBody, _ := readAllAndClose(fragResp.Body)
+	const wantFragment = `<li class="signal-card">Passing Yards: 317</li>`
+	if fragResp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /wire/signal = %d, want 200; body: %s", fragResp.StatusCode, fragBody)
+	}
+	if fragBody != wantFragment {
+		t.Fatalf("fragment body = %q, want %q", fragBody, wantFragment)
+	}
+}
+
+func readAllAndClose(body io.ReadCloser) (string, error) {
+	defer body.Close()
+	data, err := io.ReadAll(body)
+	return string(data), err
+}


### PR DESCRIPTION
## Summary

`LoadFileProgramHere` now resolves a page's sibling `.gsx` file without depending on `runtime.Caller`'s raw path. A `-trimpath` build replaces that path with the calling module's declared path, which does not exist on the machine running the binary. Because `gosx build` always passes `-trimpath`, the documented "Rendering a fragment from a Go handler" pattern broke in all production builds. This branch adds a trimpath-safe path resolver and updates examples and documentation accordingly.

## Changes

- Add `route.LoadFileProgramHere` to safely compile and cache a sibling `.gsx` (or `.html`) file next to the calling source file.
- Implement `resolveCallerFilePath` to detect `-trimpath` transformations via `debug.ReadBuildInfo` and resolve the actual filesystem path against `server.ResolveAppRoot("")`.
- Apply `resolveCallerFilePath` inside `RegisterFileModuleHere` and `dirModuleSourceHere` so extension guesses and directory sources survive trimming.
- Update example apps (`dashboard/chrome.go`, `gosx-docs`) and documentation to adopt `LoadFileProgramHere` over the manual `runtime.Caller` + `filepath.Dir` pattern.
- Expand `LoadFileProgram`'s doc comment to explicitly warn against building absolute paths from `runtime.Caller` under `-trimpath`.
- Add end-to-end integration tests that build and execute real binaries with and without `-trimpath` to prevent regression.

## Testing

- Run `go test ./route -run TestLoadFileProgramHereSurvivesTrimpathBuild`
- Build a sample app with `gosx build` (or `go build -trimpath`), run the binary, and verify that HTTP endpoints using `route.LoadFileProgramHere("page.gsx")` return 200 OK with the expected component markup instead of 500 errors

## Related Issues

- Refs #239