### PR TITLE
fix(transpile): Fix strict projection dropping typed legacy component declarations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## Unreleased
+
+### Fixed: a strict body calling a typed legacy component failed `gosx check`
+
+- **The strict projection now carries a typed legacy component as a signature
+  with a stub body** (gosx#240). That change made the composition legal at
+  lower time and correct at render time, but the projection retained only
+  strict declarations, so the projected Go named a function it did not carry
+  and the Go compiler reported `undefined: <Name>` against the author's own
+  component. Two seams accepted the composition and the third refused it.
+- **The body stays a stub on purpose.** `emitStrictSourceFile` omits legacy
+  bodies because they name `data`, `request`, and application helpers that
+  ordinary Go cannot resolve, and the legacy runtime interprets them later.
+  Only the caller's reference must resolve during the package type check, and
+  a signature carries that. Emitting the real body would reintroduce the
+  unresolvable identifiers the projection exists to avoid.
+- **An untyped legacy component stays omitted.** A strict body cannot call one
+  at all, so no projected reference to it can exist. That call still fails at
+  lower time with the diagnostic that names the remedy, never with a bare
+  undefined-symbol error from the Go compiler.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/strictcheck/strict_calls_typed_legacy_test.go
+++ b/strictcheck/strict_calls_typed_legacy_test.go
@@ -1,0 +1,74 @@
+package strictcheck
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestCheckFileAcceptsStrictCallingTypedLegacy closes the last seam of
+// gosx#240. That change made a strict body calling a TYPED legacy component
+// legal at lower time and correct at render time, but `gosx check` still
+// refused it:
+//
+//	./page.gsx:12: undefined: Chip
+//
+// The strict projection retained only strict declarations, so the projected
+// Go named a function the projection did not carry, and the Go compiler
+// reported an undefined symbol against the author's own component. Two of
+// the three seams accepted the composition and the third refused it, which
+// means the seams disagreed about what the language is.
+//
+// transpile.emitTypedLegacyStub now projects a typed legacy component as a
+// signature with a stub body. The body stays a stub deliberately:
+// emitStrictSourceFile omits legacy bodies because they name data, request,
+// and application helpers that ordinary Go cannot resolve and the legacy
+// runtime interprets later. Only the caller's reference needs to resolve
+// here, and a signature carries that.
+func TestCheckFileAcceptsStrictCallingTypedLegacy(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+type ChipProps struct {
+	Label string
+}
+func Chip(props ChipProps) Node {
+	return <span class="chip">{props.Label}</span>
+}
+component Page() {
+	return <main><Chip Label="hello"/></main>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile rejected a strict body calling a typed legacy component: %v", err)
+	}
+}
+
+// TestCheckFileStillRejectsStrictCallingUntypedLegacy pins the other half.
+// An untyped legacy component must stay out of the projection: a strict body
+// cannot call one at all, so no projected reference to it can exist. The
+// author must get the lower-time diagnostic naming the remedy, never a bare
+// undefined-symbol error from the Go compiler.
+func TestCheckFileStillRejectsStrictCallingUntypedLegacy(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+func Chip(props any) Node {
+	return <span class="chip">{props.label}</span>
+}
+component Page() {
+	return <main><Chip label="hello"/></main>
+}
+`)
+	err := CheckFile(context.Background(), path)
+	if err == nil {
+		t.Fatal("CheckFile accepted a strict body calling an untyped legacy component")
+	}
+	if got := err.Error(); !strings.Contains(got, "strict component cannot call untyped legacy component Chip") {
+		t.Errorf("want the lower-time category diagnostic, got: %v", got)
+	}
+	if got := err.Error(); strings.Contains(got, "undefined: Chip") {
+		t.Errorf("untyped legacy leaked into the Go type check instead of failing at lower time: %v", got)
+	}
+}

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -220,6 +220,31 @@ func (t *transpiler) emitStrictSourceFile(n *gotreesitter.Node) string {
 				declaration = fmt.Sprintf("//line %s:%d\n%s", filepathForLineDirective(t.sourceFile), child.StartPoint().Row+1, declaration)
 			}
 			declarations = append(declarations, declaration)
+		case "function_declaration":
+			// A TYPED legacy component reaches the projection as a signature
+			// with a stub body (gosx#244). A strict body may call one, and
+			// lower time and render time both handle that, but the projection
+			// dropped the declaration entirely — so the Go compiler reported
+			// `undefined: <Name>` against the author's own component and the
+			// composition failed at `gosx check` alone.
+			//
+			// The body is a stub on purpose. This function's own doc comment
+			// records why legacy declarations are omitted: their bodies name
+			// data, request, and application helpers that ordinary Go cannot
+			// resolve, and the legacy runtime interprets them later. Only the
+			// caller's reference needs to type-check here, and a signature
+			// carries that. Emitting the real body would reintroduce exactly
+			// the unresolvable identifiers this projection exists to avoid.
+			//
+			// An UNTYPED legacy component stays omitted: a strict body cannot
+			// call one at all (ir.Lower rejects it with its own diagnostic),
+			// so no projected reference to it can exist.
+			if stub := t.emitTypedLegacyStub(child); stub != "" {
+				if t.sourceFile != "" {
+					stub = fmt.Sprintf("//line %s:%d\n%s", filepathForLineDirective(t.sourceFile), child.StartPoint().Row+1, stub)
+				}
+				declarations = append(declarations, stub)
+			}
 		}
 	}
 
@@ -744,6 +769,51 @@ func (t *transpiler) emitStrictComponent(n *gotreesitter.Node) string {
 	t.strict--
 	t.currentPropsType = prevPropsType
 	return "func " + t.text(nameNode) + "(" + params + ") " + t.gosxRef("Node") + " " + body
+}
+
+// emitTypedLegacyStub projects a typed legacy component as a signature with a
+// stub body, so a strict caller's reference to it resolves during the package
+// type check. It returns "" for anything that is not a typed legacy component,
+// which leaves the declaration omitted exactly as before.
+//
+// A typed legacy component is a legacy func whose props parameter names a
+// struct declared in this same file — the same rule ir.Lower applies when it
+// sets ir.Component.PropsTyped. propsFields carries every same-file struct, so
+// membership there is the same-file test.
+//
+// The signature mirrors emitStrictComponent's exactly, variadic children
+// included, so a strict call site projects to one call shape whichever category
+// it resolves to. A variadic parameter accepts zero arguments, so a childless
+// call still matches.
+func (t *transpiler) emitTypedLegacyStub(funcDecl *gotreesitter.Node) string {
+	nameNode := t.childByField(funcDecl, "name")
+	if nameNode == nil {
+		return ""
+	}
+	name := t.text(nameNode)
+	if !isComponent(name) {
+		return ""
+	}
+	// Only a strict component in this same file can reference the stub, and
+	// resolveGoSXQualifier sets injectGosx from hasStrict — so without a
+	// strict declaration here there is no caller to serve and no gosx import
+	// to qualify the signature's Node type against. Emitting anyway produced
+	// `undefined: gosx` for a file carrying only a props-bearing legacy
+	// island, which reaches this projection because a sibling file in its
+	// package is strict.
+	if !t.hasStrict {
+		return ""
+	}
+	propsType := t.propsTypes[name]
+	if propsType == "" {
+		return ""
+	}
+	if _, sameFile := t.propsFields[propsType]; !sameFile {
+		return ""
+	}
+	node := t.gosxRef("Node")
+	params := "props " + propsType + ", " + strictcomponent.ChildrenBinding + " ..." + node
+	return "func " + name + "(" + params + ") " + node + " { return " + node + "{} }"
 }
 
 func (t *transpiler) extractPropsType(funcDecl *gotreesitter.Node) string {


### PR DESCRIPTION
## Summary

Updates the strict projection to carry typed legacy component declarations as signatures with stub bodies, resolving `undefined` compilation errors when a strict body calls one. Untyped legacy components remain omitted to preserve lower-time diagnostics.

## Changes

- Add `function_declaration` handling in `emitStrictSourceFile` to capture typed legacy components.
- Implement `emitTypedLegacyStub` to project a typed legacy component as a signature with a minimal stub body, allowing the caller's reference to resolve during package type checking.
- Guard stub emission to ensure a strict component exists in the file and the props struct is local, avoiding unnecessary exports or missing imports.
- Deliberately omit legacy runtime identifiers from stub bodies to prevent unresolvable symbol errors; callers only need the signature.
- Keep untyped legacy components excluded from the projection so invocations fail at lower time with the specific diagnostic rather than a generic undefined error.
- Add integration tests validating acceptance of strict calls to typed legacy components and continued rejection of calls to untyped legacy components.

## Testing

- `go test ./transpile/... ./strictcheck/...`
- Run `gosx check` on a `.gsx` file with a strict component calling a typed legacy component; verify successful type-checking.
- Confirm that a strict component calling an untyped legacy component yields the "strict component cannot call untyped legacy component" diagnostic.

## Related Issues

- Refs #240
- Refs #244