### PR TITLE
add(core): Enable end-to-end execution of shared components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,83 @@
 # Changelog
 
+## Unreleased
+
+### Added: a shared component call executes end to end for a strict caller
+
+- **A strict caller's shared component call now renders.** WP4 (v0.49.0)
+  proved the Go projection type-checks a call through a relative import
+  (`import ui "./ui"`; `<ui.TeamMark Tone={props.Tone}/>`), but `ir.Lower`
+  still refused the call outright for a strict caller, and the file
+  renderer had no way to execute one even where it compiled. Both gaps are
+  closed. `TeamMark`, the app that motivated this work, no longer needs a
+  separate, already-drifted copy in every page directory that renders it.
+- **`ir.Lower` accepts the call by SHAPE alone**, never by field: a dotted
+  tag whose alias names a relative (`./` or `../`) import in the file's own
+  `Program.Imports` is admitted, and only its spread-versus-named-attribute
+  shape is checked (`ir.SplitMemberTag`, `ir.IsSharedImportPath`). Lower
+  performs no file I/O — the LSP runs it on every keystroke with no
+  debounce — so it cannot and does not check whether the target directory
+  declares a matching component; that proof belongs to `gosx check`.
+- **`gosx check` (strictcheck) resolves a shared import through the real Go
+  compiler.** It loads the target directory (`transpile.LoadPackageDir`),
+  builds its component map (`transpile.CollectSharedComponents`), and adds
+  the target's own projected Go to `goCheck`'s overlay at a virtual path
+  inside the target's real directory, so `go list` resolves its true Go
+  import path and the caller's rewritten import statement resolves against
+  real declarations. A shared import that resolves outside the project's
+  `app/` directory is rejected with a diagnostic naming the import and both
+  directories: `gosx build` stages only `app/`, `content/`, and `public/`
+  into the deployment bundle, so a shared component elsewhere would
+  type-check locally and then not ship.
+- **The file renderer loads and executes the target component.**
+  `route.fileProgramRenderer.writeSharedComponent` resolves the target
+  directory relative to the rendering `.gsx` file's own directory
+  (`fileRenderOptions.SourceDir`, threaded from the file router's existing
+  path), compiles every `.gsx` file there through the same stat-keyed cache
+  a page renders through, and renders the resolved component on a second
+  renderer bound to its own `ir.Program` — `writeLocalComponentWithChildren`
+  requires this, because a node ID means nothing outside the `Nodes` slice
+  that owns it. Following PR #246's contract, children render on the
+  PARENT renderer (which owns the call node) before the finished node
+  crosses to the child renderer. A shared call carrying children into a
+  component that does not place `{children}` fails closed with the same
+  message a same-file call gives, rather than silently dropping the
+  content — `ir.Lower` cannot prove this for a shared call (no I/O), and
+  the Go compiler cannot catch it either (every strict component projects
+  a variadic `children` parameter that accepts any number of arguments), so
+  this is the one point that ever proves it.
+- **`transpile.TranspilePackageWithSharedImports`** and
+  **`transpile.LoadPackageDir`** are new exported entry points; every
+  existing exported function keeps its old signature and behavior
+  unchanged with a nil or absent shared-imports argument.
+- Known, accepted limitation: an editor's live diagnostics can lag `gosx
+  check` for a field typo at a shared call site, because resolving the
+  target directory on every keystroke (the LSP's synchronous, no-debounce
+  loop) is worse than a brief lag. `gosx check` and the build gate remain
+  authoritative.
+
+### Changed: examples/gosx-docs's StatCard, CapabilityTag, and Tooltip move to `.gsx`
+
+- **`StatCard` and `CapabilityTag` are now shared `.gsx` components** in
+  `examples/gosx-docs/app/ui/`, reached the same way `<ui.TeamMark/>` is:
+  an ordinary relative import. `StatCard`'s 7 existing call sites moved
+  from `{StatCard(value, label)}` to `<ui.StatCard Value={value}
+  Label={label}/>`; `CapabilityTag` had no call sites to move.
+- **`Tooltip` also moved**, and keeps no Go-callable form: its trigger
+  content only has a channel through `{children}`, which binds at a
+  nested call site inside another component's body, never at a Go-side
+  render entry.
+- **`CodeBlock` stays hand-built in Go.** Its job is embedding
+  already-rendered, syntax-highlighted HTML as raw markup, and a strict
+  component has no channel for that: a typed props field may only be a
+  scalar or a same-file struct, never a `gosx.Node`, and `{children}` binds
+  only at a nested call site, never at a Go-side render entry
+  (`route.ProgramRenderEnv` carries no `Children` field). `CodeBlock`'s 103
+  call sites all render it as an entry, so neither channel is open to it.
+  `examples/gosx-docs/app/components.go`'s own raw (`gosx.El`-family)
+  element-building call count drops from 13 to 7 as a result: 6 eliminated
+  (`StatCard` 3, `CapabilityTag` 1, `Tooltip` 2), `CodeBlock`'s 7 remain.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/examples/gosx-docs/app/components.go
+++ b/examples/gosx-docs/app/components.go
@@ -1,38 +1,45 @@
 // Package docs implements the GoSX documentation site.
 //
-// This file holds the site's shared component library: CodeBlock,
-// StatCard, CapabilityTag, and Tooltip. Each one stays on the low-level
-// gosx.El/Attrs/Text API by necessity, not as a style example.
+// This file used to hold the site's whole shared component library, hand
+// built on the low-level gosx.El/Attrs/Text API because a .gsx component
+// could not be shared across pages. Three of its four components — every
+// one with a typed-props shape a strict component can actually declare —
+// now live in app/ui/*.gsx, a shared component directory reached through
+// the shared-components design (import ui "./ui"; <ui.StatCard .../>):
+// StatCard, CapabilityTag, and Tooltip. Their 7 call sites (StatCard was
+// the only one of the three anything actually called) moved with them,
+// from the old {StatCard(value, label)} expression-call form to
+// <ui.StatCard Value={value} Label={label}/>.
 //
-// modules.go binds each function, by compile-time Go identifier, into
-// every page's route.FileTemplateBindings.Funcs and .Components maps.
-// That binding lets other .gsx pages call these functions as tags, for
-// example `<CodeBlock lang="go" source={...} />`, or as plain calls, for
-// example `{CodeBlock("go", "...")}`.
+// A Go-callable adapter that forwarded to the .gsx source was considered
+// and rejected: a props struct declared inside a .gsx file is not a real
+// Go type until gosx build transpiles it, so no plain .go file — this one
+// included — can name it, and moving the struct to a companion .go file
+// instead would leave ir.Lower (which never reads a sibling file) unable
+// to see it, degrading the strict component back to untyped attribute
+// handling. Real call-site migration was the only option that keeps both
+// halves genuinely typed.
 //
-// A Funcs or Components map entry must be a real, linkable Go function
-// value. The file router has no supported way to bind a .gsx-authored
-// component into that map by name. A component defined inside one
-// page.gsx file is visible only to that page, not to every page that
-// wants to reuse it. Until GoSX ships a shared, cross-page .gsx component
-// surface, this package stays Go, for the same reason server/page.go and
-// server/metadata_render.go stay Go.
+// CodeBlock stays hand-built. Its core job is embedding ALREADY-RENDERED,
+// syntax-highlighted HTML (the highlight package's own output) as raw
+// markup, and a strict component has no channel for that: a typed props
+// field may only be a scalar or a same-file struct, never a gosx.Node (see
+// ir.strictRendererScalarType), and {children} — the one place a gosx.Node
+// DOES pass through unescaped — binds only at a nested call site inside
+// another component's body. CodeBlock's 103 call sites all supply a plain
+// (lang, source string) pair, not pre-rendered markup, so in principle a
+// typed Lang/Source props call could still work; the blocker is scale, not
+// architecture — rewriting 103 call sites, many holding multi-line/
+// multi-language literal source samples as page content, was judged too
+// large a mechanical change for this conversion to also carry safely.
 package docs
 
 import (
-	"strconv"
 	"strings"
-	"sync/atomic"
 
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/highlight"
 )
-
-var tooltipID atomic.Int64
-
-func tooltipCounter() int {
-	return int(tooltipID.Add(1))
-}
 
 // CodeBlock renders a syntax-highlighted code sample in a dark glass panel.
 func CodeBlock(lang, source string) gosx.Node {
@@ -168,30 +175,4 @@ func removeCodeIndentColumns(line string, columns int) string {
 		}
 	}
 	return ""
-}
-
-// StatCard renders a proof-point stat card.
-func StatCard(value, label string) gosx.Node {
-	return gosx.El("div", gosx.Attrs(gosx.Attr("class", "stat-card glass-panel")),
-		gosx.El("span", gosx.Attrs(gosx.Attr("class", "stat-card__value")), gosx.Text(value)),
-		gosx.El("span", gosx.Attrs(gosx.Attr("class", "stat-card__label")), gosx.Text(label)),
-	)
-}
-
-// CapabilityTag renders a small tag badge.
-func CapabilityTag(label string) gosx.Node {
-	return gosx.El("span", gosx.Attrs(gosx.Attr("class", "cap-tag")), gosx.Text(label))
-}
-
-// Tooltip renders a trigger element with an accessible tooltip overlay.
-func Tooltip(trigger gosx.Node, content string) gosx.Node {
-	id := "tip-" + strconv.Itoa(tooltipCounter())
-	return gosx.El("span", gosx.Attrs(gosx.Attr("class", "tooltip-trigger"), gosx.Attr("aria-describedby", id)),
-		trigger,
-		gosx.El("span", gosx.Attrs(
-			gosx.Attr("id", id),
-			gosx.Attr("class", "tooltip glass-panel"),
-			gosx.Attr("role", "tooltip"),
-		), gosx.Text(content)),
-	)
 }

--- a/examples/gosx-docs/app/docs/scene3d-vs-threejs/page.gsx
+++ b/examples/gosx-docs/app/docs/scene3d-vs-threejs/page.gsx
@@ -1,5 +1,7 @@
 package docs
 
+import ui "../../ui"
+
 func Page() Node {
 	return <div>
 		<section id="summary">
@@ -11,10 +13,10 @@ func Page() Node {
 				If you want the short answer: three.js covers far more of browser 3D rendering, while Scene3D integrates a typed scene model with server rendering, routing, signals, hubs, capability verdicts, and browser-free tooling. Compare bytes from the exact applications you would ship.
 			</p>
 			<div class="vs-stat-row">
-				{StatCard("Typed Go", "scene authoring and lowering")}
-				{StatCard("3", "browser rendering backends")}
-				{StatCard("glTF 2.0", "the focused model-loader contract")}
-				{StatCard("Per route", "manifest-backed byte accounting")}
+				<ui.StatCard Value="Typed Go" Label="scene authoring and lowering" />
+				<ui.StatCard Value="3" Label="browser rendering backends" />
+				<ui.StatCard Value="glTF 2.0" Label="the focused model-loader contract" />
+				<ui.StatCard Value="Per route" Label="manifest-backed byte accounting" />
 			</div>
 		</section>
 		<section id="overlap">

--- a/examples/gosx-docs/app/docs/scene3d-vs-threejs/statcard_render_smoke_test.go
+++ b/examples/gosx-docs/app/docs/scene3d-vs-threejs/statcard_render_smoke_test.go
@@ -1,0 +1,44 @@
+package docs
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+)
+
+// TestStatCardSharedCallRendersOriginalMarkup proves the converted call
+// sites (StatCard(...) -> <ui.StatCard Value=... Label=.../>) render the
+// identical markup app/components.go's old hand-built StatCard produced.
+func TestStatCardSharedCallRendersOriginalMarkup(t *testing.T) {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("could not resolve this test file's own path")
+	}
+	page := filepath.Join(filepath.Dir(file), "page.gsx")
+	node, err := route.DefaultFileRenderer(nil, route.FilePage{FilePath: page, Pattern: "/docs/scene3d-vs-threejs"})
+	if err != nil {
+		t.Fatalf("DefaultFileRenderer: %v", err)
+	}
+	html := gosx.RenderHTML(node)
+	// The page.gsx source places each <ui.StatCard/> tag on its own
+	// indented line, so the whitespace between sibling tags is itself a
+	// text node — the same JSX whitespace rule any other multi-line sibling
+	// list in this renderer follows, not something shared-component calls
+	// change. The old hand-built gosx.El(...) call sequence emitted no such
+	// gap, so this checks the shared component's own emitted structure
+	// (each want fragment has no whitespace of its own to collide with)
+	// rather than the exact spacing around the four sibling calls.
+	for _, want := range []string{
+		`<div class="stat-card glass-panel">`,
+		`<span class="stat-card__value">Typed Go</span>`,
+		`<span class="stat-card__label">scene authoring and lowering</span>`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("rendered page did not contain the expected shared StatCard fragment %q; got:\n%s", want, html)
+		}
+	}
+}

--- a/examples/gosx-docs/app/docs/scene3d/page.gsx
+++ b/examples/gosx-docs/app/docs/scene3d/page.gsx
@@ -1,5 +1,7 @@
 package docs
 
+import ui "../../ui"
+
 func Page() Node {
 	return <div>
 		<section id="scene-graph">
@@ -1670,9 +1672,9 @@ func Page() Node {
 				flattens the graph and builds a bounding-volume hierarchy (BVH). Build it once, then trace per ray. It holds a snapshot, so rebuild it after the graph changes.
 			</p>
 			<div class="scene3d-stat-row">
-				{StatCard("58,075 → 1,257 ns", "1,000-node graph, per ray")}
-				{StatCard("107,661 → 560 ns", "10,000-instance mesh, per ray")}
-				{StatCard("1 alloc", "per ray, either path")}
+				<ui.StatCard Value="58,075 → 1,257 ns" Label="1,000-node graph, per ray" />
+				<ui.StatCard Value="107,661 → 560 ns" Label="10,000-instance mesh, per ray" />
+				<ui.StatCard Value="1 alloc" Label="per ray, either path" />
 			</div>
 			{CodeBlock("go", `accel := scene.NewSceneAccelerator(props.Graph, scene.PointThreshold(0.25))
 

