### PR TITLE
add: typed root props for file-routed strict Page entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,41 @@
 # Changelog
 
+## Unreleased
+
+### Added: a strict file-routed Page/not-found/error entry can declare typed root props
+
+- **`component Page(props: PageProps)` now renders its file module's own
+  `Load` return value as typed, proven props** (gosx#248). Before this
+  change, a strict render entry that declared props always failed to
+  render: the file renderer had no root props binding. A zero-props strict
+  entry could compile, but could not read its own loader's data either —
+  `data`, `request`, and `params` stay legacy-only reflective bindings, so a
+  strict page had no supported way to use `Load`'s result at all.
+- `renderFilePage` (`route/filesystem.go`) now passes `ctx.Data` — set from
+  this page's own `Load` hook before it renders — as `EntryProps` to
+  `renderFileNode`. A legacy (non-strict) entry never reads `EntryProps`, so
+  this changes nothing for it: it stays byte-identical.
+- The typed value is proved through `strictSpreadProps`, the exact boundary
+  a nested `<Component {...props}/>` call already runs on every render: the
+  reflect kind must be exactly `Struct`, and every rendered field is
+  re-checked against its declared leaf type.
+- A `Load` hook that returns `map[string]any` — every existing app's
+  shape — now fails closed with a message naming the component, its
+  declared props type, and what to return instead of a map. It never
+  silently coerces the map into a struct. A `Load` hook that returns the
+  wrong struct type, or one missing a rendered field, also fails closed,
+  and the message names the file and the component, not just the mismatch.
+- `strictcheck.CheckFile`'s blanket refusal of a props-bearing strict
+  render entry is narrowed to what the render path actually cannot bind: a
+  `layout.gsx` entry. No code path calls a layout's own module's `Load`
+  hook, so a layout's `EntryProps` is always `nil`; a Page, index,
+  not-found, or error entry can bind them and now passes this check.
+- `examples/dashboard/app/page.gsx`'s root page converts to
+  `component Page(props: PageProps)`, reading its existing `Load` hook's
+  data through typed props instead of the `data` binding. Its rendered
+  output is byte-identical to the pre-conversion legacy page (see
+  `TestDashboardRootPageStrictPropsMatchLegacyBytes`).
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -569,16 +569,27 @@ func TestRunBuildStrictGateRunsBeforeDistWrites(t *testing.T) {
 	}
 }
 
