### PR TITLE
add(compiler, runtime): Enable strict //gosx:island declarations on strict components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,40 @@
   Named, multiple slots are a separate, unimplemented capability; `Layout`,
   `Sidebar`, and `Footer` still build their markup with `gosx.El`.
 
+### Added: a strict island now compiles, checks, renders, and hydrates
+
+- **`component Name(props: NameProps)` now compiles with a `//gosx:island`
+  directive.** Lowering no longer rejects it. The v0.39-era refusal was
+  stale: the island lowerer, the client virtual machine (VM), and the
+  render boundary already supported it.
+- Two real gaps blocked it, not the whole pipeline. `ir/lower.go` rejected
+  the declaration outright. `route/fileprogram.go` also dispatched every
+  strict component through the same-file inline renderer before the island
+  branch could ever run.
+- Typed props cross the client boundary as plain JSON, the same as a legacy
+  island. The server proves field coverage and leaf types through
+  `localComponentProps`, the same boundary an ordinary strict component
+  uses.
+- The client VM needed no change. It already exposes every serialized prop
+  key as a flat name and as a field of a reserved `props` object
+  (`client/vm/island.go`'s `parseProps`). A strict island's `props.Field`
+  reads resolve through that existing binding.
+- `gosx check` proves a strict island exactly as it proves a legacy one. It
+  runs `ir.LowerIsland` for every island component, regardless of syntax.
+- `examples/hotswap/counter.gsx` now uses the strict spelling. It renders
+  HTML byte-identical to its legacy-syntax predecessor.
+- A new browser test, `e2e/strict_island_prod_e2e_test.go`, builds a strict
+  island with `gosx build --prod` and serves the production bundle. It
+  drives a real Chrome browser through a click that increments the
+  hydrated counter, proving hydration, not just compilation.
+- **`//gosx:engine` stays rejected.** The file renderer has no typed
+  dispatch for an engine surface's per-frame host calls. A strict engine
+  body cannot execute faithfully yet. The refusal message no longer cites
+  v0.39. It names the real, current reason.
+- Every existing legacy island and engine keeps working unchanged. No
+  exported API was removed or altered; this release only adds a new,
+  previously-rejected declaration shape.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/cmd/gosx/check_test.go
+++ b/cmd/gosx/check_test.go
@@ -126,35 +126,52 @@ component Page(props: PageProps) {
 	}
 }
 