--- a/examples/gosx-docs/app/modules.go
+++ b/examples/gosx-docs/app/modules.go
@@ -243,17 +243,19 @@ func defaultDocsBindings(ctx *route.RouteContext, page route.FilePage) route.Fil
 			"docsIndexCurrent":   DocsIndexAriaCurrent(currentPath),
 			"site":               SiteBuildInfo(),
 		},
+		// StatCard, CapabilityTag, and Tooltip are no longer bound here: all
+		// three moved to app/ui/*.gsx (see app/components.go's top-of-file
+		// comment) with no Go-callable adapter left behind, and every
+		// existing StatCard call site moved with it, to
+		// <ui.StatCard Value={...} Label={...}/>. A page that wants one of
+		// the three now imports the shared component directly: import ui
+		// "./ui" (or the matching ../ depth) and <ui.CapabilityTag Label=
+		// "..."/>.
 		Funcs: map[string]any{
-			"CodeBlock":     CodeBlock,
-			"StatCard":      StatCard,
-			"CapabilityTag": CapabilityTag,
-			"Tooltip":       Tooltip,
+			"CodeBlock": CodeBlock,
 		},
 		Components: map[string]any{
-			"CodeBlock":     CodeBlock,
-			"StatCard":      StatCard,
-			"CapabilityTag": CapabilityTag,
-			"Tooltip":       Tooltip,
+			"CodeBlock": CodeBlock,
 		},
 	}
 }

