### PR TITLE
add(rendering): Add named slots to strict components for multiple injection points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -141,10 +141,9 @@
   before this change): a propless strict component's nested call site
   wrongly received a `gosx.Props()` `AttrList` argument whenever the call
   passed slots or children. This change closes the slots-only instance of
-  that bug (a propless component with only named slots, called with no
-  attributes and no children, now projects correctly) and leaves the
-  pre-existing children-only instance exactly as it was — untouched, not
-  this change's scope.
+  that bug; the pre-existing children-only instance is closed separately,
+  below ("Fixed: a propless strict component's nested call site rejected
+  children and slots").
 - **Deliberately out of scope this release: a caller-side `slot="Name"`
   attribute for a `.gsx`-to-`.gsx` nested call** (`<Layout><div
   slot="Title">...</div></Layout>`). The binding mechanism (a reserved
@@ -180,6 +179,28 @@
   whitespace-only text node between tags to one space — ir/lower.go's
   `lowerText`) against a pre-conversion hand-written compact HTML string;
   no document structure changed.
+
+### Fixed: a propless strict component's nested call site rejected children and slots
+
+- **`emitComponentCall`'s Go projection (transpile/transpile.go) no longer
+  passes a stray `gosx.Props()` argument to a propless strict callee.**
+  `emitStrictComponent` emits no leading props parameter for a strict
+  component that declares none, but `emitComponentCall` unconditionally
+  supplied a `gosx.Props()` `AttrList` value as the first argument at any
+  nested call site whose children (or, after the named-slots change
+  above, named slots) were non-empty — a type error `gosx check` reported
+  as `cannot use gosx.Props() ... as gosx.Node value`. This predates named
+  slots and is independent of them:
+  `TestCheckFileAllowsProplessStrictCalleeWithChildren`
+  (strictcheck/check_test.go) reproduces it with no slots at all, fails on
+  unmodified `origin/main`, and passes with this fix.
+- **The fix distinguishes a propless strict callee from an untyped legacy
+  one** (`isProplessStrictComponent`): only the latter's declared
+  parameter (`props any` or `props gosx.AttrList`) can receive a
+  `gosx.Props()` value, so only it still receives one. A strict callee
+  with a declared props type never reaches this code path at all
+  (`emitGSXElement` routes it through `emitTypedComponentCall`), so this
+  narrows an existing rule rather than adding a new one.
 
 ## v0.49.0 (2026-08-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -144,14 +144,9 @@
   that bug; the pre-existing children-only instance is closed separately,
   below ("Fixed: a propless strict component's nested call site rejected
   children and slots").
-- **Deliberately out of scope this release: a caller-side `slot="Name"`
-  attribute for a `.gsx`-to-`.gsx` nested call** (`<Layout><div
-  slot="Title">...</div></Layout>`). The binding mechanism (a reserved
-  `slot<Name>` identifier, resolved generically through the existing
-  render-scope lookup) generalizes to it directly, but this change does
-  not wire caller-side attribute parsing or partitioning for it. Today a
-  named slot is supplied only from a Go caller (`ProgramRenderEnv.Slots`)
-  or filled by the renderer for the two reserved island-runtime names.
+- **A caller-side `slot="Name"` attribute for a `.gsx`-to-`.gsx` nested
+  call is implemented separately, below** ("Added: a `.gsx` page can fill
+  a named slot on a `.gsx`-to-`.gsx` nested call, with no Go glue").
 - **`examples/dashboard`'s `Layout`, `Sidebar`, and `Footer` convert to a
   new `layout.gsx`**, dropping the raw `gosx.El` call count from 49 to 42
   (all 7 of the layout-chrome sites the prior entry named). `Sidebar` and
@@ -201,6 +196,118 @@
   with a declared props type never reaches this code path at all
   (`emitGSXElement` routes it through `emitTypedComponentCall`), so this
   narrows an existing rule rather than adding a new one.
+
+### Added: a `.gsx` page can fill a named slot on a `.gsx`-to-`.gsx` nested call, with no Go glue
+
+- **A static `slot="Name"` attribute on a direct child of a nested
+  component call fills that named slot** — `<Layout><div
+  slot="Title">Standings</div><p>page content</p></Layout>` places
+  `<div>Standings</div>` (the whole tagged element, not just its inner
+  text — the same "one opaque `gosx.Node`" contract every other slot
+  supply already keeps) in Layout's `{slotTitle}` hole, and folds `<p>page
+  content</p>` into the ordinary `{children}` group. This is the `.gsx`
+  page composing a `.gsx` layout the owner named when this task was
+  redirected: before this change, a named slot was reachable only from a
+  Go caller through `ProgramRenderEnv.Slots`, so a pure `.gsx`-to-`.gsx`
+  composition could hand a layout its default children and nothing more.
+- **The child's own `slot` attribute is stripped before it renders** —
+  `ir/lower.go`'s `partitionCallSlots` removes it from the element's
+  `Attrs` whether the slot supply is valid or not, so it never leaks into
+  the output as a stray HTML attribute.
+- **A slot name must be a static string literal.** `slot={someExpr}` fails
+  to compile: "slot must be a static string literal... a computed slot
+  name... would have to be evaluated before the callee's children are
+  known, which reintroduces the ordering problem named slots close." A
+  computed name would need its value at partition time, before the
+  callee's children (and therefore its render order) are settled — exactly
+  the ordering problem the framework-filled `slotPreloadHints`/
+  `slotPageHead` slots (the prior entry) close by keeping that computation
+  inside the renderer, never inside a `.gsx` expression. No case surfaced
+  during this work where a literal name was insufficient; if one exists,
+  it is not in this codebase's own examples or test suite.
+- **`slot="Name"` is meaningful only on a DIRECT child of a component
+  call.** Two mistakes both fail closed with the same diagnostic instead
+  of silently joining the default children group: a slot on a plain HTML
+  element's own child (`<div><span slot="Title">x</span></div>`, no
+  enclosing component call at all), and a slot buried one level too deep
+  — wrapped in a plain HTML element or a Fragment before it ever reaches
+  the component call (`<Layout><div><span
+  slot="Title">x</span></div></Layout>`). An author who mistypes the
+  nesting is told so, at the exact element the mistake is on
+  (`partitionCallSlots` reports the child's own span, not the enclosing
+  call's).
+- **A slot supplied but not declared by the callee fails closed at
+  compile time** (`validateStrictCalleeSlots`, ir/lower.go) — the same
+  arity precedent `validateStrictCalleeChildren` already sets for
+  children, now provable statically here because `ir.Lower` has full
+  visibility into both the caller's supply and the callee's declared set
+  within one compiled program. A slot the callee declares but the call
+  site does not tag stays an unresolved scope identifier and renders
+  empty, exactly like an unsupplied `{children}` does today.
+- **Order at the call site never matters.** A slot-tagged child binds by
+  name, not by position among its siblings —
+  `TestCallerSideSlotOrderIndependent` (route/named_slots_test.go) proves
+  placing the tagged child first or last produces byte-identical output.
+  This matters because the OLD, unpartitioned children projection did not
+  have this property (see the next two points): `transpile.go`'s call-site
+  emission had to change to make it true.
+- **Fixed a second, closely related bug this feature's own implementation
+  surfaced: `emitTypedComponentCall`'s Go projection (a strict callee WITH
+  a declared props type) appended every child — slot-tagged or not — to
+  its call positionally, with no awareness that a slot-tagged child
+  belonged in an earlier, named parameter position.** That call still
+  compiled whenever the argument count matched (a slot count of N plus the
+  true children count still fills N-plus-variadic parameters), so a
+  caller's markup ORDER, not its `slot="Name"` tags, silently decided
+  which child filled which slot — confirmed with a reproduction where
+  swapping two children's order silently swapped which one bound to
+  `slotTitle`.
+  `TestTranspileTypedComponentCallRoutesSlotByName`
+  (transpile/named_slots_test.go) is the regression test.
+  `emitComponentCall` (the propless-strict / untyped-legacy call shape)
+  had the identical defect; `TestTranspileEmitComponentCallRoutesSlotByName`
+  covers it too. Both are fixed together, in `emitChildrenAndSlots`
+  (transpile.go): it partitions a statically slot-tagged direct child's
+  own projection out of the children list at the CST level, mirroring
+  `partitionCallSlots`, and `orderedSlotArgs` places each one in the exact
+  parameter position `emitStrictComponent` declared it in — a
+  declared-but-unsupplied slot still gets its zero `gosx.Node{}`, in
+  position, the same as before this feature added call-site syntax.
+  Neither call-site emitter duplicates `ir.Lower`'s validation
+  (non-static, non-direct-descendant, undeclared): `strictcheck.CheckFile`
+  always lowers before it transpiles (`checkPackage`'s builtin stage
+  order), so a program that reaches either emitter has already passed
+  those checks.
+- **`examples/dashboard/chrome.gsx` converts `CounterHowItWorksCard` to
+  this mechanism** — the proof this entry is checked against. It is a
+  same-file, same-program nested `<HeaderCard>` call with no
+  `RenderProgramComponent` anywhere in that specific path: `HeaderCard` is
+  a new component (`<div class="card">{slotHeader}{children}</div>`), left
+  separate from the existing `Card` component on purpose — adding a second
+  hole to `Card` itself and letting `gosx fmt` reformat its body onto
+  separate lines would have put a stray whitespace-only text node around
+  every existing `chromeCard` call's content (`ir/lower.go`'s `lowerText`
+  collapses one to a space), a real behavior change for markup this
+  conversion had no reason to touch. `CounterHowItWorksCard`'s own `<h3>`
+  heading moves to `slot="Header"`; its five `<p>` steps stay ordinary
+  children. The raw `gosx.El(` count in `examples/dashboard` does not
+  move: `chrome.gsx` was already `.gsx`, not `gosx.El`-based, before this
+  conversion — it stays at 42 (see the prior entry for the 49-to-42 move).
+- **The converted component's rendered output was diffed against the
+  pre-conversion output**, both in isolation (`CounterHowItWorksCard`
+  rendered alone through `RenderProgramComponent`) and for the full
+  `/counter` and `/kitchen-sink` page responses (a second worktree at the
+  pre-conversion commit, both dashboard servers run, both pages captured).
+  After masking the wall-clock timestamp and normalizing insignificant
+  whitespace runs to a single space, both diffs are empty: same tags, same
+  attributes, same text, same nesting, same order, everywhere on the page,
+  not only around the converted card. The unnormalized diff is two spots
+  of extra whitespace (three collapsed spaces where the pre-conversion
+  output had one, in two places) — `gosx fmt`'s canonical formatting of
+  `HeaderCard`'s new `{slotHeader}{children}` body onto separate lines,
+  and of the call site's own slot-tagged child onto its own line, each
+  adding one more whitespace-only text node than the pre-conversion
+  single-`<div class="card">` version had. No document structure changed.
 
 ## v0.49.0 (2026-08-18)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,108 @@
   Named, multiple slots are a separate, unimplemented capability; `Layout`,
   `Sidebar`, and `Footer` still build their markup with `gosx.El`.
 
+### Added: named slots close the gap one `{children}` hole left (gosx#249)
+
+- **A strict component may now declare any number of named slots**, each a
+  bare reserved identifier `slot<Name>` (`{slotTitle}`, `{slotPageHead}`),
+  parallel to `children` but distinct from it and from every other named
+  slot. `internal/strictcomponent.IsSlotBindingName` names the one shape
+  every seam recognizes: `slot` followed by an upper-case-initial name. A
+  layout-shaped component can now express the three-plus injection points
+  one `{children}` hole could not — a per-route title, an island
+  preload-hints node, the page body, and an end-of-body hydration
+  manifest — each with its own name, none of them the same content
+  repeated (see `TestMultipleNamedSlotsAddressDistinctInjectionPoints`).
+- **A Go caller supplies a named slot through `ProgramRenderEnv.Slots
+  map[string]gosx.Node`**, keyed by slot name (`"Title"`, not
+  `"slotTitle"`), threaded to `fileRenderOptions.EntrySlots` the same way
+  `Children` reaches `EntryChildren`. A key naming a slot the render
+  entry's body never declares fails closed with a descriptive error,
+  following `validateStrictCalleeChildren`'s arity-rule precedent
+  (ir/lower.go) — supplying content a callee cannot place is a caller
+  error, not a silent no-op. A slot the body declares but `Slots` does not
+  supply stays an unresolved scope identifier and renders empty, exactly
+  the way an unsupplied `{children}` already does.
+- **Slots stay unproven, exactly as `{children}` already is.** A slot
+  value never enters `PropsFields`, `PropsPaths`, or `PropsSlices`; the
+  render entry proves `Props` directly against the caller's struct,
+  independent of any slot supplied beside it. A slot value is also
+  restricted to child-expression position, the same restriction
+  `{children}` already has (`class={slotFoo}` fails to check, for the same
+  reason `class={children}` does): a slot carries one opaque `gosx.Node`
+  the caller already rendered, not scalar data a caller could read a field
+  of.
+- **The end-of-body ordering case is closed for a pure `.gsx`-to-`.gsx`
+  nested call, with no Go glue and no relaxation of the no-function-calls
+  rule in strict expressions.** Two slot names, `PreloadHints` and
+  `PageHead`, are framework-filled: no caller writes a `.gsx` expression
+  or a `Slots` entry for them anywhere. `writeLocalComponentWithChildren`
+  (route/fileprogram.go) computes and binds them itself, immediately after
+  the call site's own children have fully rendered (any island those
+  children registered is already reflected) and before the callee's own
+  body walks — the identical two-step order `writeLocalComponent` already
+  used for `children` (render children first, walk the callee body
+  second), just with two more values computed in that same window. The
+  renderer fills a reserved hole; the `.gsx` author only writes a
+  placement, never a computation. `TestFrameworkFilledSlotReflectsIslandsRegisteredByChildren`
+  (route/named_slots_test.go) proves it end to end: the manifest script
+  placed at the very end of the body names the island the children
+  registered, and a snapshot taken before those children render proves the
+  two values genuinely differ — the ordering guarantee is load-bearing,
+  not incidental.
+- **`emitStrictComponent`'s Go projection places each slot parameter
+  before the variadic `children ...gosx.Node`** (transpile/transpile.go)
+  — Go forbids any parameter after `...T`, so a slot parameter can never
+  follow it. `strictcheck.CheckFile` transpiles through this path, so
+  `gosx check` depends on the ordering. `emitComponentCall`'s nested-call
+  projection supplies a zero `gosx.Node{}` for each declared slot a call
+  site does not otherwise resolve — this projection has no `slot="Name"`
+  call-site syntax yet, so every nested call takes the "declared but not
+  supplied" branch (see the next point). Fixing this exposed a latent
+  instance of a pre-existing, unrelated bug (confirmed present on `main`
+  before this change): a propless strict component's nested call site
+  wrongly received a `gosx.Props()` `AttrList` argument whenever the call
+  passed slots or children. This change closes the slots-only instance of
+  that bug (a propless component with only named slots, called with no
+  attributes and no children, now projects correctly) and leaves the
+  pre-existing children-only instance exactly as it was — untouched, not
+  this change's scope.
+- **Deliberately out of scope this release: a caller-side `slot="Name"`
+  attribute for a `.gsx`-to-`.gsx` nested call** (`<Layout><div
+  slot="Title">...</div></Layout>`). The binding mechanism (a reserved
+  `slot<Name>` identifier, resolved generically through the existing
+  render-scope lookup) generalizes to it directly, but this change does
+  not wire caller-side attribute parsing or partitioning for it. Today a
+  named slot is supplied only from a Go caller (`ProgramRenderEnv.Slots`)
+  or filled by the renderer for the two reserved island-runtime names.
+- **`examples/dashboard`'s `Layout`, `Sidebar`, and `Footer` convert to a
+  new `layout.gsx`**, dropping the raw `gosx.El` call count from 49 to 42
+  (all 7 of the layout-chrome sites the prior entry named). `Sidebar` and
+  `Footer` are now plain strict components — `Footer` takes a `Message`
+  prop rather than a slot, since its per-request value (built with
+  `time.Now()`, which a strict expression cannot call) is scalar data, not
+  markup a slot's element-content-only contract could carry. `Layout`
+  declares `{slotTitle}`, `{slotPreloadHints}`, `{children}`, and
+  `{slotPageHead}`; `main.go`'s `chromeLayout` supplies all four in one
+  `RenderProgramComponent` call, since `/counter` and `/kitchen-sink`'s
+  own page content is deliberately hand-written Go (it needs real
+  signals, handlers, and island VM opcodes a strict `.gsx` body cannot
+  express) — the same "content built first, then the layout wraps it"
+  order every `route.LayoutFunc` already guarantees, not a new ordering
+  arrangement this conversion had to invent.
+- **The converted layout's rendered `/counter` and `/kitchen-sink`
+  responses were diffed against the pre-conversion output.** After
+  masking the wall-clock timestamp and normalizing insignificant
+  inter-tag whitespace and void-element self-closing (`<meta ... />` vs
+  `<meta ...>` — HTML5 parses both identically), the two are
+  byte-identical: same doctype, same tags, same attributes, same nesting,
+  same text, same island manifest content, in the same order. The
+  unnormalized diff is whitespace-only, a side effect of `gosx fmt`'s
+  canonical multi-line formatting (each `.gsx` grammar collapses a
+  whitespace-only text node between tags to one space — ir/lower.go's
+  `lowerText`) against a pre-conversion hand-written compact HTML string;
+  no document structure changed.
+
 ## v0.49.0 (2026-08-18)
 
 ### Fixed: LoadFileProgram's documented fragment pattern broke under a `-trimpath` build

--- a/examples/dashboard/chrome.gsx
+++ b/examples/dashboard/chrome.gsx
@@ -11,7 +11,20 @@ package main
 // only known at request time. Before gosx#246 gave strict components a
 // {children} hole, and RenderProgramComponentNode a way to splice a
 // Go-computed node into it, the card div itself had to be a gosx.El call in
-// main.go (see chromeCard in chrome.go).
+// main.go (see chromeCard in chrome.go). Card itself is left exactly as it
+// was: adding a second hole to it and letting gosx fmt reformat its body
+// onto separate lines would put a stray whitespace-only text node around
+// every existing chromeCard call's content (ir/lower.go's lowerText
+// collapses one to a space) — a real behavior change for markup this
+// conversion has no reason to touch.
+//
+// HeaderCard is CounterHowItWorksCard's own shell instead (gosx#249): a
+// caller-side slot="Header" attribute on a direct child, filled through a
+// same-file, same-program nested <HeaderCard> call — no
+// RenderProgramComponent anywhere in that path — because
+// CounterHowItWorksCard's whole heading-plus-steps body is static prose
+// with no per-request data. See the CHANGELOG entry for this change for
+// the rendered-bytes proof this conversion is checked against.
 
 component CounterIntro() {
 	return <h1>Counter (Island Demo)</h1>
@@ -19,6 +32,13 @@ component CounterIntro() {
 
 component Card() {
 	return <div class="card">{children}</div>
+}
+
+component HeaderCard() {
+	return <div class="card">
+		{slotHeader}
+		{children}
+	</div>
 }
 
 component CounterCardHeader() {
@@ -32,8 +52,8 @@ component CounterCardHeader() {
 }
 
 component CounterHowItWorksCard() {
-	return <div class="card">
-		<h3>How It Works</h3>
+	return <HeaderCard>
+		<h3 slot="Header">How It Works</h3>
 		<p>
 			1. counter.gsx is compiled to an IslandProgram at server startup
 		</p>
@@ -49,7 +69,7 @@ component CounterHowItWorksCard() {
 		<p>
 			5. Signal updates trigger reconciliation and DOM patching
 		</p>
-	</div>
+	</HeaderCard>
 }
 
 component KitchenSinkIntro() {

--- a/examples/dashboard/layout.go
+++ b/examples/dashboard/layout.go
@@ -1,0 +1,24 @@
+package main
+
+import (
+	"log"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/route"
+)
+
+// layoutProgram is layout.gsx's compiled IR, loaded once at startup —
+// chromeProgram's counterpart for the document shell (chrome.go). Every
+// route.RenderProgramComponentNode call in main.go reads through the same
+// cached program (route.LoadFileProgramHere caches by path and mtime), so
+// an edit to layout.gsx invalidates it exactly the way an edit to
+// chrome.gsx does.
+var layoutProgram = mustLoadLayoutProgram()
+
+func mustLoadLayoutProgram() *ir.Program {
+	prog, err := route.LoadFileProgramHere("layout.gsx")
+	if err != nil {
+		log.Fatalf("load layout.gsx: %v", err)
+	}
+	return prog
+}

--- a/examples/dashboard/layout.gsx
+++ b/examples/dashboard/layout.gsx
@@ -1,0 +1,84 @@
+package main
+
+// layout.gsx holds the document shell for /counter and /kitchen-sink, the
+// two routes whose own page content stays hand-written Go (see
+// CounterPage/KitchenSinkPage in main.go — they need real signals,
+// handlers, and expression opcodes the island VM executes, which a
+// strict .gsx body cannot express).
+//
+// Before named slots (gosx#249) this shell had to be a gosx.El call in
+// main.go: a single {children} hole cannot address the shell's four
+// distinct injection points — a per-route title and a per-request
+// island-preload-hints node inside <head>, the page content inside <body>,
+// and an island hydration manifest at the very end of <body>, after
+// content the file renderer has not finished writing when <head> closes.
+// Named slots give each one its own bare identifier: {slotTitle},
+// {slotPreloadHints}, {children}, and {slotPageHead}. main.go's
+// chromeLayout supplies all four in one RenderProgramComponent call, the
+// same "content built first, then the layout wraps it" order
+// LayoutFunc's own contract already guarantees for route.Route.Layout
+// (route/filesystem.go's applyLayoutFuncs) — see chromeLayout's own doc
+// comment for why that ordering makes slotPreloadHints and slotPageHead
+// correct without a strict expression ever computing a value that depends
+// on a sibling's render order.
+//
+// gosx fmt reformats this component's markup onto one line per element,
+// which inserts a single collapsed space at some tag boundaries the
+// pre-conversion hand-written HTML string did not have (ir/lower.go's
+// lowerText collapses any whitespace-only text between tags to one space).
+// The CHANGELOG entry for this change documents the exact, normalized
+// (structure-only) diff against the pre-conversion output; this is a
+// formatting-driven, semantically inert whitespace difference, not a
+// document-structure change.
+component Layout() {
+	return <html>
+		<head>
+			<meta charset="utf-8" />
+			<meta name="viewport" content="width=device-width, initial-scale=1" />
+			<title>{slotTitle}</title>
+			<link rel="stylesheet" href="/static/styles.css" />
+			{slotPreloadHints}
+		</head>
+		<body>
+			<div class="layout">
+				<Sidebar />
+				<main class="main">{children}</main>
+			</div>
+			{slotPageHead}
+		</body>
+	</html>
+}
+
+// Sidebar renders the navigation sidebar. It carries no per-request data,
+// so Layout places it with a plain nested call — no slot needed.
+component Sidebar() {
+	return <aside class="sidebar">
+		<h2>GoSX Dashboard</h2>
+		<nav>
+			<a href="/">Home</a>
+			<a href="/users">Users</a>
+			<a href="/users/new">New User</a>
+			<a href="/counter">Counter</a>
+			<a href="/kitchen-sink">Kitchen Sink</a>
+			<a href="/settings">Settings</a>
+		</nav>
+	</aside>
+}
+
+// FooterProps carries the one per-request value the footer renders: the
+// version-and-timestamp line main.go's chromeFooter computes with
+// time.Now(), which a strict .gsx expression cannot call. This is a proved
+// prop, not a slot — the value is scalar data, not markup a slot's
+// element-content-only contract could carry (see IsSlotBindingName's doc
+// comment on why a slot rejects attribute position). Footer is rendered
+// directly from Go (chromeFooter) and its result folds into the children
+// Fragment chromeLayout passes to Layout, the same way today's Footer()
+// nests inside <main> beside content — Layout's own body never calls
+// <Footer/>.
+type FooterProps struct {
+	Message string
+}
+
+component Footer(props: FooterProps) {
+	return <div class="footer">{props.Message}</div>
+}

--- a/examples/dashboard/main.go
+++ b/examples/dashboard/main.go
@@ -118,7 +118,7 @@ func main() {
 				isl := newIslands()
 				countStr := ctx.Query("count")
 				count, _ := strconv.Atoi(countStr)
-				return Layout("Dashboard", isl, CounterPage(count, isl))
+				return chromeLayout("Dashboard", isl, CounterPage(count, isl))
 			},
 			Handler: func(ctx *route.RouteContext) gosx.Node {
 				return gosx.Text("") // content built in layout
@@ -128,7 +128,7 @@ func main() {
 			Pattern: "/kitchen-sink",
 			Layout: func(ctx *route.RouteContext, content gosx.Node) gosx.Node {
 				isl := newIslands()
-				return Layout("Dashboard", isl, KitchenSinkPage(isl))
+				return chromeLayout("Dashboard", isl, KitchenSinkPage(isl))
 			},
 			Handler: func(ctx *route.RouteContext) gosx.Node {
 				return gosx.Text("")
@@ -197,69 +197,64 @@ func main() {
 	log.Fatal(http.ListenAndServe(addr, mux))
 }
 
-// Layout wraps all pages with shared navigation and structure.
-func Layout(title string, islands *island.Renderer, content gosx.Node) gosx.Node {
-	// Preload hints go in <head> — browser starts WASM download during HTML parse
-	preloadHTML := ""
+// chromeLayout wraps content with layout.gsx's Layout component: the
+// shared navigation, document shell, and island hydration hooks every
+// /counter and /kitchen-sink response needs (gosx#249). Sidebar nests
+// inside Layout's own body with no data of its own to supply — see
+// layout.gsx. Footer needs one per-request value (chromeFooter's message,
+// built with time.Now()), which a strict .gsx expression cannot compute,
+// so it renders through chromeFooter here and folds into the same
+// Fragment as content, matching this file's pre-conversion nesting of
+// content and the footer together inside the layout's main element.
+//
+// islands, when non-nil, has already registered every island content
+// contains by the time this function runs: content is a fully built
+// gosx.Node BEFORE chromeLayout is called (CounterPage/KitchenSinkPage run
+// as an argument to this call, and Go evaluates a function's arguments
+// before the call), so PreloadHints and PageHead already reflect it here —
+// the same "content built first, then the layout wraps it" order
+// route.LayoutFunc's own contract guarantees for a file-routed layout
+// (route/filesystem.go's applyLayoutFuncs), not a special case this
+// function has to arrange for itself.
+func chromeLayout(title string, islands *island.Renderer, content gosx.Node) gosx.Node {
+	preloadHints := gosx.Text("")
+	pageHead := gosx.Text("")
 	if islands != nil {
-		preloadHTML = gosx.RenderHTML(islands.PreloadHints())
+		preloadHints = islands.PreloadHints()
+		pageHead = islands.PageHead()
 	}
-
-	return gosx.RawHTML(fmt.Sprintf(`<!DOCTYPE html>
-<html>
-<head>
-<meta charset="utf-8">
-<meta name="viewport" content="width=device-width, initial-scale=1">
-<title>%s</title>
-<link rel="stylesheet" href="/static/styles.css">
-%s</head>
-<body>
-`, title, preloadHTML) + gosx.RenderHTML(
-		gosx.El("div", gosx.Attrs(gosx.Attr("class", "layout")),
-			Sidebar(),
-			gosx.El("main", gosx.Attrs(gosx.Attr("class", "main")),
-				content,
-				Footer(),
-			),
-		),
-	) + "\n" + func() string {
-		if islands != nil {
-			return gosx.RenderHTML(islands.PageHead())
-		}
-		return ""
-	}() + "\n</body>\n</html>")
+	html, err := route.RenderProgramComponent(layoutProgram, "Layout", route.ProgramRenderEnv{
+		Slots: map[string]gosx.Node{
+			"Title":        gosx.Text(title),
+			"PreloadHints": preloadHints,
+			"PageHead":     pageHead,
+		},
+	}, gosx.Fragment(content, chromeFooter()))
+	if err != nil {
+		log.Fatalf("render layout.gsx Layout: %v", err)
+	}
+	// <!DOCTYPE html> has no .gsx element spelling — a doctype is not a tag
+	// — so it is prepended here, in Go, the one part of the pre-conversion
+	// document shell layout.gsx's Layout component does not itself express.
+	return gosx.RawHTML("<!DOCTYPE html>\n" + html)
 }
 
-// Sidebar renders the navigation sidebar.
-func Sidebar() gosx.Node {
-	type navItem struct {
-		href  string
-		label string
+// chromeFooter renders layout.gsx's Footer component with the one
+// per-request value it needs: a version-and-timestamp line built with
+// time.Now(), which a strict .gsx expression cannot call (calls are
+// categorically unsupported in a strict server expression — see
+// strictcomponent.validate's CallExpr case). Message is a proved prop, not
+// a slot: it is scalar data, not markup, and a slot's contract carries
+// only "one opaque gosx.Node" the same way children's does.
+func chromeFooter() gosx.Node {
+	message := fmt.Sprintf("GoSX v%s — Server rendered at %s", gosx.Version, time.Now().Format("15:04:05"))
+	node, err := route.RenderProgramComponentNode(layoutProgram, "Footer", route.ProgramRenderEnv{
+		Props: struct{ Message string }{Message: message},
+	})
+	if err != nil {
+		log.Fatalf("render layout.gsx Footer: %v", err)
 	}
-	items := []navItem{
-		{"/", "Home"},
-		{"/users", "Users"},
-		{"/users/new", "New User"},
-		{"/counter", "Counter"},
-		{"/kitchen-sink", "Kitchen Sink"},
-		{"/settings", "Settings"},
-	}
-
-	return gosx.El("aside", gosx.Attrs(gosx.Attr("class", "sidebar")),
-		gosx.El("h2", gosx.Text("GoSX Dashboard")),
-		gosx.El("nav",
-			gosx.Map(items, func(item navItem, _ int) gosx.Node {
-				return gosx.El("a", gosx.Attrs(gosx.Attr("href", item.href)), gosx.Text(item.label))
-			}),
-		),
-	)
-}
-
-// Footer renders the page footer.
-func Footer() gosx.Node {
-	return gosx.El("div", gosx.Attrs(gosx.Attr("class", "footer")),
-		gosx.Text(fmt.Sprintf("GoSX v%s — Server rendered at %s", gosx.Version, time.Now().Format("15:04:05"))),
-	)
+	return node
 }
 
 // CounterPage demonstrates an interactive island compiled from counter.gsx.

--- a/internal/strictcomponent/expression.go
+++ b/internal/strictcomponent/expression.go
@@ -74,6 +74,60 @@ func (s Scope) isBinding(name string) bool {
 //     component with it (emitStrictComponent, transpile/transpile.go).
 const ChildrenBinding = "children"
 
+// SlotBindingPrefix is the reserved prefix a named slot's bare identifier
+// carries in a strict component's body — "slot" followed by the slot's own
+// PascalCase name, e.g. slotTitle for a slot named "Title". A named slot is
+// children's counterpart for a strict component that needs more than one
+// caller-supplied injection point: children is the one anonymous hole every
+// strict component may place; a named slot is an additional, explicitly
+// named hole, bound the same way (beside props, never inside it, never
+// proved against the declared schema — see IsSlotBindingName).
+const SlotBindingPrefix = "slot"
+
+// IsSlotBindingName reports whether name is a valid named-slot binding
+// identifier: SlotBindingPrefix followed by a non-empty, upper-case-initial
+// name. It is the one shape test every seam that recognizes a slot binding
+// shares — the render scope lookup (route/fileprogram.go), the lowerer's
+// <Each> binding reservation and declared-slot collection (ir/lower.go),
+// and the Go projection's parameter emission (emitStrictComponent,
+// transpile/transpile.go) — so "what counts as a slot identifier" cannot
+// drift between them the way ChildrenBinding's single reserved spelling
+// cannot drift for children.
+//
+// The upper-case-initial rule keeps a slot binding visually distinct from
+// an ordinary lower-case identifier at a glance, and gives SlotName an
+// unambiguous inverse: slotTitle names a slot called "Title", not "title".
+func IsSlotBindingName(name string) bool {
+	if !strings.HasPrefix(name, SlotBindingPrefix) {
+		return false
+	}
+	rest := name[len(SlotBindingPrefix):]
+	if rest == "" {
+		return false
+	}
+	return rest[0] >= 'A' && rest[0] <= 'Z'
+}
+
+// SlotName reports the slot name a valid slot binding identifier names, e.g.
+// SlotName("slotTitle") returns ("Title", true). ok is false when binding is
+// not a valid slot binding identifier (IsSlotBindingName).
+func SlotName(binding string) (name string, ok bool) {
+	if !IsSlotBindingName(binding) {
+		return "", false
+	}
+	return binding[len(SlotBindingPrefix):], true
+}
+
+// SlotBindingName reports the reserved bare identifier a slot named name
+// binds to in a strict component's body, e.g. SlotBindingName("Title")
+// returns "slotTitle". It is SlotName's inverse and ChildrenBinding's
+// counterpart for a named slot: every seam that binds a slot value into
+// render scope, or declares one, spells the identifier through this one
+// function so the "slot" + PascalCase convention cannot drift between them.
+func SlotBindingName(name string) string {
+	return SlotBindingPrefix + name
+}
+
 // exprPosition names the syntactic slot an expression occupies. The strict
 // contract admits a different identifier set per slot, so the slot is an
 // explicit input to validation rather than a property of the source text.
@@ -164,6 +218,25 @@ func IsChildrenExpression(source string) bool {
 	return ok && ident.Name == ChildrenBinding
 }
 
+// IsSlotExpression reports whether source is exactly a named-slot binding
+// identifier (IsSlotBindingName), with parentheses transparent, and if so
+// returns the slot name (SlotName's inverse). It is the slot counterpart to
+// IsChildrenExpression: the single spelling test for "this expression hole
+// places a named slot's caller-supplied value", so the lowerer's declared-
+// slot collection and the Go projection's parameter emission can never
+// disagree about what a named slot looks like.
+func IsSlotExpression(source string) (name string, ok bool) {
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return "", false
+	}
+	ident, isIdent := unwrapParens(expr).(*ast.Ident)
+	if !isIdent {
+		return "", false
+	}
+	return SlotName(ident.Name)
+}
+
 func validateAt(source string, scope Scope, pos exprPosition) error {
 	expr, err := parser.ParseExpr(source)
 	if err != nil {
@@ -190,6 +263,12 @@ func validate(expr ast.Expr, source string, scope Scope, pos exprPosition) error
 			}
 			return fmt.Errorf("children renders as element content, not as an attribute value")
 		default:
+			if IsSlotBindingName(node.Name) {
+				if pos == positionChild {
+					return nil
+				}
+				return fmt.Errorf("%s renders as element content, not as an attribute value", node.Name)
+			}
 			if scope.isIndex(node.Name) {
 				// An Each index binding is always a plain int — the same
 				// parity class already proven for an int props field, so a

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -142,6 +142,37 @@ type Component struct {
 	// and a gosx.Node-typed props field is a separate feature.
 	AcceptsChildren bool
 
+	// AcceptsSlots names every slot this strict component's body declares —
+	// a named, additional caller-supplied injection point beside children,
+	// each placed by its own {slotName} expression hole (gosx#249). Unlike
+	// children, a strict component may declare any number of slots, each
+	// with its own name, because a layout-shaped component can need more
+	// than one distinct injection point (a per-route title and an end-of-
+	// body script are not the same content repeated — see
+	// TestStrictComponentRendersChildrenTwice for why repeating {children}
+	// cannot express that).
+	//
+	// Entries name the slot itself ("Title", not "slotTitle" — see
+	// strictcomponent.SlotBindingName for the reserved identifier a name
+	// binds to). Order matches emitStrictComponent's own parameter order
+	// (sorted), so a caller that needs a stable order for diagnostics or
+	// projection can rely on it without re-deriving it.
+	//
+	// The zero value (nil) is "declares no slots", exactly right for every
+	// program serialized before this field existed and for every component
+	// that never declares one — such a component behaves exactly as it did
+	// before named slots existed, and route/fileprogram.go's runtime check
+	// only ever consults this for a strict render entry that a caller
+	// supplied at least one named slot to (see RenderProgramComponent's
+	// Slots... no caller reaches this path with zero slots to check).
+	//
+	// It does NOT record anything about a slot's type, count, or contents,
+	// the same restriction AcceptsChildren documents: a slot value is one
+	// opaque gosx.Node the caller already rendered and already proved. It
+	// never enters PropsFields, PropsPaths, or PropsSlices, and no boundary
+	// proof reads it.
+	AcceptsSlots []string
+
 	// Syntax distinguishes legacy `func` components from strict
 	// `component Name(props: Type)` declarations.
 	Syntax ComponentSyntax
@@ -202,6 +233,21 @@ type Component struct {
 	// component's function body. Populated by the body analyzer when
 	// the source is a .gsx file with a full component body.
 	Scope *ComponentScope
+}
+
+// AcceptsSlot reports whether this component's body declares a named slot
+// called name (AcceptsSlots' membership test). route/fileprogram.go uses it
+// to decide whether to compute and bind a framework-filled slot value (the
+// island preload-hints and page-head slots) only for a component that
+// actually places it, instead of paying for the computation unconditionally
+// on every strict call.
+func (c *Component) AcceptsSlot(name string) bool {
+	for _, slot := range c.AcceptsSlots {
+		if slot == name {
+			return true
+		}
+	}
+	return false
 }
 
 // SlicePropSchema records the element struct type and the binding-relative

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -340,6 +340,21 @@ type Node struct {
 	// Children holds indices into Program.Nodes.
 	Children []NodeID
 
+	// Slots holds, for a NodeComponent call node only, the caller-supplied
+	// named-slot children a static slot="Name" attribute on a direct child
+	// element partitioned out of Children (gosx#249's caller-side supply).
+	// Keyed by slot name ("Title", not "slotTitle" — see
+	// strictcomponent.SlotBindingName for the reserved identifier a name
+	// binds to). A slot-tagged child's own NodeID lives here instead of in
+	// Children, so the default children group never repeats it.
+	//
+	// The zero value (nil) is "no named slots supplied at this call site",
+	// exactly right for every program serialized before this field
+	// existed and for every call that supplies none — such a call takes no
+	// new branch anywhere this field is read (route/fileprogram.go's
+	// writeLocalComponent).
+	Slots map[string]NodeID
+
 	// IsStatic is true when this subtree contains no expressions or dynamic content.
 	// The renderer can skip hydration for static subtrees.
 	IsStatic bool

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -113,6 +113,22 @@ type lowerer struct {
 	// {children} hole and this map does not claim it is.
 	childrenHoles map[string]bool
 
+	// slotHoles records, per same-file component name, the sorted set of
+	// named slots that component's body declares — every {slotName}
+	// expression hole it contains (gosx#249), childrenHoles' counterpart for
+	// a named, additional injection point. Filled by collectStrictSchemas
+	// the same pass, and for the same reason: a caller's slot-arity rule
+	// must read a callee's declared set from inside the CALLER's own body
+	// walk, and a callee may be declared later in the file.
+	//
+	// Unlike childrenHoles, this is populated for strict components only:
+	// the design brief scopes named slots to strict components ("A strict
+	// component accepts exactly one children slot" is the problem it
+	// solves), and a legacy component already reads an arbitrary value out
+	// of its flattened props map with no reserved-identifier scheme to
+	// collide with.
+	slotHoles map[string][]string
+
 	// currentStrictComponent and currentStrictPropsType name the strict
 	// component whose body lowerGSXNode is currently walking (empty
 	// outside strict lowering). E2 tier 1 (validateStrictToStrictSpreadCall)
@@ -1065,6 +1081,7 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 	l.legacyProps = make(map[string]string)
 	l.typedLegacyProps = make(map[string]string)
 	l.childrenHoles = make(map[string]bool)
+	l.slotHoles = make(map[string][]string)
 	// Pass 1: every same-file strict component's name and props type,
 	// every legacy (non-strict) top-level renderer function's name and
 	// declared props type, every component's {children} hole, and every
@@ -1114,6 +1131,9 @@ func (l *lowerer) collectStrictSchemas(root *gotreesitter.Node) {
 				// complete for the file regardless of declaration order.
 				if l.componentRendersChildren(child) {
 					l.childrenHoles[componentName] = true
+				}
+				if slots := l.componentDeclaredSlots(child); len(slots) > 0 {
+					l.slotHoles[componentName] = slots
 				}
 			}
 		case "type_declaration":
@@ -1208,6 +1228,53 @@ func (l *lowerer) componentRendersChildren(decl *gotreesitter.Node) bool {
 	}
 	walk(body)
 	return found
+}
+
+// componentDeclaredSlots reports the sorted, de-duplicated set of named
+// slots decl's body declares — every {slotName} child expression hole it
+// contains (strictcomponent.IsSlotExpression), the slot counterpart to
+// componentRendersChildren. It shares that function's CST walk shape,
+// including the same deliberate refusal to descend into an attribute value
+// (see componentRendersChildren's doc comment for why: class={slotFoo}
+// would otherwise register a slot placement that can never render markup).
+//
+// Unlike componentRendersChildren it does not stop at the first match: a
+// layout-shaped component may declare more than one named slot, and every
+// one of them must reach l.slotHoles so validateStrictCalleeSlots-shaped
+// callers and the runtime EntrySlots check both see the complete set.
+func (l *lowerer) componentDeclaredSlots(decl *gotreesitter.Node) []string {
+	body := l.childByField(decl, "body")
+	if body == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var names []string
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		switch l.nodeType(node) {
+		case "jsx_attribute", "jsx_spread_attribute":
+			return
+		case "jsx_expression_container":
+			exprNode := l.childByField(node, "expression")
+			if exprNode != nil {
+				if name, ok := strictcomponent.IsSlotExpression(l.text(exprNode)); ok {
+					if _, dup := seen[name]; !dup {
+						seen[name] = struct{}{}
+						names = append(names, name)
+					}
+				}
+			}
+		}
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			walk(node.NamedChild(i))
+		}
+	}
+	walk(body)
+	sort.Strings(names)
+	return names
 }
 
 // collectStrictPropReads records every props field path (dot-joined, e.g.
@@ -2629,6 +2696,7 @@ func (l *lowerer) lowerStrictComponentDecl(n *gotreesitter.Node) {
 		// for every strict component in the file, and every call-site rule
 		// read the same map. One owner.
 		AcceptsChildren: l.childrenHoles[componentName],
+		AcceptsSlots:    l.slotHoles[componentName],
 		Syntax:          ComponentSyntaxStrict,
 		Root:            rootID,
 		IsIsland:        isIsland,
@@ -3235,8 +3303,12 @@ func (l *lowerer) strictEachShape(node *Node, scope *eachScope) (itemName, index
 		}
 		// The reservation predates the children feature and is what makes it
 		// safe: a loop binding may not shadow the identifier a body uses to
-		// place its caller's markup.
-		if binding == "props" || binding == strictcomponent.ChildrenBinding {
+		// place its caller's markup. strictcomponent.IsSlotBindingName
+		// extends the same protection to a named slot (gosx#249): a loop
+		// binding spelled slotFoo would otherwise shadow a real slot
+		// placement inside the loop the same way a binding named "children"
+		// would shadow children.
+		if binding == "props" || binding == strictcomponent.ChildrenBinding || strictcomponent.IsSlotBindingName(binding) {
 			l.errs = append(l.errs, Diagnostic{Span: node.Span, Message: fmt.Sprintf("strict <Each> binding %q is reserved; choose another name", binding)})
 			ok = false
 			continue

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -2194,6 +2194,45 @@ func (l *lowerer) validateStrictCalleeChildren(n *gotreesitter.Node, tag string,
 	l.errorf(n, "strict component %s renders no children; remove the child content or render {children} in %s's body", tag, tag)
 }
 
+// validateStrictCalleeSlots is validateStrictCalleeChildren's named-slot
+// counterpart (gosx#249): every slot name a caller supplies through a
+// static slot="Name" attribute on a direct child must be one the callee
+// actually declares (l.slotHoles), the same arity precedent — a caller
+// error, not a silent no-op, when a callee cannot place what it is
+// handed. It answers this independently of props shape, so it is called
+// once, from lowerGSXElement, rather than duplicated across
+// validateStrictComponentCall's three call shapes the way
+// validateStrictCalleeChildren is: a named slot is supplied only through
+// a direct child's own attribute, never through the call's own attribute
+// list, so which of the three prop-shapes the call uses (named
+// attributes, a strict caller's single spread, a legacy caller's single
+// spread) has nothing to do with which slots it filled.
+//
+// l.slotHoles is populated for a strict component only (gosx#249 scopes
+// named slots to strict components, the same scope AcceptsChildren's own
+// legacy-inclusive comment explicitly does NOT extend to slots), so a
+// slot supplied to a legacy or unresolved callee always fails this check
+// — l.slotHoles[tag] is empty for one, so nothing is ever "declared".
+func (l *lowerer) validateStrictCalleeSlots(n *gotreesitter.Node, tag string, slots map[string]NodeID) {
+	if len(slots) == 0 {
+		return
+	}
+	declared := make(map[string]struct{}, len(l.slotHoles[tag]))
+	for _, name := range l.slotHoles[tag] {
+		declared[name] = struct{}{}
+	}
+	names := make([]string, 0, len(slots))
+	for name := range slots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if _, ok := declared[name]; !ok {
+			l.errorf(n, "strict component %s declares no slot named %q; declare {%s} in %s's body or remove this slot", tag, name, strictcomponent.SlotBindingName(name), tag)
+		}
+	}
+}
+
 // attrHasSpread reports whether attrs contains at least one spread
 // attribute — the trigger for validateStrictComponentCall's E2 branches.
 func attrHasSpread(attrs []Attr) bool {
@@ -3540,8 +3579,10 @@ func (l *lowerer) lowerGSXElement(n *gotreesitter.Node) NodeID {
 
 	tag := l.extractTagName(openNode)
 	attrs := l.extractAttrs(openNode)
-	children := l.extractChildren(n)
+	rawChildren := l.extractChildren(n)
+	children, slots := l.partitionCallSlots(IsComponent(tag), rawChildren)
 	l.validateStrictComponentCall(n, tag, attrs, children)
+	l.validateStrictCalleeSlots(n, tag, slots)
 	l.validateStrictHTMLElement(n, tag, attrs)
 	if l.strict && !IsComponent(tag) {
 		normalizeStrictHTMLAttrs(attrs)
@@ -3571,6 +3612,7 @@ func (l *lowerer) lowerGSXElement(n *gotreesitter.Node) NodeID {
 		Tag:      tag,
 		Attrs:    attrs,
 		Children: children,
+		Slots:    slots,
 		IsStatic: l.isStaticNode(attrs, children),
 		Span:     l.span(n),
 	}
@@ -3665,7 +3707,14 @@ func normalizeStrictHTMLAttrs(attrs []Attr) {
 }
 
 func (l *lowerer) lowerFragment(n *gotreesitter.Node) NodeID {
-	children := l.extractChildren(n)
+	rawChildren := l.extractChildren(n)
+	// A Fragment is never a component call (isComponentCall false
+	// unconditionally): partitionCallSlots still runs, so a slot="Name" on
+	// a Fragment's own direct child is reported instead of silently
+	// joining the Fragment's children — see partitionCallSlots' doc
+	// comment on why an intervening Fragment disqualifies a slot the same
+	// way an intervening plain HTML element does.
+	children, _ := l.partitionCallSlots(false, rawChildren)
 	node := Node{
 		Kind:     NodeFragment,
 		Children: children,
@@ -3895,6 +3944,98 @@ func (l *lowerer) extractChildren(n *gotreesitter.Node) []NodeID {
 		}
 	}
 	return children
+}
+
+// partitionCallSlots splits rawChildren — n's own already-lowered direct
+// children — into the default children group and named-slot children
+// (gosx#249's caller-side supply), following a static slot="Name"
+// attribute on each direct child.
+//
+// isComponentCall must be IsComponent(tag) for the element rawChildren
+// belongs to: a Fragment and an ordinary HTML element both call this
+// (lowerFragment, lowerGSXElement) with isComponentCall false, since
+// neither is a call a named slot can bind against — nothing anywhere
+// reads a slots map keyed to a Fragment or a <div>. A slot found there is
+// reported, never silently dropped: an author who mistypes the nesting —
+// wraps a slot-tagged element in a plain HTML element or a Fragment
+// before handing it to the component call, so the tagged element is no
+// longer a DIRECT child of the call — deserves to hear about it, not have
+// the element silently join the anonymous children group instead.
+//
+// A slot's own "slot" attribute is stripped from its rendered Attrs
+// either way, valid or not: it is gosx's routing marker, never a real
+// HTML attribute a browser should see. An invalid one still fails the
+// whole compile, so what its element renders as does not matter, but a
+// valid one must never leak "slot" into the output.
+func (l *lowerer) partitionCallSlots(isComponentCall bool, rawChildren []NodeID) (children []NodeID, slots map[string]NodeID) {
+	children = rawChildren
+	for _, childID := range rawChildren {
+		if int(childID) >= len(l.prog.Nodes) {
+			continue
+		}
+		child := &l.prog.Nodes[childID]
+		idx, attr, ok := findSlotAttr(child.Attrs)
+		if !ok {
+			continue
+		}
+		child.Attrs = append(child.Attrs[:idx:idx], child.Attrs[idx+1:]...)
+		// child.Span, not the call site's own span: a diagnostic about a
+		// mistagged element should point at that element, not at whatever
+		// happens to enclose it.
+		errAt := func(format string, args ...any) {
+			l.errs = append(l.errs, Diagnostic{Span: child.Span, Message: fmt.Sprintf(format, args...)})
+		}
+
+		if !isComponentCall {
+			errAt("slot attribute is only meaningful on a direct child of a component call; this element is not one")
+			continue
+		}
+		if attr.Kind != AttrStatic {
+			errAt("slot must be a static string literal; a computed slot name is not supported because the caller-supplied value would have to be evaluated before the callee's children are known, which reintroduces the ordering problem named slots close")
+			continue
+		}
+		name := strings.TrimSpace(attr.Value)
+		if !strictcomponent.IsSlotBindingName(strictcomponent.SlotBindingName(name)) {
+			errAt("slot name %q is not valid; use a non-empty, upper-case-initial name (e.g. slot=\"Title\")", attr.Value)
+			continue
+		}
+		if _, dup := slots[name]; dup {
+			errAt("slot %q is supplied more than once at this call", name)
+			continue
+		}
+		if slots == nil {
+			slots = make(map[string]NodeID)
+		}
+		slots[name] = childID
+		children = removeNodeID(children, childID)
+	}
+	return children, slots
+}
+
+// findSlotAttr reports the index and value of the first "slot" attribute
+// in attrs, if any.
+func findSlotAttr(attrs []Attr) (idx int, attr Attr, ok bool) {
+	for i, a := range attrs {
+		if a.Name == "slot" {
+			return i, a, true
+		}
+	}
+	return 0, Attr{}, false
+}
+
+// removeNodeID returns ids with id's first occurrence removed, preserving
+// the relative order of every other element.
+func removeNodeID(ids []NodeID, id NodeID) []NodeID {
+	out := make([]NodeID, 0, len(ids))
+	removed := false
+	for _, existing := range ids {
+		if !removed && existing == id {
+			removed = true
+			continue
+		}
+		out = append(out, existing)
+	}
+	return out
 }
 
 func (l *lowerer) isStaticNode(attrs []Attr, children []NodeID) bool {

--- a/route/fileeval.go
+++ b/route/fileeval.go
@@ -29,6 +29,27 @@ type fileRenderEnv struct {
 	renderEngine    func(engine.Config, gosx.Node) gosx.Node
 	renderIsland    func(*islandprogram.Program, any) gosx.Node
 	enableBootstrap func()
+	// islandPreloadHints and islandPageHead compute the two framework-filled
+	// named slots a strict component may declare — {slotPreloadHints} and
+	// {slotPageHead} (gosx#249) — from the same page runtime renderIsland
+	// already mutates as island children render. Nil unless the caller
+	// wired an island-capable env (see newFileRenderEnv), in which case
+	// writeLocalComponentWithChildren calls them only after the call
+	// site's own children have fully rendered, so the values they return
+	// reflect every island those children registered.
+	//
+	// Neither is a caller-suppliable named slot the way Slots (gosx.Slots
+	// map[string]gosx.Node on ProgramRenderEnv) is: no author writes a
+	// value for these anywhere, at any call site, in any .gsx expression.
+	// The renderer computes them itself and binds them the same way it
+	// binds children — the "framework-filled slot" that lets a pure
+	// .gsx-to-.gsx layout composition place an end-of-body island manifest
+	// without a strict expression ever computing a value that depends on a
+	// sibling's render order (strict expressions still admit no function
+	// calls; this is the renderer filling a reserved hole, not the .gsx
+	// author computing one).
+	islandPreloadHints func() gosx.Node
+	islandPageHead     func() gosx.Node
 	// strictSpreadSource is the raw, already-boundary-proved value that
 	// localComponentProps used to build the CURRENT strict component
 	// render frame's own "props" binding — set only when that frame came
@@ -188,12 +209,14 @@ func (env fileRenderEnv) withValue(name string, value any) fileRenderEnv {
 // request, not per node, so it may pay the full map copy.
 func (env fileRenderEnv) withBindings(bindings FileTemplateBindings) fileRenderEnv {
 	next := fileRenderEnv{
-		values:          env.flattenedValues(),
-		funcs:           make(map[string]any, len(env.funcs)+len(bindings.Funcs)),
-		components:      make(map[string]any, len(env.components)+len(bindings.Components)),
-		renderEngine:    env.renderEngine,
-		renderIsland:    env.renderIsland,
-		enableBootstrap: env.enableBootstrap,
+		values:             env.flattenedValues(),
+		funcs:              make(map[string]any, len(env.funcs)+len(bindings.Funcs)),
+		components:         make(map[string]any, len(env.components)+len(bindings.Components)),
+		renderEngine:       env.renderEngine,
+		renderIsland:       env.renderIsland,
+		enableBootstrap:    env.enableBootstrap,
+		islandPreloadHints: env.islandPreloadHints,
+		islandPageHead:     env.islandPageHead,
 	}
 	for key, value := range env.funcs {
 		next.funcs[key] = value
@@ -270,6 +293,8 @@ func newFileRenderEnv(ctx *RouteContext, page FilePage) fileRenderEnv {
 		env.renderEngine = ctx.Engine
 		env.renderIsland = ctx.Runtime().Island
 		env.enableBootstrap = ctx.Runtime().EnableBootstrap
+		env.islandPreloadHints = ctx.Runtime().PreloadHints
+		env.islandPageHead = func() gosx.Node { return ctx.Runtime().PageHeadWithNonce(ctx.Nonce()) }
 		env.funcs["actionPath"] = func(name string) string {
 			return ctx.ActionPath(name)
 		}

--- a/route/filelayout.go
+++ b/route/filelayout.go
@@ -304,6 +304,24 @@ type fileRenderOptions struct {
 	// behavior byte for byte, not a bound empty Fragment. See
 	// renderFileProgramHTML's strict-entry branch.
 	EntryChildren gosx.Node
+	// EntrySlots supplies named-slot values for a strict component rendered
+	// as the render entry (gosx#249). Only RenderProgramComponent sets this
+	// field, from ProgramRenderEnv.Slots. Keyed by slot name ("Title", not
+	// "slotTitle" — see strictcomponent.SlotBindingName for the reserved
+	// identifier a name binds to).
+	//
+	// A nil or empty map means "no slots supplied", the same "take no new
+	// branch" contract EntryChildren's zero-Node sentinel keeps: every
+	// caller that predates this field reproduces prior behavior exactly.
+	// A key naming a slot comp's body does not declare (ir.Component.
+	// AcceptsSlot) fails closed with a descriptive error instead of
+	// silently rendering nothing — see renderFileProgramHTML's strict-entry
+	// branch, and validateStrictCalleeChildren's arity-rule precedent for
+	// why an unrecognized supply is an error rather than a silent no-op. A
+	// slot comp's body declares but this map does not supply stays
+	// unresolved, rendering empty, exactly the way an unsupplied
+	// {children} does today.
+	EntrySlots map[string]gosx.Node
 }
 
 func renderFileNode(path string, opts fileRenderOptions) (gosx.Node, error) {

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -19,6 +19,7 @@ import (
 	gosxcss "m31labs.dev/gosx/css"
 	"m31labs.dev/gosx/engine"
 	"m31labs.dev/gosx/internal/htmlattr"
+	"m31labs.dev/gosx/internal/strictcomponent"
 	"m31labs.dev/gosx/ir"
 	islandprogram "m31labs.dev/gosx/island/program"
 	gosxscene "m31labs.dev/gosx/scene"
@@ -107,6 +108,34 @@ func renderFileProgramHTML(prog *ir.Program, component string, opts fileRenderOp
 			return "", false, fmt.Errorf("render entry %s is not a strict component; children only bind to a strict render entry (see RenderProgramComponent)", comp.Name)
 		}
 		entryEnv = entryEnv.withValue("children", opts.EntryChildren)
+	}
+	// gosx#249: a strict component rendered as the render entry has no
+	// caller-side slot="Name" markup for writeLocalComponent to partition,
+	// the same gap EntryChildren closes for the anonymous children hole.
+	// opts.EntrySlots is the only other place a named-slot value can come
+	// from — RenderProgramComponent builds it from ProgramRenderEnv.Slots.
+	//
+	// A nil or empty EntrySlots means "no slots supplied" — see its doc
+	// comment — so every caller that predates this field takes no new
+	// branch here. A key naming a slot comp's body does not declare fails
+	// closed instead of silently doing nothing, the same arity-rule
+	// precedent validateStrictCalleeChildren (ir/lower.go) sets for a
+	// caller-side children supply the callee cannot place.
+	if len(opts.EntrySlots) > 0 {
+		if comp.Syntax != ir.ComponentSyntaxStrict {
+			return "", false, fmt.Errorf("render entry %s is not a strict component; slots only bind to a strict render entry (see RenderProgramComponent)", comp.Name)
+		}
+		names := make([]string, 0, len(opts.EntrySlots))
+		for name := range opts.EntrySlots {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			if !comp.AcceptsSlot(name) {
+				return "", false, fmt.Errorf("render entry %s declares no slot named %q; declare {%s} in its body or remove this slot from ProgramRenderEnv.Slots", comp.Name, name, strictcomponent.SlotBindingName(name))
+			}
+			entryEnv = entryEnv.withValue(strictcomponent.SlotBindingName(name), opts.EntrySlots[name])
+		}
 	}
 	// One builder carries the whole document. The renderer used to allocate a
 	// fresh strings.Builder per element and let the parent copy the child's
@@ -1200,6 +1229,28 @@ func (r *fileProgramRenderer) writeLocalComponentWithChildren(b *strings.Builder
 	}
 	scope := env.withValue("props", props)
 	scope = scope.withValue("children", childrenNode)
+	// gosx#249: the two framework-filled named slots, bound only for a
+	// callee that actually declares them (AcceptsSlot) and only when env
+	// carries an island-capable runtime (islandPreloadHints/islandPageHead
+	// non-nil — see newFileRenderEnv). childrenNode above is already fully
+	// rendered by the time this function runs (writeLocalComponent renders
+	// the call site's children BEFORE calling this function — see its own
+	// doc comment), so any island the caller's children registered through
+	// env.renderIsland has already reached the page runtime's manifest.
+	// Computing these two values HERE, after childrenNode but before
+	// r.writeNode walks comp.Root below, is what lets a pure .gsx-to-.gsx
+	// nested call (<Layout>{page content with an island}</Layout>, all in
+	// one compiled program, no Go glue) place an end-of-body island
+	// manifest that reflects every island its children rendered: the
+	// renderer computes and binds the value, the same way it binds
+	// children, so no strict expression ever has to compute a value that
+	// depends on a sibling's render order.
+	if env.islandPreloadHints != nil && comp.AcceptsSlot("PreloadHints") {
+		scope = scope.withValue(strictcomponent.SlotBindingName("PreloadHints"), env.islandPreloadHints())
+	}
+	if env.islandPageHead != nil && comp.AcceptsSlot("PageHead") {
+		scope = scope.withValue(strictcomponent.SlotBindingName("PageHead"), env.islandPageHead())
+	}
 	// Always overwrite, never inherit from env: rawSource is nil unless
 	// THIS call just proved it (single-spread shape), so an explicit-attrs
 	// call correctly clears whatever an enclosing strict frame left set,

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -1210,18 +1210,47 @@ func (r *fileProgramRenderer) writeLocalComponent(b *strings.Builder, comp *ir.C
 	// Children render into their own string because the component body may
 	// reference them through the `children` binding.
 	childrenNode := gosx.RawHTML(r.renderChildren(node.Children, env))
-	r.writeLocalComponentWithChildren(b, comp, node, env, childrenNode)
+	// gosx#249's caller-side supply: each named slot the lowerer
+	// partitioned out of node.Children (a static slot="Name" attribute on
+	// a direct child — ir/lower.go's partitionCallSlots) renders here too,
+	// on the SAME renderer that owns the call node, for the identical
+	// reason childrenNode does — see this function's own doc comment: a
+	// slot child's NodeID is an index into the CALLER's program, and only
+	// r (bound to that program at this call) can resolve it; the callee's
+	// own renderer, in the cross-program case, cannot.
+	slotNodes := r.renderCallSlots(node.Slots, env)
+	r.writeLocalComponentWithChildren(b, comp, node, env, childrenNode, slotNodes)
+}
+
+// renderCallSlots renders each named-slot child in slots — keyed by slot
+// name, valued by a NodeID into r's own program — into its own gosx.Node,
+// the same way renderChildren renders the default children group: markup
+// the CALLER owns, rendered by the caller's renderer, in the caller's env,
+// against the caller's program, before the callee is entered.
+func (r *fileProgramRenderer) renderCallSlots(slots map[string]ir.NodeID, env fileRenderEnv) map[string]gosx.Node {
+	if len(slots) == 0 {
+		return nil
+	}
+	out := make(map[string]gosx.Node, len(slots))
+	for name, childID := range slots {
+		out[name] = gosx.RawHTML(r.renderChildren([]ir.NodeID{childID}, env))
+	}
+	return out
 }
 
 // writeLocalComponentWithChildren renders comp's body with childrenNode
-// already rendered by whichever renderer owns the call node. r must own
-// comp's BODY, because writeNode resolves comp.Root against r.prog.
+// and slotNodes already rendered by whichever renderer owns the call node.
+// r must own comp's BODY, because writeNode resolves comp.Root against
+// r.prog.
 //
 // childrenNode is one opaque gosx.Node. The callee places it and does nothing
 // else with it: it cannot read a field of it, count it, or branch on it.
 // Children are not a prop — they are bound beside props, never inside it, and
-// no boundary proof reads them.
-func (r *fileProgramRenderer) writeLocalComponentWithChildren(b *strings.Builder, comp *ir.Component, node *ir.Node, env fileRenderEnv, childrenNode gosx.Node) {
+// no boundary proof reads them. slotNodes (gosx#249) is childrenNode's
+// named-plural counterpart, keyed by slot name ("Title", not "slotTitle"):
+// each entry is one opaque gosx.Node the caller already rendered, bound the
+// same way and proved nothing about, the same way.
+func (r *fileProgramRenderer) writeLocalComponentWithChildren(b *strings.Builder, comp *ir.Component, node *ir.Node, env fileRenderEnv, childrenNode gosx.Node, slotNodes map[string]gosx.Node) {
 	props, rawSource, err := localComponentProps(comp, node.Attrs, env, childrenNode)
 	if err != nil {
 		r.err = fmt.Errorf("render strict component %s: %w", comp.Name, err)
@@ -1229,6 +1258,23 @@ func (r *fileProgramRenderer) writeLocalComponentWithChildren(b *strings.Builder
 	}
 	scope := env.withValue("props", props)
 	scope = scope.withValue("children", childrenNode)
+	// gosx#249: each caller-supplied named slot, bound beside children.
+	// validateStrictCalleeSlots (ir/lower.go) already proved every key here
+	// names a slot comp's body declares, so no runtime re-check is needed
+	// — unlike the Go-entry EntrySlots path, which has no compile-time
+	// visibility into a Go caller's map and re-proves it at render time.
+	//
+	// Bound BEFORE the two framework-filled slots below, on purpose: a
+	// later binding shadows an earlier one (fileRenderScope's own doc
+	// comment), so if a caller's markup ever supplies slot="PreloadHints"
+	// or slot="PageHead" — the two reserved, framework-computed names — the
+	// framework's own value still wins. Those two names are never
+	// caller-suppliable in practice (nothing renders such a call from
+	// authored .gsx source), but this ordering keeps the invariant true
+	// regardless.
+	for name, value := range slotNodes {
+		scope = scope.withValue(strictcomponent.SlotBindingName(name), value)
+	}
 	// gosx#249: the two framework-filled named slots, bound only for a
 	// callee that actually declares them (AcceptsSlot) and only when env
 	// carries an island-capable runtime (islandPreloadHints/islandPageHead

--- a/route/named_slots_test.go
+++ b/route/named_slots_test.go
@@ -238,3 +238,219 @@ func TestFrameworkFilledSlotReflectsIslandsRegisteredByChildren(t *testing.T) {
 		t.Fatalf("end-of-body manifest does not name the Counter island: %q", manifestScript)
 	}
 }
+
+// TestCallerSideSlotAttributeFillsANamedSlot is the caller-side counterpart
+// to TestStrictComponentAcceptsANamedSlot: a static slot="Name" attribute
+// on a direct child at a nested .gsx-to-.gsx call site — no Go glue
+// anywhere in the path — partitions that child out of the default children
+// group and into the named slot it names (gosx#249's caller-side supply,
+// ir/lower.go's partitionCallSlots). The whole tagged element becomes the
+// slot's value, matching the web-platform slot="" convention: the caller
+// projects the element itself, not just its inner text.
+func TestCallerSideSlotAttributeFillsANamedSlot(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>{slotTitle}</h1><main>{children}</main></div>
+}
+component Page() {
+	return <Layout><div slot="Title">Standings</div><p>page content</p></Layout>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1><div>Standings</div></h1><main><p>page content</p></main></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestCallerSideSlotOrderIndependent proves the slot-tagged child binds by
+// NAME, not by its position among its siblings: placing it after an
+// ordinary child must produce the identical result placing it before one
+// does (TestCallerSideSlotAttributeFillsANamedSlot) — a position-based
+// implementation would swap which child fills the slot and which fills
+// children.
+func TestCallerSideSlotOrderIndependent(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>{slotTitle}</h1><main>{children}</main></div>
+}
+component Page() {
+	return <Layout><p>page content</p><div slot="Title">Standings</div></Layout>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1><div>Standings</div></h1><main><p>page content</p></main></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestCallerSideMultipleSlotsAndChildrenCoexist proves several named
+// slots and the default children group all resolve correctly from one
+// call site, each holding only the content tagged for it.
+func TestCallerSideMultipleSlotsAndChildrenCoexist(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>{slotTitle}</h1><nav>{slotNav}</nav><main>{children}</main></div>
+}
+component Page() {
+	return <Layout><div slot="Title">Standings</div><i>middle</i><div slot="Nav">Links</div><b>end</b></Layout>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1><div>Standings</div></h1><nav><div>Links</div></nav><main><i>middle</i><b>end</b></main></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestCallerSideSlotMustBeAStaticStringLiteral proves the design brief's
+// explicit restriction: a computed slot="{expr}" name fails to compile
+// with a diagnostic naming the reason, rather than silently falling back
+// to the default children group or evaluating the expression at an
+// ordering-unsafe time.
+func TestCallerSideSlotMustBeAStaticStringLiteral(t *testing.T) {
+	_, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div>{slotTitle}{children}</div>
+}
+component Page(props: struct{ Name string }) {
+	return <Layout>
+		<div slot={props.Name}>x</div>
+	</Layout>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "slot must be a static string literal") {
+		t.Fatalf("Compile error = %v, want a static-literal diagnostic", err)
+	}
+}
+
+// TestCallerSideSlotOnNonDirectDescendantFailsClosed proves a slot="Name"
+// buried one level too deep — wrapped in a plain HTML element before it
+// ever reaches the component call — is reported, not silently absorbed
+// into the default children group: an author who mistypes the nesting
+// deserves to hear about it.
+func TestCallerSideSlotOnNonDirectDescendantFailsClosed(t *testing.T) {
+	_, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div>{slotTitle}{children}</div>
+}
+component Page() {
+	return <Layout>
+		<div><span slot="Title">x</span></div>
+	</Layout>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "only meaningful on a direct child of a component call") {
+		t.Fatalf("Compile error = %v, want a not-a-direct-child diagnostic", err)
+	}
+}
+
+// TestCallerSideSlotOnPlainHTMLElementFailsClosed is the same rule for a
+// slot="Name" attribute with no enclosing component call anywhere: a
+// plain HTML element's own direct child cannot address a slot, since
+// nothing at that level ever reads a slots map.
+func TestCallerSideSlotOnPlainHTMLElementFailsClosed(t *testing.T) {
+	_, err := gosx.Compile([]byte(`package app
+component Page() {
+	return <div><span slot="Title">x</span></div>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), "only meaningful on a direct child of a component call") {
+		t.Fatalf("Compile error = %v, want a not-a-direct-child diagnostic", err)
+	}
+}
+
+// TestCallerSideSlotSuppliedButNotDeclaredFailsClosed is the caller-side
+// counterpart to TestNamedSlotSuppliedButNotDeclaredFailsClosed: a
+// slot="Name" the callee's body never places is a caller error at COMPILE
+// time here (ir.Lower has full static visibility into both sides of a
+// same-program call), rather than the Go-entry path's runtime check.
+func TestCallerSideSlotSuppliedButNotDeclaredFailsClosed(t *testing.T) {
+	_, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div>{children}</div>
+}
+component Page() {
+	return <Layout>
+		<div slot="Title">x</div>
+	</Layout>
+}
+`))
+	if err == nil || !strings.Contains(err.Error(), `declares no slot named "Title"`) {
+		t.Fatalf("Compile error = %v, want a declares-no-slot diagnostic", err)
+	}
+}
+
+// TestCallerSideSlotDeclaredButNotSuppliedRendersEmpty is the caller-side
+// counterpart to TestNamedSlotDeclaredButNotSuppliedRendersEmpty: a slot
+// the callee declares but no call-site child tags stays an unresolved
+// scope identifier and renders empty, the same as an unsupplied
+// {children} does.
+func TestCallerSideSlotDeclaredButNotSuppliedRendersEmpty(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>[{slotTitle}]</h1><main>{children}</main></div>
+}
+component Page() {
+	return <Layout><p>content</p></Layout>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1>[]</h1><main><p>content</p></main></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestExistingChildrenOnlyCallsStayByteIdentical proves the caller-side
+// slot mechanism changes nothing for any call that never uses slot="Name"
+// — the exact call shape every strict component call used before this
+// change, still projected the same way (TestStrictComponentRendersChildrenTwice
+// and the rest of strict_children_test.go already pin the byte-identical
+// contract this test names for the record).
+func TestExistingChildrenOnlyCallsStayByteIdentical(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Panel() {
+	return <section>{children}</section>
+}
+component Page() {
+	return <Panel><p>wrapped</p><b>markup</b></Panel>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<section><p>wrapped</p><b>markup</b></section>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}

--- a/route/named_slots_test.go
+++ b/route/named_slots_test.go
@@ -1,0 +1,240 @@
+package route
+
+import (
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/island"
+	islandprogram "m31labs.dev/gosx/island/program"
+)
+
+// TestStrictComponentAcceptsANamedSlot proves the basic named-slot shape: a
+// Go caller supplies a value through ProgramRenderEnv.Slots, keyed by slot
+// name ("Title", not "slotTitle"), and the callee's {slotTitle} expression
+// hole places it — exactly the way {children} already places a Go-supplied
+// children value (gosx#246, gosx#248), but under its own name, beside
+// children rather than instead of it.
+func TestStrictComponentAcceptsANamedSlot(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>{slotTitle}</h1><main>{children}</main></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Layout", ProgramRenderEnv{
+		Slots: map[string]gosx.Node{"Title": gosx.Text("Dashboard")},
+	}, gosx.Text("body content"))
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1>Dashboard</h1><main>body content</main></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestNamedSlotDeclaredButNotSuppliedRendersEmpty proves the "declared but
+// not supplied" half of the slot contract: an unsupplied {slotTitle} stays
+// an unresolved scope identifier, the same as an unsupplied {children} does
+// today (see entryChildrenNode's doc comment) — it renders empty, not an
+// error.
+func TestNamedSlotDeclaredButNotSuppliedRendersEmpty(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div><h1>[{slotTitle}]</h1></div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Layout", ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<div><h1>[]</h1></div>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// TestNamedSlotSuppliedButNotDeclaredFailsClosed proves the other half: a
+// Slots key naming a slot the render entry's body never places is a
+// caller error, following validateStrictCalleeChildren's arity-rule
+// precedent (ir/lower.go) — supplying content a callee cannot place fails
+// closed instead of silently discarding it.
+func TestNamedSlotSuppliedButNotDeclaredFailsClosed(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <div>{children}</div>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	_, err = RenderProgramComponent(prog, "Layout", ProgramRenderEnv{
+		Slots: map[string]gosx.Node{"Title": gosx.Text("Dashboard")},
+	})
+	if err == nil {
+		t.Fatal("RenderProgramComponent: want an error for an undeclared slot, got nil")
+	}
+	if !strings.Contains(err.Error(), "Title") || !strings.Contains(err.Error(), "slotTitle") {
+		t.Fatalf("error = %q, want it to name the slot and its binding identifier", err.Error())
+	}
+}
+
+// TestMultipleNamedSlotsAddressDistinctInjectionPoints proves the reason
+// named slots exist at all: three separate injection points, each with its
+// own content, in one render — the case one repeatable {children} hole
+// cannot express (TestStrictComponentRendersChildrenTwice pins every
+// repeat to the SAME content).
+func TestMultipleNamedSlotsAddressDistinctInjectionPoints(t *testing.T) {
+	prog, err := gosx.Compile([]byte(`package app
+component Layout() {
+	return <html><head><title>{slotTitle}</title>{slotPreload}</head><body>{children}{slotManifest}</body></html>
+}
+`))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Layout", ProgramRenderEnv{
+		Slots: map[string]gosx.Node{
+			"Title":    gosx.Text("Dashboard"),
+			"Preload":  gosx.RawHTML(`<link rel="preload">`),
+			"Manifest": gosx.RawHTML(`<script id="m"></script>`),
+		},
+	}, gosx.Text("page content"))
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	want := `<html><head><title>Dashboard</title><link rel="preload"></head><body>page content<script id="m"></script></body></html>`
+	if html != want {
+		t.Fatalf("html = %q, want %q", html, want)
+	}
+}
+
+// namedSlotIslandLayoutProgram hand-builds an ir.Program with a strict
+// "Layout" component declaring {children} and the framework-filled
+// {slotPageHead} hole, and a call node that supplies content through a
+// registerIsland() legacy-expression child. It bypasses gosx.Compile
+// entirely (mirroring childrenProgramPair in strict_children_test.go): this
+// test exercises the RENDERER's own sequencing (writeLocalComponent /
+// writeLocalComponentWithChildren), which is independent of whether a
+// strict .gsx source may reference an island tag directly — a strict
+// component cannot declare or call one today (a pre-existing, orthogonal
+// restriction this feature does not touch; see the CHANGELOG entry for
+// this change).
+func namedSlotIslandLayoutProgram() (prog *ir.Program, callNode *ir.Node, comp *ir.Component) {
+	prog = &ir.Program{Package: "app"}
+
+	// The call site: <Layout>{registerIsland()}</Layout>. registerIsland is
+	// a plain legacy-expression call (route/exprlower.go supports
+	// *ast.CallExpr for the file renderer's general expression evaluator),
+	// bound to a Go closure the test wires through env.funcs — its only job
+	// is to register an island into a real *island.Renderer as a side
+	// effect, standing in for whatever real content (a compiled island
+	// child, in a real page) triggers island registration while children
+	// render.
+	childID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "registerIsland()"})
+	callID := prog.AddNode(ir.Node{Kind: ir.NodeComponent, Tag: "Layout", Children: []ir.NodeID{childID}})
+	callNode = prog.NodeAt(callID)
+
+	// Layout's body: BEFORE{children}AFTER{slotPageHead} — the end-of-body
+	// manifest placement the design brief names, expressed as plain
+	// element children in document order. Nothing here computes
+	// slotPageHead's value; the renderer binds it.
+	beforeID := prog.AddNode(ir.Node{Kind: ir.NodeText, Text: "BEFORE"})
+	childrenHoleID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "children"})
+	afterID := prog.AddNode(ir.Node{Kind: ir.NodeText, Text: "AFTER"})
+	pageHeadHoleID := prog.AddNode(ir.Node{Kind: ir.NodeExpr, Text: "slotPageHead"})
+	rootID := prog.AddNode(ir.Node{
+		Kind:     ir.NodeElement,
+		Tag:      "div",
+		Children: []ir.NodeID{beforeID, childrenHoleID, afterID, pageHeadHoleID},
+	})
+
+	prog.Components = append(prog.Components, ir.Component{
+		Name:            "Layout",
+		Syntax:          ir.ComponentSyntaxStrict,
+		Root:            rootID,
+		AcceptsChildren: true,
+		AcceptsSlots:    []string{"PageHead"},
+	})
+	comp = &prog.Components[0]
+	return prog, callNode, comp
+}
+
+// TestFrameworkFilledSlotReflectsIslandsRegisteredByChildren is the direct
+// proof for the coordinator's demanded case: a pure same-program
+// .gsx-to-.gsx nested call (<Layout>{content}</Layout>, no Go glue between
+// caller and callee) places an end-of-body island manifest that reflects
+// every island its children registered, with the value computed by the
+// RENDERER — never by a strict .gsx expression, which still cannot express
+// "compute this after that sibling renders" and is not asked to here.
+//
+// The manifest value is asserted to change between "before children
+// render" and "after children render, before Layout's own body walks" —
+// the exact window writeLocalComponentWithChildren computes it in — so a
+// regression that moved the computation earlier (losing the ordering
+// guarantee) would be caught by content, not just by a passing render.
+func TestFrameworkFilledSlotReflectsIslandsRegisteredByChildren(t *testing.T) {
+	prog, callNode, comp := namedSlotIslandLayoutProgram()
+
+	renderer := island.NewRenderer("test")
+	renderer.SetBundle("test", "/gosx/runtime.wasm")
+	renderer.SetRuntime("/gosx/runtime.wasm", "", 0)
+
+	// Before any content renders, the manifest is empty — proving the
+	// "before" snapshot really is different from the "after" one below,
+	// not coincidentally identical regardless of ordering.
+	before := gosx.RenderHTML(renderer.PageHeadWithNonce(""))
+	if strings.Contains(before, "Counter") {
+		t.Fatalf("manifest already names Counter before any island rendered: %q", before)
+	}
+
+	var registerCalled bool
+	env := fileRenderEnv{
+		funcs: map[string]any{
+			"registerIsland": func() gosx.Node {
+				registerCalled = true
+				return renderer.RenderIslandFromProgram(islandprogram.CounterProgram(), map[string]any{"initial": 0})
+			},
+		},
+		islandPageHead: func() gosx.Node { return renderer.PageHeadWithNonce("") },
+	}
+
+	r := newFileProgramRenderer(prog, fileRenderOptions{})
+	var b strings.Builder
+	r.writeLocalComponent(&b, comp, callNode, env)
+	if r.err != nil {
+		t.Fatalf("writeLocalComponent: %v", r.err)
+	}
+	html := b.String()
+
+	if !registerCalled {
+		t.Fatal("registerIsland() was never called; children did not render")
+	}
+
+	beforeIdx := strings.Index(html, "BEFORE")
+	islandIdx := strings.Index(html, `data-gosx-island="Counter"`)
+	afterIdx := strings.Index(html, "AFTER")
+	manifestIdx := strings.Index(html, `id="gosx-manifest"`)
+	if beforeIdx < 0 || islandIdx < 0 || afterIdx < 0 || manifestIdx < 0 {
+		t.Fatalf("html missing an expected marker: %q", html)
+	}
+	if !(beforeIdx < islandIdx && islandIdx < afterIdx && afterIdx < manifestIdx) {
+		t.Fatalf("html = %q, want BEFORE, then the island, then AFTER, then the manifest script, in that order", html)
+	}
+
+	// The manifest script placed at the END of the body must name the
+	// island the children registered — proving slotPageHead's value was
+	// computed AFTER children rendered, not before (the "before" snapshot
+	// above proves the two would differ).
+	manifestScript := html[manifestIdx:]
+	if !strings.Contains(manifestScript, "Counter") {
+		t.Fatalf("end-of-body manifest does not name the Counter island: %q", manifestScript)
+	}
+}

--- a/route/program_render.go
+++ b/route/program_render.go
@@ -48,6 +48,43 @@ type ProgramRenderEnv struct {
 	Props        any
 	RenderIsland func(*islandprogram.Program, any) gosx.Node
 	Profile      *RenderProfile
+	// IslandPreloadHints and IslandPageHead compute the two framework-filled
+	// named slots a strict component may declare — {slotPreloadHints} and
+	// {slotPageHead} (gosx#249) — from the same island runtime RenderIsland
+	// renders through. Unlike Slots below, neither is a caller-authored
+	// value: this env supplies the two callbacks, and the renderer decides
+	// when to call them and what to bind the result to, the same way it
+	// binds children. A nested <Layout>{content}</Layout> call inside a
+	// compiled program's own body renders content (and every RenderIsland
+	// call it makes) BEFORE calling either of these, so the value they
+	// return reflects every island content registered — see
+	// writeLocalComponentWithChildren (route/fileprogram.go). Each is
+	// called only for a component that actually declares the matching slot
+	// (ir.Component.AcceptsSlot), so a page with no island runtime, or a
+	// component that never places {slotPreloadHints}/{slotPageHead}, pays
+	// nothing for it. Nil is the default: no pre-gosx#249 caller sets
+	// these, so none takes a new branch.
+	IslandPreloadHints func() gosx.Node
+	IslandPageHead     func() gosx.Node
+	// Slots supplies named-slot values for a strict render entry that
+	// declares more than the one anonymous children hole (gosx#249) — a
+	// per-route title and an end-of-body script are two different
+	// injection points a layout-shaped component needs, and repeating
+	// {children} cannot express that (TestStrictComponentRendersChildrenTwice
+	// pins every repeat to the same content). Keyed by slot name ("Title",
+	// not "slotTitle" — see strictcomponent.SlotBindingName for the
+	// reserved identifier a name binds to in the component's body).
+	//
+	// A nil or empty Slots reproduces every pre-gosx#249 call's behavior
+	// exactly, the same "take no new branch" contract Children keeps
+	// (RenderProgramComponent's own doc comment). A key naming a slot the
+	// entry component's body does not declare fails closed with a
+	// descriptive error; a slot the body declares but this map does not
+	// supply stays unresolved and renders empty, exactly like an
+	// unsupplied {children} does today. Slots are unproven, the same way
+	// Children is: never entering PropsFields, PropsPaths, or PropsSlices,
+	// and never overwriting a proved props field.
+	Slots map[string]gosx.Node
 }
 
 // RenderProgramComponent renders the named component of a compiled program (from
@@ -83,12 +120,15 @@ type ProgramRenderEnv struct {
 func RenderProgramComponent(prog *ir.Program, component string, env ProgramRenderEnv, children ...gosx.Node) (string, error) {
 	html, _, err := renderFileProgramHTML(prog, component, fileRenderOptions{
 		EvalEnv: fileRenderEnv{
-			values:       env.Values,
-			funcs:        env.Funcs,
-			renderIsland: env.RenderIsland,
+			values:             env.Values,
+			funcs:              env.Funcs,
+			renderIsland:       env.RenderIsland,
+			islandPreloadHints: env.IslandPreloadHints,
+			islandPageHead:     env.IslandPageHead,
 		},
 		EntryProps:    env.Props,
 		EntryChildren: entryChildrenNode(children),
+		EntrySlots:    env.Slots,
 		Profile:       env.Profile,
 	})
 	return html, err

--- a/route/strict_children_test.go
+++ b/route/strict_children_test.go
@@ -280,7 +280,7 @@ func TestChildrenResolveAgainstTheCallersProgram(t *testing.T) {
 		// call node, then hand the finished node across.
 		var right strings.Builder
 		childrenNode := gosx.RawHTML(parent.renderChildren(callNode.Children, env))
-		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode)
+		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode, nil)
 		want := "<section>CALLER OWNS THIS</section>"
 		if right.String() != want {
 			t.Fatalf("html = %q, want %q", right.String(), want)
@@ -305,7 +305,7 @@ func TestChildrenResolveAgainstTheCallersProgram(t *testing.T) {
 
 		var right strings.Builder
 		childrenNode := gosx.RawHTML(parent.renderChildren(callNode.Children, env))
-		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode)
+		child.writeLocalComponentWithChildren(&right, comp, callNode, env, childrenNode, nil)
 		want := "<section>CALLER OWNS THIS</section>"
 		if right.String() != want {
 			t.Fatalf("html = %q, want %q", right.String(), want)
@@ -338,7 +338,7 @@ func TestSameFileChildrenPathStaysByteIdentical(t *testing.T) {
 
 	var split strings.Builder
 	childrenNode := gosx.RawHTML(r.renderChildren(callNode.Children, env))
-	r.writeLocalComponentWithChildren(&split, &caller.Components[0], callNode, env, childrenNode)
+	r.writeLocalComponentWithChildren(&split, &caller.Components[0], callNode, env, childrenNode, nil)
 
 	if single.String() != split.String() {
 		t.Fatalf("writeLocalComponent = %q, writeLocalComponentWithChildren = %q, want identical", single.String(), split.String())

--- a/server/runtime.go
+++ b/server/runtime.go
@@ -261,6 +261,37 @@ func (r *PageRuntime) HeadWithNonce(nonce string) gosx.Node {
 	return gosx.Fragment(nodes...)
 }
 
+// PreloadHints renders <link rel="preload"/rel="prefetch"> hints for every
+// island, engine, and hub this page runtime has registered so far — the
+// half of Head/HeadWithNonce that belongs in <head>, split out on its own
+// (gosx#249) so a caller that needs to place it separately from the
+// manifest/bootstrap script — a strict .gsx layout's {slotPreloadHints}
+// versus its {slotPageHead}, most often — can bind each to its own named
+// slot without also getting the other's markup bundled in.
+func (r *PageRuntime) PreloadHints() gosx.Node {
+	if r == nil || !r.active {
+		return gosx.Text("")
+	}
+	return r.renderer.PreloadHints()
+}
+
+// PageHead renders the hydration manifest and bootstrap script for every
+// island, engine, and hub this page runtime has registered so far, with no
+// CSP nonce attached. See PageHeadWithNonce and PreloadHints' doc comment
+// for why this is split out from the combined Head/HeadWithNonce.
+func (r *PageRuntime) PageHead() gosx.Node {
+	return r.PageHeadWithNonce("")
+}
+
+// PageHeadWithNonce is PageHead, attaching nonce to GoSX-owned script
+// elements when nonce is non-empty.
+func (r *PageRuntime) PageHeadWithNonce(nonce string) gosx.Node {
+	if r == nil || !r.active {
+		return gosx.Text("")
+	}
+	return r.renderer.PageHeadWithNonce(nonce)
+}
+
 // Active reports whether the page registered any runtime engines.
 func (r *PageRuntime) Active() bool {
 	return r != nil && r.active

--- a/strictcheck/check_test.go
+++ b/strictcheck/check_test.go
@@ -889,3 +889,30 @@ component Page() {
 		t.Fatalf("CheckFile: %v", err)
 	}
 }
+
+// TestCheckFileAllowsProplessStrictCalleeWithChildren is the regression
+// test for a pre-existing bug in emitComponentCall's nested-call
+// projection (transpile/transpile.go): a propless strict callee has no
+// leading props parameter in its Go signature (emitStrictComponent emits
+// none when the component declares no props), but emitComponentCall
+// unconditionally emitted a gosx.Props() AttrList argument at any nested
+// call site whose children were non-empty — confirmed broken on
+// unmodified origin/main before this fix, independent of and predating
+// gosx#249's named slots.
+func TestCheckFileAllowsProplessStrictCalleeWithChildren(t *testing.T) {
+	dir := newTestModule(t)
+	path := filepath.Join(dir, "page.gsx")
+	mustWrite(t, path, `package main
+
+component Card() {
+	return <div>{children}</div>
+}
+
+component Page() {
+	return <Card><p>hello</p></Card>
+}
+`)
+	if err := CheckFile(context.Background(), path); err != nil {
+		t.Fatalf("CheckFile: %v", err)
+	}
+}

--- a/transpile/named_slots_test.go
+++ b/transpile/named_slots_test.go
@@ -1,0 +1,111 @@
+package transpile
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestTranspileEmitComponentCallRoutesSlotByName is the regression test for
+// a bug emitComponentCall (the propless-strict / untyped-legacy call
+// shape) had before slot-aware child partitioning existed: every child —
+// slot-tagged or not — sat in one positional list, so a slot="Name" child
+// filled whichever slot parameter its DOCUMENT ORDER happened to line up
+// with, not the one it was tagged for. This fixture places the slot-tagged
+// child SECOND, after an ordinary child, specifically to catch that: a
+// position-based projection would put the ordinary child in slotTitle's
+// argument position instead.
+func TestTranspileEmitComponentCallRoutesSlotByName(t *testing.T) {
+	source := []byte(`package app
+
+component Layout() {
+	return <div>{slotTitle}{children}</div>
+}
+
+component Page() {
+	return <Layout>
+		<p>content</p>
+		<div slot="Title">Standings</div>
+	</Layout>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	for _, want := range []string{
+		`func Layout(slotTitle gosx.Node, children ...gosx.Node) gosx.Node`,
+		// The slot-tagged child's own projection must be the FIRST argument
+		// (slotTitle's position), even though it is the SECOND child in
+		// source order.
+		`Layout(gosx.El("div", gosx.Attrs(gosx.Attr("slot", "Title")), gosx.Text("Standings")), gosx.El("p", gosx.Text("content")))`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTranspileTypedComponentCallRoutesSlotByName is
+// TestTranspileEmitComponentCallRoutesSlotByName for emitTypedComponentCall
+// — the call shape a strict component WITH a declared props type takes
+// (emitGSXElement routes it through typedPropsType, a separate code path
+// from emitComponentCall with its own, independently broken positional
+// append before this fix).
+func TestTranspileTypedComponentCallRoutesSlotByName(t *testing.T) {
+	source := []byte(`package app
+
+type LayoutProps struct {
+	ID string
+}
+
+component Layout(props: LayoutProps) {
+	return <div id={props.ID}>{slotTitle}{children}</div>
+}
+
+component Page() {
+	return <Layout ID="x">
+		<p>content</p>
+		<div slot="Title">Standings</div>
+	</Layout>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	for _, want := range []string{
+		`func Layout(props LayoutProps, slotTitle gosx.Node, children ...gosx.Node) gosx.Node`,
+		`Layout(LayoutProps{ID: "x"}, gosx.El("div", gosx.Attrs(gosx.Attr("slot", "Title")), gosx.Text("Standings")), gosx.El("p", gosx.Text("content")))`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// TestTranspileComponentCallFillsUnsuppliedSlotWithZeroNode proves the
+// "declared but not supplied" half at the transpile level: a call that
+// supplies no slot at all still produces a call with a zero gosx.Node{}
+// in the slot's parameter position, so the projection keeps compiling —
+// the render-time equivalent of an unresolved {slotTitle} rendering
+// empty (route/fileprogram.go).
+func TestTranspileComponentCallFillsUnsuppliedSlotWithZeroNode(t *testing.T) {
+	source := []byte(`package app
+
+component Layout() {
+	return <div>{slotTitle}{children}</div>
+}
+
+component Page() {
+	return <Layout><p>content</p></Layout>
+}
+`)
+	out, err := Transpile(source, Options{SourceFile: "page.gsx"})
+	if err != nil {
+		t.Fatalf("Transpile: %v", err)
+	}
+	want := `Layout(gosx.Node{}, gosx.El("p", gosx.Text("content")))`
+	if !strings.Contains(out, want) {
+		t.Fatalf("missing %q in:\n%s", want, out)
+	}
+}

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -892,7 +892,14 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 		return t.emitStrictEach(openNode, n)
 	}
 
-	children := t.emitChildren(n)
+	// emitChildrenAndSlots partitions any statically slot-tagged direct
+	// child out of children (gosx#249). slots is only ever consulted by
+	// the two component-call branches below — <If>/<Each> (handled above)
+	// and a plain HTML element (emitElementCall) never declare a slot to
+	// route one into, so discarding it there is correct: ir.Lower already
+	// rejects a slot="Name" attribute reaching either shape before this
+	// function runs (see emitChildrenAndSlots' doc comment).
+	children, slots := t.emitChildrenAndSlots(n)
 
 	if t.isStrictConditionalTag(tag) {
 		if cond, ok := t.strictConditionalCondExpr(openNode); ok {
@@ -906,15 +913,40 @@ func (t *transpiler) emitGSXElement(n *gotreesitter.Node) string {
 
 	if isComponent(tag) {
 		if propsType, ok := t.typedPropsType(tag); ok {
-			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, openNode), children)
+			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, openNode), children, t.orderedSlotArgs(tag, slots))
 		}
 		if rawPath, shared := t.sharedImportPath(memberTagAlias(tag)); shared {
 			t.errUnresolvedSharedCall(openNode, tag, rawPath)
 			return ""
 		}
-		return t.emitComponentCall(tag, t.emitAttrs(openNode), children)
+		return t.emitComponentCall(tag, t.emitAttrs(openNode), children, t.orderedSlotArgs(tag, slots))
 	}
 	return t.emitElementCall(tag, t.emitHTMLAttrs(openNode), children)
+}
+
+// orderedSlotArgs projects slots — a call site's statically slot-tagged
+// children, keyed by slot name — into positional Go argument text, one
+// entry per slot tag declares (t.slotNames, sorted the same way
+// emitStrictComponent orders its own slot parameters), so the returned
+// slice lines up 1:1 with those parameters regardless of what the call
+// site did or did not supply. A slot the call site did not tag falls back
+// to the zero gosx.Node{} — the same "declared but not supplied" sentinel
+// the render-entry EntrySlots path (route/fileprogram.go) leaves
+// unresolved, which renders empty.
+func (t *transpiler) orderedSlotArgs(tag string, slots map[string]string) []string {
+	declared := t.slotNames[tag]
+	if len(declared) == 0 {
+		return nil
+	}
+	args := make([]string, len(declared))
+	for i, name := range declared {
+		if value, ok := slots[name]; ok {
+			args[i] = value
+			continue
+		}
+		args[i] = t.gosxRef("Node") + "{}"
+	}
+	return args
 }
 
 // memberTagAlias returns tag's alias segment for a dotted tag ("ui" for
@@ -1209,14 +1241,19 @@ func (t *transpiler) emitSelfClosing(n *gotreesitter.Node) string {
 	}
 
 	if isComponent(tag) {
+		// A self-closing tag has no children at all, so no direct child
+		// can ever carry a static slot="Name" attribute here — nil slots
+		// (orderedSlotArgs' zero value) correctly produces one zero
+		// gosx.Node{} per slot tag declares, and none where it declares
+		// none.
 		if propsType, ok := t.typedPropsType(tag); ok {
-			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, n), nil)
+			return t.emitTypedComponentCall(tag, propsType, t.emitTypedAttrsForTag(tag, n), nil, t.orderedSlotArgs(tag, nil))
 		}
 		if rawPath, shared := t.sharedImportPath(memberTagAlias(tag)); shared {
 			t.errUnresolvedSharedCall(n, tag, rawPath)
 			return ""
 		}
-		return t.emitComponentCall(tag, t.emitAttrs(n), nil)
+		return t.emitComponentCall(tag, t.emitAttrs(n), nil, t.orderedSlotArgs(tag, nil))
 	}
 	return t.emitElementCall(tag, t.emitHTMLAttrs(n), nil)
 }
@@ -1295,8 +1332,7 @@ func (t *transpiler) isProplessStrictComponent(tag string) bool {
 	return strings.TrimSpace(t.propsTypes[tag]) == ""
 }
 
-func (t *transpiler) emitComponentCall(tag string, attrs []string, children []string) string {
-	slots := t.slotNames[tag]
+func (t *transpiler) emitComponentCall(tag string, attrs []string, children []string, slotArgs []string) string {
 	proplessStrict := t.isProplessStrictComponent(tag)
 
 	var b strings.Builder
@@ -1328,16 +1364,16 @@ func (t *transpiler) emitComponentCall(tag string, attrs []string, children []st
 
 	// A callee that declares one or more named slots (gosx#249) takes a
 	// gosx.Node parameter for each, positioned before its variadic children
-	// parameter (emitStrictComponent). This projection has no call-site
-	// slot syntax of its own yet — see the CHANGELOG entry for this
-	// change — so every nested call supplies the zero Node for each: the
-	// same "declared but not supplied" sentinel the render-entry EntrySlots
-	// path (route/fileprogram.go) leaves unresolved, which renders empty.
-	for range slots {
+	// parameter (emitStrictComponent). slotArgs (orderedSlotArgs,
+	// emitGSXElement) already lines up 1:1 with those parameters — a
+	// statically slot-tagged child's own projection where the call site
+	// supplied one, the zero gosx.Node{} where it did not — so this loop
+	// only ever places what it is given, in the order it is given.
+	for _, arg := range slotArgs {
 		if wroteArg {
 			b.WriteString(", ")
 		}
-		b.WriteString(t.gosxRef("Node") + "{}")
+		b.WriteString(arg)
 		wroteArg = true
 	}
 
@@ -1461,7 +1497,7 @@ func (t *transpiler) gosxUIPropsType(tag string) (string, bool) {
 	return alias + "." + propsType, true
 }
 
-func (t *transpiler) emitTypedComponentCall(tag, propsType string, attrs []string, children []string) string {
+func (t *transpiler) emitTypedComponentCall(tag, propsType string, attrs []string, children []string, slotArgs []string) string {
 	var b strings.Builder
 	literalType, pointer := typedPropsLiteralType(propsType)
 	b.WriteString(tag)
@@ -1478,6 +1514,29 @@ func (t *transpiler) emitTypedComponentCall(tag, propsType string, attrs []strin
 		b.WriteString(attr)
 	}
 	b.WriteByte('}')
+
+	// A callee that declares one or more named slots (gosx#249) takes a
+	// gosx.Node parameter for each, positioned before its variadic
+	// children parameter (emitStrictComponent), right after the props
+	// literal above. slotArgs (orderedSlotArgs, emitGSXElement/
+	// emitSelfClosing) already lines up 1:1 with those parameters.
+	//
+	// Before this loop existed, every child — slot-tagged or not — sat in
+	// the plain children slice below in document order, and this function
+	// appended them all positionally after the props literal with no
+	// awareness that some belonged in an earlier, named parameter
+	// position instead. That call still compiled whenever the total
+	// argument count matched (a slot count of N plus the true children
+	// count still fills N+variadic parameters), so a caller's markup
+	// order alone — not its slot="Name" tags — silently decided which
+	// child filled which slot. See staticSlotName's doc comment
+	// (transpile.go) for the same defect in emitComponentCall's sibling
+	// path, and TestCheckFileTypedComponentRoutesSlotByNameNotPosition
+	// (strictcheck/check_test.go) for the regression test.
+	for _, arg := range slotArgs {
+		b.WriteString(", ")
+		b.WriteString(arg)
+	}
 
 	for _, child := range children {
 		if child != "" {
@@ -1751,7 +1810,30 @@ func (t *transpiler) emitAttrValue(n *gotreesitter.Node) (string, bool, bool) {
 }
 
 func (t *transpiler) emitChildren(n *gotreesitter.Node) []string {
-	var children []string
+	children, _ := t.emitChildrenAndSlots(n)
+	return children
+}
+
+// emitChildrenAndSlots is emitChildren's slot-aware twin (gosx#249): it
+// additionally partitions a statically slot-tagged direct child's own
+// projection out of the returned children list and into slots, keyed by
+// slot name, mirroring ir/lower.go's partitionCallSlots at the CST level.
+//
+// It does not duplicate that function's validation. strictcheck.CheckFile
+// always runs ir.Lower before this projection (checkPackage's builtin
+// stage order — validateStrictRenderEntries and the transpile pass both
+// read a *ir.Program lowering already built, so a program that reaches
+// this function has already passed partitionCallSlots' checks: a
+// non-static slot value, a slot on a call that is not a component, or a
+// slot the callee does not declare all fail lowering first, with a
+// clearer message than a Go compiler error would give, and
+// strictcheck.CheckFile returns that failure without ever reaching this
+// function. This function's only job, for an already-proved-valid
+// program, is routing a static slot supply to the right Go parameter
+// position instead of leaving it in the shared children group by
+// argument-count coincidence — see staticSlotName's doc comment for what
+// went wrong before this split existed.
+func (t *transpiler) emitChildrenAndSlots(n *gotreesitter.Node) (children []string, slots map[string]string) {
 	for i := 0; i < int(n.NamedChildCount()); i++ {
 		child := n.NamedChild(i)
 		typ := t.nodeType(child)
@@ -1763,9 +1845,17 @@ func (t *transpiler) emitChildren(n *gotreesitter.Node) []string {
 			typ == "jsx_expression_container" || typ == "jsx_fragment" ||
 			typ == "jsx_text" {
 			result := t.emit(child)
-			if result != "" {
-				children = append(children, result)
+			if result == "" {
+				continue
 			}
+			if name, ok := t.staticSlotName(child); ok {
+				if slots == nil {
+					slots = make(map[string]string)
+				}
+				slots[name] = result
+				continue
+			}
+			children = append(children, result)
 			continue
 		}
 		// Any other jsx_* child is a node kind this function does not know how
@@ -1776,7 +1866,59 @@ func (t *transpiler) emitChildren(n *gotreesitter.Node) []string {
 			t.errorf(child, "unhandled GSX child node %q; transpiler and grammar are out of sync", typ)
 		}
 	}
-	return children
+	return children, slots
+}
+
+// staticSlotName reports child's slot="Name" attribute value, when child
+// carries one spelled as a plain string literal. ok is false for a child
+// with no slot attribute at all, or one whose slot value is not a static
+// string literal — ir.Lower already rejects the latter shape before this
+// function is ever reached (see emitChildrenAndSlots' doc comment), so
+// returning ok=false for it here just keeps such a child in the ordinary
+// children group, in a projection the build never reaches anyway.
+//
+// Before this function existed, a slot-tagged child's own projection sat
+// in the plain children list like any other, and the call-site emitters
+// (emitComponentCall, emitTypedComponentCall) appended every child
+// positionally after the callee's declared slot parameters — filling
+// slotTitle with whichever child happened to come first in document
+// order, not the one actually marked slot="Title". That call still
+// compiled (argument count and type both matched by coincidence whenever
+// the slot count matched the non-slot child count), so nothing caught it
+// except reading the generated source by hand.
+func (t *transpiler) staticSlotName(child *gotreesitter.Node) (name string, ok bool) {
+	var attrsHost *gotreesitter.Node
+	switch t.nodeType(child) {
+	case "jsx_element":
+		attrsHost = t.childByField(child, "open")
+	case "jsx_self_closing_element":
+		attrsHost = child
+	default:
+		return "", false
+	}
+	if attrsHost == nil {
+		return "", false
+	}
+	for i := 0; i < int(attrsHost.NamedChildCount()); i++ {
+		a := attrsHost.NamedChild(i)
+		if t.nodeType(a) != "jsx_attribute" {
+			continue
+		}
+		nameNode := t.childByField(a, "name")
+		if nameNode == nil || t.text(nameNode) != "slot" {
+			continue
+		}
+		valueNode := t.childByField(a, "value")
+		if valueNode == nil || t.nodeType(valueNode) != "jsx_string_literal" {
+			return "", false
+		}
+		raw := t.text(valueNode)
+		if len(raw) >= 2 {
+			raw = raw[1 : len(raw)-1]
+		}
+		return raw, true
+	}
+	return "", false
 }
 
 func (t *transpiler) extractTagName(n *gotreesitter.Node) string {

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -110,6 +110,20 @@ type transpiler struct {
 	// ir.Component (transpile.go works from the CST directly, not the IR).
 	structFieldTypes map[string]map[string]string
 	strictNames      map[string]struct{} // same-file gosx_component_declaration names, props or not
+	// slotNames records, per same-file strict component name, the sorted
+	// set of named slots that component's body declares (gosx#249) —
+	// transpile's own CST-walk-based twin of ir/lower.go's l.slotHoles,
+	// needed because emitStrictComponent must place a gosx.Node parameter
+	// for each BEFORE the variadic children parameter (Go forbids a
+	// parameter after "...T"), and emitComponentCall must supply a value
+	// for each at every nested call site. Two independent implementations
+	// of "which slots does this body declare" is an accepted, pre-existing
+	// risk in this file: transpile has no ir.Program to read a decided
+	// answer from (see emitStrictComponent's children-arity comment for
+	// why that same tradeoff was made once already), so this walks the CST
+	// directly through componentDeclaredSlots, the same shape
+	// ir/lower.go's componentDeclaredSlots uses.
+	slotNames map[string][]string
 	// currentPropsType is the props type of the strict component whose body
 	// is currently being emitted (empty outside strict emission) — needed
 	// to resolve a same-file <Each of> or spread source's element/struct
@@ -687,11 +701,61 @@ func (t *transpiler) collectComponentProps(n *gotreesitter.Node) {
 				t.strictNames = make(map[string]struct{})
 			}
 			t.strictNames[name] = struct{}{}
+			if bodyNode := t.childByField(child, "body"); bodyNode != nil {
+				if slots := t.componentDeclaredSlots(bodyNode); len(slots) > 0 {
+					if t.slotNames == nil {
+						t.slotNames = make(map[string][]string)
+					}
+					t.slotNames[name] = slots
+				}
+			}
 		}
 		if propsType := t.extractPropsType(child); propsType != "" {
 			t.propsTypes[name] = propsType
 		}
 	}
+}
+
+// componentDeclaredSlots reports the sorted, de-duplicated set of named
+// slots bodyNode declares — every {slotName} child expression hole it
+// contains (strictcomponent.IsSlotExpression). It mirrors
+// ir/lower.go's lowerer.componentDeclaredSlots, including the same
+// deliberate refusal to descend into an attribute value (an attribute
+// expression can never place rendered markup, so counting one here would
+// wrongly declare a parameter for a slot the body can never actually
+// place).
+func (t *transpiler) componentDeclaredSlots(bodyNode *gotreesitter.Node) []string {
+	if bodyNode == nil {
+		return nil
+	}
+	seen := make(map[string]struct{})
+	var names []string
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		switch t.nodeType(node) {
+		case "jsx_attribute", "jsx_spread_attribute":
+			return
+		case "jsx_expression_container":
+			exprNode := t.childByField(node, "expression")
+			if exprNode != nil {
+				if name, ok := strictcomponent.IsSlotExpression(t.text(exprNode)); ok {
+					if _, dup := seen[name]; !dup {
+						seen[name] = struct{}{}
+						names = append(names, name)
+					}
+				}
+			}
+		}
+		for i := 0; i < int(node.NamedChildCount()); i++ {
+			walk(node.NamedChild(i))
+		}
+	}
+	walk(bodyNode)
+	sort.Strings(names)
+	return names
 }
 
 func (t *transpiler) emitStrictComponent(n *gotreesitter.Node) string {
@@ -715,6 +779,20 @@ func (t *transpiler) emitStrictComponent(n *gotreesitter.Node) string {
 				params = t.text(paramName) + " " + t.text(paramType)
 			}
 		}
+	}
+
+	// Each named slot this body declares (a {slotName} child expression
+	// hole) takes its own gosx.Node parameter (gosx#249), positioned before
+	// the variadic children parameter below — Go forbids a parameter after
+	// "...T", so a slot param can never follow it. componentDeclaredSlots
+	// walks the same body this function is about to emit, so the parameter
+	// list and the body's own {slotName} references can never name a
+	// different slot set.
+	for _, slot := range t.componentDeclaredSlots(bodyNode) {
+		if params != "" {
+			params += ", "
+		}
+		params += strictcomponent.SlotBindingName(slot) + " " + t.gosxRef("Node")
 	}
 
 	// Every strict component takes children, unconditionally.
@@ -1203,19 +1281,54 @@ func (t *transpiler) emitElementCall(tag string, attrs []string, children []stri
 }
 
 func (t *transpiler) emitComponentCall(tag string, attrs []string, children []string) string {
+	slots := t.slotNames[tag]
+
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s(", tag)
 
+	// wroteArg tracks whether the call has written its first argument yet,
+	// so the slot loop below can prepend its own separating comma correctly
+	// whether or not Props(...) came first. len(attrs) > 0 || len(children)
+	// > 0 is unchanged from before gosx#249 on purpose: this call shape (no
+	// typedPropsType match — see emitGSXElement) is shared between a
+	// propless strict callee and an untyped legacy one, and only the
+	// latter's declared parameter can actually receive an AttrList value.
+	// Whether Props(...) belongs here at all for the former is a
+	// pre-existing question this change does not touch; len(slots) > 0 is
+	// deliberately NOT one of this gate's conditions, so a propless
+	// component that declares only named slots (no attrs, no children)
+	// keeps compiling instead of gaining a new, gosx#249-only instance of
+	// that same question.
+	wroteArg := false
 	if len(attrs) > 0 || len(children) > 0 {
 		b.WriteString(t.gosxRef("Props") + "(")
 		b.WriteString(strings.Join(attrs, ", "))
 		b.WriteByte(')')
+		wroteArg = true
+	}
+
+	// A callee that declares one or more named slots (gosx#249) takes a
+	// gosx.Node parameter for each, positioned before its variadic children
+	// parameter (emitStrictComponent). This projection has no call-site
+	// slot syntax of its own yet — see the CHANGELOG entry for this
+	// change — so every nested call supplies the zero Node for each: the
+	// same "declared but not supplied" sentinel the render-entry EntrySlots
+	// path (route/fileprogram.go) leaves unresolved, which renders empty.
+	for range slots {
+		if wroteArg {
+			b.WriteString(", ")
+		}
+		b.WriteString(t.gosxRef("Node") + "{}")
+		wroteArg = true
 	}
 
 	for _, child := range children {
 		if child != "" {
-			b.WriteString(", ")
+			if wroteArg {
+				b.WriteString(", ")
+			}
 			b.WriteString(child)
+			wroteArg = true
 		}
 	}
 

--- a/transpile/transpile.go
+++ b/transpile/transpile.go
@@ -1280,27 +1280,46 @@ func (t *transpiler) emitElementCall(tag string, attrs []string, children []stri
 	return b.String()
 }
 
+// isProplessStrictComponent reports whether tag names a same-file strict
+// component (t.strictNames) with no declared props type. emitStrictComponent
+// emits such a component's Go signature with no leading props parameter at
+// all, so no value — Props() included — belongs in that argument position
+// at any nested call site. A strict component WITH a declared props type
+// never reaches emitComponentCall in the first place (emitGSXElement routes
+// it through emitTypedComponentCall via typedPropsType), so this check
+// only ever needs to rule the propless case in or out.
+func (t *transpiler) isProplessStrictComponent(tag string) bool {
+	if _, ok := t.strictNames[tag]; !ok {
+		return false
+	}
+	return strings.TrimSpace(t.propsTypes[tag]) == ""
+}
+
 func (t *transpiler) emitComponentCall(tag string, attrs []string, children []string) string {
 	slots := t.slotNames[tag]
+	proplessStrict := t.isProplessStrictComponent(tag)
 
 	var b strings.Builder
 	fmt.Fprintf(&b, "%s(", tag)
 
 	// wroteArg tracks whether the call has written its first argument yet,
 	// so the slot loop below can prepend its own separating comma correctly
-	// whether or not Props(...) came first. len(attrs) > 0 || len(children)
-	// > 0 is unchanged from before gosx#249 on purpose: this call shape (no
-	// typedPropsType match — see emitGSXElement) is shared between a
-	// propless strict callee and an untyped legacy one, and only the
-	// latter's declared parameter can actually receive an AttrList value.
-	// Whether Props(...) belongs here at all for the former is a
-	// pre-existing question this change does not touch; len(slots) > 0 is
-	// deliberately NOT one of this gate's conditions, so a propless
-	// component that declares only named slots (no attrs, no children)
-	// keeps compiling instead of gaining a new, gosx#249-only instance of
-	// that same question.
+	// whether or not Props(...) came first.
+	//
+	// Props(...) belongs here only for an UNTYPED LEGACY callee — this call
+	// shape (no typedPropsType match — see emitGSXElement) is reached by
+	// both a propless strict callee and an untyped legacy one, but only
+	// the legacy callee's declared parameter (`props any` or `props
+	// gosx.AttrList`) can actually receive an AttrList value. A propless
+	// strict callee has no leading parameter at all (emitStrictComponent
+	// emits none when the component declares no props), so passing one
+	// positionally there either fails to compile or, worse, silently
+	// binds to the wrong parameter. This was a pre-existing bug — see the
+	// CHANGELOG entry naming it and TestCheckFileAllowsProplessStrictCalleeWithChildren
+	// (strictcheck/check_test.go), which fails on the unfixed code and
+	// passes here — independent of and predating gosx#249's named slots.
 	wroteArg := false
-	if len(attrs) > 0 || len(children) > 0 {
+	if !proplessStrict && (len(attrs) > 0 || len(children) > 0) {
 		b.WriteString(t.gosxRef("Props") + "(")
 		b.WriteString(strings.Join(attrs, ", "))
 		b.WriteByte(')')


### PR DESCRIPTION
## Summary

Strict components now support any number of named slots ({slotTitle}, {slotPreloadHints}, etc.) alongside {children}, enabling layout-shaped components to express distinct injection points without repeating markup. This change also introduces framework-filled slots for island preload hints and page head, ensuring correct rendering order while preserving the no-function-calls restriction in strict .gsx expressions.

## Changes

- Introduce {slot<Name>} identifiers in strict component bodies as distinct, named injection points parallel to {children}.
- Extend ProgramRenderEnv with a Slots map so Go callers can supply slot values keyed by name, validated against the callee's declared set to fail closed on mismatches.
- Implement framework-filled slots PreloadHints and PageHead computed by the renderer after children render, guaranteeing correct island manifest ordering without requiring strict expression function calls.
- Update IR lowering (ir/lower.go), transpilation (transpile/transpile.go), and route rendering (route/fileprogram.go) to collect, project, and bind slot parameters/values consistently across the compiler and runtime.
- Refactor examples/dashboard to adopt named slots, replacing raw gosx.El layouts with a structured layout.gsx that cleanly separates title, preload hints, body content, and hydration scripts.
- Add comprehensive test coverage validating slot declaration, unsupplied rendering, caller-side validation errors, and island ordering guarantees.