### PR TITLE
add: Add variadic children parameter to RenderProgramComponent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,55 @@
 # Changelog
 
+## Unreleased
+
+### Added: a Go caller can place a Go-computed node in a .gsx render entry's children slot
+
+- **`RenderProgramComponent` takes a new `children ...gosx.Node` parameter**
+  (gosx#226, gosx#246). A Go handler that renders a `.gsx`-authored component
+  through `RenderProgramComponent` can now pass one or more Go-computed
+  nodes — an island's rendered HTML, most often — for the component to place
+  wherever its body writes `{children}`. Before this, only a nested
+  `<Component>...</Component>` call inside another component's body could
+  reach that hole; a Go caller rendering the entry component itself had no
+  way in, and built the surrounding markup by hand with `gosx.El` instead.
+- **The added parameter is variadic, so no existing call changes.** A call
+  that passes no children reproduces the exact prior behavior: an
+  unresolved `children` identifier still fails soft to empty. Passing
+  children against a legacy (non-strict) component fails closed with an
+  error, since a legacy render entry has no `{children}` hole to bind them
+  to.
+- **Children stay unproven by design, exactly as gosx#246 defined them at a
+  nested call site.** They never enter `PropsFields`, `PropsPaths`, or
+  `PropsSlices`, and `setStrictComponentChildren`'s refusal to overwrite a
+  proved props field still holds — the render entry proves `Props` through
+  `strictSpreadProps` directly against the caller's struct, never through a
+  map `EntryChildren` could write into, so a declared `Children` props
+  field and Go-supplied entry children coexist without conflict.
+- **`RenderProgramComponentNode` returns a `gosx.Node` instead of a
+  string**, so the result composes directly into a `gosx.El(...)` tree
+  instead of forcing a caller to wrap the rendered string in `gosx.RawHTML`
+  by hand. It wraps the render with `gosx.RawHTML` exactly once; nothing
+  re-renders or re-escapes the result.
+- **`examples/dashboard`'s chrome.gsx gains a `Card` component**, and
+  `main.go`'s `chromeCard` helper calls `RenderProgramComponentNode` to
+  splice a chrome header, an island node, and (for the counter page) a
+  no-JS fallback into it. This converts the 9 `gosx.El("div", class="card",
+  ...)` call sites the framework's own examples audit attributed to this
+  gap, dropping `examples/dashboard`'s raw element-building call count from
+  58 to 49.
+- **This does not close the remaining 7 call sites the same audit
+  attributed to "layout chrome needing head and body injection hooks."**
+  `Layout` in `examples/dashboard/main.go` needs three separate injection
+  points — a per-route title and a per-request preload-hints node inside
+  `<head>`, the page content inside `<body>`, and an island manifest script
+  at the end of `<body>`, after content the file renderer has not finished
+  writing when `<head>` closes. `RenderProgramComponent` and
+  `RenderProgramComponentNode` bind one `children` slot, repeatable but
+  always the same content on each repeat (gosx#246's own two-holes test
+  pins this). One slot cannot address three distinct injection points.
+  Named, multiple slots are a separate, unimplemented capability; `Layout`,
+  `Sidebar`, and `Footer` still build their markup with `gosx.El`.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/examples/dashboard/chrome.go
+++ b/examples/dashboard/chrome.go
@@ -34,3 +34,16 @@ func chrome(component string) gosx.Node {
 	}
 	return gosx.RawHTML(html)
 }
+
+// chromeCard renders chrome.gsx's Card component around children — a
+// request-time mix of a chrome() header, a Go-computed island node, and
+// sometimes a no-JS fallback — through RenderProgramComponentNode (gosx#226,
+// gosx#246). Before that function existed this div.card wrapper had to be
+// built by hand with gosx.El in main.go, once per card.
+func chromeCard(children ...gosx.Node) gosx.Node {
+	node, err := route.RenderProgramComponentNode(chromeProgram, "Card", route.ProgramRenderEnv{}, children...)
+	if err != nil {
+		log.Fatalf("render chrome.gsx Card: %v", err)
+	}
+	return node
+}

