### PR TITLE
update(compiler,cli,lsp): warn on untyped legacy component syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,37 @@
 # Changelog
 
+## Unreleased
+
+### Added: `gosx check` warns on an untyped legacy component
+
+- **`gosx check` now warns on a `func Name(props any) Node` declaration.**
+  This is step one of retiring legacy component syntax. GoSX has three
+  component shapes today: strict, typed legacy, and untyped legacy. The
+  plan collapses them to one. The warning names the component and states
+  that this form is deprecated and removed before v1.0. It also names the
+  strict replacement: `component Name(props: NameProps)`, with the struct
+  declared in the same file.
+- The warning does not fail the check. Every existing untyped legacy
+  component keeps compiling, checking, and rendering exactly as before.
+  `gosx check` still exits 0 on a file that declares one.
+- `ir.Diagnostic` gains a `Severity` field (`SeverityError`, the zero
+  value, or `SeverityWarning`). The new `ir.ValidateWarnings` function
+  returns advisory findings that never block `gosx.Compile` or `gosx
+  check`, unlike `ir.Validate`'s diagnostics. The Language Server Protocol
+  (LSP) server maps `SeverityWarning` onto the LSP `Warning` severity, so
+  an editor renders it as a warning, not an error.
+- A zero-props legacy function (`func Page() Node`, with no props
+  parameter at all) does not warn. It is the dominant page and layout
+  entry shape today, with about 72 declarations in this repository alone.
+  Most of them read route-loader data or route parameters, which a
+  zero-props strict component cannot reach yet. Warning on it now would
+  bury the untyped legacy signal this change targets.
+- `README.md` and the `examples/gosx-docs` docs site now teach the strict
+  `component Name(props: Type)` form as the one way to declare a
+  component. The legacy Go-function form appears only in a clearly marked
+  deprecation note with conversion guidance. It also appears in the pages
+  that document islands and engines, which still require it.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # GoSX
 
-A Go-native web platform. Write `.gsx` components with strict typed declarations or ordinary Go-function syntax, compile through a real compiler pipeline, render on the server by default, and hydrate interactive islands with WebAssembly. No app-side JavaScript toolchain. No CGo. A deliberately small dependency budget.
+A Go-native web platform. Declare `.gsx` components with the strict, typed `component Name(props: Type)` form. GoSX compiles through a real compiler pipeline. It renders on the server by default and hydrates interactive islands with WebAssembly. It needs no app-side JavaScript toolchain and no CGo, and it keeps a small dependency budget.
 
 Current release: **v0.49.0**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
@@ -23,10 +23,6 @@ type GreetingProps struct {
     Name string
 }
 