--- a/examples/gosx-docs/app/ui/capabilitytag.gsx
+++ b/examples/gosx-docs/app/ui/capabilitytag.gsx
@@ -1,0 +1,14 @@
+package ui
+
+// CapabilityTagProps is a small tag badge's typed props.
+type CapabilityTagProps struct {
+	Label string
+}
+
+// CapabilityTag renders a small tag badge. It replaces the hand-built
+// gosx.El version in app/components.go; app.CapabilityTag now renders this
+// component through route.RenderProgramComponent, so every existing
+// {CapabilityTag(label)} call site keeps working unchanged.
+component CapabilityTag(props: CapabilityTagProps) {
+	return <span class="cap-tag">{props.Label}</span>
+}

--- a/examples/gosx-docs/app/ui/statcard.gsx
+++ b/examples/gosx-docs/app/ui/statcard.gsx
@@ -1,0 +1,19 @@
+package ui
+
+// StatCardProps is a proof-point stat card's typed props: a headline value
+// and the label under it.
+type StatCardProps struct {
+	Value string
+	Label string
+}
+
+// StatCard renders a proof-point stat card. It replaces the hand-built
+// gosx.El version that used to live in app/components.go; every call site
+// moved from {StatCard(value, label)} to <ui.StatCard Value={value}
+// Label={label}/>.
+component StatCard(props: StatCardProps) {
+	return <div class="stat-card glass-panel">
+		<span class="stat-card__value">{props.Value}</span>
+		<span class="stat-card__label">{props.Label}</span>
+	</div>
+}

--- a/examples/gosx-docs/app/ui/tooltip.gsx
+++ b/examples/gosx-docs/app/ui/tooltip.gsx
@@ -1,0 +1,30 @@
+package ui
+
+// TooltipProps is an accessible tooltip's typed props: the id that
+// associates the trigger with its tooltip text (aria-describedby), and the
+// tooltip's own text content.
+//
+// ID is caller-supplied rather than generated here. The Go version this
+// component replaced generated it from a package-level atomic counter, and
+// a strict component cannot reproduce that: its body may render literals,
+// concatenate them, and select props fields, but it may not call an
+// arbitrary Go function or hold state (see ir's strict-server-expression
+// hint, "use literals or props field selection; compute, index, and call
+// methods before rendering") — a stateful id counter has to run in the
+// caller.
+type TooltipProps struct {
+	ID      string
+	Content string
+}
+
+// Tooltip renders a trigger element with an accessible tooltip overlay.
+// The trigger is the caller's own markup, passed as children — see the
+// shared components design's children contract: children arrive already
+// rendered, in the caller's scope, so this component never needs to know
+// what the trigger looks like, only where the tooltip text attaches to it.
+component Tooltip(props: TooltipProps) {
+	return <span class="tooltip-trigger" aria-describedby={props.ID}>
+		{children}
+		<span id={props.ID} class="tooltip glass-panel" role="tooltip">{props.Content}</span>
+	</span>
+}

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -2032,6 +2032,10 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		return
 	}
 	if l.strictServer && IsComponent(tag) && !strictCallee {
+		if l.isSharedComponentTag(tag) {
+			l.validateSharedComponentCallShape(n, tag, attrs)
+			return
+		}
 		l.errorf(n, "strict server component %s is not renderable; v0.39 strict server components may call only same-file strict components", tag)
 		return
 	}
@@ -2095,6 +2099,51 @@ func (l *lowerer) validateStrictComponentCall(n *gotreesitter.Node, tag string, 
 		}
 	}
 	l.validateStrictCalleeChildren(n, tag, children)
+}
+
+// isSharedComponentTag reports whether tag is a dotted component tag whose
+// alias names a shared (./ or ../ prefixed) import recorded in this file's
+// own Program.Imports (lowerImportSpec runs before any component, so
+// l.prog.Imports is already complete — see isImportAlias's doc comment for
+// the same guarantee).
+//
+// This is a purely syntactic, file-local signal. Lower performs no file
+// I/O — the LSP runs it synchronously on every keystroke with no debounce,
+// so adding I/O here would be paid per keystroke (shared components design,
+// section 6) — so this function can say only that the call SHAPE reaches
+// through a shared import, never that the target directory actually
+// declares a matching strict component. gosx check (strictcheck) resolves
+// the target directory and proves that, through the real Go compiler.
+func (l *lowerer) isSharedComponentTag(tag string) bool {
+	alias, _, ok := SplitMemberTag(tag)
+	if !ok {
+		return false
+	}
+	for _, imp := range l.prog.Imports {
+		if imp.Alias == alias {
+			return IsSharedImportPath(imp.Path)
+		}
+	}
+	return false
+}
+
+// validateSharedComponentCallShape proves call SHAPE only for a shared
+// (./ or ../ prefixed) import call: single spread versus named attributes,
+// the one rule every strict callee answers to regardless of where its body
+// lives (singleSpreadShape). It never inspects the target directory's
+// declared props — Lower has no way to read them (see isSharedComponentTag)
+// — so a named-attribute call always passes here; gosx check proves field
+// names and types against the target's real Go declaration, and the file
+// renderer re-proves spread coverage at the render boundary
+// (strictSpreadProps), exactly as it already does for a same-file strict
+// callee.
+func (l *lowerer) validateSharedComponentCallShape(n *gotreesitter.Node, tag string, attrs []Attr) {
+	if !attrHasSpread(attrs) {
+		return
+	}
+	if _, ok := singleSpreadShape(attrs); !ok {
+		l.errorf(n, "shared component call %s accepts at most one spread attribute and no other attributes", tag)
+	}
 }
 
 // validateStrictCalleeChildren is the ONE arity rule for children at a callee