-func TestRunCheckAndRenderRejectStrictClientDirectiveComponents(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		directive string
-		want      string
-	}{
-		{name: "island", directive: "//gosx:island", want: "strict island declarations are not supported"},
-		{name: "engine", directive: "//gosx:engine surface", want: "strict engine declarations are not supported"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := newInvalidStrictStarter(t, "check-render-strict-"+tc.name)
-			path := filepath.Join(dir, "app", "page.gsx")
-			mustWriteFile(t, path, "package app\n"+tc.directive+"\ncomponent Page() {\nreturn <canvas />\n}\n")
-			for _, check := range []struct {
-				name string
-				fn   func() error
-			}{
-				{name: "check", fn: func() error { return runCheck(path, &bytes.Buffer{}) }},
-				{name: "render", fn: func() error { return runRender(path, "", &bytes.Buffer{}) }},
-			} {
-				t.Run(check.name, func(t *testing.T) {
-					err := check.fn()
-					if err == nil || !strings.Contains(err.Error(), tc.want) {
-						t.Fatalf("error = %v", err)
-					}
-				})
+// TestRunCheckAndRenderAcceptStrictIslandRejectStrictEngine covers the split
+// verdict cmd/gosx check and render must agree on: a strict island now
+// passes both (LowerIsland — the same island-lowering gate check runs for
+// every IsIsland component — succeeds, and rendering produces real HTML), a
+// strict engine still fails both, with an updated, version-accurate reason.
+func TestRunCheckAndRenderAcceptStrictIslandRejectStrictEngine(t *testing.T) {
+	t.Run("island", func(t *testing.T) {
+		dir := newInvalidStrictStarter(t, "check-render-strict-island")
+		path := filepath.Join(dir, "app", "page.gsx")
+		mustWriteFile(t, path, "package app\n//gosx:island\ncomponent Page() {\nreturn <canvas />\n}\n")
+		t.Run("check", func(t *testing.T) {
+			var out bytes.Buffer
+			if err := runCheck(path, &out); err != nil {
+				t.Fatalf("runCheck: %v", err)
 			}
 		})
-	}
+		t.Run("render", func(t *testing.T) {
+			var out bytes.Buffer
+			if err := runRender(path, "", &out); err != nil {
+				t.Fatalf("runRender: %v", err)
+			}
+			if !strings.Contains(out.String(), "<canvas") {
+				t.Fatalf("rendered output = %q, want it to contain <canvas", out.String())
+			}
+		})
+	})
+	t.Run("engine", func(t *testing.T) {
+		dir := newInvalidStrictStarter(t, "check-render-strict-engine")
+		path := filepath.Join(dir, "app", "page.gsx")
+		mustWriteFile(t, path, "package app\n//gosx:engine surface\ncomponent Page() {\nreturn <canvas />\n}\n")
+		want := "strict engine declarations are not yet supported"
+		for _, check := range []struct {
+			name string
+			fn   func() error
+		}{
+			{name: "check", fn: func() error { return runCheck(path, &bytes.Buffer{}) }},
+			{name: "render", fn: func() error { return runRender(path, "", &bytes.Buffer{}) }},
+		} {
+			t.Run(check.name, func(t *testing.T) {
+				err := check.fn()
+				if err == nil || !strings.Contains(err.Error(), want) {
+					t.Fatalf("error = %v, want to contain %q", err, want)
+				}
+			})
+		}
+	})
 }
 
 func TestRunCheckRejectsLegacyCallerIntoStrictCalleeBeforePropTyping(t *testing.T) {

--- a/e2e/strict_island_prod_e2e_test.go
+++ b/e2e/strict_island_prod_e2e_test.go
@@ -1,0 +1,94 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+)
+
+// TestProductionBuildHydratesStrictIsland is the browser half of the strict
+// island proof (the server-side half lives in strict_island_render_test.go
+// at the repo root). It builds e2e/testdata/strict-island with `gosx build
+// --prod` — the real production pipeline, not a stub — serves the resulting
+// bundle, and drives a real Chrome browser: it asserts the server-rendered
+// props (Label="Draft Pick", Start=7) appear in the initial HTML, then
+// clicks the island's button and asserts the DOM updates from a real
+// dispatched click, not a server round trip.
+func TestProductionBuildHydratesStrictIsland(t *testing.T) {
+	chrome := e2eChromePath(t)
+	root := e2eRepoRoot(t)
+	fixture := filepath.Join(t.TempDir(), "strict-island")
+	copyFixtureTree(t, filepath.Join(root, "e2e", "testdata", "strict-island"), fixture)
+
+	module := fmt.Sprintf("module example.com/gosx-strict-island\n\ngo 1.26\n\nrequire m31labs.dev/gosx v0.0.0\n\nreplace m31labs.dev/gosx => %s\n", filepath.ToSlash(root))
+	if err := os.WriteFile(filepath.Join(fixture, "go.mod"), []byte(module), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	build := exec.Command("go", "run", "./cmd/gosx", "build", "--prod", fixture)
+	build.Dir = root
+	build.Env = append(os.Environ(), "GOWORK=off")
+	output, err := build.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gosx build --prod: %v\n%s", err, output)
+	}
+	if !strings.Contains(string(output), "Counter") {
+		t.Fatalf("gosx build --prod did not report the Counter island:\n%s", output)
+	}
+
+	dist := filepath.Join(fixture, "dist")
+	port := freeE2EPort(t)
+	baseURL := fmt.Sprintf("http://127.0.0.1:%d", port)
+	logs := startBuiltFixture(t, dist, port)
+	if err := waitForHealthy(baseURL+"/", 45*time.Second); err != nil {
+		t.Fatalf("%v\n%s", err, logs.String())
+	}
+
+	resp, err := http.Get(baseURL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("root status = %d\n%s", resp.StatusCode, logs.String())
+	}
+
+	page := newBrowserPage(t, chrome, nil, 1024, 768, "", 60*time.Second)
+	if status := page.navigate(t, baseURL+"/"); status != http.StatusOK {
+		t.Fatalf("fixture status %d\n%s", status, logs.String())
+	}
+	if err := chromedp.Run(page.ctx,
+		chromedp.WaitVisible(`#strict-counter`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatalf("wait for strict island: %v\nconsole:\n%s\npage errors: %v", err, page.Console(), page.PageErrors())
+	}
+
+	var before string
+	page.eval(t, `document.querySelector("#strict-counter").textContent`, &before)
+	if !strings.Contains(before, "Draft Pick") || !strings.Contains(strings.TrimSpace(before), "7") {
+		t.Fatalf("initial hydrated island text = %q, want it to contain the proven props \"Draft Pick\" and \"7\"", before)
+	}
+
+	page.eval(t, `document.querySelector("#strict-counter-button").click()`, nil)
+	if err := chromedp.Run(page.ctx, chromedp.Poll(
+		`document.querySelector("#strict-counter-button").textContent === "8"`,
+		nil,
+		chromedp.WithPollingTimeout(10*time.Second),
+	)); err != nil {
+		t.Fatalf("wait for strict island increment: %v\nconsole:\n%s\npage errors: %v", err, page.Console(), page.PageErrors())
+	}
+	var after string
+	page.eval(t, `document.querySelector("#strict-counter-button").textContent`, &after)
+	if strings.TrimSpace(after) != "8" {
+		t.Fatalf("strict island did not hydrate: button text=%q", after)
+	}
+}

--- a/e2e/testdata/go-wasm-mixed/app/counter.gsx
+++ b/e2e/testdata/go-wasm-mixed/app/counter.gsx
@@ -1,7 +1,16 @@
 package app
 
+import "m31labs.dev/gosx/signal"
+
+// Counter is not the island the mixed-runtime browser fixture renders (that
+// one is island/program.CounterProgram, a hand-built reference bytecode
+// fixture, kept byte-identical to this file on purpose). It exists so
+// `gosx build --prod` has a real strict island source to discover, lower,
+// and bundle from this module, proving that pipeline works for a strict
+// declaration exactly as it works for the legacy spelling.
+//
 //gosx:island
-func Counter() Node {
+component Counter() {
 	count := signal.New(0)
 	decrement := func() { count.Set(count.Get() - 1) }
 	increment := func() { count.Set(count.Get() + 1) }

--- a/e2e/testdata/strict-island/app/page.gsx
+++ b/e2e/testdata/strict-island/app/page.gsx
@@ -1,0 +1,31 @@
+package app
+
+import "m31labs.dev/gosx/signal"
+
+type CounterProps struct {
+	Label string
+	Start int
+}
+
+// Counter is a strict island: its props cross the server/client boundary
+// through the same proof route/fileprogram.go's localComponentProps runs
+// for every strict component, then travel to the browser as the flat JSON
+// map every island already ships. Page calls it with named attributes,
+// exercising that boundary the same way a production caller would.
+//
+//gosx:island
+component Counter(props: CounterProps) {
+	count := signal.New(props.Start)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <div class="counter" id="strict-counter">
+		<span class="counter-label">{props.Label}</span>
+		<button class="counter-btn" onClick={increment} id="strict-counter-button">{count.Get()}</button>
+	</div>
+}
+
+component Page() {
+	return <main class="shell">
+		<h1>Strict island e2e fixture</h1>
+		<Counter label="Draft Pick" start={7} />
+	</main>
+}

--- a/e2e/testdata/strict-island/main.go
+++ b/e2e/testdata/strict-island/main.go
@@ -1,0 +1,47 @@
+// Command strict-island is the e2e fixture for a strict //gosx:island.
+//
+// app/page.gsx declares CounterProps, a strict `component Counter(props:
+// CounterProps)` island, and a strict `component Page()` that calls it with
+// named attributes. The e2e test builds this fixture with `gosx build
+// --prod`, serves the production bundle, and drives a real browser to prove
+// the island renders the proven props server-side and hydrates them
+// client-side, responding to a real click.
+package main
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+	"m31labs.dev/gosx/server"
+)
+
+func main() {
+	_, thisFile, _, _ := runtime.Caller(0)
+	root := server.ResolveAppRoot(thisFile)
+
+	router := route.NewRouter()
+	router.SetLayout(func(ctx *route.RouteContext, body gosx.Node) gosx.Node {
+		return server.HTMLDocument(ctx.Title("strict-island fixture"), ctx.Head(), body)
+	})
+	if err := router.AddDir(filepath.Join(root, "app"), route.FileRoutesOptions{}); err != nil {
+		log.Fatal(err)
+	}
+
+	app := server.New()
+	rootHandler, err := router.BuildChecked()
+	if err != nil {
+		log.Fatal(err)
+	}
+	app.Mount("/", rootHandler)
+
+	port := os.Getenv("PORT")
+	if port == "" {
+		port = "8080"
+	}
+	log.Printf("strict-island fixture listening on http://localhost:%s", port)
+	log.Fatal(app.ListenAndServe(":" + port))
+}

--- a/examples/hotswap/counter.gsx
+++ b/examples/hotswap/counter.gsx
@@ -1,5 +1,7 @@
 package main
 
+import "m31labs.dev/gosx/signal"
+
 // Counter is the island you edit to see hot-swap in action.
 //
 // Run `gosx dev` in this directory, open the page, bump the count a few times,
@@ -13,8 +15,16 @@ package main
 //   - change `count.Get() + 1` to `+ 5` and `- 1` to `- 5` (handler swap)
 //   - add a class to the <div> (attribute swap)
 //
+// Counter is declared with the strict `component` syntax rather than the
+// legacy `func Name(...) Node` style. Lowering, `gosx check`, server
+// rendering, and client hydration all treat a strict island exactly like a
+// legacy one — this file is proof of that, not a special case: the compiled
+// island program main.go loads through compileIsland is byte-identical in
+// shape to what the legacy spelling produced, and the hot-swap flow above
+// still works unchanged.
+//
 //gosx:island
-func Counter() Node {
+component Counter() {
 	count := signal.New(0)
 	increment := func() { count.Set(count.Get() + 1) }
 	decrement := func() { count.Set(count.Get() - 1) }

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -2581,13 +2581,16 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 	l.checkDirectiveTypos(n)
 	isIsland := l.hasIslandDirective(n)
 	engineKind, isEngine := l.parseEngineDirective(n)
-	if isIsland {
-		l.errorf(n, "strict island declarations are not supported in v0.39; island VM semantics do not yet preserve typed server-component behavior")
-		l.hintLast("declare this island with the legacy func Name(...) Node style")
-		return
-	}
+	// A strict island's props cross the client boundary through the same
+	// proof a strict server component uses (localComponentProps /
+	// strictSpreadProps in route/fileprogram.go), then travel to the
+	// browser as the same flat JSON map every island already ships — the
+	// client VM already exposes that map under both its flat keys and a
+	// reserved "props" object binding (client/vm/island.go's parseProps),
+	// so a strict island body's props.Field selectors resolve with no VM
+	// change. See CHANGELOG.md for the full writeup.
 	if isEngine {
-		l.errorf(n, "strict engine declarations are not supported in v0.39; the file renderer cannot execute typed engine components faithfully")
+		l.errorf(n, "strict engine declarations are not yet supported: the file renderer has no typed dispatch for an engine surface's per-frame host calls, so a strict engine body cannot be executed faithfully")
 		l.hintLast("declare this engine with the legacy func Name(...) Node style")
 		return
 	}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -274,7 +274,15 @@ func (r *fileProgramRenderer) writeComponent(b *strings.Builder, node *ir.Node, 
 	// that declaration authoritative even when its name collides with a layout
 	// replacement or one of the legacy renderer builtins; otherwise generated Go
 	// and file rendering would execute different components.
-	if comp, ok := r.components[node.Tag]; ok && comp.Syntax == ir.ComponentSyntaxStrict {
+	//
+	// A strict ISLAND is excluded here on purpose. Its call site still owns
+	// the same-file declaration, but rendering it inline through
+	// writeLocalComponent would emit its body as ordinary server HTML and
+	// skip env.island entirely — no hydration script, no client VM program,
+	// no props payload. The switch below routes IsIsland to
+	// renderLocalIsland instead, which builds the proven props map through
+	// the same localComponentProps boundary and hands it to env.island.
+	if comp, ok := r.components[node.Tag]; ok && comp.Syntax == ir.ComponentSyntaxStrict && !comp.IsIsland && !comp.IsEngine {
 		r.writeLocalComponent(b, comp, node, env)
 		return
 	}

--- a/strict_component_test.go
+++ b/strict_component_test.go
@@ -1915,22 +1915,40 @@ func TestCompileStrictEachSerializationRoundTrip(t *testing.T) {
 	}
 }
 
+// TestCompileAcceptsStrictIslandRejectsStrictEngine covers the split verdict
+// for the two client directives on a strict component. A strict island
+// compiles: its props cross to the client exactly as an ordinary strict
+// component's props are proved server-side (localComponentProps), then
+// travel to the browser as the same JSON map every island already ships. A
+// strict engine still fails closed: the file renderer has no typed dispatch
+// for a surface's per-frame host calls, so a strict engine body cannot be
+// executed faithfully — see TestCompileRejectsStrictClientDirectiveComponents.
+func TestCompileAcceptsStrictIslandRejectsStrictEngine(t *testing.T) {
+	source := []byte("package app\n//gosx:island\ncomponent Client() {\nreturn <button>count</button>\n}\n")
+	prog, err := Compile(source)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	if len(prog.Components) != 1 {
+		t.Fatalf("components = %d, want 1", len(prog.Components))
+	}
+	comp := prog.Components[0]
+	if comp.Syntax != ir.ComponentSyntaxStrict {
+		t.Fatalf("Syntax = %v, want ComponentSyntaxStrict", comp.Syntax)
+	}
+	if !comp.IsIsland {
+		t.Fatalf("IsIsland = false, want true")
+	}
+	if _, err := ir.LowerIsland(prog, 0); err != nil {
+		t.Fatalf("LowerIsland: %v", err)
+	}
+}
+
 func TestCompileRejectsStrictClientDirectiveComponents(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		directive string
-		root      string
-		want      string
-	}{
-		{name: "island", directive: "//gosx:island", root: `<button>count</button>`, want: "strict island declarations are not supported"},
-		{name: "engine", directive: "//gosx:engine surface", root: `<canvas />`, want: "strict engine declarations are not supported"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			source := []byte("package app\n" + tc.directive + "\ncomponent Client() {\nreturn " + tc.root + "\n}\n")
-			_, err := Compile(source)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("error = %v", err)
-			}
-		})
+	source := []byte("package app\n//gosx:engine surface\ncomponent Client() {\nreturn <canvas />\n}\n")
+	_, err := Compile(source)
+	want := "strict engine declarations are not yet supported"
+	if err == nil || !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %v, want to contain %q", err, want)
 	}
 }

--- a/strict_island_boundary_test.go
+++ b/strict_island_boundary_test.go
@@ -1,0 +1,47 @@
+package gosx_test
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/island"
+	"m31labs.dev/gosx/route"
+)
+
+// TestStrictIslandPropsBoundaryFailsClosed proves a strict island is held to
+// the identical field-coverage and leaf-type proof as an ordinary strict
+// component: a caller-side type mismatch must be rejected at render time,
+// not silently coerced or passed through.
+func TestStrictIslandPropsBoundaryFailsClosed(t *testing.T) {
+	src := []byte(`package app
+
+type BadgeProps struct {
+	Count int
+}
+
+//gosx:island
+component Badge(props: BadgeProps) {
+	return <span>{props.Count}</span>
+}
+
+component Page() {
+	return <main><Badge count={"not-a-number"} /></main>
+}
+`)
+	prog, err := gosx.Compile(src)
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	renderer := island.NewRenderer("test-bundle")
+	_, err = route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{
+		RenderIsland: renderer.RenderIslandFromProgram,
+	})
+	if err == nil {
+		t.Fatalf("expected a boundary error for a wrong-typed prop, got nil")
+	}
+	if !strings.Contains(err.Error(), "Badge") {
+		t.Fatalf("error = %v, want it to name the strict island Badge", err)
+	}
+	t.Logf("got expected boundary error: %v", err)
+}

--- a/strict_island_render_test.go
+++ b/strict_island_render_test.go
@@ -1,0 +1,167 @@
+package gosx_test
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	vmpkg "m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/island"
+	"m31labs.dev/gosx/route"
+)
+
+// This file proves a strict island end to end: lowering accepts it, the
+// server renders it with proven props, and the client VM (the same Go code
+// the production WASM build ships, run natively here) hydrates it and
+// answers a real dispatched event with the correct new state.
+//
+// Typed props cross the server/client boundary as plain JSON, the same as a
+// legacy island: localComponentProps (route/fileprogram.go) proves the
+// call's field coverage and leaf types against the strict island's declared
+// props struct, exactly as it does for an ordinary strict component, then
+// hands the proven map[string]any to env.island for JSON serialization. On
+// the client, client/vm/island.go's parseProps exposes every serialized key
+// as both a flat prop (legacy convention, e.g. "Label") and a field of a
+// reserved "props" object binding (client/vm/island.go, parseProps) — so a
+// strict island body's props.Label selector resolves with no VM change.
+
+type counterProps struct {
+	Label string
+	Start int
+}
+
+const strictCounterIslandSource = `package app
+
+import "m31labs.dev/gosx/signal"
+
+type CounterProps struct {
+	Label string
+	Start int
+}
+
+//gosx:island
+component Counter(props: CounterProps) {
+	count := signal.New(props.Start)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <div class="counter">
+		<span>{props.Label}</span>
+		<button onClick={increment}>{count.Get()}</button>
+	</div>
+}
+
+component Page(props: CounterProps) {
+	return <main><Counter label={props.Label} start={props.Start} /></main>
+}
+`
+
+// TestStrictIslandRendersProvenPropsServerSide is the server-side half of
+// the proof: it asserts on the actual rendered HTML bytes and the actual
+// manifest JSON bytes a real page would ship to the browser.
+func TestStrictIslandRendersProvenPropsServerSide(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictCounterIslandSource))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+
+	var counter *ir.Component
+	for i, c := range prog.Components {
+		if c.Name == "Counter" {
+			counter = &prog.Components[i]
+		}
+	}
+	if counter == nil {
+		t.Fatalf("Counter component not found")
+	}
+	if counter.Syntax != ir.ComponentSyntaxStrict {
+		t.Fatalf("Counter.Syntax = %v, want ComponentSyntaxStrict", counter.Syntax)
+	}
+	if !counter.IsIsland {
+		t.Fatalf("Counter.IsIsland = false, want true")
+	}
+
+	// gosx check's own island gate: LowerIsland must succeed for every
+	// IsIsland component (cmd/gosx/main.go's runCheck runs the same call).
+	if _, err := ir.LowerIsland(prog, indexOf(prog, "Counter")); err != nil {
+		t.Fatalf("LowerIsland(Counter): %v", err)
+	}
+
+	renderer := island.NewRenderer("test-bundle")
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{
+		Props:        counterProps{Label: "Draft Pick", Start: 7},
+		RenderIsland: renderer.RenderIslandFromProgram,
+	})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	const wantHTML = `<main><div id="gosx-island-0" data-gosx-island="Counter" data-gosx-enhance="island" data-gosx-enhance-layer="runtime" data-gosx-fallback="server"><div class="counter"> <span>Draft Pick</span> <button data-gosx-on-click="increment" data-gosx-handler="increment" data-gosx-path="0/3">7</button> </div></div></main>`
+	if html != wantHTML {
+		t.Fatalf("rendered HTML =\n%s\nwant\n%s", html, wantHTML)
+	}
+
+	manifestJSON, err := renderer.ManifestJSON()
+	if err != nil {
+		t.Fatalf("ManifestJSON: %v", err)
+	}
+	for _, want := range []string{`"Label": "Draft Pick"`, `"Start": 7`, `"handlerName": "increment"`} {
+		if !strings.Contains(manifestJSON, want) {
+			t.Fatalf("manifest JSON missing %q:\n%s", want, manifestJSON)
+		}
+	}
+}
+
+// TestStrictIslandClientVMHydratesAndDispatches is the client-side half of
+// the proof: it runs the actual client/vm package (the code the production
+// WASM build ships, compiled here as native Go) against the island program
+// LowerIsland produced, feeds it the same JSON a real hydration script tag
+// would carry, and dispatches the same click event a real browser click
+// would dispatch — then asserts the resulting DOM text changed correctly.
+func TestStrictIslandClientVMHydratesAndDispatches(t *testing.T) {
+	prog, err := gosx.Compile([]byte(strictCounterIslandSource))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	clientProg, err := ir.LowerIsland(prog, indexOf(prog, "Counter"))
+	if err != nil {
+		t.Fatalf("LowerIsland: %v", err)
+	}
+	if len(clientProg.Handlers) != 1 || clientProg.Handlers[0].Name != "increment" {
+		t.Fatalf("client program handlers = %#v, want exactly one named %q", clientProg.Handlers, "increment")
+	}
+
+	isl := vmpkg.NewIsland(clientProg, `{"Label":"Draft Pick","Start":7}`)
+	if isl == nil {
+		t.Fatalf("NewIsland returned nil")
+	}
+	if got := strings.TrimSpace(renderTreeText(isl.CurrentTree())); got != "Draft Pick 7" {
+		t.Fatalf("hydrated tree before dispatch = %q, want %q", got, "Draft Pick 7")
+	}
+
+	isl.Dispatch("increment", "{}")
+	if got := strings.TrimSpace(renderTreeText(isl.CurrentTree())); got != "Draft Pick 8" {
+		t.Fatalf("hydrated tree after dispatch = %q, want %q", got, "Draft Pick 8")
+	}
+}
+
+func indexOf(prog *ir.Program, name string) int {
+	for i, c := range prog.Components {
+		if c.Name == name {
+			return i
+		}
+	}
+	return -1
+}
+
+// renderTreeText concatenates every text/expr leaf in a ResolvedTree's node
+// list, in order, giving a compact byte-level assertion surface without a
+// full HTML serializer.
+func renderTreeText(tree *vmpkg.ResolvedTree) string {
+	if tree == nil {
+		return ""
+	}
+	var b strings.Builder
+	for _, n := range tree.Nodes {
+		b.WriteString(n.Text)
+	}
+	return b.String()
+}

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -560,25 +560,31 @@ func Counter(props CounterProps) Node {
 	}
 }
 