-type CounterProps struct {
-    Initial int
-}
-
 // Strict typed server component: renders to HTML, zero JavaScript.
 component Greeting(props: GreetingProps) {
     return <div class="greeting">
@@ -39,10 +35,11 @@ component WelcomePage() {
     return <main><Greeting name="GoSX" /></main>
 }
 
-// Legacy Go-function style: still supported, here as an island.
+// Islands hydrate client-side, so they still use the Go-function form.
+// See "Legacy component syntax" below.
 //gosx:island
-func Counter(props CounterProps) Node {
-    count := signal.New(props.Initial)
+func Counter(initial int) Node {
+    count := signal.New(initial)
     increment := func() { count.Update(func(n int) int { return n + 1 }) }
     decrement := func() { count.Update(func(n int) int { return n - 1 }) }
 
@@ -54,69 +51,32 @@ func Counter(props CounterProps) Node {
 }
 ```
 
-Both component styles can live in the same file. A component call stays
-within its declaration style, with one exception: a **typed legacy**
-component — `func Name(props T) Node` whose `T` is a struct declared in the
-same `.gsx` file — declares the same prop contract a strict component does,
-so it takes part in strict calls in both directions. A component that
-declares no such type (`props any`, an attribute list, or a type from
-another file) is an **untyped legacy** component and keeps the cross-style
-ban, because nothing about its props can be checked. The strict
-`component Name(props: GoType) { ... }` form uses an ordinary Go type as its
-prop contract, so the package check catches unknown fields and incompatible
-values. `component` supplies the `Node` result type; it does not make returns
-implicit. Strict server bodies currently contain one top-level GSX return and
-use a deliberately small renderer-safe expression surface. Each expression is
-either a quoted string, `true` or `false`, an ungrouped non-negative base-10
-integer in the `int64` range, a finite ungrouped decimal float, or one direct
-field on `props` whose same-file type is an exact built-in scalar. The original
-`func Name(props GoType) Node { ... }` form remains supported for existing and
-dynamic components.
+`component Name(props: Type) { ... }` is the one way GoSX teaches to declare
+a server component. `Type` is an ordinary Go struct declared in the same
+`.gsx` file, so the package check catches an unknown field or an
+incompatible value. `component` supplies the `Node` result type; it does not
+make the return implicit. A strict body currently contains one top-level GSX
+return, with a deliberately small, renderer-safe expression surface. A
+`props` field expression accepts only:
 
-Strict same-file calls accept an exported Go field name or its TSX-like
-lower-camel alias (`Label`/`label`, `HTMLFor`/`htmlFor`, `URL`/`url`);
-ambiguous aliases must use exact Go spelling. Every field the callee renders
-must be supplied explicitly, including `0`, `false`, and `""`, so generated Go
-and server rendering observe the same zero values.
+- a quoted string
+- `true` or `false`
+- an ungrouped non-negative base-10 integer in the `int64` range
+- a finite ungrouped decimal float
+- one direct field whose same-file type is an exact built-in scalar
+
+A same-file strict call accepts an exported Go field name or its TSX-like
+lower-camel alias (`Label`/`label`, `HTMLFor`/`htmlFor`, `URL`/`url`). An
+ambiguous alias needs the exact Go spelling. Supply every field the callee
+renders explicitly, including `0`, `false`, and `""`, so the generated Go
+and the server rendering observe the same zero values.
 
 ### Spreading a value into a strict component
 
 A strict component accepts one `{...source}` spread instead of named
-attributes. Three callers may write one, one per component category:
-
-- A **strict** caller spreads a value whose declared type is exactly the
-  callee's props type. The compiler proves the type; the generated Go call
-  is emitted verbatim.
-- A **typed legacy** caller — `func Name(props T) Node`, `T` a struct
-  declared in the same file — spreads its whole `props`, a field of it, or
-  any other expression. A whole-`props` forward is proved at the
-  declaration: `T` must declare every field the callee renders, with the
-  same declared type. Any other expression is proved at the renderer
-  boundary, as below.
-- An **untyped legacy** caller spreads any expression. That expression
-  carries no declared type, so the renderer proves the value at the
-  boundary: the source must be a struct, and every field the callee renders
-  must be present with a matching type.
-
-An untyped legacy component **cannot** spread its own `props` into a strict
-component. An untyped legacy render frame binds `props` to a `map[string]any`
-built from the call site's attributes, and the strict boundary proves struct
-values only, so that composition fails on every render. The compiler rejects
-it and names both components and the spread site. Write the props struct
-down and the same code compiles as a typed legacy component; alternatively,
-spread a struct-typed field of `props`, or declare the caller as a strict
-component.
-
-A typed legacy component keeps the legacy render frame's flattened map
-binding, so its body observes its props exactly as it always has: children
-arrive under `props.Children`, an attribute the struct does not name still
-arrives, and a caller may spread a map into it. Writing the props type down
-widens what the component may compose with; it does not change what the
-component sees.
-
-A strict body may call a typed legacy component, by one spread or by named
-attributes, under the same rules a strict callee answers to. It may not call
-an untyped legacy component.
+attributes. A strict caller spreads a value whose declared type is exactly
+the callee's props type. The compiler proves the type and emits the
+generated Go call verbatim.
 
 A nested struct field inside a spread is proved **structurally**, by the
 fields the callee renders under it, not by the declared type's name. A
@@ -138,11 +98,63 @@ A strict `component Name` compiles to a package-level Go `func Name`, and a
 sibling `.go` file in the same package already declares, naming both
 declarations and their positions.
 
-In v0.39, islands and engines continue to use the legacy Go-function spelling.
-The `//gosx:island` directive marks a legacy component for client-side
-hydration. The compiler extracts signals, computed values, and handlers from
-the Go source, compiles expressions to VM instructions, and serializes an
-island program. Server components emit static HTML with no client-side cost.
+### Islands and engines still use the function form
+
+In v0.49, islands and engines have no strict spelling; both continue to use
+`func Name(...) Node`. The `//gosx:island` directive marks a component for
+client-side hydration. The compiler extracts signals, computed values, and
+handlers from the Go source, compiles expressions to VM instructions, and
+serializes an island program. Server components emit static HTML with no
+client-side cost.
+
+### Legacy component syntax (deprecated)
+
+Earlier GoSX releases also accepted `func Name(props T) Node` as a
+component declaration, in two forms:
+
+- A **typed legacy** component, where `T` is a struct declared in the same
+  `.gsx` file. It carries the same prop contract a strict component does.
+- An **untyped legacy** component, where `T` is `any`, an attribute list, or
+  a type declared elsewhere (`props any` is the common case). Nothing about
+  its props can be checked.
+
+Both forms still compile, check, and render today, so existing code keeps
+working. `gosx check` now warns on a `func Name(props any) Node`
+declaration. This untyped legacy form is deprecated, and GoSX removes it
+before v1.0. A typed legacy component gets no warning yet, but new code
+should not add either form; declare `component Name(props: Type)` instead.
+
+To convert an untyped legacy component, declare its props as a struct in
+the same file, then switch the declaration:
+
+```gsx
+// Before: untyped legacy, no schema, deprecated.
+func Card(props any) Node {
+    return <div>{props.Label}</div>
+}
+
+// After: strict, checked by the Go compiler.
+type CardProps struct {
+    Label string
+}
+
+component Card(props: CardProps) {
+    return <div>{props.Label}</div>
+}
+```
+
+A strict caller cannot call an untyped legacy component at all. It can call
+a typed legacy component only through the rules a strict callee follows.
+
+An untyped legacy component cannot spread its own `props` into a strict
+component either. An untyped legacy render frame binds `props` to a
+`map[string]any`. The strict boundary proves struct values only, so that
+composition fails on every render. Converting the callee to a typed legacy
+or strict component removes the restriction.
+
+An island or an engine component cannot convert to strict syntax today (see
+"Islands and engines still use the function form" above). Leave its
+declaration as `func Name(...) Node`, whether or not its props are typed.
 
 ## Philosophy
 

--- a/cmd/gosx/check_test.go
+++ b/cmd/gosx/check_test.go
@@ -43,6 +43,49 @@ func Page(item Item, ok bool) Node {
 	}
 }
 
+// TestRunCheckWarnsOnUntypedLegacyComponent covers step one of retiring
+// legacy component syntax: an untyped legacy component (`func Name(props
+// any) Node`) must produce a warning naming the component and the strict
+// replacement, but must not fail the check — 7 such declarations exist in
+// this repo today and must keep checking, compiling, and rendering exactly
+// as they do now.
+func TestRunCheckWarnsOnUntypedLegacyComponent(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.gsx")
+	writeTempFile(t, dir, "page.gsx", `package main
+
+func FeatureCard(props any) Node {
+	return <div class="card">{props}</div>
+}
+
+func Page() Node {
+	return <FeatureCard>hi</FeatureCard>
+}
+`)
+
+	var stderr bytes.Buffer
+	if err := runCheck(path, &stderr); err != nil {
+		t.Fatalf("runCheck failed: %v", err)
+	}
+
+	output := stderr.String()
+	if !strings.Contains(output, "warning:") {
+		t.Fatalf("expected a warning line, got: %q", output)
+	}
+	if !strings.Contains(output, "FeatureCard") {
+		t.Fatalf("expected the warning to name FeatureCard, got: %q", output)
+	}
+	if !strings.Contains(output, "component FeatureCard(props: FeatureCardProps)") {
+		t.Fatalf("expected the warning to point at the strict replacement, got: %q", output)
+	}
+	if !strings.Contains(output, "v1.0") {
+		t.Fatalf("expected the warning to say the form is removed before v1.0, got: %q", output)
+	}
+	if !strings.Contains(output, "ok: 2 components") {
+		t.Fatalf("expected check to still pass, got: %q", output)
+	}
+}
+
 func TestRunCheckReportsReadError(t *testing.T) {
 	var stderr bytes.Buffer
 	err := runCheck(filepath.Join(t.TempDir(), "missing.gsx"), &stderr)

--- a/cmd/gosx/main.go
+++ b/cmd/gosx/main.go
@@ -420,6 +420,12 @@ func runCheck(file string, stderr io.Writer) error {
 			return fmt.Errorf("lower island %s: %w", component.Name, err)
 		}
 	}
+	// Advisory findings (for example an untyped legacy component) are
+	// printed but never fail the check: ir.ValidateWarnings never blocks
+	// compilation, unlike ir.Validate's diagnostics — see its doc comment.
+	for _, diag := range ir.ValidateWarnings(prog) {
+		fmt.Fprintln(stderr, diag.String())
+	}
 	fmt.Fprintf(stderr, "ok: %d components\n", len(prog.Components))
 	for _, c := range prog.Components {
 		fmt.Fprintf(stderr, "  %s", c.Name)

--- a/examples/gosx-docs/app/docs/compiler/page.gsx
+++ b/examples/gosx-docs/app/docs/compiler/page.gsx
@@ -28,7 +28,7 @@ func Page() Node {
 		<div class="page-topper">
 			<span class="eyebrow">Language pipeline</span>
 			<p class="lede">
-				A single parser and IR serve both GSX component spellings. Strict declarations add a fail-closed typed boundary; legacy Go-function components preserve the established dynamic route and island model.
+				A single parser and IR serve both GSX component spellings. Strict declarations add a fail-closed typed boundary and are the only spelling GoSX teaches. The legacy Go-function form still parses for existing code, islands, engines, and loader-bound routes.
 			</p>
 		</div>
 		<h2 id="source-model">GSX source model</h2>
@@ -44,7 +44,9 @@ func Page() Node {
 		<CodeBlock lang="gosx" source={data.strictSample} />
 		<CodeBlock lang="gosx" source={data.legacySample} />
 		<p>
-			The two spellings lower into the same component and node representation. Existing legacy source remains valid; adopting strict components is opt-in and local. Calls stay within one declaration style in v0.39, keeping dynamic legacy attributes from bypassing strict Go prop checks.
+			The two spellings lower into the same component and node representation. Existing legacy source remains valid, but new code should declare
+			<span class="inline-code">component Name(props: Type)</span>
+			instead. Calls stay within one declaration style in v0.39, keeping dynamic legacy attributes from bypassing strict Go prop checks.
 		</p>
 		<h2 id="strict-validation">Strict validation</h2>
 		<p>

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -5,14 +5,20 @@ func Page() Node {
 		<div class="page-topper">
 			<span class="eyebrow">Authoring model</span>
 			<p class="lede">
-				GoSX supports two component spellings in the same
+				GoSX teaches one component spelling: a strict, typed form. Declare a
 				<span class="inline-code">.gsx</span>
-				file: a strict, typed form for deliberately small server components and the established Go-function form for routes, islands, and richer bodies.
+				component with
+				<span class="inline-code">component Name(props: Type)</span>
+				, and the project-aware CLI checks its props as Go types.
 			</p>
 		</div>
-		<h2 id="two-styles">Two authoring styles</h2>
+		<h2 id="two-styles">One authoring style</h2>
 		<p>
-			Both styles lower to the same GoSX component IR. Choosing a style changes the source contract and validation boundary; it does not create a second renderer or runtime.
+			Every new component uses
+			<span class="inline-code">component Name(props: Type)</span>
+			. GoSX still runs the older Go-function spelling,
+			<span class="inline-code">func Name(...) Node</span>
+			, for islands, engines, and loader-bound routes. See "Legacy components (deprecated)" below for that spelling. This page does not teach it to a new author.
 		</p>
 		<section class="feature-grid">
 			<div class="card">
@@ -24,11 +30,10 @@ func Page() Node {
 				</p>
 			</div>
 			<div class="card">
-				<strong>Legacy and flexible</strong>
+				<strong>Legacy (deprecated)</strong>
 				<p>
-					Use
 					<span class="inline-code">func Name(...) Node</span>
-					for route data bindings, local statements, helpers, structural builtins, and existing applications.
+					still runs, but it is deprecated for ordinary server components. Islands, engines, and loader-bound routes still need it. See below.
 				</p>
 			</div>
 		</section>
@@ -167,11 +172,21 @@ func Page() Node {
 			<span class="inline-code">false</span>
 			, and an empty string; omission is rejected so Go and the server renderer observe the same zero values.
 		</p>
-		<h2 id="legacy-components">Legacy components</h2>
+		<h2 id="legacy-components">Legacy components (deprecated)</h2>
 		<p>
-			The Go-function spelling remains fully supported and is the compatibility path for existing source. It is also the documented route form when a loader exposes the dynamic
+			This section is a migration note, not something to write in new code. The Go-function spelling still compiles, checks, and renders, so existing source keeps working. It is also today's only route form when a loader exposes the dynamic
 			<span class="inline-code">data</span>
 			binding.
+		</p>
+		<p>
+			<span class="inline-code">gosx check</span>
+			now warns on an
+			<span class="inline-code">untyped legacy</span>
+			component:
+			<span class="inline-code">func Name(props any) Node</span>
+			. This form is deprecated, and GoSX removes it before v1.0. Declare its props as a same-file struct, then switch to
+			<span class="inline-code">component Name(props: Type)</span>
+			.
 		</p>
 		<p>
 			Both declaration styles may coexist in one file. A component call stays within its declaration style, with one exception: a
@@ -274,19 +289,21 @@ func Page() Node {
 			<span class="inline-code">gosx render</span>
 			as the executable source of truth for strict diagnostics.
 		</p>
-		<h2 id="choosing">Choosing a style</h2>
+		<h2 id="choosing">When legacy is still necessary</h2>
+		<p>
+			Declare every new server component with
+			<span class="inline-code">component Name(props: Type)</span>
+			. The legacy Go-function form remains necessary in three cases only, all structural limits of the current release, not a style choice.
+		</p>
 		<ul>
 			<li>
-				Start strict for small, presentational, same-file server components with stable prop types.
+				A route reads loader data, route params, structural control flow, or a helper-rich body that the strict expression subset does not cover yet.
 			</li>
 			<li>
-				Use legacy pages for loader data, route params, layouts, structural control flow, and helper-rich bodies.
+				A component hydrates client-side as an island. Strict islands are not supported yet.
 			</li>
 			<li>
-				Keep existing legacy components as-is; migration is optional and can happen one local component at a time.
-			</li>
-			<li>
-				Use islands only for browser interaction, not as a workaround for a server component that needs richer Go logic.
+				A component runs as an engine (canvas, WebGL, WebGPU, or a background worker). Strict engines are not supported yet.
 			</li>
 		</ul>
 	</article>

--- a/examples/gosx-docs/app/docs/getting-started/page.gsx
+++ b/examples/gosx-docs/app/docs/getting-started/page.gsx
@@ -86,23 +86,36 @@ func Page() Node {
 				<span class="inline-code">page.server.go</span>
 				sibling registers a server module that supplies data to the template through the
 				<span class="inline-code">data</span>
-				binding.
+				binding. Loader data is not available to a strict component yet. A route that reads
+				<span class="inline-code">data</span>
+				keeps the older
+				<span class="inline-code">func Page() Node</span>
+				form below; see "Component Syntax" further down.
 			</p>
 			{CodeBlock("go", "// app/page.server.go\npackage app\n\nimport (\n\t\"log\"\n\n\t\"m31labs.dev/gosx/route\"\n)\n\nfunc init() {\n\tif err := route.RegisterFileModuleHere(route.FileModuleOptions{\n\t\tLoad: func(ctx *route.RouteContext, page route.FilePage) (any, error) {\n\t\t\treturn map[string]any{\n\t\t\t\t\"greeting\": \"Hello from the server\",\n\t\t\t}, nil\n\t\t},\n\t}); err != nil {\n\t\tlog.Fatal(err)\n\t}\n}")}
 			{CodeBlock("gsx", "// app/page.gsx\npackage app\n\nfunc Page() Node {\n\treturn <div>\n\t\t<h1>{data.greeting}</h1>\n\t</div>\n}")}
 		</section>
 		<section id="authoring-styles" class="docs-section-block">
-			<h2>Choose an Authoring Style</h2>
+			<h2>Component Syntax</h2>
 			<p>
-				GoSX supports strict typed components and the established Go-function form side by side. Keep route pages that read loader
-				<span class="inline-code">data</span>
-				in the legacy form shown above. Use the TSX-like strict form for small same-file components with explicit Go prop types.
+				Declare every component with the strict, typed form:
+				<span class="inline-code">component Name(props: Type)</span>
+				. The project-aware CLI checks
+				<span class="inline-code">props</span>
+				as an ordinary Go type.
 			</p>
 			{CodeBlock("gsx", "package app\n\ntype BadgeProps struct {\n\tLabel string\n\tCount int\n}\n\ncomponent Badge(props: BadgeProps) {\n\treturn <span className=\"badge\">\n\t\t{props.Label}: {props.Count}\n\t</span>\n}\n\ncomponent Page() {\n\treturn <main><Badge label=\"Inbox\" count={0} /></main>\n}")}
 			<p>
-				Strict server components deliberately allow one top-level GSX return and narrow renderer-safe expressions. Calls use exact or unambiguous lower-camel prop names and explicitly pass every field the callee renders, even zero values. Use the legacy form for local statements, structural control flow, helpers, renderer builtins, client directives, or dynamic route bindings. See
+				A strict server component allows one top-level GSX return and a narrow, renderer-safe expression set. A call uses an exact or unambiguous lower-camel prop name. It passes every field the callee renders explicitly, even a zero value.
+			</p>
+			<p>
+				The older
+				<span class="inline-code">func Name(...) Node</span>
+				form is deprecated for ordinary components; GoSX removes its untyped variant before v1.0.
+				<span class="inline-code">gosx check</span>
+				already warns on it. It remains necessary today only for loader-bound routes (as above), islands, and engines. See
 				<a href="/docs/components" data-gosx-link="true">Components</a>
-				for the exact boundary.
+				for the exact boundary and the migration note.
 			</p>
 		</section>
 		<section id="dev-server" class="docs-section-block">
@@ -129,7 +142,7 @@ func Page() Node {
 			<ul>
 				<li>
 					<a href="/docs/components" data-gosx-link="true">Components</a>
-					— Strict typed and legacy authoring styles, props, and renderer boundaries.
+					— Strict component syntax, props, renderer boundaries, and the legacy migration note.
 				</li>
 				<li>
 					<a href="/docs/routing" data-gosx-link="true">Routing</a>

--- a/examples/gosx-docs/app/page.gsx
+++ b/examples/gosx-docs/app/page.gsx
@@ -19,7 +19,7 @@ func Page() Node {
 					</div>
 					<ul class="hero__facts" aria-label="Platform summary">
 						<li>Server HTML</li>
-						<li>Typed + legacy GSX</li>
+						<li>Strict, typed GSX</li>
 						<li>Go/WASM islands</li>
 					</ul>
 				</div>

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -9,6 +9,18 @@ import (
 	"time"
 )
 
+// Severity distinguishes a diagnostic that must block compilation from one
+// that only advises the author. The zero value is SeverityError, so every
+// Diagnostic literal written before Severity existed keeps failing exactly
+// as it always did — this field is additive and changes no existing
+// behavior on its own.
+type Severity uint8
+
+const (
+	SeverityError Severity = iota
+	SeverityWarning
+)
+
 // Diagnostic represents a validation error or warning.
 type Diagnostic struct {
 	Span    Span
@@ -21,6 +33,13 @@ type Diagnostic struct {
 	// checker (see strictcheck.Lint) can surface that checker's own rule
 	// codes without a second, differently-shaped diagnostic type.
 	Code string
+
+	// Severity marks whether this diagnostic must block compilation
+	// (SeverityError, the zero value) or only advises the author
+	// (SeverityWarning). Validate's own diagnostics all leave this at the
+	// zero value; ValidateWarnings is the one built-in source of
+	// SeverityWarning diagnostics today.
+	Severity Severity
 }
 
 func (d Diagnostic) String() string {
@@ -44,6 +63,9 @@ func (d Diagnostic) String() string {
 		s += d.Span.File + ":"
 	}
 	s += fmt.Sprintf("%d:%d: ", d.Span.StartLine, d.Span.StartCol)
+	if d.Severity == SeverityWarning {
+		s += "warning: "
+	}
 	if d.Code != "" {
 		s += d.Code + ": "
 	}
@@ -61,6 +83,56 @@ func Validate(prog *Program) []Diagnostic {
 	v := &validator{prog: prog}
 	v.validate()
 	return v.diags
+}
+
+// ValidateWarnings runs advisory checks over the IR program and returns
+// SeverityWarning diagnostics only. Unlike Validate, nothing here blocks
+// compilation: gosx.Compile does not call this function, and a caller that
+// wants these findings (gosx check, the language server) reports them
+// itself and keeps going regardless of what it finds.
+func ValidateWarnings(prog *Program) []Diagnostic {
+	var diags []Diagnostic
+	if prog == nil {
+		return diags
+	}
+	for i := range prog.Components {
+		diags = append(diags, untypedLegacyPropsWarning(&prog.Components[i])...)
+	}
+	return diags
+}
+
+// untypedLegacyPropsWarning flags a component declared as untyped legacy:
+// `func Name(props any) Node`. This is step one of retiring legacy
+// component syntax — the goal is one component shape, `component
+// Name(props: NameProps)` — and the untyped form is the one with no schema
+// proof at all, so it is the first flagged.
+//
+// The check is deliberately narrow, matching only a props type of exactly
+// "any": a legacy component that takes no props (PropsType == ""), or a
+// TYPED legacy component whose props struct is declared in this file
+// (Component.PropsTyped), is excluded — see the zero-props census in
+// gosx's untyped-legacy-warning change for why zero-props legacy functions
+// stay silent here. An engine or island component is excluded too, because
+// strict syntax rejects both outright today (see the "strict engine
+// declarations are not supported" and "strict island declarations are not
+// supported" diagnostics in lowerStrictComponentDecl) — the warning must
+// never recommend a form the compiler itself refuses.
+func untypedLegacyPropsWarning(comp *Component) []Diagnostic {
+	if comp.Syntax != ComponentSyntaxLegacy || comp.PropsTyped || comp.IsEngine || comp.IsIsland {
+		return nil
+	}
+	if strings.TrimSpace(comp.PropsType) != "any" {
+		return nil
+	}
+	return []Diagnostic{{
+		Span:     comp.Span,
+		Severity: SeverityWarning,
+		Message: fmt.Sprintf(
+			"component %s is declared as untyped legacy (func %s(%s any) Node); this form is deprecated and will be removed before v1.0",
+			comp.Name, comp.Name, comp.PropsName,
+		),
+		Hint: fmt.Sprintf("declare component %s(props: %sProps) with the struct in this file instead", comp.Name, comp.Name),
+	}}
 }
 
 type validator struct {

--- a/ir/validate_test.go
+++ b/ir/validate_test.go
@@ -777,3 +777,79 @@ func Page() Node {
 		t.Fatalf("expected no diagnostics for valid live/region attributes, got %+v", diags)
 	}
 }
+
+// TestValidateWarningsFlagsUntypedLegacyProps covers step one of retiring
+// legacy component syntax: an untyped legacy component (`func Name(props
+// any) Node`) gets one SeverityWarning diagnostic naming the component and
+// the strict replacement. ir.Validate itself must stay silent — the
+// warning must never become a compile-blocking error.
+func TestValidateWarningsFlagsUntypedLegacyProps(t *testing.T) {
+	source := []byte(`package main
+
+func FeatureCard(props any) Node {
+	return <div class="card">{props}</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	if diags := ir.Validate(prog); len(diags) != 0 {
+		t.Fatalf("expected ir.Validate to stay silent on an untyped legacy component, got %+v", diags)
+	}
+
+	warnings := ir.ValidateWarnings(prog)
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning, got %+v", warnings)
+	}
+	warning := warnings[0]
+	if warning.Severity != ir.SeverityWarning {
+		t.Fatalf("expected SeverityWarning, got %v", warning.Severity)
+	}
+	if !strings.Contains(warning.Message, "FeatureCard") {
+		t.Fatalf("expected the warning to name FeatureCard, got %q", warning.Message)
+	}
+	if !strings.Contains(warning.Message, "v1.0") {
+		t.Fatalf("expected the warning to say the form is removed before v1.0, got %q", warning.Message)
+	}
+	if !strings.Contains(warning.Hint, "component FeatureCard(props: FeatureCardProps)") {
+		t.Fatalf("expected the hint to name the strict replacement, got %q", warning.Hint)
+	}
+}
+
+// TestValidateWarningsSilentOnZeroPropsAndTypedLegacy covers the boundary
+// of the untyped-legacy warning: a zero-props legacy function, a TYPED
+// legacy component (its props struct declared in the same file), and a
+// strict component must all stay silent. Warning on zero-props legacy
+// functions is out of scope for this step — see the zero-props census in
+// gosx's untyped-legacy-warning change.
+func TestValidateWarningsSilentOnZeroPropsAndTypedLegacy(t *testing.T) {
+	source := []byte(`package main
+
+type CardProps struct {
+	Title string
+}
+
+func Page() Node {
+	return <div>{"hi"}</div>
+}
+
+func Card(props CardProps) Node {
+	return <div>{props.Title}</div>
+}
+
+component Strict(props: CardProps) {
+	return <div>{props.Title}</div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	warnings := ir.ValidateWarnings(prog)
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warnings for zero-props, typed legacy, or strict components, got %+v", warnings)
+	}
+}

--- a/lsp/diagnostics.go
+++ b/lsp/diagnostics.go
@@ -11,9 +11,24 @@ import (
 	"m31labs.dev/gosx/ir"
 )
 
+// Severity values follow the LSP DiagnosticSeverity enum (textDocument/
+// publishDiagnostics): 1 is Error, 2 is Warning. Only these two are used
+// today; gosx has no Information (3) or Hint (4) diagnostics.
 const (
-	SeverityError = 1
+	SeverityError   = 1
+	SeverityWarning = 2
 )
+
+// severityFromIR maps an ir.Severity onto the matching LSP severity value.
+// ir.SeverityError (the zero value) maps to SeverityError, so every
+// existing built-in diagnostic — none of which sets ir.Diagnostic.Severity
+// — keeps its current LSP severity unchanged.
+func severityFromIR(sev ir.Severity) int {
+	if sev == ir.SeverityWarning {
+		return SeverityWarning
+	}
+	return SeverityError
+}
 
 // Position is an LSP line/character coordinate.
 type Position struct {

--- a/lsp/diagnostics_test.go
+++ b/lsp/diagnostics_test.go
@@ -64,6 +64,33 @@ func alsoBroken() Node {
 	}
 }
 
+// TestAnalyzeWarnsOnUntypedLegacyComponent covers step one of retiring
+// legacy component syntax: an untyped legacy component (`func Name(props
+// any) Node`) must reach the editor as a SeverityWarning diagnostic, not a
+// SeverityError one — the file itself is otherwise valid, so Analyze must
+// not report it as broken.
+func TestAnalyzeWarnsOnUntypedLegacyComponent(t *testing.T) {
+	diags := Analyze("page.gsx", []byte(`package main
+
+func FeatureCard(props any) Node {
+	return <div class="card">{props}</div>
+}
+`))
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %d: %+v", len(diags), diags)
+	}
+	diag := diags[0]
+	if diag.Severity != SeverityWarning {
+		t.Fatalf("expected warning severity, got %d", diag.Severity)
+	}
+	if !strings.Contains(diag.Message, "FeatureCard") {
+		t.Fatalf("expected the diagnostic to name FeatureCard, got %q", diag.Message)
+	}
+	if !strings.Contains(diag.Message, "component FeatureCard(props: FeatureCardProps)") {
+		t.Fatalf("expected the diagnostic to point at the strict replacement, got %q", diag.Message)
+	}
+}
+
 func TestFormatSource(t *testing.T) {
 	formatted, err := FormatSource([]byte(`package main
 

--- a/lsp/symbols.go
+++ b/lsp/symbols.go
@@ -83,11 +83,20 @@ func indexSource(path string, source []byte) (sourceIndex, []Diagnostic) {
 	idx.indexComponentRefs()
 
 	raw := ir.Validate(prog)
-	diags := make([]Diagnostic, 0, len(raw))
+	warnings := ir.ValidateWarnings(prog)
+	diags := make([]Diagnostic, 0, len(raw)+len(warnings))
 	for _, diag := range raw {
 		diags = append(diags, Diagnostic{
 			Range:    rangeFromSpan(diag.Span),
-			Severity: SeverityError,
+			Severity: severityFromIR(diag.Severity),
+			Source:   diagnosticSource(path),
+			Message:  diagnosticMessage(diag),
+		})
+	}
+	for _, diag := range warnings {
+		diags = append(diags, Diagnostic{
+			Range:    rangeFromSpan(diag.Span),
+			Severity: severityFromIR(diag.Severity),
 			Source:   diagnosticSource(path),
 			Message:  diagnosticMessage(diag),
 		})


### PR DESCRIPTION
## Summary

Introduce diagnostic severity levels to separate advisory warnings from compile-blocking errors, starting with warnings for the deprecated untyped legacy component syntax (`func Name(props any) Node`). Updates the CLI and language server to surface these advisories without failing checks, and revises documentation to promote the strict typed component form as the standard authoring style.

## Changes

- Add `ir.Severity` (`SeverityError`, `SeverityWarning`) to differentiate blocking diagnostics from advisory findings.
- Implement `ir.ValidateWarnings()` to scan the IR for untyped legacy components and return non-blocking warnings.
- Update `gosx check` to execute validation warnings, print them to stderr, and continue with a successful exit code.
- Extend LSP diagnostics mapping to translate `ir.SeverityWarning` into LSP Warning severity for editor rendering.
- Rewrite documentation across README and example sites to establish the strict `component Name(props: Type)` form as the primary syntax, clearly marking the untyped legacy form as deprecated with migration instructions.
- Add targeted tests for IR validation, CLI behavior, and LSP analysis to verify warning emission and exclusion of zero-props/typed legacy/strict components.

## Testing

- `go test ./...` executes full test suite including new IR, CLI, and LSP tests.
- Run `echo 'package main; func X(props any) Node { return nil }' > x.gsx && gosx check x.gsx` to verify warning text prints and exit code is 0.
- Use a `.gsx` file with untyped legacy syntax in your editor to confirm the language server highlights it as a yellow warning rather than a red error.