--- a/examples/dashboard/chrome.gsx
+++ b/examples/dashboard/chrome.gsx
@@ -5,9 +5,20 @@ package main
 // the comment on CounterPage and KitchenSinkPage in main.go for why — but
 // everything in this file is ordinary markup with no per-request data, so it
 // renders through route.RenderProgramComponent (gosx#226) instead of El.
+//
+// Card is the exception: its content — a header from this file, plus a
+// Go-computed island node and, for the counter card, a no-JS fallback — is
+// only known at request time. Before gosx#246 gave strict components a
+// {children} hole, and RenderProgramComponentNode a way to splice a
+// Go-computed node into it, the card div itself had to be a gosx.El call in
+// main.go (see chromeCard in chrome.go).
 
 component CounterIntro() {
 	return <h1>Counter (Island Demo)</h1>
+}
+
+component Card() {
+	return <div class="card">{children}</div>
 }
 
 component CounterCardHeader() {

--- a/examples/dashboard/main.go
+++ b/examples/dashboard/main.go
@@ -301,11 +301,7 @@ func CounterPage(count int, islands *island.Renderer) gosx.Node {
 
 	return gosx.Fragment(
 		chrome("CounterIntro"),
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("CounterCardHeader"),
-			islandNode,
-			noscriptFallback,
-		),
+		chromeCard(chrome("CounterCardHeader"), islandNode, noscriptFallback),
 		chrome("CounterHowItWorksCard"),
 	)
 }
@@ -512,47 +508,14 @@ func main() {
 
 	return gosx.Fragment(
 		chrome("KitchenSinkIntro"),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSCounterHeader"),
-			counterIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSTabsHeader"),
-			tabsIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSToggleHeader"),
-			toggleIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSTodoHeader"),
-			todoIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSFormHeader"),
-			formIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSPriceHeader"),
-			derivedIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSListHeader"),
-			listIsland,
-		),
-
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "card")),
-			chrome("KSEditorHeader"),
-			editorIsland,
-			editorScript,
-		),
+		chromeCard(chrome("KSCounterHeader"), counterIsland),
+		chromeCard(chrome("KSTabsHeader"), tabsIsland),
+		chromeCard(chrome("KSToggleHeader"), toggleIsland),
+		chromeCard(chrome("KSTodoHeader"), todoIsland),
+		chromeCard(chrome("KSFormHeader"), formIsland),
+		chromeCard(chrome("KSPriceHeader"), derivedIsland),
+		chromeCard(chrome("KSListHeader"), listIsland),
+		chromeCard(chrome("KSEditorHeader"), editorIsland, editorScript),
 	)
 }
 

--- a/route/filelayout.go
+++ b/route/filelayout.go
@@ -288,6 +288,22 @@ type fileRenderOptions struct {
 	// entry's data comes from ctx.Data and a DataLoader, not a Go-typed
 	// caller. See renderFileProgramHTML's strict-entry branch.
 	EntryProps any
+	// EntryChildren supplies the children node for a strict component
+	// rendered as the render entry (gosx#226, gosx#246). Only
+	// RenderProgramComponent sets this field, built from its own
+	// children ...gosx.Node parameter with gosx.Fragment: renderFileNode
+	// has no children parameter of its own to build it from, so a
+	// file-routed page or layout still cannot accept Go-supplied
+	// children — same limitation as EntryProps, for the same reason.
+	//
+	// The zero Node (EntryChildren.IsZero()) means "no children
+	// supplied", not "an empty children node": renderFileProgramHTML
+	// only binds the "children" scope value when this is non-zero, so a
+	// caller that never sets it — every existing caller before this
+	// field existed — reproduces the prior unresolved-identifier
+	// behavior byte for byte, not a bound empty Fragment. See
+	// renderFileProgramHTML's strict-entry branch.
+	EntryChildren gosx.Node
 }
 
 func renderFileNode(path string, opts fileRenderOptions) (gosx.Node, error) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -88,6 +88,26 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 		}
 		entryEnv = entryEnv.withValue("props", props)
 	}