-func TestCheckFileRejectsStrictClientDirectiveComponents(t *testing.T) {
-	for _, tc := range []struct {
-		name      string
-		directive string
-		want      string
-	}{
-		{name: "island", directive: "//gosx:island", want: "strict island declarations are not supported"},
-		{name: "engine", directive: "//gosx:engine surface", want: "strict engine declarations are not supported"},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			dir := newTestModule(t)
-			path := filepath.Join(dir, "client.gsx")
-			mustWrite(t, path, "package main\n"+tc.directive+"\ncomponent Client() {\nreturn <canvas />\n}\n")
-			err := CheckFile(context.Background(), path)
-			if err == nil || !strings.Contains(err.Error(), tc.want) {
-				t.Fatalf("CheckFile error = %v", err)
-			}
-		})
-	}
+// TestCheckFileAcceptsStrictIslandRejectsStrictEngine covers the split
+// verdict: strictcheck.CheckFile now passes a strict island (its props cross
+// to the client the same way an ordinary strict component's props are
+// proved server-side, then travel to the browser as plain JSON), and still
+// fails a strict engine, whose per-frame host calls the file renderer has no
+// typed dispatch for.
+func TestCheckFileAcceptsStrictIslandRejectsStrictEngine(t *testing.T) {
+	t.Run("island", func(t *testing.T) {
+		dir := newTestModule(t)
+		path := filepath.Join(dir, "client.gsx")
+		mustWrite(t, path, "package main\n//gosx:island\ncomponent Client() {\nreturn <canvas />\n}\n")
+		if err := CheckFile(context.Background(), path); err != nil {
+			t.Fatalf("CheckFile error = %v", err)
+		}
+	})
+	t.Run("engine", func(t *testing.T) {
+		dir := newTestModule(t)
+		path := filepath.Join(dir, "client.gsx")
+		mustWrite(t, path, "package main\n//gosx:engine surface\ncomponent Client() {\nreturn <canvas />\n}\n")
+		want := "strict engine declarations are not yet supported"
+		err := CheckFile(context.Background(), path)
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("CheckFile error = %v, want to contain %q", err, want)
+		}
+	})
 }
 
 func TestCheckTreeSkipsGeneratedHiddenAndNestedGitButChecksUnderscoreRoutes(t *testing.T) {


### PR DESCRIPTION
## Summary

Allow `component Name(props)` declared with `//gosx:island` to compile, render, and hydrate. The pipeline previously rejected this syntax entirely; `ir/lower.go` and `route/fileprogram.go` are updated to treat strict islands identically to legacy ones, routing them through the island lowerer and hydration path while preserving typed prop proofs. Strict engine declarations (`//gosx:engine`) remain unsupported due to file renderer limitations.

## Changes

- Remove the v0.39-era rejection in `ir/lower.go` for strict `//gosx:island` components, allowing them to pass the compiler gate.
- Update `route/fileprogram.go` to exclude strict islands from inline local-component rendering so they correctly route to the island hydration path (`renderLocalIsland`) with proven props maps.
- Keep `//gosx:engine` strictly rejected, updating the error message to cite the actual current limitation (no typed dispatch for per-frame host calls) instead of a stale version number.
- Add comprehensive tests (`strict_island_boundary_test.go`, `strict_island_render_test.go`, `e2e/strict_island_prod_e2e_test.go`) covering compilation, server-side prop validation, client VM hydration, and real browser click dispatches.
- Convert existing example fixtures (`examples/hotswap/counter.gsx`, `e2e/testdata/go-wasm-mixed/app/counter.gsx`) and update unit/integration tests to verify strict island behavior matches legacy spelling exactly.

## Testing

- Run `go test ./... -run "TestCompileAcceptsStrictIsland|TestStrictIslandPropsBoundaryFailsClosed|TestStrictIslandRendersProvenPropsServerSide|TestStrictIslandClientVMHydratesAndDispatches"` to verify server-side lowering, prop typing, and VM hydration.
- Run `cd e2e && go test -tags=e2e -run TestProductionBuildHydratesStrictIsland` to build a production bundle and drive Chrome to confirm initial render and DOM updates.
- Verify `gosx check` and `gosx render` pass for `//gosx:island` strict components and fail cleanly for `//gosx:engine`.