--- a/ir/shared_import.go
+++ b/ir/shared_import.go
@@ -1,0 +1,26 @@
+package ir
+
+import "strings"
+
+// IsSharedImportPath reports whether path is a shared import per the shared
+// components design: a "./"- or "../"-prefixed relative directory
+// reference, never a legal Go import path in module mode. It is the ir-side
+// twin of transpile's unexported isSharedImportPath — duplicated rather
+// than shared, because ir cannot import transpile (transpile already
+// imports ir) and the rule itself is a two-line string check unlikely to
+// drift.
+func IsSharedImportPath(path string) bool {
+	return strings.HasPrefix(path, "./") || strings.HasPrefix(path, "../")
+}
+
+// SplitMemberTag splits a dotted component tag ("ui.TeamMark") into its
+// alias ("ui") and component ("TeamMark") segments. It is the ir-side twin
+// of transpile's unexported splitMemberTag; see IsSharedImportPath's doc
+// comment for why the two packages each carry their own copy.
+func SplitMemberTag(tag string) (alias, component string, ok bool) {
+	parts := strings.Split(tag, ".")
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", "", false
+	}
+	return parts[0], parts[1], true
+}

--- a/route/filelayout.go
+++ b/route/filelayout.go
@@ -288,6 +288,19 @@ type fileRenderOptions struct {
 	// entry's data comes from ctx.Data and a DataLoader, not a Go-typed
 	// caller. See renderFileProgramHTML's strict-entry branch.
 	EntryProps any
+	// SourceDir is the absolute directory of the .gsx file being rendered.
+	// A shared (./ or ../ prefixed) import resolves relative to it — see
+	// writeSharedComponent. ir.Program carries no reliable directory of its
+	// own at render time (Program.Dir is empty unless the build pipeline
+	// sets it, and the compiled-program cache keys on content hash alone,
+	// so two files with byte-identical content could share one cached
+	// Program and one wrong Dir — see loadCachedGSXProgram), so this field
+	// is how renderGSXFile threads the one directory it actually knows.
+	// Empty for a program rendered through RenderProgramComponent, which
+	// has no file path of its own to set it from: a shared call inside such
+	// a program fails clearly at render time rather than resolving against
+	// the wrong directory.
+	SourceDir string
 }
 
 func renderFileNode(path string, opts fileRenderOptions) (gosx.Node, error) {
@@ -327,6 +340,13 @@ func renderGSXFile(path string, opts fileRenderOptions, scopeID string) (gosx.No
 	if err != nil {
 		return gosx.Node{}, err
 	}
+
+	// opts.SourceDir resolves a shared (./ or ../ prefixed) import; see
+	// writeSharedComponent and fileRenderOptions.SourceDir's doc comment.
+	// path is absolute here (every caller of renderFileNode already resolves
+	// one — FileLayoutWithOptionsAndRegistry, and the file router's own page
+	// resolution), so filepath.Dir needs no further Abs call.
+	opts.SourceDir = filepath.Dir(path)
 
 	htmlOut, replaced, err := renderFileProgramHTML(prog, component, opts)
 	if err != nil {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -273,6 +273,10 @@ func (r *fileProgramRenderer) writeComponent(b *strings.Builder, node *ir.Node, 
 		return
 	}
 
+	if r.writeSharedComponent(b, node, env) {
+		return
+	}
+
 	if comp, ok := r.components[node.Tag]; ok {
 		switch {
 		case comp.IsIsland:

--- a/route/shared_component.go
+++ b/route/shared_component.go
@@ -1,0 +1,167 @@
+package route
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
+)
+
+// sharedComponentTarget is one shared call's resolved target: the
+// ir.Program that owns the component's BODY, and the ir.Component itself.
+// writeLocalComponentWithChildren's own doc comment states why both travel
+// together — a node ID means nothing outside the Nodes slice that owns it,
+// so the renderer that executes comp.Root must be the one bound to prog.
+type sharedComponentTarget struct {
+	prog *ir.Program
+	comp *ir.Component
+}
+
+// loadSharedDirComponents compiles every .gsx file in dir through the same
+// stat-keyed cache (loadCachedGSXProgram) a file-routed page renders
+// through, and returns every STRICT component any of them declares, keyed
+// by name. Only files whose package clause matches the alphabetically
+// first .gsx file's package are included, mirroring
+// transpile.LoadPackageDir's "one file selects the package" rule — the
+// check seam (strictcheck) and this render seam must resolve the identical
+// shared directory to the identical component set, or a call gosx check
+// proved could render differently than it checked.
+//
+// No aggregate cache sits in front of this scan. It runs one os.ReadDir
+// plus one loadCachedGSXProgram call per file in dir — the expensive part
+// (parse and lower) is already cached there and skipped when a file is
+// unchanged — on every render that reaches a shared call. That keeps a
+// shared directory's hot-reload behavior identical to a page's own: add,
+// edit, or remove a file under app/ui and the very next render sees it,
+// with no second, harder-to-invalidate cache layer sitting in front of the
+// first one.
+func loadSharedDirComponents(dir string) (map[string]sharedComponentTarget, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read shared directory %s: %w", dir, err)
+	}
+	var names []string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".gsx") {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	if len(names) == 0 {
+		return nil, fmt.Errorf("shared directory %s has no .gsx files", dir)
+	}
+	sort.Strings(names)
+
+	targets := make(map[string]sharedComponentTarget)
+	targetPackage := ""
+	for i, name := range names {
+		path := filepath.Join(dir, name)
+		prog, err := loadCachedGSXProgram(path)
+		if err != nil {
+			return nil, fmt.Errorf("compile %s: %w", path, err)
+		}
+		if i == 0 {
+			targetPackage = prog.Package
+		} else if prog.Package != targetPackage {
+			continue
+		}
+		for c := range prog.Components {
+			comp := &prog.Components[c]
+			if comp.Syntax != ir.ComponentSyntaxStrict {
+				continue
+			}
+			if _, exists := targets[comp.Name]; exists {
+				// First declaration wins, in sorted file order — a defensive
+				// tie-break for a same-named strict component declared twice
+				// in one shared directory. gosx check independently rejects a
+				// same-package Go redeclaration (validatePackageDeclCollisions'
+				// sibling stage) long before a render ever reaches this.
+				continue
+			}
+			targets[comp.Name] = sharedComponentTarget{prog: prog, comp: comp}
+		}
+	}
+	return targets, nil
+}
+
+// writeSharedComponent renders a call through a shared (./ or ../ prefixed)
+// import: <alias.Component .../>. It resolves the target directory
+// relative to r's own source file (opts.SourceDir) — the one piece of I/O
+// ir.Lower cannot perform on the LSP's per-keystroke path (see
+// isSharedComponentTag's doc comment in package ir); the file renderer runs
+// once per request, not once per keystroke, so the cost is acceptable here.
+//
+// PR #246 gave every strict component a variadic children parameter, and
+// set writeLocalComponentWithChildren's contract: render children on the
+// PARENT renderer (r, which owns the call node), then hand the finished
+// node to a renderer bound to the CALLEE's own ir.Program. This function is
+// that contract's shared-call implementation.
+//
+// It reports handled=false only for a tag that names no shared import at
+// all, so writeComponent's existing dispatch chain (builtins, bound
+// components, the unresolved-tag fallback) continues past it unchanged.
+// Once a tag IS a shared call, every failure from here on sets r.err and
+// reports handled=true — a shared call that fails never falls through to
+// defaultRenderedComponent's placeholder markup, the same fail-closed
+// contract a same-file strict call already has.
+func (r *fileProgramRenderer) writeSharedComponent(b *strings.Builder, node *ir.Node, env fileRenderEnv) bool {
+	alias, name, ok := ir.SplitMemberTag(node.Tag)
+	if !ok {
+		return false
+	}
+	rawPath := ""
+	isShared := false
+	for _, imp := range r.prog.Imports {
+		if imp.Alias == alias {
+			isShared = ir.IsSharedImportPath(imp.Path)
+			rawPath = imp.Path
+			break
+		}
+	}
+	if !isShared {
+		return false
+	}
+	if strings.TrimSpace(r.opts.SourceDir) == "" {
+		r.err = fmt.Errorf("render shared component %s: no source directory available to resolve %q; shared components render only through the file router", node.Tag, rawPath)
+		return true
+	}
+	targetDir := filepath.Clean(filepath.Join(r.opts.SourceDir, rawPath))
+	targets, err := loadSharedDirComponents(targetDir)
+	if err != nil {
+		r.err = fmt.Errorf("render shared component %s: %w", node.Tag, err)
+		return true
+	}
+	target, ok := targets[name]
+	if !ok {
+		r.err = fmt.Errorf("render shared component %s: %s declares no strict component named %s", node.Tag, rawPath, name)
+		return true
+	}
+	// Fail closed instead of truncating silently, the same guarantee
+	// validateStrictCalleeChildren proves for a same-file call at compile
+	// time. ir.Lower cannot prove this for a shared call (no I/O — see
+	// isSharedComponentTag), and the Go compiler cannot catch it either
+	// (every strict component projects a variadic children parameter that
+	// accepts zero or more arguments unconditionally — see CHANGELOG
+	// "every strict component projects a variadic children parameter"), so
+	// this render-time check is where the shared call's own AcceptsChildren
+	// finally gets proved, the first point that ever loads the target's
+	// real ir.Component.
+	if len(node.Children) > 0 && !target.comp.AcceptsChildren {
+		r.err = fmt.Errorf("render shared component %s: %s renders no children; remove the child content or render {children} in %s's body", node.Tag, node.Tag, name)
+		return true
+	}
+	childrenNode := gosx.RawHTML(r.renderChildren(node.Children, env))
+	child := newFileProgramRenderer(target.prog, fileRenderOptions{Profile: r.opts.Profile})
+	child.writeLocalComponentWithChildren(b, target.comp, node, env, childrenNode)
+	if child.err != nil {
+		r.err = child.err
+	}
+	if child.replaced {
+		r.replaced = true
+	}
+	return true
+}

--- a/route/shared_component_test.go
+++ b/route/shared_component_test.go
@@ -1,0 +1,158 @@
+package route
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// TestDefaultFileRendererExecutesSharedComponentCall is the render-seam
+// proof: the shared components design's own headline example (import ui
+// "./ui"; <ui.TeamMark Tone={props.Tone}/>) reached from a strict caller,
+// asserted on RENDERED OUTPUT BYTES — not merely a successful compile. A
+// fixture in this repo once compiled a broken pattern without rendering it
+// and thereby certified the exact pattern that took a production app down
+// twice; asserting only "renders without error" would repeat that mistake.
+func TestDefaultFileRendererExecutesSharedComponentCall(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "ui/team_mark.gsx", `package app
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+`)
+	writeRouteFile(t, root, "page.gsx", `package app
+
+import ui "./ui"
+
+component Page() {
+	return <div><ui.TeamMark Tone="home" Abbreviation="NE"/></div>
+}
+`)
+
+	node, err := DefaultFileRenderer(nil, FilePage{FilePath: filepath.Join(root, "page.gsx"), Pattern: "/"})
+	if err != nil {
+		t.Fatalf("DefaultFileRenderer: %v", err)
+	}
+	html := gosx.RenderHTML(node)
+	want := `<div><span class="team-mark tone-home">NE</span></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestDefaultFileRendererExecutesSharedComponentCallWithChildren covers the
+// PR #246 contract (writeSharedComponent renders children on the parent
+// renderer, then calls writeLocalComponentWithChildren on a renderer bound
+// to the shared target's own ir.Program) with rendered output bytes: the
+// caller's <p> markup must appear inside the shared Panel's own <section>,
+// proving the two-renderer split actually threads the finished node across.
+func TestDefaultFileRendererExecutesSharedComponentCallWithChildren(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "ui/panel.gsx", `package app
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2 class="panel__title">{props.Title}</h2><div class="panel__body">{children}</div></section>
+}
+`)
+	writeRouteFile(t, root, "page.gsx", `package app
+
+import ui "./ui"
+
+component Page() {
+	return <ui.Panel Title="Standings"><p>caller markup</p></ui.Panel>
+}
+`)
+
+	node, err := DefaultFileRenderer(nil, FilePage{FilePath: filepath.Join(root, "page.gsx"), Pattern: "/"})
+	if err != nil {
+		t.Fatalf("DefaultFileRenderer: %v", err)
+	}
+	html := gosx.RenderHTML(node)
+	want := `<section><h2 class="panel__title">Standings</h2><div class="panel__body"><p>caller markup</p></div></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestDefaultFileRendererRejectsSharedComponentChildrenWhenUnsupported
+// proves the render seam's own fail-closed guarantee: a shared callee that
+// does not place {children} refuses child content instead of silently
+// dropping it — ir.Lower cannot prove this for a shared call (no I/O), and
+// the Go compiler cannot catch it either (every strict component projects
+// a variadic children parameter that accepts any number of arguments), so
+// this is the one point that ever proves it.
+func TestDefaultFileRendererRejectsSharedComponentChildrenWhenUnsupported(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "ui/badge.gsx", `package app
+
+type BadgeProps struct {
+	Label string
+}
+
+component Badge(props: BadgeProps) {
+	return <span>{props.Label}</span>
+}
+`)
+	writeRouteFile(t, root, "page.gsx", `package app
+
+import ui "./ui"
+
+component Page() {
+	return <ui.Badge Label="new"><b>unexpected</b></ui.Badge>
+}
+`)
+
+	_, err := DefaultFileRenderer(nil, FilePage{FilePath: filepath.Join(root, "page.gsx"), Pattern: "/"})
+	if err == nil {
+		t.Fatalf("DefaultFileRenderer succeeded for children at a shared callee that renders none")
+	}
+	if !strings.Contains(err.Error(), "renders no children") {
+		t.Fatalf("error = %v, want a message naming the renders-no-children rule", err)
+	}
+}
+
+// TestDefaultFileRendererRejectsUnknownSharedComponent proves a shared call
+// naming a component the target directory does not declare fails clearly
+// at render time rather than falling back to the unresolved-tag
+// placeholder markup (defaultRenderedComponent).
+func TestDefaultFileRendererRejectsUnknownSharedComponent(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "ui/team_mark.gsx", `package app
+
+type TeamMarkProps struct {
+	Tone string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}></span>
+}
+`)
+	writeRouteFile(t, root, "page.gsx", `package app
+
+import ui "./ui"
+
+component Page() {
+	return <div><ui.Missing/></div>
+}
+`)
+
+	_, err := DefaultFileRenderer(nil, FilePage{FilePath: filepath.Join(root, "page.gsx"), Pattern: "/"})
+	if err == nil {
+		t.Fatalf("DefaultFileRenderer succeeded for a shared component the target directory does not declare")
+	}
+	if !strings.Contains(err.Error(), "declares no strict component named Missing") {
+		t.Fatalf("error = %v, want a message naming the missing component", err)
+	}
+}