+	// gosx#226, gosx#246: a strict component rendered as the render entry has
+	// no caller-side <Component>...</Component> children for writeLocalComponent
+	// to render, the same gap EntryProps closes for props. opts.EntryChildren is
+	// the only other place a children node can come from — RenderProgramComponent
+	// builds it from its own children ...gosx.Node parameter. Checked
+	// independently of the props branch above: a bare strict component (no
+	// PropsType at all) can still declare {children} in its body and accept
+	// them.
+	//
+	// A zero EntryChildren means "no children supplied" (see its doc comment),
+	// so every caller that predates this field — including every file-routed
+	// page and layout, which never sets it — takes no new branch here and
+	// reproduces the prior unresolved-identifier "children" behavior
+	// byte-for-byte, not a bound empty Fragment.
+	if !opts.EntryChildren.IsZero() {
+		if comp.Syntax != ir.ComponentSyntaxStrict {
+			return "", false, fmt.Errorf("render entry %s is not a strict component; children only bind to a strict render entry (see RenderProgramComponent)", comp.Name)
+		}
+		entryEnv = entryEnv.withValue("children", opts.EntryChildren)
+	}
 	// One builder carries the whole document. The renderer used to allocate a
 	// fresh strings.Builder per element and let the parent copy the child's
 	// string, which cost O(nodes x depth) byte traffic — a depth-100 page