-func TestRunBuildRejectsPropsBearingStrictEntryBeforeDistWrites(t *testing.T) {
+// TestRunBuildRejectsPropsBearingStrictLayoutEntryBeforeDistWrites proves
+// the narrowed gate (gosx#248) still refuses a props-bearing strict layout
+// before any dist write: no code path calls a layout's own module's Load
+// hook, so a layout's EntryProps is always nil. A props-bearing strict Page
+// entry, by contrast, now passes this gate — see route/fileprogram_test.go
+// and examples/basic for the render-time proof.
+func TestRunBuildRejectsPropsBearingStrictLayoutEntryBeforeDistWrites(t *testing.T) {
 	dir := newInvalidStrictStarter(t, "build-root-props-gate")
 	mustWriteFile(t, filepath.Join(dir, "app", "page.gsx"), `package app
-type PageProps struct { Title string }
-component Page(props: PageProps) {
+component Page() {
+	return <main>ok</main>
+}
+`)
+	mustWriteFile(t, filepath.Join(dir, "app", "layout.gsx"), `package app
+type LayoutProps struct { Title string }
+component Layout(props: LayoutProps) {
 	return <main>{props.Title}</main>
 }
 `)
 	err := RunBuild(dir, false)
-	if err == nil || !strings.Contains(err.Error(), "file routes do not bind root props") {
+	if err == nil || !strings.Contains(err.Error(), "layout has no Load hook wired to its own root props") {
 		t.Fatalf("RunBuild error = %v", err)
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "dist")); !os.IsNotExist(statErr) {

--- a/cmd/gosx/check_test.go
+++ b/cmd/gosx/check_test.go
@@ -101,12 +101,18 @@ component Page(props: Props) {
 	}
 }
 
-func TestRunCheckAndRenderRejectPropsBearingStrictEntry(t *testing.T) {
+// TestRunCheckAndRenderRejectPropsBearingStrictLayoutEntry proves the
+// narrowed gate (gosx#248) still refuses a props-bearing strict entry where
+// the render path genuinely cannot bind it: a layout. No code path calls a
+// layout's own module's Load hook, so a layout's EntryProps is always nil.
+// A props-bearing strict Page entry, by contrast, now passes — see
+// TestRunCheckAndRenderAcceptPropsBearingStrictPageEntry.
+func TestRunCheckAndRenderRejectPropsBearingStrictLayoutEntry(t *testing.T) {
 	dir := newInvalidStrictStarter(t, "check-render-root-props-gate")
-	path := filepath.Join(dir, "app", "page.gsx")
+	path := filepath.Join(dir, "app", "layout.gsx")
 	mustWriteFile(t, path, `package app
-type PageProps struct { Title string }
-component Page(props: PageProps) {
+type LayoutProps struct { Title string }
+component Layout(props: LayoutProps) {
 	return <main>{props.Title}</main>
 }
 `)
@@ -119,10 +125,40 @@ component Page(props: PageProps) {
 	} {
 		t.Run(check.name, func(t *testing.T) {
 			err := check.fn()
-			if err == nil || !strings.Contains(err.Error(), "file routes do not bind root props") {
+			if err == nil || !strings.Contains(err.Error(), "layout has no Load hook wired to its own root props") {
 				t.Fatalf("error = %v", err)
 			}
 		})
+	}
+}
+
+// TestRunCheckAcceptsPropsBearingStrictPageEntry proves gosx#248's
+// narrowing: `gosx check` now accepts a strict Page entry that declares
+// props, because renderFilePage binds it from this file's own Load hook at
+// request time (see route/filesystem.go).
+//
+// `gosx render` still refuses the same file, but for a different, correct
+// reason: it renders through route.RenderProgramComponent with an empty
+// ProgramRenderEnv, a standalone preview path with no Load hook and no HTTP
+// request to draw ctx.Data from — so EntryProps is genuinely nil here, the
+// same "no root props binding" refusal ProgramRenderEnv.Props documents for
+// any caller that renders a props-declaring strict entry without supplying
+// Props (see TestRenderProgramComponentRejectsStrictRootProps).
+func TestRunCheckAcceptsPropsBearingStrictPageEntry(t *testing.T) {
+	dir := newInvalidStrictStarter(t, "check-render-root-props-accept")
+	path := filepath.Join(dir, "app", "page.gsx")
+	mustWriteFile(t, path, `package app
+type PageProps struct { Title string }
+component Page(props: PageProps) {
+	return <main>{props.Title}</main>
+}
+`)
+	if err := runCheck(path, &bytes.Buffer{}); err != nil {
+		t.Fatalf("runCheck error = %v, want a props-bearing Page entry to pass", err)
+	}
+	err := runRender(path, "", &bytes.Buffer{})
+	if err == nil || !strings.Contains(err.Error(), "no root props binding") {
+		t.Fatalf("runRender error = %v, want the no-Props-supplied refusal", err)
 	}
 }
 

--- a/examples/dashboard/app/page.gsx
+++ b/examples/dashboard/app/page.gsx
@@ -1,24 +1,38 @@
 package app
 
-func Page() Node {
+// PageProps is the dashboard root page's typed root props (gosx#248). This
+// type only ever compiles through the gosx toolchain, never through `go
+// build` — page.server.go's Load hook, real Go, cannot spell this name, so
+// it returns its own same-shaped dashboardStats instead. The strict
+// boundary proves field coverage structurally, not type identity (see
+// ProgramRenderEnv.Props), so a same-shaped struct under a different Go
+// type name satisfies this declaration.
+type PageProps struct {
+	Users   string
+	Active  string
+	Revenue string
+	Growth  string
+}
+
+component Page(props: PageProps) {
 	return <>
 		<h1>Dashboard</h1>
 		<div class="grid">
 			<div class="card">
 				<h3>Users</h3>
-				<div class="stat">{data.users}</div>
+				<div class="stat">{props.Users}</div>
 			</div>
 			<div class="card">
 				<h3>Active</h3>
-				<div class="stat">{data.active}</div>
+				<div class="stat">{props.Active}</div>
 			</div>
 			<div class="card">
 				<h3>Revenue</h3>
-				<div class="stat">{data.revenue}</div>
+				<div class="stat">{props.Revenue}</div>
 			</div>
 			<div class="card">
 				<h3>Growth</h3>
-				<div class="stat">{data.growth}</div>
+				<div class="stat">{props.Growth}</div>
 			</div>
 		</div>
 		<div class="card">

--- a/examples/dashboard/app/page.server.go
+++ b/examples/dashboard/app/page.server.go
@@ -7,14 +7,28 @@ import (
 	"m31labs.dev/gosx/server"
 )
 
+// dashboardStats is a real Go type, buildable and importable the normal
+// way — unlike app/page.gsx's PageProps, which is only ever compiled by the
+// gosx toolchain, never by `go build`. It mirrors PageProps field for
+// field, which is what the strict boundary actually proves at render time
+// (structural field coverage, not this struct's own type identity — see
+// ProgramRenderEnv.Props and TestStrictSpreadProps), so returning it here
+// satisfies app/page.gsx's `component Page(props: PageProps)` (gosx#248).
+type dashboardStats struct {
+	Users   string
+	Active  string
+	Revenue string
+	Growth  string
+}
+
 func init() {
 	if err := route.RegisterFileModuleHere(route.FileModuleOptions{
 		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
-			return map[string]string{
-				"users":   "1,247",
-				"active":  "892",
-				"revenue": "$48,290",
-				"growth":  "+12.5%",
+			return dashboardStats{
+				Users:   "1,247",
+				Active:  "892",
+				Revenue: "$48,290",
+				Growth:  "+12.5%",
 			}, nil
 		},
 		Metadata: func(ctx *route.RouteContext, page route.FilePage, data any) (server.Metadata, error) {

--- a/examples/dashboard/dashboard_conversion_test.go
+++ b/examples/dashboard/dashboard_conversion_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"regexp"
+	"testing"
+
+	"m31labs.dev/gosx"
+	_ "m31labs.dev/gosx/examples/dashboard/modules"
+	"m31labs.dev/gosx/route"
+)
+
+// dashboardConversionGolden is the dashboard root page's rendered output,
+// captured from app/page.gsx BEFORE gosx#248's conversion — when Page was
+// `func Page() Node` reading `data.users`/`data.active`/`data.revenue`/
+// `data.growth` from a Load hook returning map[string]string — with the
+// footer's live clock read normalized to TIME.
+//
+// This is the task's required proof: not that app/page.gsx compiles as
+// `component Page(props: PageProps)`, but that it renders BYTE-IDENTICAL
+// output once converted, reading the same Load hook's data through typed,
+// proven props instead of the untyped `data` binding.
+const dashboardConversionGolden = `<div class="layout"> <aside class="sidebar"> <h2>GoSX Dashboard</h2> <nav> <a href="/">Home</a> <a href="/users">Users</a> <a href="/users/new">New User</a> <a href="/counter">Counter</a> <a href="/kitchen-sink">Kitchen Sink</a> <a href="/settings">Settings</a> </nav> </aside> <main class="main">  <h1>Dashboard</h1> <div class="grid"> <div class="card"> <h3>Users</h3> <div class="stat">1,247</div> </div> <div class="card"> <h3>Active</h3> <div class="stat">892</div> </div> <div class="card"> <h3>Revenue</h3> <div class="stat">$48,290</div> </div> <div class="card"> <h3>Growth</h3> <div class="stat">+12.5%</div> </div> </div> <div class="card"> <h3>Recent Activity</h3> <table> <thead> <tr> <th>User</th> <th>Action</th> <th>When</th> </tr> </thead> <tbody> <tr> <td>Alice</td> <td>Created account</td> <td>2 min ago</td> </tr> <tr> <td>Bob</td> <td>Updated profile</td> <td>15 min ago</td> </tr> <tr> <td>Carol</td> <td>Uploaded document</td> <td>1 hour ago</td> </tr> <tr> <td>Dave</td> <td>Changed settings</td> <td>3 hours ago</td> </tr> <tr> <td>Eve</td> <td>Logged in</td> <td>5 hours ago</td> </tr> </tbody> </table> </div>  <div class="footer">GoSX v0.49.0 — Server rendered at TIME</div> </main> </div>`
+
+var dashboardFooterClockRE = regexp.MustCompile(`Server rendered at \d{2}:\d{2}:\d{2}`)
+
+// TestDashboardRootPageStrictPropsMatchLegacyBytes renders app/'s converted
+// strict Page entry through the real Router.AddDir file-routing path (the
+// same path main() builds) and asserts the response body, with the
+// footer's live clock read normalized, is byte-identical to
+// dashboardConversionGolden.
+func TestDashboardRootPageStrictPropsMatchLegacyBytes(t *testing.T) {
+	router := route.NewRouter()
+	router.SetLayout(func(ctx *route.RouteContext, content gosx.Node) gosx.Node {
+		return content
+	})
+	if err := router.AddDir("app", route.FileRoutesOptions{}); err != nil {
+		t.Fatalf("AddDir: %v", err)
+	}
+	handler, err := router.BuildChecked()
+	if err != nil {
+		t.Fatalf("BuildChecked: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+
+	got := dashboardFooterClockRE.ReplaceAllString(rec.Body.String(), "Server rendered at TIME")
+	if got != dashboardConversionGolden {
+		t.Fatalf("rendered body does not byte-match the pre-conversion golden.\ngot:  %s\nwant: %s", got, dashboardConversionGolden)
+	}
+}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -75,6 +75,19 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 		if opts.EntryProps == nil {
 			return "", false, fmt.Errorf("strict render entry %s accepts props %s, but the file renderer has no root props binding; use a zero-props Page/Layout entry", comp.Name, comp.PropsType)
 		}
+		// gosx#248: a file-routed Load hook returns `any`, and every
+		// existing app returns map[string]any from it — the shape
+		// strictSpreadProps below always rejects, because a map cannot
+		// prove field coverage the way a struct's declared fields can. Name
+		// that specific, expected mistake here, before strictSpreadProps'
+		// generic struct-kind check, so the message tells the author what
+		// to return instead of just what was wrong: return a %s value (a
+		// struct or *%s) from Load, not a map. A legacy entry never reaches
+		// this branch (see comp.Syntax above), so a legacy Load hook
+		// returning map[string]any keeps rendering unchanged.
+		if rv, ok := indirectReflectValue(reflect.ValueOf(opts.EntryProps)); ok && rv.Kind() == reflect.Map {
+			return "", false, fmt.Errorf("strict render entry %s accepts props %s, but Load returned %s; return a %s value (a struct or *%s) instead of a map — the strict boundary proves declared struct fields, which a map cannot provide", comp.Name, comp.PropsType, rv.Type(), comp.PropsType, comp.PropsType)
+		}
 		// strictSpreadProps is the exact same boundary proof a nested
 		// <Component {...props}/> call re-runs on every render (see
 		// localComponentProps): reflect kind must be exactly Struct (a map
@@ -84,7 +97,7 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 		// never around it.
 		props, err := strictSpreadProps(comp, opts.EntryProps)
 		if err != nil {
-			return "", false, fmt.Errorf("render strict entry %s: %w", comp.Name, err)
+			return "", false, fmt.Errorf("render strict entry %s (props %s): %w", comp.Name, comp.PropsType, err)
 		}
 		entryEnv = entryEnv.withValue("props", props)
 	}

--- a/route/filesystem.go
+++ b/route/filesystem.go
@@ -554,6 +554,15 @@ func renderFilePage(ctx *RouteContext, page FilePage, module FileModule, renderF
 	if renderFn == nil {
 		return renderFileNode(page.FilePath, fileRenderOptions{
 			EvalEnv: filePageRenderEnv(ctx, page, module),
+			// EntryProps threads this page's own Load return value to a
+			// strict Page/not-found/error entry that declares props
+			// (gosx#248): ctx.Data already holds it, set by
+			// prepareFileRouteContext before this renders. A legacy
+			// component never reads EntryProps (see
+			// renderFileProgramHTML's strict-entry branch), so this is a
+			// no-op for every non-strict page and does not change what
+			// ctx.Data itself renders through data.X.
+			EntryProps: ctx.Data,
 		})
 	}
 	return renderFn(ctx, page)

--- a/route/filesystem_strict_entry_props_test.go
+++ b/route/filesystem_strict_entry_props_test.go
@@ -1,0 +1,257 @@
+package route
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+// signalPageProps is the strict props type the tests below declare on a
+// `component Page(props: signalPageProps)` entry — the shape a Load hook
+// (route/filemodule.go's FileLoadFunc) must return for gosx#248's binding to
+// prove it.
+type signalPageProps struct {
+	Scene string
+	Down  int
+}
+
+const strictEntryPropsPageSource = `package docs
+
+type PageProps struct {
+	Scene string
+	Down  int
+}
+
+component Page(props: PageProps) {
+	return <main data-down={props.Down}>{props.Scene}</main>
+}
+`
+
+// TestRenderFilePageBindsLoadReturnToStrictPageProps is the render-time proof
+// for gosx#248: a strict Page entry that declares props renders its file
+// module's own Load return value, proved through strictSpreadProps, the same
+// boundary a nested <Component {...props}/> call re-runs. Byte assertion,
+// not a compile-only check — see the task's warning about a fixture that
+// once compiled a broken pattern without ever rendering it.
+func TestRenderFilePageBindsLoadReturnToStrictPageProps(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", strictEntryPropsPageSource)
+
+	module := FileModule{
+		Source: "page.gsx",
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return signalPageProps{Scene: "Fourth and Long", Down: 4}, nil
+		},
+	}
+	ctx := &RouteContext{}
+	page := FilePage{FilePath: root + "/page.gsx", Pattern: "/"}
+	if err := prepareFileRouteContext(ctx, page, module, nil); err != nil {
+		t.Fatalf("prepareFileRouteContext: %v", err)
+	}
+	node, err := renderFilePage(ctx, page, module, nil)
+	if err != nil {
+		t.Fatalf("renderFilePage: %v", err)
+	}
+
+	html := gosx.RenderHTML(node)
+	const want = `<main data-down="4">Fourth and Long</main>`
+	if html != want {
+		t.Fatalf("rendered html = %q, want %q", html, want)
+	}
+}
+
+// TestRouterAddDirBindsLoadReturnToStrictPageProps repeats the proof above
+// through the full HTTP path (Router.AddDir -> Router.Build -> ServeHTTP),
+// so the DataLoader/ctx.Data wiring route.go's buildHandler performs before
+// calling the route Handler is covered too, not just the direct
+// renderFilePage call.
+func TestRouterAddDirBindsLoadReturnToStrictPageProps(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", strictEntryPropsPageSource)
+
+	modules := NewFileModuleRegistry()
+	if err := modules.Register(FileModuleFor("page.gsx", FileModuleOptions{
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return signalPageProps{Scene: "Fourth and Long", Down: 4}, nil
+		},
+	})); err != nil {
+		t.Fatal(err)
+	}
+
+	router := NewRouter()
+	router.SetLayout(func(ctx *RouteContext, body gosx.Node) gosx.Node { return body })
+	if err := router.AddDir(root, FileRoutesOptions{Modules: modules}); err != nil {
+		t.Fatal(err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+	w := httptest.NewRecorder()
+	router.Build().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %q", w.Code, w.Body.String())
+	}
+	const want = `<main data-down="4">Fourth and Long</main>`
+	if w.Body.String() != want {
+		t.Fatalf("body = %q, want %q", w.Body.String(), want)
+	}
+}
+
+// TestRenderFilePageLegacyPageIgnoresEntryPropsMapLoad proves the framework
+// side of gosx#248's byte-identity constraint: EntryProps now always carries
+// ctx.Data (see renderFilePage), but a legacy (non-strict) component never
+// reads it — renderFileProgramHTML's strict-entry branch is gated on
+// comp.Syntax — so a legacy page.gsx with a Load hook returning
+// map[string]any, the shape every existing app uses, renders exactly as it
+// did before this change.
+func TestRenderFilePageLegacyPageIgnoresEntryPropsMapLoad(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", `package docs
+
+func Page() Node {
+	return <main>{data.Scene}</main>
+}
+`)
+	module := FileModule{
+		Source: "page.gsx",
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return map[string]any{"Scene": "Fourth and Long"}, nil
+		},
+	}
+	ctx := &RouteContext{}
+	page := FilePage{FilePath: root + "/page.gsx", Pattern: "/"}
+	if err := prepareFileRouteContext(ctx, page, module, nil); err != nil {
+		t.Fatalf("prepareFileRouteContext: %v", err)
+	}
+	node, err := renderFilePage(ctx, page, module, nil)
+	if err != nil {
+		t.Fatalf("renderFilePage: %v", err)
+	}
+	html := gosx.RenderHTML(node)
+	const want = `<main>Fourth and Long</main>`
+	if html != want {
+		t.Fatalf("rendered html = %q, want %q", html, want)
+	}
+}
+
+// TestRenderFilePageStrictPageRejectsMapLoadReturn is the first of the three
+// required negative diagnostics: a strict Page entry whose Load hook
+// returns map[string]any — every existing app's shape — fails closed with a
+// message naming the component, its declared props type, and what to
+// return instead of a map. It does not silently coerce the map into
+// PageProps.
+func TestRenderFilePageStrictPageRejectsMapLoadReturn(t *testing.T) {
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", strictEntryPropsPageSource)
+
+	module := FileModule{
+		Source: "page.gsx",
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return map[string]any{"Scene": "Fourth and Long", "Down": 4}, nil
+		},
+	}
+	ctx := &RouteContext{}
+	page := FilePage{FilePath: root + "/page.gsx", Pattern: "/"}
+	if err := prepareFileRouteContext(ctx, page, module, nil); err != nil {
+		t.Fatalf("prepareFileRouteContext: %v", err)
+	}
+	_, err := renderFilePage(ctx, page, module, nil)
+	if err == nil {
+		t.Fatal("renderFilePage unexpectedly accepted a map Load return for a strict entry")
+	}
+	for _, want := range []string{
+		root + "/page.gsx",
+		"strict render entry Page",
+		"props PageProps",
+		"Load returned map[string]interface {}",
+		"return a PageProps value",
+		"instead of a map",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// TestRenderFilePageStrictPageRejectsWrongStructType is the second required
+// negative diagnostic: a Load hook that returns a real, differently-typed
+// struct — every field PageProps declares is present by name, but Down is a
+// string instead of an int — still fails closed on the leaf-type mismatch,
+// naming the file and the component, not just the mismatch. (A struct
+// missing a field entirely is TestRenderFilePageStrictPageRejectsMissingField,
+// the other required negative case.)
+func TestRenderFilePageStrictPageRejectsWrongStructType(t *testing.T) {
+	type unrelatedProps struct {
+		Scene string
+		Down  string // PageProps declares Down as int
+	}
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", strictEntryPropsPageSource)
+
+	module := FileModule{
+		Source: "page.gsx",
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return unrelatedProps{Scene: "Fourth and Long", Down: "4"}, nil
+		},
+	}
+	ctx := &RouteContext{}
+	page := FilePage{FilePath: root + "/page.gsx", Pattern: "/"}
+	if err := prepareFileRouteContext(ctx, page, module, nil); err != nil {
+		t.Fatalf("prepareFileRouteContext: %v", err)
+	}
+	_, err := renderFilePage(ctx, page, module, nil)
+	if err == nil {
+		t.Fatal("renderFilePage unexpectedly accepted a Load return of the wrong struct type")
+	}
+	for _, want := range []string{
+		root + "/page.gsx",
+		"render strict entry Page (props PageProps)",
+		"prop Down (int)",
+		"runtime value has type string, want exact int",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	}
+}
+
+// TestRenderFilePageStrictPageRejectsMissingField is the third required
+// negative diagnostic: a Load hook that returns the right props type but
+// omits one rendered field fails closed instead of zero-filling it, naming
+// the file, the component, and the missing field.
+func TestRenderFilePageStrictPageRejectsMissingField(t *testing.T) {
+	type partialPageProps struct {
+		Scene string
+		// Down is missing, but the page renders props.Down.
+	}
+	root := t.TempDir()
+	writeRouteFile(t, root, "page.gsx", strictEntryPropsPageSource)
+
+	module := FileModule{
+		Source: "page.gsx",
+		Load: func(ctx *RouteContext, page FilePage) (any, error) {
+			return partialPageProps{Scene: "Fourth and Long"}, nil
+		},
+	}
+	ctx := &RouteContext{}
+	page := FilePage{FilePath: root + "/page.gsx", Pattern: "/"}
+	if err := prepareFileRouteContext(ctx, page, module, nil); err != nil {
+		t.Fatalf("prepareFileRouteContext: %v", err)
+	}
+	_, err := renderFilePage(ctx, page, module, nil)
+	if err == nil {
+		t.Fatal("renderFilePage unexpectedly accepted a Load return missing a rendered field")
+	}
+	for _, want := range []string{
+		root + "/page.gsx",
+		"render strict entry Page (props PageProps)",
+		"partialPageProps has no field Down",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
+	}
+}

--- a/route/render_component_test.go
+++ b/route/render_component_test.go
@@ -77,6 +77,11 @@ func TestRenderProgramComponentStrictEntryMatchesNestedRenderByteForByte(t *test
 // boundary still rejects a map at the entry point, the same way it rejects
 // one at a nested {...props} call site: a map cannot prove field coverage,
 // no matter how the render was reached.
+//
+// gosx#248 gives this specific case (a map at the render entry, the shape
+// every existing file-routed Load hook returns) its own diagnostic, ahead
+// of strictSpreadProps' generic struct-kind message: it names the
+// component, its declared props type, and what to return instead of a map.
 func TestRenderProgramComponentStrictEntryRejectsMapProps(t *testing.T) {
 	prog, err := gosx.Compile([]byte(signalCardFixtureSource))
 	if err != nil {
@@ -88,8 +93,10 @@ func TestRenderProgramComponentStrictEntryRejectsMapProps(t *testing.T) {
 	if err == nil {
 		t.Fatal("RenderProgramComponent unexpectedly accepted a map for strict typed props")
 	}
-	if !strings.Contains(err.Error(), "maps cannot prove field coverage") {
-		t.Fatalf("error = %v, want the strict map-rejection boundary message", err)
+	for _, want := range []string{"strict render entry SignalCard", "props SignalCardProps", "return a SignalCardProps value", "instead of a map"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("error = %v, want it to contain %q", err, want)
+		}
 	}
 }
 

--- a/strictcheck/check.go
+++ b/strictcheck/check.go
@@ -173,6 +173,25 @@ func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts O
 	return goCheck(ctx, files, generated, opts)
 }
 
+// validateStrictRenderEntries refuses a strict render entry's declared props
+// exactly where the file render path cannot bind them (gosx#248).
+//
+// A Page, index, not-found, or error entry CAN bind them: renderFilePage
+// passes ctx.Data — set from this file's own Load hook before the entry
+// renders — as EntryProps, and renderFileProgramHTML's strict-entry branch
+// proves it through strictSpreadProps, the same boundary proof a nested
+// <Component {...props}/> call re-runs. A Load hook that returns nothing, a
+// map, or the wrong struct still fails, but at render time against the
+// real returned value, not here: this static check has no visibility into
+// a sibling *.server.go file's Load return type, and the render-time proof
+// gives a strictly more accurate answer than a guess made here ever could.
+//
+// A Layout entry cannot: no code path calls a layout's own module's Load
+// hook (see route/filelayout.go's renderFileLayout — it reads the page's
+// ctx.Data for Bindings, never invokes its own module.Load), so a layout's
+// EntryProps is always nil today. That refusal stays, and stays here,
+// because it is the one case this check can still decide for certain
+// without ever running the render path.
 func validateStrictRenderEntries(files []transpile.PackageFile) error {
 	for _, file := range files {
 		if file.Program == nil || len(file.Program.Components) == 0 {
@@ -181,11 +200,12 @@ func validateStrictRenderEntries(files []transpile.PackageFile) error {
 		if !strictFileRouteName(file.Path) {
 			continue
 		}
-		components := file.Program.Components
-		preferred := []string{"Page"}
-		if strings.EqualFold(strings.TrimSuffix(filepath.Base(file.Path), filepath.Ext(file.Path)), "layout") {
-			preferred = []string{"Layout", "Page"}
+		isLayout := strings.EqualFold(strings.TrimSuffix(filepath.Base(file.Path), filepath.Ext(file.Path)), "layout")
+		if !isLayout {
+			continue
 		}
+		components := file.Program.Components
+		preferred := []string{"Layout", "Page"}
 		entry := &components[0]
 		for _, name := range preferred {
 			found := false
@@ -201,7 +221,7 @@ func validateStrictRenderEntries(files []transpile.PackageFile) error {
 			}
 		}
 		if entry.Syntax == ir.ComponentSyntaxStrict && strings.TrimSpace(entry.PropsType) != "" {
-			return fmt.Errorf("%s: strict render entry %s accepts props %s, but file routes do not bind root props; use a zero-props Page/Layout entry", file.Path, entry.Name, entry.PropsType)
+			return fmt.Errorf("%s: strict render entry %s accepts props %s, but a file-routed layout has no Load hook wired to its own root props; declare props on a Page/not-found/error entry instead, or make %s a zero-props Layout and read request data through a Page entry's Load", file.Path, entry.Name, entry.PropsType, entry.Name)
 		}
 	}
 	return nil

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -478,7 +478,13 @@ component Page() {
 	}
 }
 
-func TestCheckFileRejectsPropsBearingStrictRenderEntry(t *testing.T) {
+// TestCheckFileAllowsPropsBearingStrictPageRenderEntry proves gosx#248's
+// narrowing: a strict Page render entry that declares props now passes
+// CheckFile, because renderFilePage binds it from this file's own Load hook
+// (see route/filesystem.go and TestRenderFilePageBindsLoadReturnToStrictProps).
+// A wrong-shaped or missing Load return still fails, but at render time, not
+// here — see the strictSpreadProps-backed tests in route/fileprogram_test.go.
+func TestCheckFileAllowsPropsBearingStrictPageRenderEntry(t *testing.T) {
 	dir := newTestModule(t)
 	path := filepath.Join(dir, "page.gsx")
 	mustWrite(t, path, `package main
@@ -487,8 +493,28 @@ component Page(props: PageProps) {
 	return <main>{props.Title}</main>
 }
 `)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile error = %v, want a props-bearing Page entry to pass", err)
+	}
+}
+
+// TestCheckFileRejectsPropsBearingStrictLayoutRenderEntry proves the
+// narrowed refusal still applies to a layout: no code path calls a layout's
+// own module's Load hook, so a layout's EntryProps is always nil (see
+// route/filelayout.go's renderFileLayout), and validateStrictRenderEntries
+// still catches this statically instead of deferring to a render-time
+// failure that would fire on every request.
+func TestCheckFileRejectsPropsBearingStrictLayoutRenderEntry(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "layout.gsx")
+	mustWrite(t, path, `package main
+type LayoutProps struct { Title string }
+component Layout(props: LayoutProps) {
+	return <main>{props.Title}</main>
+}
+`)
 	err := CheckFile(context.Background(), path)
-	if err == nil || !strings.Contains(err.Error(), "file routes do not bind root props") {
+	if err == nil || !strings.Contains(err.Error(), "layout has no Load hook wired to its own root props") {
 		t.Fatalf("CheckFile error = %v", err)
 	}
 }

--- a/strictcheck/extension_test.go
+++ b/strictcheck/extension_test.go
@@ -325,12 +325,17 @@ func alwaysLint(name string) Lint {
 // before any lint sees the package.
 func TestCheckFileJoinsLintFindingsWhenRenderEntryValidationFails(t *testing.T) {
 	dir := newTestModule(t)
-	path := filepath.Join(dir, "page.gsx")
+	// A layout entry, not a page: gosx#248 narrowed validateStrictRenderEntries
+	// to refuse only a props-bearing strict Layout entry (no code path calls a
+	// layout's own module's Load hook, so its EntryProps is always nil). A
+	// props-bearing Page entry now passes this check, so it can no longer
+	// stand in for "the first early-return path fails" here.
+	path := filepath.Join(dir, "layout.gsx")
 	mustWrite(t, path, `package main
 
-type PageProps struct { Title string }
+type LayoutProps struct { Title string }
 
-component Page(props: *PageProps) {
+component Layout(props: *LayoutProps) {
 	return <div>{props.Title}</div>
 }
 `)
@@ -339,7 +344,7 @@ component Page(props: *PageProps) {
 		t.Fatal("expected an error")
 	}
 	message := err.Error()
-	if !strings.Contains(message, "file routes do not bind root props") {
+	if !strings.Contains(message, "layout has no Load hook wired to its own root props") {
 		t.Fatalf("missing the render-entry built-in error: %s", message)
 	}
 	if !strings.Contains(message, "EM999") {


### PR DESCRIPTION
## Summary

Strict file-routed Page, not-found, and error entries can now declare typed root props bound from their file module's own Load hook return value. Before this change, any strict render entry declaring props would fail at compile time — even though Page/not-found/error entries have a clear data source via ctx.Data — leaving zero way for a strict page to safely consume its loader's data. This PR wires ctx.Data through to EntryProps at the render boundary, validates it strictly at runtime (rejecting maps and wrong struct shapes with precise diagnostics), and narrows the static gate to refuse only layouts, which genuinely cannot receive their own Load return.

## Changes

- Route wiring (`route/filesystem.go`)**: `renderFilePage` now passes `ctx.Data` — already populated from this page's `Load` hook — as `EntryProps` to `renderFileNode`, enabling strict Page/not-found/error entries to bind props. Legacy entries never read `EntryProps`, so they remain byte-identical.
- Static check narrowing (`strictcheck/check.go`)**: `validateStrictRenderEntries` stops rejecting all props-bearing strict entries and refuses only layout entries. A layout has no code path calling its own module's `Load` hook, so `EntryProps` is always nil there; Page/not-found/error entries can bind them and now pass.
- Runtime diagnostics (`route/fileprogram.go`)**: When a strict entry's `EntryProps` is a `map[string]any` (every existing app's shape), render fails early with a message naming the component, declared props type, and what to return instead. Wrong struct types and missing fields also fail with precise, file-scoped errors before reaching the generic `strictSpreadProps` check.
- Dashboard example conversion (`examples/dashboard/`)**: Root `page.gsx` converts to `component Page(props: PageProps)`, reading loader data through typed props instead of the legacy `data.X` bindings. Its `page.server.go` `Load` returns a `dashboardStats` struct matching the declared shape. A golden test proves byte-identical rendered output.
- Tests**: Extensive new coverage — positive binding proofs at direct and HTTP levels, negative diagnostics for map returns/wrong struct types/missing fields, legacy-page isolation confirming unchanged behavior, and cmd-level acceptance/rejection gates aligned to the narrowed check logic.

## Testing

- `go test ./...` to run the full suite including the new filesystem, dashboard, and strictcheck tests
- Run the dashboard golden comparison specifically: `go test m31labs.dev/gosx/examples/dashboard -run TestDashboardRootPageStrictPropsMatchLegacyBytes`
- Convert any existing strict Page entry and confirm it compiles and renders correctly, while a strict Layout entry with props still produces a clear static-check error mentioning layouts lack a Load hook

## Related Issues

- Refs #248