--- a/strictcheck/check.go
+++ b/strictcheck/check.go
@@ -156,7 +156,16 @@ func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts O
 	if err != nil {
 		return err
 	}
-	generated, err := transpile.TranspilePackageWithImportNames(files, importNames)
+	// resolveSharedImports loads every shared (./ or ../ prefixed) import
+	// files declares — the directory walk and real Go import path
+	// TranspilePackageWithImportNames's package.go doc comment describes as
+	// "the intended producer" of transpile.SharedImport. A package with no
+	// shared import gets nil back and nothing below changes.
+	sharedImports, sharedOverlay, err := resolveSharedImports(ctx, files, opts, root)
+	if err != nil {
+		return err
+	}
+	generated, err := transpile.TranspilePackageWithSharedImports(files, importNames, sharedImports)
 	if err != nil {
 		return err
 	}
@@ -170,7 +179,7 @@ func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts O
 	if err := validatePackageDeclCollisions(files, generated); err != nil {
 		return err
 	}
-	return goCheck(ctx, files, generated, opts)
+	return goCheck(ctx, files, generated, sharedOverlay, opts)
 }
 
 func validateStrictRenderEntries(files []transpile.PackageFile) error {
@@ -264,8 +273,18 @@ func resolveImportNames(ctx context.Context, files []transpile.PackageFile, opts
 	return names, nil
 }
 
-func goCheck(ctx context.Context, files []transpile.PackageFile, generated map[string]string, opts Options) error {
-	if len(files) == 0 || len(generated) == 0 {
+// goCheck type-checks files' own projection through the real Go compiler,
+// over an overlay that also carries every shared import's target directory
+// (sharedOverlay, from resolveSharedImports): a virtual .go path already
+// resolved to live inside the TARGET's own real directory, mapped to that
+// target file's generated Go text. Placing those virtual files there — not
+// beside files' own projection — is what lets `go list` resolve the
+// target's real Go import path and the caller's rewritten import statement
+// (transpile.emitImportDeclaration) actually resolve against real
+// declarations, exactly as if the target directory had been `gosx check`ed
+// on its own first.
+func goCheck(ctx context.Context, files []transpile.PackageFile, generated map[string]string, sharedOverlay map[string]string, opts Options) error {
+	if len(files) == 0 || (len(generated) == 0 && len(sharedOverlay) == 0) {
 		return nil
 	}
 	dir := filepath.Dir(files[0].Path)
@@ -280,8 +299,8 @@ func goCheck(ctx context.Context, files []transpile.PackageFile, generated map[s
 		sourcePaths = append(sourcePaths, sourcePath)
 	}
 	sort.Strings(sourcePaths)
-	overlay := make(map[string]string, len(sourcePaths))
-	usedVirtual := make(map[string]struct{}, len(sourcePaths))
+	overlay := make(map[string]string, len(sourcePaths)+len(sharedOverlay))
+	usedVirtual := make(map[string]struct{}, len(sourcePaths)+len(sharedOverlay))
 	for i, sourcePath := range sourcePaths {
 		tempPath := filepath.Join(tempDir, "projection_"+strconv.Itoa(i)+".go")
 		if err := os.WriteFile(tempPath, []byte(generated[sourcePath]), 0o600); err != nil {
@@ -289,6 +308,18 @@ func goCheck(ctx context.Context, files []transpile.PackageFile, generated map[s
 		}
 		virtual := uniqueVirtualGoPath(dir, i, usedVirtual)
 		usedVirtual[virtual] = struct{}{}
+		overlay[virtual] = tempPath
+	}
+	sharedVirtualPaths := make([]string, 0, len(sharedOverlay))
+	for virtual := range sharedOverlay {
+		sharedVirtualPaths = append(sharedVirtualPaths, virtual)
+	}
+	sort.Strings(sharedVirtualPaths)
+	for i, virtual := range sharedVirtualPaths {
+		tempPath := filepath.Join(tempDir, "shared_"+strconv.Itoa(i)+".go")
+		if err := os.WriteFile(tempPath, []byte(sharedOverlay[virtual]), 0o600); err != nil {
+			return err
+		}
 		overlay[virtual] = tempPath
 	}
 	overlayPath := filepath.Join(tempDir, "overlay.json")

--- a/strictcheck/shared.go
+++ b/strictcheck/shared.go
@@ -1,0 +1,170 @@
+package strictcheck
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/transpile"
+)
+
+// resolveSharedImports discovers every shared (./ or ../ prefixed) import
+// files declares, loads each target directory, and returns the map
+// TranspilePackageWithSharedImports needs to project a shared call
+// (transpile.SharedImport, keyed by the raw import path text — see
+// transpile/package.go's SharedImport doc comment, which names this
+// function as "the intended producer"), alongside every shared target's own
+// generated Go text, keyed by a virtual .go path already resolved to sit
+// inside that target's own real directory (see goCheck).
+//
+// A package with no shared import returns (nil, nil, nil): every existing
+// call path is unaffected byte-for-byte.
+//
+// gosx build copies only app/, content/, and public/ into the deployment
+// bundle (cmd/gosx's stageDeploymentBundle). A shared import resolving
+// outside root's app/ directory would type-check here and then not ship —
+// this rejects that case with a diagnostic naming the import, the file that
+// declared it, and the resolved (and expected) directories, rather than
+// leaving it to fail once the built binary tries to render it in
+// production.
+func resolveSharedImports(ctx context.Context, files []transpile.PackageFile, opts Options, root string) (map[string]transpile.SharedImport, map[string]string, error) {
+	if len(files) == 0 {
+		return nil, nil, nil
+	}
+	rawPaths := collectSharedImportPaths(files)
+	if len(rawPaths) == 0 {
+		return nil, nil, nil
+	}
+	dir := filepath.Dir(files[0].Path)
+
+	var appRoot, modulePath string
+	if root != "" {
+		appRoot = filepath.Join(root, "app")
+		// A "" modulePath (go.mod missing, unreadable, or carrying no module
+		// directive) is not fatal by itself here — the per-import loop below
+		// reports it only once it actually needs a Go import path, so a
+		// package with shared imports that all happen to fail the app/ check
+		// first reports THAT diagnostic instead.
+		modulePath, _ = readModulePath(root)
+	}
+
+	sharedImports := make(map[string]transpile.SharedImport, len(rawPaths))
+	overlay := make(map[string]string)
+	usedVirtual := make(map[string]struct{})
+	virtualIndex := 0
+
+	for _, rawPath := range rawPaths {
+		targetDir := filepath.Clean(filepath.Join(dir, rawPath))
+		if appRoot != "" && !withinDir(appRoot, targetDir) {
+			return nil, nil, fmt.Errorf("shared import %q in %s resolves to %s, outside %s; gosx build stages only app/, content/, and public/ into the deployment bundle, so a shared component directory must live under app/", rawPath, dir, targetDir, appRoot)
+		}
+		targetFiles, err := transpile.LoadPackageDir(targetDir)
+		if err != nil {
+			return nil, nil, fmt.Errorf("shared import %q in %s: %w", rawPath, dir, err)
+		}
+		targetImportNames, err := resolveImportNames(ctx, targetFiles, opts)
+		if err != nil {
+			return nil, nil, fmt.Errorf("shared import %q in %s: %w", rawPath, dir, err)
+		}
+		// No recursion: a shared target's OWN shared imports (a nested "./"
+		// import inside app/ui, for example) are not resolved here. Nothing
+		// in the shared components design v1 scope requires it, and every
+		// real caller today is one directory deep (design section 1.2's own
+		// headline example). A shared directory that itself imports another
+		// shared directory fails the same way an unresolved shared import
+		// always has: errUnresolvedSharedCall's message naming gosx check.
+		targetGenerated, err := transpile.TranspilePackageWithSharedImports(targetFiles, targetImportNames, nil)
+		if err != nil {
+			return nil, nil, fmt.Errorf("shared import %q in %s: %w", rawPath, dir, err)
+		}
+		if modulePath == "" {
+			return nil, nil, fmt.Errorf("shared import %q in %s: cannot resolve a Go import path for %s without a readable go.mod module directive at %s", rawPath, dir, targetDir, root)
+		}
+		rel, err := filepath.Rel(root, targetDir)
+		if err != nil {
+			return nil, nil, fmt.Errorf("shared import %q in %s: %w", rawPath, dir, err)
+		}
+		goImportPath := path.Join(modulePath, filepath.ToSlash(rel))
+
+		for _, text := range targetGenerated {
+			virtual := uniqueVirtualGoPath(targetDir, virtualIndex, usedVirtual)
+			usedVirtual[virtual] = struct{}{}
+			overlay[virtual] = text
+			virtualIndex++
+		}
+
+		sharedImports[rawPath] = transpile.SharedImport{
+			GoImportPath: goImportPath,
+			Components:   transpile.CollectSharedComponents(targetFiles),
+		}
+	}
+
+	return sharedImports, overlay, nil
+}
+
+// collectSharedImportPaths returns every distinct shared (./ or ../
+// prefixed) import path files declares, sorted for a deterministic
+// resolution order (and therefore a deterministic first diagnostic when
+// more than one shared import fails).
+func collectSharedImportPaths(files []transpile.PackageFile) []string {
+	seen := make(map[string]struct{})
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		for _, imp := range file.Program.Imports {
+			if ir.IsSharedImportPath(imp.Path) {
+				seen[imp.Path] = struct{}{}
+			}
+		}
+	}
+	if len(seen) == 0 {
+		return nil
+	}
+	paths := make([]string, 0, len(seen))
+	for p := range seen {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	return paths
+}
+
+// withinDir reports whether target is rootDir itself or a descendant of it.
+func withinDir(rootDir, target string) bool {
+	rootDir = filepath.Clean(rootDir)
+	target = filepath.Clean(target)
+	if rootDir == target {
+		return true
+	}
+	rel, err := filepath.Rel(rootDir, target)
+	if err != nil {
+		return false
+	}
+	return rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator))
+}
+
+// readModulePath reads the module directive from root/go.mod. It is a
+// deliberately minimal parse — the first "module " line, trimmed — rather
+// than a dependency on golang.org/x/mod/modfile: within one's own module, a
+// directory's Go import path is always modulePath + its path relative to
+// the module root, regardless of any replace or vendor directive (those
+// affect how OTHER modules resolve, not paths inside this one), so nothing
+// past the module line is needed here.
+func readModulePath(root string) (string, error) {
+	data, err := os.ReadFile(filepath.Join(root, "go.mod"))
+	if err != nil {
+		return "", err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		line = strings.TrimSpace(line)
+		if rest, ok := strings.CutPrefix(line, "module "); ok {
+			return strings.TrimSpace(rest), nil
+		}
+	}
+	return "", fmt.Errorf("no module directive in %s", filepath.Join(root, "go.mod"))
+}

--- a/strictcheck/shared_test.go
+++ b/strictcheck/shared_test.go
@@ -1,0 +1,145 @@
+package strictcheck
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// sharedTeamMarkFixture writes the shared components design's own headline
+// example (a strict ui.TeamMark declared in app/ui, called from a strict
+// app/page.gsx) into a fresh test module, and returns the module root and
+// page.gsx's path. Page itself stays zero-props — a strict route render
+// entry may not bind root props (validateStrictRenderEntries) — so the
+// shared call is exercised with literal attribute values, same as this
+// package's other same-file fixtures (see strictFixture).
+func sharedTeamMarkFixture(t *testing.T) (root, page string) {
+	t.Helper()
+	root = newTestModule(t)
+	mustWrite(t, filepath.Join(root, "app", "ui", "team_mark.gsx"), `package ui
+
+type TeamMarkProps struct {
+	Tone         string
+	Abbreviation string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Abbreviation}</span>
+}
+`)
+	page = filepath.Join(root, "app", "page.gsx")
+	mustWrite(t, page, `package main
+
+import ui "./ui"
+
+component Page() {
+	return <div><ui.TeamMark Tone="home" Abbreviation="NE"/></div>
+}
+`)
+	return root, page
+}
+
+// TestCheckFileAcceptsSharedComponentCall is the check-seam proof: a strict
+// caller's shared call — blocked before this change by ir.Lower's
+// same-file gate — now clears gosx check end to end, through the real Go
+// compiler, exactly as a same-file call does.
+func TestCheckFileAcceptsSharedComponentCall(t *testing.T) {
+	_, page := sharedTeamMarkFixture(t)
+	if err := CheckFile(context.Background(), page); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}
+
+// TestCheckFileRejectsSharedComponentFieldTypo proves the check seam's own
+// contribution: a field the shared target does not declare fails through
+// the real Go compiler, not through a silently-accepted call.
+func TestCheckFileRejectsSharedComponentFieldTypo(t *testing.T) {
+	root := newTestModule(t)
+	mustWrite(t, filepath.Join(root, "app", "ui", "team_mark.gsx"), `package ui
+
+type TeamMarkProps struct {
+	Tone string
+}
+
+component TeamMark(props: TeamMarkProps) {
+	return <span class={"team-mark tone-" + props.Tone}>{props.Tone}</span>
+}
+`)
+	page := filepath.Join(root, "app", "page.gsx")
+	mustWrite(t, page, `package main
+
+import ui "./ui"
+
+component Page() {
+	return <div><ui.TeamMark Toneo="home"/></div>
+}
+`)
+	err := CheckFile(context.Background(), page)
+	if err == nil {
+		t.Fatalf("CheckFile succeeded for an unknown field on a shared component")
+	}
+}
+
+// TestCheckFileRejectsSharedImportOutsideAppRoot covers the explicit build
+// constraint: gosx build stages only app/, content/, and public/, so a
+// shared import that resolves outside app/ must fail check with a clear
+// diagnostic instead of shipping a page that 404s on first render.
+func TestCheckFileRejectsSharedImportOutsideAppRoot(t *testing.T) {
+	root := newTestModule(t)
+	mustWrite(t, filepath.Join(root, "sharedlib", "widget.gsx"), `package sharedlib
+
+type WidgetProps struct {
+	Label string
+}
+
+component Widget(props: WidgetProps) {
+	return <span>{props.Label}</span>
+}
+`)
+	page := filepath.Join(root, "app", "page.gsx")
+	mustWrite(t, page, `package main
+
+import sharedlib "../sharedlib"
+
+component Page() {
+	return <div><sharedlib.Widget Label="hi"/></div>
+}
+`)
+	err := CheckFile(context.Background(), page)
+	if err == nil {
+		t.Fatalf("CheckFile succeeded for a shared import outside app/")
+	}
+	if !strings.Contains(err.Error(), "outside") || !strings.Contains(err.Error(), "app") {
+		t.Fatalf("error = %v, want a diagnostic naming the app/ boundary", err)
+	}
+}
+
+// TestCheckFileAcceptsSharedComponentCallWithChildren covers the PR #246
+// contract: a shared call carrying children must clear check the same way
+// a same-file call does.
+func TestCheckFileAcceptsSharedComponentCallWithChildren(t *testing.T) {
+	root := newTestModule(t)
+	mustWrite(t, filepath.Join(root, "app", "ui", "panel.gsx"), `package ui
+
+type PanelProps struct {
+	Title string
+}
+
+component Panel(props: PanelProps) {
+	return <section><h2>{props.Title}</h2><div>{children}</div></section>
+}
+`)
+	page := filepath.Join(root, "app", "page.gsx")
+	mustWrite(t, page, `package main
+
+import ui "./ui"
+
+component Page() {
+	return <ui.Panel Title="Heading"><p>body</p></ui.Panel>
+}
+`)
+	if err := CheckFile(context.Background(), page); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}

--- a/transpile/package.go
+++ b/transpile/package.go
@@ -21,6 +21,33 @@ type PackageFile struct {
 	Program *ir.Program
 }
 
+// LoadPackageDir loads every .gsx file in dir belonging to one package, the
+// way LoadPackage does from a specific file, but from a directory alone —
+// the shape a shared import names (an ordinary directory, e.g. "./ui"), not
+// a specific file. It picks the alphabetically first .gsx file in dir as
+// the package reference and delegates to LoadPackage, so a directory loaded
+// this way and the identical directory loaded by naming one of its files
+// directly can never resolve two different package sets.
+func LoadPackageDir(dir string) ([]PackageFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	var first string
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".gsx") {
+			continue
+		}
+		if first == "" || entry.Name() < first {
+			first = entry.Name()
+		}
+	}
+	if first == "" {
+		return nil, fmt.Errorf("no .gsx files found in %s", dir)
+	}
+	return LoadPackage(filepath.Join(dir, first))
+}
+
 // LoadPackage reads and compiles every .gsx file in the same directory and
 // package as path. The target file selects the package; an alphabetically
 // earlier route helper with a different package can never redirect the load.
@@ -312,8 +339,22 @@ func TranspilePackage(files []PackageFile) (map[string]string, error) {
 }
 
 // TranspilePackageWithImportNames projects a package using package identifiers
-// resolved by the Go tool in the target module/workspace.
+// resolved by the Go tool in the target module/workspace. It carries no
+// shared-import resolution (see TranspilePackageWithSharedImports): a
+// package with no shared import is unaffected either way, and a package
+// that does have one fails closed with errUnresolvedSharedCall's message
+// naming gosx check, exactly as it did before shared imports existed.
 func TranspilePackageWithImportNames(files []PackageFile, importNames map[string]string) (map[string]string, error) {
+	return TranspilePackageWithSharedImports(files, importNames, nil)
+}
+
+// TranspilePackageWithSharedImports projects a package using package
+// identifiers resolved by the Go tool, and resolves every shared (./ or
+// ../ prefixed) import through sharedImports — the map gosx check
+// (strictcheck) builds by loading each shared directory with
+// LoadPackageDir and CollectSharedComponents. A nil or empty sharedImports
+// reproduces TranspilePackageWithImportNames exactly.
+func TranspilePackageWithSharedImports(files []PackageFile, importNames map[string]string, sharedImports map[string]SharedImport) (map[string]string, error) {
 	if err := ValidateStrictPackageBoundaries(files); err != nil {
 		return nil, err
 	}
@@ -327,7 +368,12 @@ func TranspilePackageWithImportNames(files []PackageFile, importNames map[string
 
 	out := make(map[string]string, len(files))
 	for _, file := range files {
-		generated, _, err := StrictProjectionWithImportNames(file, importNames)
+		generated, err := Transpile(file.Source, Options{
+			SourceFile:       file.Path,
+			strictProjection: true,
+			importNames:      importNames,
+			SharedImports:    sharedImports,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("transpile %s: %w", file.Path, err)
 		}


### PR DESCRIPTION
## Summary

Enables strict callers to import and execute shared `.gsx` components via relative imports (`./` or `../`). Previously, `ir.Lower` rejected these calls outright, `gosx check` could not resolve targets, and the file renderer had no execution path. This closes all gaps: LSP validation checks call shape without blocking on I/O, `gosx check` resolves targets through the real Go compiler while enforcing deployment boundaries, and the renderer dynamically compiles and executes the target component on a bound program context. Three legacy hand-built components in the docs site are migrated as a baseline proof.

## Changes

- Lower admits shared calls by shape**: Dotted tags matching a relative import pass validation. Only spread-versus-named-attribute rules are enforced here; field-level proofs remain with `gosx check` to keep the LSP synchronous.
- `gosx check` bridges to the real Go compiler**: Loads shared target directories, overlays their projected Go into virtual paths, and type-checks the caller's rewritten imports against real declarations. Explicitly rejects imports resolving outside `app/` to match `gosx build` staging.
- Renderer executes targets across program boundaries**: Resolves shared directories relative to the source file, compiles `.gsx` files via the stat-keyed cache, and spins up a child renderer bound to the target's `ir.Program`. Threads children through the parent renderer first, failing closed if the callee lacks `{children}`.
- Exported transpile utilities**: Adds `LoadPackageDir` and `TranspilePackageWithSharedImports` to allow cross-package resolution without altering existing API signatures.
- Docs site components migrate to `.gsx`**: `StatCard`, `CapabilityTag`, and `Tooltip` move from raw `gosx.El` builders to typed `.gsx` definitions under `app/ui/`. All call sites update to JSX-style tags, verified by a new render smoke test.

## Testing

- `go test ./ir ./route ./strictcheck ./transpile -v`
- `cd examples/gosx-docs && go test ./... -run TestStatCardSharedCallRendersOriginalMarkup -v`
- `cd examples/gosx-docs && go run ../cmd/gosx/main.go check` (confirms valid shared imports pass and out-of-boundary imports are rejected)