--- a/route/program_render.go
+++ b/route/program_render.go
@@ -67,20 +67,67 @@ type ProgramRenderEnv struct {
 // nested call to it is: see ProgramRenderEnv.Props for the typed-props
 // contract this requires.
 //
+// children places one or more Go-computed gosx.Node values wherever component's
+// body writes {children} (gosx#226, gosx#246) — the same "one opaque node,
+// emitted where written" contract a nested <Component>...</Component> call's
+// children get, not a prop: children are never proved against component's
+// declared schema, and cannot overwrite a proved props field. Passing no
+// children reproduces every pre-#246 call's behavior exactly: an unresolved
+// "children" identifier fails soft to empty, the same as today. Passing
+// children against a legacy (non-strict) component fails closed with an
+// error, since a legacy render entry has no {children} hole to bind them to.
+//
 // When env.Profile is set and its Validate hook reports any diagnostic,
 // RenderProgramComponent returns a *RenderProfileError and an empty string;
 // no partial HTML is ever returned alongside that error.
-func RenderProgramComponent(prog *ir.Program, component string, env ProgramRenderEnv) (string, error) {
+func RenderProgramComponent(prog *ir.Program, component string, env ProgramRenderEnv, children ...gosx.Node) (string, error) {
 	html, _, err := renderFileProgramHTML(prog, component, fileRenderOptions{
 		EvalEnv: fileRenderEnv{
 			values:       env.Values,
 			funcs:        env.Funcs,
 			renderIsland: env.RenderIsland,
 		},
-		EntryProps: env.Props,
-		Profile:    env.Profile,
+		EntryProps:    env.Props,
+		EntryChildren: entryChildrenNode(children),
+		Profile:       env.Profile,
 	})
 	return html, err
+}
+
+// RenderProgramComponentNode is RenderProgramComponent's Node-returning
+// sibling (gosx#226, gosx#246): it renders the same way, but returns a
+// gosx.Node instead of a string, so the result composes directly into a
+// gosx.El(...) tree instead of forcing a caller to wrap a rendered string in
+// gosx.RawHTML by hand — the pattern examples/dashboard's chrome() helper
+// used before this function existed (see examples/dashboard/chrome.go).
+//
+// The returned Node wraps the rendered HTML with gosx.RawHTML, the same
+// wrapping RenderProgramComponent's own callers were already doing, and the
+// same wrapping writeLocalComponent uses internally for a nested call's own
+// children — the render still happens exactly once; nothing here re-renders
+// or re-escapes it. On error, the returned Node is the zero Node, and the
+// caller must not render it: like RenderProgramComponent, no partial HTML is
+// ever returned alongside an error.
+func RenderProgramComponentNode(prog *ir.Program, component string, env ProgramRenderEnv, children ...gosx.Node) (gosx.Node, error) {
+	html, err := RenderProgramComponent(prog, component, env, children...)
+	if err != nil {
+		return gosx.Node{}, err
+	}
+	return gosx.RawHTML(html), nil
+}
+
+// entryChildrenNode folds a RenderProgramComponent caller's children slice
+// into the single gosx.Node fileRenderOptions.EntryChildren carries,
+// matching writeLocalComponentWithChildren's own childrenNode parameter
+// shape. An empty slice folds to the zero Node on purpose: EntryChildren's
+// own doc comment names the zero Node as the "no children supplied" sentinel,
+// so a caller that passes none must produce that same sentinel, not a bound
+// empty Fragment, to keep every pre-existing call byte-identical.
+func entryChildrenNode(children []gosx.Node) gosx.Node {
+	if len(children) == 0 {
+		return gosx.Node{}
+	}
+	return gosx.Fragment(children...)
 }
 
 // LoadFileProgram compiles the .gsx file at path and returns its IR program,

--- a/route/program_render_children_test.go
+++ b/route/program_render_children_test.go
@@ -1,0 +1,158 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// TestRenderProgramComponentAcceptsEntryChildren proves the render-entry half
+// of gosx#226's remaining gap: a Go caller can place one or more Go-computed
+// gosx.Node values wherever a .gsx-authored render entry writes {children},
+// the same hole a nested <Component>...</Component> call fills, without
+// hand-building the surrounding chrome with gosx.El.
+func TestRenderProgramComponentAcceptsEntryChildren(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Card() {
+	return <div class="card">{children}</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Card", ProgramRenderEnv{},
+		gosx.El("h3", gosx.Text("Header")),
+		gosx.RawHTML("<span>island</span>"),
+	)
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div class="card"><h3>Header</h3><span>island</span></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestRenderProgramComponentNoChildrenStaysByteIdentical pins that adding the
+// children ...gosx.Node parameter changed nothing for a call that supplies
+// none: an unresolved "children" identifier still fails soft to empty, the
+// same as every call before gosx#246 gave RenderProgramComponent a children
+// parameter to omit.
+func TestRenderProgramComponentNoChildrenStaysByteIdentical(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Card() {
+	return <div class="card">{children}</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Card", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if want := `<div class="card"></div>`; html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestRenderProgramComponentNodeReturnsAComposableNode proves
+// RenderProgramComponentNode's result composes into a further gosx.El(...)
+// tree with no double escaping and no double rendering: the Node it returns
+// wraps the rendered HTML exactly once, via gosx.RawHTML, so splicing it into
+// a parent element reproduces the same bytes RenderProgramComponent's string
+// plus a hand-written gosx.RawHTML would have produced.
+func TestRenderProgramComponentNodeReturnsAComposableNode(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Greeting() {
+	return <p>Hello, {children}!</p>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	node, err := RenderProgramComponentNode(prog, "Greeting", ProgramRenderEnv{}, gosx.Text(`<world>`))
+	if err != nil {
+		t.Fatalf("RenderProgramComponentNode: %v", err)
+	}
+	composed := gosx.El("section", node)
+	want := `<section><p>Hello, &lt;world&gt;!</p></section>`
+	if got := gosx.RenderHTML(composed); got != want {
+		t.Fatalf("composed html = %q, want %q", got, want)
+	}
+}
+
+// TestRenderProgramComponentNodeReturnsZeroNodeOnError proves the error
+// contract matches RenderProgramComponent's own: no partial HTML, and here,
+// no partial Node either.
+func TestRenderProgramComponentNodeReturnsZeroNodeOnError(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Card() {
+	return <div class="card">{children}</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	node, err := RenderProgramComponentNode(prog, "DoesNotExist", ProgramRenderEnv{})
+	if err == nil {
+		t.Fatal("expected an error for an unknown component")
+	}
+	if !node.IsZero() {
+		t.Fatalf("node = %#v, want the zero Node on error", node)
+	}
+}
+
+// TestRenderProgramComponentChildrenAgainstALegacyEntryFailsClosed proves
+// EntryChildren's legacy guard: a legacy render entry has no {children} hole
+// for writeLocalComponent's binding to reach, so a caller-supplied child node
+// against one fails closed with a clear error instead of silently dropping
+// the caller's markup.
+func TestRenderProgramComponentChildrenAgainstALegacyEntryFailsClosed(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+func Legacy() Node {
+	return <div>legacy</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	_, err = RenderProgramComponent(prog, "Legacy", ProgramRenderEnv{}, gosx.Text("dropped?"))
+	if err == nil {
+		t.Fatal("expected an error for children against a legacy render entry")
+	}
+	if !strings.Contains(err.Error(), "not a strict component") {
+		t.Fatalf("err = %v, want it to name the legacy-entry refusal", err)
+	}
+}
+
+// TestRenderProgramComponentEntryChildrenNeverOverwriteAProvedPropsField is
+// the entry-render-path sibling of TestChildrenNeverOverwriteAProvedPropsField:
+// the render entry proves Props through strictSpreadProps directly against
+// the caller's struct, never through a props map EntryChildren could write
+// into, so a declared `Children` props field and Go-supplied entry children
+// coexist exactly as they do at a nested call site.
+func TestRenderProgramComponentEntryChildrenNeverOverwriteAProvedPropsField(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+type CardProps struct {
+	Children string
+}
+component Card(props: CardProps) {
+	return <section><b>{props.Children}</b><div>{children}</div></section>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Card", ProgramRenderEnv{
+		Props: struct{ Children string }{Children: "proved string"},
+	}, gosx.El("i", gosx.Text("caller")))
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section><b>proved string</b><div><i>caller</i></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}


### PR DESCRIPTION
## Summary

Enables Go callers rendering .gsx components through RenderProgramComponent to inject computed gosx.Node values into the component's {children} slot, removing the need to manually build surrounding markup with gosx.El. Also introduces RenderProgramComponentNode to return a composable Node directly.

## Changes

- **Added `children ...gosx.Node` to `RenderProgramComponent`**: Allows callers to pass one or more computed nodes into a `.gsx` component's `{children}` hole. Omitting them preserves pre-existing behavior exactly; passing them against a legacy (non-strict) component returns a clear error.
- **Introduced `RenderProgramComponentNode`**: Returns a `gosx.Node` wrapped in `RawHTML` instead of a string, letting callers splice the result directly into `gosx.El(...)` trees without manual wrapping or risk of double escaping.
- **Extended internal routing options**: Added `EntryChildren` to `fileRenderOptions` and updated `renderFileProgramHTML` to bind it to the `children` scope for strict components, keeping file-routed pages/layouts unaffected by default.
- **Refactored `examples/dashboard`**: Replaced repetitive `gosx.El("div", class="card", ...)` boilerplate with a `chromeCard` helper that uses `RenderProgramComponentNode` to render a `Card` component from `chrome.gsx`, significantly simplifying the example layout code.
- **Added unit tests**: Covers successful entry children injection, backward-compatibility when children are omitted, Node composition correctness, error handling on failure, refusal to inject children into legacy entries, and coexistence with declared `Props.Children` fields.

## Testing

- Run `go test ./route/... -v -run TestRenderProgramComponent` to verify all new unit tests pass.
- Run `go run examples/dashboard/main.go` and verify the dashboard page renders correctly with all card components visible and no malformed HTML wrappers.

## Review Focus

Focus on how EntryChildren is bound in renderFileProgramHTML and the backward-compatibility guarantees for existing callers omitting the children parameter.