### PR TITLE
add: Add whole-application static checks and warning severity channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,87 @@
   component. The legacy Go-function form appears only in a clearly marked
   deprecation note with conversion guidance. It also appears in the pages
   that document islands and engines, which still require it.
+
+### Added: whole-application static correctness checks, before build and in the editor (gosx#249)
+
+- **A new warning severity channel.** `ir.Diagnostic` carries a `Severity`
+  field (`SeverityError`, the zero value, or `SeverityWarning`).
+  `ir.ValidateWarnings` is a sibling of `ir.Validate`: it runs the same
+  no-I/O pass over one `*ir.Program`, but returns only warnings. Nothing in
+  the fatal compile path (`gosx.Compile`) calls it. `strictcheck.Options`
+  gains a `Warnings *[]ir.Diagnostic` field; a whole-project check appends
+  its warning-severity findings there instead of failing the build.
+  `cmd/gosx check` and the build gate (`gosx build`) both print collected
+  warnings to stderr and still exit 0. `lsp` maps a warning to LSP
+  `SeverityWarning` (2) and reports it beside every error.
+- **Check 1 — a form action must resolve to a registered action (error).**
+  `strictcheck.validateFormActionContract` (`strictcheck/formaction.go`)
+  reads a static `action`/`formaction` attribute holding
+  `actionPath("name")` and confirms `"name"` is a key in the page's
+  `route.FileActions`, read from a composite literal in a `*.server.go`
+  file. An unresolved name is a guaranteed 404: `route.RouteContext.
+  ActionPath` builds the URL with no such lookup. This is the
+  `examples/dashboard` defect from the framework owner's premise: a form
+  posting to an action nothing ever registered.
+- **Check 2 — a required control must stay reachable (warning, heuristic).**
+  `strictcheck.validateRequiredReachabilityContract`
+  (`strictcheck/requiredreach.go`) cross-references a `required` control's
+  class and id against every `*.css` file under the project's `public/`
+  directory for a rule this scan recognizes as hiding it (`display: none`,
+  `visibility: hidden`, `opacity: 0`, or the `position: absolute` plus
+  zero/1px clip-box "visually-hidden" idiom). A browser refuses to submit a
+  form holding a required control it cannot focus — silently, with no
+  request and no console error. Every message states plainly that the
+  match ignores the cascade, specificity, and ancestor combinators, and
+  says so is a heuristic to verify by hand.
+- **Check 3 — every routable page must be mounted (warning).** `strict
+  check.validateRouteMountContract` (`strictcheck/routemount.go`) resolves
+  every `router.AddDir` call in the project (the `runtime.Caller(0)` +
+  `filepath.Dir`/`filepath.Join` idiom, and `server.ResolveAppRoot`) to an
+  absolute directory, asks `route.ScanDir` — the framework's own
+  file-route discovery — what each one actually mounts, and flags a
+  `page.gsx`/`index.gsx` outside every mounted tree. If any `AddDir` call's
+  target cannot be resolved with confidence, the whole run stays silent
+  rather than risk a false positive: an unresolvable call could mount
+  anywhere.
+- **Check 4 — a template's `data.X` read must resolve to a loader key
+  (warning, heuristic).** `strictcheck.validateDataLoaderKeysContract`
+  (`strictcheck/dataloader.go`) reads a page's `Load` hook (also matched
+  across a `route.FileModuleFor(source, opts)` registration one directory
+  up, for a shared parent server file registering a dynamic child route),
+  and — only when every return path is a fully literal
+  `map[string]any{...}` — flags a `data.X` read whose `X` never appears.
+  A page with no `Load` hook at all resolves to a confidently empty key
+  set: `data` is never assigned, so every read is certain, always nil. A
+  `Load` built through a helper call, a merge, or a `Bindings` hook that
+  might overwrite `data` abstains instead of guessing.
+- **Check 5 — a `data-gosx-*` attribute must name a real primitive with a
+  well-formed value.** `ir.ValidateWarnings` flags a name within edit
+  distance 1 of a known declarative navigation primitive (`data-gosx-
+  reorder`, `-heartbeat`, `-filter`, `-link`, and the rest of the
+  `server/navigation_contract.go` and `runtime_contract.go` family) as a
+  likely typo (warning) — scoped to that one closed family, not every
+  `data-gosx-*` name in the framework, so an unrelated attribute (`data-
+  gosx-motion`, `-scene3d-*`) stays out of scope. `ir.Validate` gains
+  error-severity value-shape checks for `data-gosx-heartbeat-interval` and
+  `-revalidate-interval` (the shared whole-seconds/whole-minutes grammar),
+  `data-gosx-link-current-policy`, and `data-gosx-prefetch` (each a fixed
+  enum two existing normalizer functions already silently coerce an
+  unrecognized value into).
+- **Every check accumulates I/O-heavy work in `strictcheck`
+  (`gosx check`, the build gate), never in `ir.Lower`'s per-keystroke
+  path.** The LSP runs `ir.Validate`/`ir.ValidateWarnings` — no file I/O —
+  on every keystroke, unchanged. A whole-project check that reads the
+  stylesheet, the action registry, or the route tree runs only through
+  `strictcheck`, which the CLI invokes explicitly.
+- **Run across this repository, every finding sits in
+  `cmd/gosx/templates/docs/`** — a scaffold `gosx init` copies into a new
+  project, backed by `*.gotmpl` sources rather than a live `*.server.go`
+  or `main.go`, so the finding is real but does not describe a running
+  application. No example application (`examples/basic`, `examples/
+  dashboard`, `examples/goetrope-watch`, `examples/gosx-docs`) produced a
+  finding.
+
 ### Added: a Go caller can place a Go-computed node in a .gsx render entry's children slot
 
 - **`RenderProgramComponent` takes a new `children ...gosx.Node` parameter**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -129,13 +129,26 @@
   every `router.AddDir` call in the whole project tree, a cost this
   package does not ask an editor to pay on every save, so it remains
   `gosx check`/build-gate only.
-- **Run across this repository, every finding sits in
-  `cmd/gosx/templates/docs/`** — a scaffold `gosx init` copies into a new
-  project, backed by `*.gotmpl` sources rather than a live `*.server.go`
-  or `main.go`, so the finding is real but does not describe a running
-  application. No example application (`examples/basic`, `examples/
-  dashboard`, `examples/goetrope-watch`, `examples/gosx-docs`) produced a
-  finding.
+- **A `*.gotmpl` sibling abstains a check the same way an unresolvable
+  registration call does.** `cmd/gosx/templates/docs/` — the scaffold
+  `gosx init` copies into a new project — ships `page.server.gotmpl`
+  beside every `page.gsx` that needs one, `main.gotmpl` at its root, and
+  no live `*.server.go` or `main.go` at all: `gosx init` renders each
+  template into a real file only when scaffolding a new project, never
+  before. Checks 1 and 4 (`strictcheck.hasUnrenderedServerGoTemplate`,
+  `strictcheck/servergo.go`) abstain when a `*.server.gotmpl` sits where
+  the expected `*.server.go` would; check 3
+  (`strictcheck.hasUnrenderedMainTemplate`, `strictcheck/routemount.go`)
+  abstains for a page below a directory holding an unrendered
+  `main.gotmpl`. Before this existed, the first `gosx check` run across
+  this repository reported 3 errors and 11 warnings, every one inside
+  that same scaffold, all false — the framework's own tooling reporting
+  its own scaffold as broken, which is exactly the "first impression is
+  noise" outcome a check that stays trustworthy must avoid. Run again
+  after fixing it, all five checks produce zero findings across this
+  entire repository; the checks landing beside this one (`ir.
+  ValidateWarnings`' own untyped-legacy-component check) are unaffected
+  and continue reporting normally.
 
 ### Added: a Go caller can place a Go-computed node in a .gsx render entry's children slot
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -119,9 +119,16 @@
 - **Every check accumulates I/O-heavy work in `strictcheck`
   (`gosx check`, the build gate), never in `ir.Lower`'s per-keystroke
   path.** The LSP runs `ir.Validate`/`ir.ValidateWarnings` — no file I/O —
-  on every keystroke, unchanged. A whole-project check that reads the
-  stylesheet, the action registry, or the route tree runs only through
-  `strictcheck`, which the CLI invokes explicitly.
+  on every keystroke, unchanged: this covers check 5 in full. `lsp` gains
+  a second cadence for the checks that do need file I/O: `textDocument/
+  didSave` now runs `lsp.AnalyzeProject` (checks 1, 2, and 4 — the ones
+  scoped to one package directory) and republishes the combined
+  diagnostic set; the server's `initialize` response now advertises save
+  support (`textDocumentSync.save`) so a real client actually sends the
+  notification. Check 3 (route mount) still needs every `.gsx` file and
+  every `router.AddDir` call in the whole project tree, a cost this
+  package does not ask an editor to pay on every save, so it remains
+  `gosx check`/build-gate only.
 - **Run across this repository, every finding sits in
   `cmd/gosx/templates/docs/`** — a scaffold `gosx init` copies into a new
   project, backed by `*.gotmpl` sources rather than a live `*.server.go`

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -18,6 +18,7 @@ import (
 	"m31labs.dev/gosx"
 	"m31labs.dev/gosx/buildmanifest"
 	runtimewasm "m31labs.dev/gosx/client/runtime/wasm"
+	"m31labs.dev/gosx/ir"
 	"m31labs.dev/gosx/island/program"
 	sceneinspect "m31labs.dev/gosx/scene/inspect"
 	"m31labs.dev/gosx/strictcheck"
@@ -755,11 +756,19 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 }
 
 func checkStrictProject(ctx context.Context, dir string) error {
-	return strictcheck.CheckTreeWithOptions(ctx, dir, strictcheck.Options{
-		Env:     execEnvWithoutGoFlags(),
-		GOWORK:  "off",
-		GOFLAGS: goModuleCommandFlags,
+	// Warnings (gosx#249) are collected and printed to stderr regardless of
+	// whether the build gate itself passes or fails -- a warning never
+	// changes this function's return value; see Options.Warnings' doc
+	// comment for why that split exists.
+	var warnings []ir.Diagnostic
+	err := strictcheck.CheckTreeWithOptions(ctx, dir, strictcheck.Options{
+		Env:      execEnvWithoutGoFlags(),
+		GOWORK:   "off",
+		GOFLAGS:  goModuleCommandFlags,
+		Warnings: &warnings,
 	})
+	printCheckWarnings(os.Stderr, warnings)
+	return err
 }
 
 func countRuntimeVariantAssets(variants map[string]buildmanifest.RuntimeVariantAsset) int {

--- a/cmd/gosx/checkwarnings.go
+++ b/cmd/gosx/checkwarnings.go
@@ -1,0 +1,23 @@
+package main
+
+import (
+	"fmt"
+	"io"
+
+	"m31labs.dev/gosx/ir"
+)
+
+// printCheckWarnings prints every warning-severity diagnostic (gosx#249)
+// to w, one per line, and never affects a caller's exit code -- a warning
+// informs; it never fails a build. Both cmdCheck's single-file path and
+// checkStrictProject's whole-project build-gate path share this so a
+// warning always prints the same way regardless of which one produced it.
+func printCheckWarnings(w io.Writer, warnings []ir.Diagnostic) {
+	if len(warnings) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "warning: %d check warning(s):\n", len(warnings))
+	for _, diag := range warnings {
+		fmt.Fprintf(w, "  %s\n", diag.String())
+	}
+}

--- a/cmd/gosx/main.go
+++ b/cmd/gosx/main.go
@@ -409,8 +409,15 @@ func runCheck(file string, stderr io.Writer) error {
 	if err != nil {
 		return err
 	}
-	if err := strictcheck.CheckFile(context.Background(), file); err != nil {
-		return err
+	// Warnings (gosx#249) are collected and printed regardless of whether
+	// the check itself passes or fails below -- a warning never changes
+	// this command's exit code; see strictcheck.Options.Warnings' doc
+	// comment for why that split exists.
+	var warnings []ir.Diagnostic
+	checkErr := strictcheck.CheckFileWithOptions(context.Background(), file, strictcheck.Options{Warnings: &warnings})
+	printCheckWarnings(stderr, warnings)
+	if checkErr != nil {
+		return checkErr
 	}
 	for i, component := range prog.Components {
 		if !component.IsIsland {
@@ -420,12 +427,12 @@ func runCheck(file string, stderr io.Writer) error {
 			return fmt.Errorf("lower island %s: %w", component.Name, err)
 		}
 	}
-	// Advisory findings (for example an untyped legacy component) are
-	// printed but never fail the check: ir.ValidateWarnings never blocks
-	// compilation, unlike ir.Validate's diagnostics — see its doc comment.
-	for _, diag := range ir.ValidateWarnings(prog) {
-		fmt.Fprintln(stderr, diag.String())
-	}
+	// Advisory findings (an untyped legacy component, gosx#249's own
+	// checks 1/2/4/5) already printed above by printCheckWarnings:
+	// strictcheck.CheckFileWithOptions' Warnings collection runs
+	// ir.ValidateWarnings per file (see strictcheck/warnings.go), so a
+	// second, direct ir.ValidateWarnings(prog) call here would print every
+	// one of those findings twice.
 	fmt.Fprintf(stderr, "ok: %d components\n", len(prog.Components))
 	for _, c := range prog.Components {
 		fmt.Fprintf(stderr, "  %s", c.Name)

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -98,6 +98,11 @@ func ValidateWarnings(prog *Program) []Diagnostic {
 	for i := range prog.Components {
 		diags = append(diags, untypedLegacyPropsWarning(&prog.Components[i])...)
 	}
+	// navigationAttrNameWarnings (ir/validate_warnings.go, gosx#249) is the
+	// other built-in source of SeverityWarning diagnostics: a static
+	// "data-gosx-*" attribute name close to, but not exactly, one of the
+	// declarative navigation primitives.
+	diags = append(diags, navigationAttrNameWarnings(prog)...)
 	return diags
 }
 
@@ -320,6 +325,29 @@ const (
 	regionIntervalAttr = "data-gosx-region-interval"
 )
 
+// revalidateIntervalAttr and heartbeatIntervalAttr (gosx#216, gosx#217)
+// share liveIntervalAttr and regionIntervalAttr's exact whole-seconds/
+// whole-minutes grammar (see isValidPollIntervalValue below), pinned
+// against NavigationRevalidateIntervalAttr and NavigationHeartbeatIntervalAttr
+// in server/navigation_contract.go and their shared parseRevalidateInterval
+// parser in client/runtime/host/navigation.ts.
+//
+// linkCurrentPolicyAttr and prefetchAttr (gosx#210) are the two enumerated
+// data-gosx-link companion values: NormalizeNavigationLinkCurrentPolicy in
+// server/navigation_contract.go silently coerces anything outside
+// {auto,page,ancestor,none} to "none", and NormalizeNavigationLinkPrefetch
+// silently accepts anything at all once it sees a non-empty value, so
+// neither one fails at run time on a bad value the way a missing key or a
+// 404 does — this is the same "renders, does the wrong thing, says
+// nothing" shape gosx#213's countdown pairs check was written for, applied
+// to the link contract instead of the countdown one.
+const (
+	revalidateIntervalAttr = "data-gosx-revalidate-interval"
+	heartbeatIntervalAttr  = "data-gosx-heartbeat-interval"
+	linkCurrentPolicyAttr  = "data-gosx-link-current-policy"
+	prefetchAttr           = "data-gosx-prefetch"
+)
+
 // countdownThresholdIntegerPattern and countdownThresholdDurationPattern
 // mirror the small declarative duration subset
 // parseCountdownThresholdSeconds accepts in client/runtime/host/navigation.ts:
@@ -480,6 +508,32 @@ func isValidLiveBindKeyValue(value string) bool {
 	return liveBindKeyPattern.MatchString(strings.TrimSpace(value))
 }
 
+// isValidLinkCurrentPolicyValue reports whether value is one of the four
+// policies NormalizeNavigationLinkCurrentPolicy recognizes by name
+// (case-insensitively, surrounding whitespace ignored) rather than
+// silently folding into its "none" default.
+func isValidLinkCurrentPolicyValue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "auto", "page", "ancestor", "none":
+		return true
+	default:
+		return false
+	}
+}
+
+// isValidPrefetchValue reports whether value is one of the four prefetch
+// policies NormalizeNavigationLinkPrefetch's own switch names
+// (case-insensitively, surrounding whitespace ignored), rather than
+// falling into that function's pass-through default branch.
+func isValidPrefetchValue(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "off", "intent", "render", "force":
+		return true
+	default:
+		return false
+	}
+}
+
 // validateStaticCountdownAttr flags a static data-gosx-countdown-*,
 // data-gosx-watch, data-gosx-watch-effect, data-gosx-live-*, or
 // data-gosx-region-interval value outside its documented vocabulary: an instant
@@ -491,12 +545,15 @@ func isValidLiveBindKeyValue(value string) bool {
 // "revalidate", a watch condition with no "=", a watch effect list with an
 // unrecognized token (gosx#214), a live or region interval outside the
 // whole-seconds/whole-minutes subset data-gosx-revalidate-interval uses, a
-// live bind key with an empty or whitespace-containing segment, or a live
-// flash class with embedded whitespace (gosx#217). This follows the same
+// live bind key with an empty or whitespace-containing segment, a live
+// flash class with embedded whitespace (gosx#217), a revalidate or
+// heartbeat interval outside that same whole-seconds/whole-minutes subset,
+// a link current-policy outside {auto,page,ancestor,none}, or a prefetch
+// policy outside {off,intent,render,force}. This follows the same
 // fail-closed principle as the ".length" rule above: a bad value here
-// renders a silently inert (or silently ignored) countdown, watcher, or
-// live/region poll today, with nothing at the terminal to explain why, so
-// Validate now catches it at check time instead.
+// renders a silently inert (or silently mis-normalized) countdown,
+// watcher, live/region poll, or link today, with nothing at the terminal
+// to explain why, so Validate now catches it at check time instead.
 //
 // A dynamic expression value ({...}) is exempt — attr.Kind is AttrExpr for
 // those, and this method only runs from the AttrStatic case in validateAttr
@@ -572,12 +629,28 @@ func (v *validator) validateStaticCountdownAttr(node *Node, attr *Attr) {
 				Hint:    `a "cue:<name>" token's name must be "beep" or "chime"; a "class:<name>" token may add "@<selector>" to target another element`,
 			})
 		}
-	case liveIntervalAttr, regionIntervalAttr:
+	case liveIntervalAttr, regionIntervalAttr, revalidateIntervalAttr, heartbeatIntervalAttr:
 		if !isValidPollIntervalValue(attr.Value) {
 			v.diags = append(v.diags, Diagnostic{
 				Span:    node.Span,
 				Message: fmt.Sprintf("invalid %s value %q: must be a whole number of seconds or minutes", attr.Name, attr.Value),
 				Hint:    `for example "4s" or "2m" — the same subset data-gosx-revalidate-interval accepts`,
+			})
+		}
+	case linkCurrentPolicyAttr:
+		if !isValidLinkCurrentPolicyValue(attr.Value) {
+			v.diags = append(v.diags, Diagnostic{
+				Span:    node.Span,
+				Message: fmt.Sprintf("invalid %s value %q: must be \"auto\", \"page\", \"ancestor\", or \"none\"", linkCurrentPolicyAttr, attr.Value),
+				Hint:    `NormalizeNavigationLinkCurrentPolicy silently treats any other value as "none"; write one of the four recognized values instead`,
+			})
+		}
+	case prefetchAttr:
+		if !isValidPrefetchValue(attr.Value) {
+			v.diags = append(v.diags, Diagnostic{
+				Span:    node.Span,
+				Message: fmt.Sprintf("invalid %s value %q: must be \"off\", \"intent\", \"render\", or \"force\"", prefetchAttr, attr.Value),
+				Hint:    `NormalizeNavigationLinkPrefetch does not reject an unrecognized value at run time, so a typo here silently disables prefetch instead of failing loudly`,
 			})
 		}
 	case liveBindAttr:

--- a/ir/validate_warnings.go
+++ b/ir/validate_warnings.go
@@ -1,0 +1,219 @@
+package ir
+
+import (
+	"fmt"
+	"strings"
+)
+
+// navigationAttrNameWarnings is one of two built-in sources
+// ValidateWarnings (ir/validate.go) combines -- the other is
+// untypedLegacyPropsWarning -- so this file only exports the one function
+// ValidateWarnings' own body calls, matching untypedLegacyPropsWarning's
+// own standalone shape rather than adding a second, competing entry point.
+// Both no-I/O passes run over the same *Program Validate already saw and
+// are safe to run on every keystroke.
+func navigationAttrNameWarnings(prog *Program) []Diagnostic {
+	if prog == nil {
+		return nil
+	}
+	var diags []Diagnostic
+	for i := range prog.Components {
+		diags = append(diags, navigationAttrNameWarningsForComponent(prog, &prog.Components[i])...)
+	}
+	return diags
+}
+
+func navigationAttrNameWarningsForComponent(prog *Program, comp *Component) []Diagnostic {
+	if int(comp.Root) >= len(prog.Nodes) {
+		return nil
+	}
+	var diags []Diagnostic
+	for _, id := range collectComponentNodeIDs(prog, comp.Root) {
+		node := &prog.Nodes[id]
+		for _, attr := range node.Attrs {
+			if diag, ok := navigationAttrNameWarning(node, attr); ok {
+				diags = append(diags, diag)
+			}
+		}
+	}
+	return diags
+}
+
+// navigationPrimitiveAttrs is the closed set of declarative client
+// primitives the bootstrap navigation runtime
+// (client/runtime/host/navigation.ts and regions.ts) reads by exact
+// attribute name (gosx#212, #213, #214, #215, #216, #217, #227, #228, #236).
+// This is deliberately NOT every "data-gosx-*" attribute the framework
+// defines anywhere -- scene3d, motion, text-layout, stripe, engine, and
+// island each own a separate, actively evolving attribute contract of
+// their own, most of it runtime-written telemetry rather than
+// author-typed markup, and folding all of it into one "closed set" here
+// would make an ordinary, correct use of one of those surfaces look like a
+// misspelled navigation primitive. Scoping this list to the one family
+// gosx#212-#236 actually describes keeps a false positive rare: a name has
+// to be a near-miss of one of THESE names, not merely absent from a much
+// larger list, before nearestNavigationPrimitiveAttr below suggests it.
+var navigationPrimitiveAttrs = []string{
+	"data-gosx-enhance",
+	"data-gosx-enhance-layer",
+	"data-gosx-fallback",
+	"data-gosx-managed",
+	"data-gosx-form",
+	"data-gosx-form-mode",
+	"data-gosx-form-state",
+	"data-gosx-form-project",
+	"data-gosx-action",
+	"data-gosx-reset",
+	"data-gosx-submit-on",
+	"data-gosx-action-event",
+	"data-gosx-action-signal",
+	"data-gosx-action-target",
+	"data-gosx-region",
+	"data-gosx-region-url",
+	"data-gosx-region-signal",
+	"data-gosx-region-on",
+	"data-gosx-region-field",
+	"data-gosx-region-allow-empty",
+	"data-gosx-region-interval",
+	"data-gosx-runtime-surface",
+	"data-gosx-runtime-surface-version",
+	"data-gosx-link",
+	"data-gosx-link-state",
+	"data-gosx-link-current",
+	"data-gosx-link-current-policy",
+	"data-gosx-prefetch",
+	"data-gosx-prefetch-state",
+	"data-gosx-aria-current-managed",
+	"data-gosx-revalidate-interval",
+	"data-gosx-revalidate-src",
+	countdownInstantAttr,
+	countdownFormatAttr,
+	countdownSegmentAttr,
+	countdownWarnAttr,
+	countdownCueAttr,
+	countdownThenAttr,
+	watchAttr,
+	watchEffectAttr,
+	"data-gosx-watch-title",
+	"data-gosx-reorder",
+	"data-gosx-reorder-action",
+	"data-gosx-reorder-item",
+	"data-gosx-reorder-handle",
+	"data-gosx-reorder-item-field",
+	"data-gosx-reorder-index-field",
+	"data-gosx-reorder-placeholder",
+	"data-gosx-live-src",
+	liveIntervalAttr,
+	liveBindAttr,
+	liveFlashClassAttr,
+	"data-gosx-live-signal",
+	"data-gosx-live-on",
+	"data-gosx-filter",
+	"data-gosx-filter-text",
+	"data-gosx-filter-announce",
+	"data-gosx-heartbeat",
+	"data-gosx-heartbeat-interval",
+	regionIntervalAttr,
+}
+
+// navigationPrimitiveAttrSet is navigationPrimitiveAttrs as a lookup set,
+// built once at package init.
+var navigationPrimitiveAttrSet = func() map[string]bool {
+	set := make(map[string]bool, len(navigationPrimitiveAttrs))
+	for _, name := range navigationPrimitiveAttrs {
+		set[name] = true
+	}
+	return set
+}()
+
+// navigationPrimitiveTypoDistance is the maximum Levenshtein distance a
+// name may sit from a known primitive before warnDataGosxAttrName treats it
+// as an unrelated attribute rather than a likely typo. 1 catches the
+// single dropped/doubled/transposed/substituted-character typos this check
+// exists for ("data-gosx-hearbeat" is distance 1 from
+// "data-gosx-heartbeat"). 2 was tried first and rejected: it also matched
+// "data-gosx-motion" (the motion package's own, unrelated attribute) to
+// "data-gosx-action" (distance 2, one substitution short of "motion" and
+// "action" sharing their last four letters "tion"), a real false positive
+// this check caught running across this repository's own examples before
+// shipping -- see the CHANGELOG entry for gosx#249.
+const navigationPrimitiveTypoDistance = 1
+
+// navigationAttrNameWarning flags a static "data-gosx-*" attribute name
+// that is close to, but not exactly, one of the declarative navigation
+// primitives (gosx#212-#236) -- a likely misspelling that will render and
+// silently no-op, with nothing at the terminal to explain why (see the
+// closed-set requirement in the check's own design notes). An attribute
+// already in the closed set is exempt; its VALUE is checked elsewhere
+// (validateStaticCountdownAttr and its siblings), at error severity, not
+// here. An attribute whose name is not close to any known primitive is
+// silently out of scope -- it may belong to a different subsystem's own
+// attribute contract (scene3d, motion, text-layout, stripe, engine,
+// island) or be an application's own data attribute, and this check has no
+// way to tell those apart from a typo of a name it has never heard of.
+func navigationAttrNameWarning(node *Node, attr Attr) (Diagnostic, bool) {
+	name := attr.Name
+	if !strings.HasPrefix(name, "data-gosx-") || navigationPrimitiveAttrSet[name] {
+		return Diagnostic{}, false
+	}
+	match, ok := nearestNavigationPrimitiveAttr(name)
+	if !ok {
+		return Diagnostic{}, false
+	}
+	return Diagnostic{
+		Span:     node.Span,
+		Severity: SeverityWarning,
+		Message:  fmt.Sprintf("%q is not a recognized gosx navigation attribute; did you mean %q?", name, match),
+	}, true
+}
+
+// nearestNavigationPrimitiveAttr returns the closed-set name nearest to
+// name, if any sit within navigationPrimitiveTypoDistance.
+func nearestNavigationPrimitiveAttr(name string) (string, bool) {
+	best := ""
+	bestDistance := navigationPrimitiveTypoDistance + 1
+	for _, candidate := range navigationPrimitiveAttrs {
+		distance := attrNameEditDistance(name, candidate)
+		if distance < bestDistance {
+			bestDistance = distance
+			best = candidate
+		}
+	}
+	if bestDistance > navigationPrimitiveTypoDistance {
+		return "", false
+	}
+	return best, true
+}
+
+// attrNameEditDistance is the Levenshtein distance between two short
+// strings, an unexported copy of the same small algorithm used elsewhere
+// in this module for an unrelated closed-set nearest-match search (see
+// scene/schema/vocabulary.go's editDistance) -- there is no shared
+// internal package either could import from without a new dependency
+// edge, so each caller keeps its own copy, matching that precedent.
+func attrNameEditDistance(a, b string) int {
+	previous := make([]int, len(b)+1)
+	current := make([]int, len(b)+1)
+	for j := range previous {
+		previous[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		current[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			current[j] = minInt(previous[j]+1, minInt(current[j-1]+1, previous[j-1]+cost))
+		}
+		previous, current = current, previous
+	}
+	return previous[len(b)]
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/ir/validate_warnings_test.go
+++ b/ir/validate_warnings_test.go
@@ -1,0 +1,220 @@
+package ir_test
+
+import (
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+// TestValidateWarningsFlagsNearMissAttrName covers gosx#249 check 5: a
+// misspelled declarative navigation primitive renders and silently
+// no-ops, with nothing anywhere to explain why. ValidateWarnings must
+// catch a near-miss of a real primitive name.
+func TestValidateWarningsFlagsNearMissAttrName(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <span data-gosx-hearbeat="/api/version" data-gosx-heartbeat-interval="4s"></span>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	warnings := ir.ValidateWarnings(prog)
+	if len(warnings) != 1 {
+		t.Fatalf("expected exactly one warning, got %+v", warnings)
+	}
+	want := `"data-gosx-hearbeat" is not a recognized gosx navigation attribute; did you mean "data-gosx-heartbeat"?`
+	if warnings[0].Message != want {
+		t.Fatalf("unexpected warning message: got %q, want %q", warnings[0].Message, want)
+	}
+	if warnings[0].Severity != ir.SeverityWarning {
+		t.Fatalf("expected SeverityWarning, got %v", warnings[0].Severity)
+	}
+}
+
+// TestValidateWarningsAllowsRecognizedAttrName proves a correctly spelled
+// primitive produces no warning.
+func TestValidateWarningsAllowsRecognizedAttrName(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <span data-gosx-heartbeat="/api/version" data-gosx-heartbeat-interval="4s"></span>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	if warnings := ir.ValidateWarnings(prog); len(warnings) != 0 {
+		t.Fatalf("expected no warnings for a recognized attribute, got %+v", warnings)
+	}
+}
+
+// TestValidateWarningsIgnoresUnrelatedDataGosxAttr proves an attribute
+// belonging to an entirely different subsystem's own contract (here,
+// scene3d) is out of scope -- it is not close to any navigation primitive,
+// so it must not be flagged as a typo of one.
+func TestValidateWarningsIgnoresUnrelatedDataGosxAttr(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <canvas data-gosx-scene3d-poster="/poster.png"></canvas>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	if warnings := ir.ValidateWarnings(prog); len(warnings) != 0 {
+		t.Fatalf("expected no warnings for an unrelated data-gosx- attribute, got %+v", warnings)
+	}
+}
+
+// TestValidateWarningsIgnoresMotionAttr is a regression test for a real
+// false positive gosx#249 caught running this check across this
+// repository's own examples: "data-gosx-motion" (the motion package's own
+// attribute) sits at Levenshtein distance 2 from "data-gosx-action" --
+// close enough that an earlier, looser threshold flagged it as a likely
+// typo of an unrelated primitive.
+func TestValidateWarningsIgnoresMotionAttr(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <div data-gosx-motion="fade-in"></div>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	if warnings := ir.ValidateWarnings(prog); len(warnings) != 0 {
+		t.Fatalf("expected no warnings for data-gosx-motion, got %+v", warnings)
+	}
+}
+
+// TestValidateWarningsNeverReturnsAnError proves ValidateWarnings and
+// Validate are true siblings: a warning-only finding must never also
+// appear from Validate, and vice versa (see Severity's doc comment).
+func TestValidateWarningsNeverReturnsAnError(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <span data-gosx-hearbeat="/api/version"></span>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+
+	if diags := ir.Validate(prog); len(diags) != 0 {
+		t.Fatalf("expected Validate to find nothing for a warning-only finding, got %+v", diags)
+	}
+	for _, w := range ir.ValidateWarnings(prog) {
+		if w.Severity != ir.SeverityWarning {
+			t.Fatalf("expected every ValidateWarnings result to be SeverityWarning, got %+v", w)
+		}
+	}
+}
+
+// --- Value-shape checks (error severity, gosx#249 check 5) ---------------
+
+func TestValidateRejectsInvalidHeartbeatInterval(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <body data-gosx-heartbeat="/api/version" data-gosx-heartbeat-interval="4 seconds"></body>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	diags := ir.Validate(prog)
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %+v", diags)
+	}
+	want := `invalid data-gosx-heartbeat-interval value "4 seconds": must be a whole number of seconds or minutes`
+	if diags[0].Message != want {
+		t.Fatalf("unexpected diagnostic message: got %q, want %q", diags[0].Message, want)
+	}
+}
+
+func TestValidateAllowsValidHeartbeatInterval(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <body data-gosx-heartbeat="/api/version" data-gosx-heartbeat-interval="4s"></body>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	if diags := ir.Validate(prog); len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for a valid heartbeat interval, got %+v", diags)
+	}
+}
+
+func TestValidateRejectsInvalidLinkCurrentPolicy(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <a href="/x" data-gosx-link data-gosx-link-current-policy="always"></a>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	diags := ir.Validate(prog)
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %+v", diags)
+	}
+	want := `invalid data-gosx-link-current-policy value "always": must be "auto", "page", "ancestor", or "none"`
+	if diags[0].Message != want {
+		t.Fatalf("unexpected diagnostic message: got %q, want %q", diags[0].Message, want)
+	}
+}
+
+func TestValidateRejectsInvalidPrefetchValue(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <a href="/x" data-gosx-link data-gosx-prefetch="eager"></a>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	diags := ir.Validate(prog)
+	if len(diags) != 1 {
+		t.Fatalf("expected exactly one diagnostic, got %+v", diags)
+	}
+	want := `invalid data-gosx-prefetch value "eager": must be "off", "intent", "render", or "force"`
+	if diags[0].Message != want {
+		t.Fatalf("unexpected diagnostic message: got %q, want %q", diags[0].Message, want)
+	}
+}
+
+func TestValidateAllowsValidLinkAttrs(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <a href="/x" data-gosx-link data-gosx-link-current-policy="ancestor" data-gosx-prefetch="intent"></a>
+}
+`)
+	prog, err := parse(t, source)
+	if err != nil {
+		t.Fatalf("Lower failed: %v", err)
+	}
+	if diags := ir.Validate(prog); len(diags) != 0 {
+		t.Fatalf("expected no diagnostics for valid link attributes, got %+v", diags)
+	}
+}

--- a/lsp/projectcheck.go
+++ b/lsp/projectcheck.go
@@ -1,0 +1,56 @@
+package lsp
+
+import (
+	"context"
+	"errors"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/strictcheck"
+)
+
+// AnalyzeProject runs the whole-project checks (gosx#249's form-action,
+// required-reachability, and data-loader-key checks) against the package
+// containing path, reading whatever "*.server.go" siblings and
+// "public/*.css" files are on disk. Unlike Analyze, this performs file
+// I/O and must never run on every keystroke -- see the didSave handler in
+// server.go, the one cadence this package affords it, and Analyze's own
+// doc comment for the fast, no-I/O half of the split.
+//
+// The route-mount check (gosx#249 check 3) is deliberately absent here:
+// it needs every "*.gsx" file and every router.AddDir call in the whole
+// project tree, not just the one package path names, and re-walking a
+// whole project on every save is a cost this package does not think an
+// editor should pay. It still runs at `gosx check`/build-gate time
+// through strictcheck.CheckTreeWithOptions.
+func AnalyzeProject(path string) []Diagnostic {
+	var warnings []ir.Diagnostic
+	err := strictcheck.CheckFileWithOptions(context.Background(), path, strictcheck.Options{Warnings: &warnings})
+
+	// A non-DiagnosticsError err (a strict-syntax Go compiler failure, an
+	// import-resolution failure) is out of gosx#249's own scope and is
+	// silently not turned into a Diagnostic here -- Analyze's fast,
+	// per-keystroke path already reports every parse/lower error this
+	// package surfaces today, and widening what didSave reports is a
+	// separate change from the one this function exists for.
+	diags := make([]Diagnostic, 0, len(warnings))
+	var diagErr *ir.DiagnosticsError
+	if errors.As(err, &diagErr) {
+		for _, raw := range diagErr.Diagnostics {
+			diags = append(diags, Diagnostic{
+				Range:    rangeFromSpan(raw.Span),
+				Severity: SeverityError,
+				Source:   diagnosticSource(path),
+				Message:  diagnosticMessage(raw),
+			})
+		}
+	}
+	for _, diag := range warnings {
+		diags = append(diags, Diagnostic{
+			Range:    rangeFromSpan(diag.Span),
+			Severity: SeverityWarning,
+			Source:   diagnosticSource(path),
+			Message:  diagnosticMessage(diag),
+		})
+	}
+	return diags
+}

--- a/lsp/projectcheck_test.go
+++ b/lsp/projectcheck_test.go
@@ -1,0 +1,74 @@
+package lsp
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestAnalyzeProjectFlagsUnregisteredFormAction proves AnalyzeProject
+// reaches strictcheck's whole-project form-action check (gosx#249): a
+// page reading the file back off disk, not the in-memory buffer, still
+// finds the same unregistered actionPath(...) reference gosx check would.
+func TestAnalyzeProjectFlagsUnregisteredFormAction(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.gsx")
+	source := "package main\n\nfunc Page() Node {\n\treturn <form method=\"post\" action={actionPath(\"missing\")}></form>\n}\n"
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write page.gsx: %v", err)
+	}
+
+	diags := AnalyzeProject(path)
+	if len(diags) == 0 {
+		t.Fatal("expected at least one diagnostic")
+	}
+	found := false
+	for _, diag := range diags {
+		if diag.Severity == SeverityError && strings.Contains(diag.Message, `actionPath("missing")`) {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected an unregistered-action error, got %+v", diags)
+	}
+}
+
+// TestServerPublishesProjectDiagnosticsOnSave proves the didSave wiring
+// end to end: initialize advertises save support, and a save notification
+// for a page with an unregistered form action republishes a diagnostic a
+// keystroke-only didChange never would (it never touches disk).
+func TestServerPublishesProjectDiagnosticsOnSave(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "page.gsx")
+	source := "package main\n\nfunc Page() Node {\n\treturn <form method=\"post\" action={actionPath(\"missing\")}></form>\n}\n"
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatalf("write page.gsx: %v", err)
+	}
+	uri := "file://" + filepath.ToSlash(path)
+
+	input := bytes.NewBuffer(nil)
+	output := bytes.NewBuffer(nil)
+
+	writeFramedJSON(input, `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}`)
+	writeFramedJSON(input, fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":%q,"version":1,"text":%q}}}`,
+		uri, source))
+	writeFramedJSON(input, fmt.Sprintf(
+		`{"jsonrpc":"2.0","method":"textDocument/didSave","params":{"textDocument":{"uri":%q}}}`, uri))
+	writeFramedJSON(input, `{"jsonrpc":"2.0","id":3,"method":"shutdown","params":{}}`)
+
+	if err := Serve(input, output); err != nil {
+		t.Fatalf("serve: %v", err)
+	}
+
+	wire := output.String()
+	if !strings.Contains(wire, `"save":{"includeText":false}`) {
+		t.Fatalf("expected initialize to advertise save support, got %s", wire)
+	}
+	if !strings.Contains(wire, `actionPath(\"missing\")`) {
+		t.Fatalf("expected the save-triggered diagnostic in wire output, got %s", wire)
+	}
+}

--- a/lsp/server.go
+++ b/lsp/server.go
@@ -70,6 +70,12 @@ type didCloseParams struct {
 	} `json:"textDocument"`
 }
 
+type didSaveParams struct {
+	TextDocument struct {
+		URI string `json:"uri"`
+	} `json:"textDocument"`
+}
+
 type formattingParams struct {
 	TextDocument struct {
 		URI string `json:"uri"`
@@ -129,7 +135,24 @@ func (s *server) handle(req request) error {
 	case "initialize":
 		return s.respond(req.ID, map[string]any{
 			"capabilities": map[string]any{
-				"textDocumentSync":           textDocumentSyncFull,
+				// An object, not the bare TextDocumentSyncKind int this used
+				// to be: a client only ever sends textDocument/didSave when
+				// the server's own capabilities advertise "save" support
+				// (gosx#249) -- the whole-project checks (form action,
+				// required-control reachability, data-loader keys; see
+				// AnalyzeProject) need file I/O the per-keystroke didChange
+				// path must never pay, so didSave is their one cadence into
+				// the editor. "includeText: false" is deliberate:
+				// AnalyzeProject reads the file back off disk itself (it
+				// already needs disk access for the *.server.go siblings and
+				// public/*.css a save-time check reads), so the save
+				// notification's own body does not need to carry the text
+				// too.
+				"textDocumentSync": map[string]any{
+					"openClose": true,
+					"change":    textDocumentSyncFull,
+					"save":      map[string]any{"includeText": false},
+				},
 				"documentFormattingProvider": true,
 				"documentSymbolProvider":     true,
 				"hoverProvider":              true,
@@ -164,6 +187,12 @@ func (s *server) handle(req request) error {
 			s.docs[params.TextDocument.URI] = params.ContentChanges[len(params.ContentChanges)-1].Text
 		}
 		return s.publishDiagnostics(params.TextDocument.URI)
+	case "textDocument/didSave":
+		var params didSaveParams
+		if err := json.Unmarshal(req.Params, &params); err != nil {
+			return s.respondError(req.ID, -32602, err.Error())
+		}
+		return s.publishProjectDiagnostics(params.TextDocument.URI)
 	case "textDocument/didClose":
 		var params didCloseParams
 		if err := json.Unmarshal(req.Params, &params); err != nil {
@@ -235,6 +264,26 @@ func (s *server) handle(req request) error {
 func (s *server) publishDiagnostics(uri string) error {
 	source := s.docs[uri]
 	diags := Analyze(URIToPath(uri), []byte(source))
+	return s.notify("textDocument/publishDiagnostics", map[string]any{
+		"uri":         uri,
+		"diagnostics": diags,
+	})
+}
+
+// publishProjectDiagnostics republishes uri's full diagnostic set on save:
+// the same fast, no-I/O pass publishDiagnostics already runs on every
+// keystroke, plus AnalyzeProject's whole-project findings (gosx#249),
+// which read the file back off disk (the just-written save, not the
+// in-memory buffer) since they also need its "*.server.go" siblings and
+// the project's public/*.css. A publishDiagnostics call from a later
+// keystroke replaces this combined set with the fast half alone -- the
+// project findings go stale until the next save, a deliberate trade
+// against re-running file I/O on every keystroke.
+func (s *server) publishProjectDiagnostics(uri string) error {
+	source := s.docs[uri]
+	path := URIToPath(uri)
+	diags := Analyze(path, []byte(source))
+	diags = append(diags, AnalyzeProject(path)...)
 	return s.notify("textDocument/publishDiagnostics", map[string]any{
 		"uri":         uri,
 		"diagnostics": diags,

--- a/lsp/symbols.go
+++ b/lsp/symbols.go
@@ -82,10 +82,19 @@ func indexSource(path string, source []byte) (sourceIndex, []Diagnostic) {
 	idx.indexComponents()
 	idx.indexComponentRefs()
 
-	raw := ir.Validate(prog)
+	// ir.Validate and ir.ValidateWarnings are siblings (see the latter's doc
+	// comment): the LSP is the one caller that always wants both, since an
+	// author benefits from seeing a warning-severity finding (for example a
+	// near-miss data-gosx-* attribute name, gosx#249) as they type just as
+	// much as an error -- neither pass performs file I/O, so running both on
+	// every keystroke keeps the same "no I/O in ir.Lower's synchronous path"
+	// constraint the fast path already holds. A whole-project check that
+	// does need I/O (the stylesheet, the action registry, the route tree)
+	// is out of scope here; see AnalyzeProject for where those land instead.
+	errs := ir.Validate(prog)
 	warnings := ir.ValidateWarnings(prog)
-	diags := make([]Diagnostic, 0, len(raw)+len(warnings))
-	for _, diag := range raw {
+	diags := make([]Diagnostic, 0, len(errs)+len(warnings))
+	for _, diag := range errs {
 		diags = append(diags, Diagnostic{
 			Range:    rangeFromSpan(diag.Span),
 			Severity: severityFromIR(diag.Severity),

--- a/strictcheck/check.go
+++ b/strictcheck/check.go
@@ -52,6 +52,27 @@ type Options struct {
 	//     complete. gosx's lsp package does not feed it ExtraLints results
 	//     today, so it is unaffected; this note is for a consumer that does.
 	ExtraLints []Lint
+
+	// Warnings, when non-nil, receives every warning-severity
+	// (ir.SeverityWarning) diagnostic found across the run, appended in the
+	// order each check produces them. A warning is never part of the
+	// returned error and never fails a build -- see ir.ValidateWarnings'
+	// doc comment for why that split exists. The zero value (nil) means
+	// the caller does not want warnings collected; every warning-only
+	// check below still runs (its findings are cheap to compute alongside
+	// the error-severity work already sharing its file reads), but its
+	// results are discarded rather than appended anywhere.
+	Warnings *[]ir.Diagnostic
+}
+
+// addWarnings appends diags to opts.Warnings if the caller asked to collect
+// them (see the Warnings field's doc comment); a nil Warnings pointer is a
+// deliberate no-op, not an error.
+func addWarnings(opts Options, diags []ir.Diagnostic) {
+	if opts.Warnings == nil || len(diags) == 0 {
+		return
+	}
+	*opts.Warnings = append(*opts.Warnings, diags...)
 }
 
 // CheckFile checks the complete .gsx package containing path.
@@ -149,6 +170,22 @@ func runBuiltinChecks(ctx context.Context, files []transpile.PackageFile, opts O
 	if err := validateImageContract(files, root); err != nil {
 		return err
 	}
+	// The whole-application correctness checks below (gosx#249) share
+	// validateImageContract's placement and reasoning exactly: every one
+	// targets ordinary legacy .gsx syntax (a file-routed page's <form>, its
+	// data.X reads, its data-gosx-* attributes), so none of them may sit
+	// behind the packageHasStrict return either. addFileGosxWarnings is
+	// error-free by construction (ir.ValidateWarnings never returns a
+	// SeverityError diagnostic); the other three return an error only for
+	// their own error-severity finding (gosx#249's check 1, the
+	// unregistered form action) or never at all (checks 2 and 4 are
+	// warning-only and report through opts.Warnings instead).
+	addFileGosxWarnings(files, opts)
+	if err := validateFormActionContract(files, opts); err != nil {
+		return err
+	}
+	validateRequiredReachabilityContract(files, root, opts)
+	validateDataLoaderKeysContract(files, opts)
 	if !packageHasStrict(files) {
 		return nil
 	}
@@ -410,6 +447,14 @@ func CheckTreeWithOptions(ctx context.Context, root string, opts Options) error 
 	if err != nil {
 		return err
 	}
+	// validateRouteMountContract (gosx#249, check 3) is the one whole-app
+	// check that cannot run per package the way runBuiltinChecks' other
+	// checks do: knowing whether a page is reached needs every AddDir call
+	// in the whole tree, which only CheckTreeWithOptions has gathered.
+	// CheckFileWithOptions and CheckPackageWithOptions never call it, so a
+	// single-file "gosx check" cannot see an unmounted-page finding --
+	// intentional; see that function's own doc comment.
+	validateRouteMountContract(abs, sources, opts)
 	return checkSourcePackages(ctx, sources, opts, abs)
 }
 

--- a/strictcheck/css.go
+++ b/strictcheck/css.go
@@ -1,0 +1,505 @@
+package strictcheck
+
+import "strings"
+
+// This file is a small, purpose-built CSS reader for
+// validateRequiredReachabilityContract (gosx#249, check 2) only -- it is
+// not a general CSS parser, has no notion of specificity or the cascade,
+// and does not attempt to resolve custom properties, imports, or nested
+// CSS. It reads just enough structure (rule -> selector list +
+// declarations, descending into @media/@supports/@layer/@container) to
+// ask one narrow question per rule: "do this rule's own declarations look
+// like they hide whatever they match", and if so, "what is the rightmost
+// compound selector of each entry in its selector list".
+
+// cssDecl is one "prop: value" declaration, both already lower-cased.
+type cssDecl struct {
+	prop  string
+	value string
+}
+
+// parseCSSHidingRules extracts every rule in source whose declarations
+// hidingReason recognizes as hiding whatever the rule matches.
+func parseCSSHidingRules(source string) []cssHidingRule {
+	var rules []cssHidingRule
+	walkCSSRules(source, func(selectorList, body string) {
+		reason, hides := hidingReason(parseCSSDeclarations(body))
+		if !hides {
+			return
+		}
+		rules = append(rules, cssHidingRule{
+			selectors: parseSelectorList(selectorList),
+			selector:  strings.TrimSpace(selectorList),
+			reason:    reason,
+		})
+	})
+	return rules
+}
+
+// walkCSSRules scans source for top-level style rules, calling visit with
+// each rule's raw selector-list text and declaration-block text.
+// @media/@supports/@layer/@container conditionally wrap ordinary rules, so
+// this descends into their bodies; any other at-rule (@keyframes,
+// @font-face, @page, and so on) has no element selectors to offer this
+// check, so its body is skipped whole.
+func walkCSSRules(source string, visit func(selector, body string)) {
+	i := 0
+	for {
+		prelude, body, next, ok := nextCSSBlock(source, i)
+		if !ok {
+			return
+		}
+		i = next
+		if strings.HasPrefix(prelude, "@") {
+			switch atRuleKeyword(prelude) {
+			case "media", "supports", "layer", "container":
+				walkCSSRules(body, visit)
+			}
+			continue
+		}
+		if prelude == "" {
+			continue
+		}
+		visit(prelude, body)
+	}
+}
+
+func atRuleKeyword(prelude string) string {
+	prelude = strings.TrimPrefix(prelude, "@")
+	for i := 0; i < len(prelude); i++ {
+		switch prelude[i] {
+		case ' ', '\t', '\n', '\r', '(', '{':
+			return strings.ToLower(prelude[:i])
+		}
+	}
+	return strings.ToLower(prelude)
+}
+
+// nextCSSBlock finds the next "prelude { body }" block in source starting
+// at from, respecting quoted strings and comments so a "{" or "}"
+// appearing inside either is never mistaken for structure.
+func nextCSSBlock(source string, from int) (prelude, body string, next int, ok bool) {
+	n := len(source)
+	i := from
+	start := from
+	for i < n {
+		c := source[i]
+		switch {
+		case c == '/' && i+1 < n && source[i+1] == '*':
+			end := strings.Index(source[i+2:], "*/")
+			if end < 0 {
+				return "", "", n, false
+			}
+			i = i + 2 + end + 2
+		case c == '"' || c == '\'':
+			i = skipCSSString(source, i)
+		case c == '{':
+			prelude = strings.TrimSpace(source[start:i])
+			blockEnd := matchCSSBrace(source, i)
+			if blockEnd < 0 {
+				return "", "", n, false
+			}
+			return prelude, source[i+1 : blockEnd], blockEnd + 1, true
+		case c == '}':
+			// An unmatched "}" this scan did not open (malformed CSS, or a
+			// nesting shape this reader does not model): treat everything
+			// up to here as consumed and keep scanning past it rather than
+			// looping forever.
+			i++
+			start = i
+		default:
+			i++
+		}
+	}
+	return "", "", n, false
+}
+
+// matchCSSBrace returns the index of the "}" matching the "{" at open.
+func matchCSSBrace(source string, open int) int {
+	n := len(source)
+	depth := 0
+	i := open
+	for i < n {
+		c := source[i]
+		switch {
+		case c == '/' && i+1 < n && source[i+1] == '*':
+			end := strings.Index(source[i+2:], "*/")
+			if end < 0 {
+				return -1
+			}
+			i = i + 2 + end + 2
+		case c == '"' || c == '\'':
+			i = skipCSSString(source, i)
+		case c == '{':
+			depth++
+			i++
+		case c == '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+			i++
+		default:
+			i++
+		}
+	}
+	return -1
+}
+
+func skipCSSString(source string, i int) int {
+	n := len(source)
+	quote := source[i]
+	i++
+	for i < n {
+		if source[i] == '\\' && i+1 < n {
+			i += 2
+			continue
+		}
+		if source[i] == quote {
+			return i + 1
+		}
+		i++
+	}
+	return n
+}
+
+// parseCSSDeclarations splits body on top-level ";" (respecting quoted
+// strings, comments, and parenthesized values such as rect(...) or
+// url(...)) into individual declarations.
+func parseCSSDeclarations(body string) []cssDecl {
+	var decls []cssDecl
+	n := len(body)
+	i := 0
+	start := 0
+	depth := 0
+	for i < n {
+		c := body[i]
+		switch {
+		case c == '/' && i+1 < n && body[i+1] == '*':
+			end := strings.Index(body[i+2:], "*/")
+			if end < 0 {
+				i = n
+				continue
+			}
+			i = i + 2 + end + 2
+			continue
+		case c == '"' || c == '\'':
+			i = skipCSSString(body, i)
+			continue
+		case c == '(':
+			depth++
+		case c == ')':
+			if depth > 0 {
+				depth--
+			}
+		case c == ';':
+			if depth == 0 {
+				if d, ok := parseOneCSSDeclaration(body[start:i]); ok {
+					decls = append(decls, d)
+				}
+				start = i + 1
+			}
+		}
+		i++
+	}
+	if d, ok := parseOneCSSDeclaration(body[start:]); ok {
+		decls = append(decls, d)
+	}
+	return decls
+}
+
+func parseOneCSSDeclaration(text string) (cssDecl, bool) {
+	text = strings.TrimSpace(text)
+	if text == "" {
+		return cssDecl{}, false
+	}
+	idx := strings.Index(text, ":")
+	if idx < 0 {
+		return cssDecl{}, false
+	}
+	prop := strings.ToLower(strings.TrimSpace(text[:idx]))
+	value := strings.ToLower(strings.TrimSpace(text[idx+1:]))
+	value = strings.TrimSpace(strings.TrimSuffix(value, "!important"))
+	if prop == "" || value == "" {
+		return cssDecl{}, false
+	}
+	return cssDecl{prop: prop, value: value}, true
+}
+
+// hidingReason inspects one rule's declarations for the small set of
+// shapes this check recognizes as hiding whatever the rule matches, and
+// returns a human-readable reason for the diagnostic message. See
+// ruleMatchesElement's doc comment in requiredreach.go for the companion
+// selector-matching simplification; this function is the declaration-side
+// half of the same documented heuristic.
+func hidingReason(decls []cssDecl) (string, bool) {
+	var display, visibility, opacity, position, width, height, clip, clipPath, left, top string
+	for _, d := range decls {
+		switch d.prop {
+		case "display":
+			display = d.value
+		case "visibility":
+			visibility = d.value
+		case "opacity":
+			opacity = d.value
+		case "position":
+			position = d.value
+		case "width":
+			width = d.value
+		case "height":
+			height = d.value
+		case "clip":
+			clip = d.value
+		case "clip-path":
+			clipPath = d.value
+		case "left":
+			left = d.value
+		case "top":
+			top = d.value
+		}
+	}
+	switch {
+	case display == "none":
+		return `"display: none"`, true
+	case visibility == "hidden":
+		return `"visibility: hidden"`, true
+	case isZeroCSSNumber(opacity):
+		return `"opacity: 0"`, true
+	}
+	if position != "absolute" {
+		return "", false
+	}
+	if isOnePixelOrZero(width) || isOnePixelOrZero(height) || isZeroSizeClipRect(clip) || isCollapsingClipPath(clipPath) {
+		return `"position: absolute" combined with a zero/1px clip box, the common visually-hidden/sr-only pattern`, true
+	}
+	if isFarOffscreenOffset(left) || isFarOffscreenOffset(top) {
+		return `"position: absolute" combined with a large off-screen offset`, true
+	}
+	return "", false
+}
+
+func isZeroCSSNumber(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "0", "0.0", "0%", ".0", "0.00":
+		return true
+	default:
+		return false
+	}
+}
+
+func isOnePixelOrZero(v string) bool {
+	switch strings.TrimSpace(v) {
+	case "1px", "0", "0px":
+		return true
+	default:
+		return false
+	}
+}
+
+func isZeroSizeClipRect(v string) bool {
+	v = strings.TrimSpace(v)
+	if !strings.HasPrefix(v, "rect(") || !strings.HasSuffix(v, ")") {
+		return false
+	}
+	inner := v[len("rect(") : len(v)-1]
+	parts := strings.FieldsFunc(inner, func(r rune) bool { return r == ',' || r == ' ' })
+	if len(parts) == 0 {
+		return false
+	}
+	for _, p := range parts {
+		switch p {
+		case "0", "0px", "0%":
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func isCollapsingClipPath(v string) bool {
+	v = strings.TrimSpace(v)
+	return strings.Contains(v, "inset(50%") || strings.Contains(v, "inset(100%") || strings.HasPrefix(v, "polygon(0")
+}
+
+// isFarOffscreenOffset reports whether v is a negative length with at
+// least 4 digits of magnitude ("-9999px" and similar), the common
+// off-screen-positioning idiom -- an ordinary small negative offset used
+// for everyday layout ("-8px", "-20px") never matches.
+func isFarOffscreenOffset(v string) bool {
+	v = strings.TrimSpace(v)
+	if !strings.HasPrefix(v, "-") {
+		return false
+	}
+	digits := 0
+	for _, r := range v {
+		if r >= '0' && r <= '9' {
+			digits++
+		}
+	}
+	return digits >= 4
+}
+
+// parseSelectorList splits a CSS selector list on top-level commas and
+// reduces each entry to its rightmost compound selector.
+func parseSelectorList(selectorList string) []simpleSelector {
+	var out []simpleSelector
+	for _, raw := range splitTopLevelComma(selectorList) {
+		sel := strings.TrimSpace(raw)
+		if sel == "" {
+			continue
+		}
+		out = append(out, rightmostCompoundSelector(sel))
+	}
+	return out
+}
+
+func splitTopLevelComma(s string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '(', '[':
+			depth++
+		case ')', ']':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}
+
+// rightmostCompoundSelector returns the last combinator-separated compound
+// in sel -- see ruleMatchesElement's doc comment for why only the
+// rightmost compound is matched.
+func rightmostCompoundSelector(sel string) simpleSelector {
+	segments := splitCSSCombinators(sel)
+	if len(segments) == 0 {
+		return simpleSelector{}
+	}
+	return parseCompoundSelector(segments[len(segments)-1])
+}
+
+func splitCSSCombinators(sel string) []string {
+	var segments []string
+	depth := 0
+	var current strings.Builder
+	flush := func() {
+		s := strings.TrimSpace(current.String())
+		if s != "" {
+			segments = append(segments, s)
+		}
+		current.Reset()
+	}
+	for i := 0; i < len(sel); i++ {
+		c := sel[i]
+		switch {
+		case c == '[' || c == '(':
+			depth++
+			current.WriteByte(c)
+		case c == ']' || c == ')':
+			if depth > 0 {
+				depth--
+			}
+			current.WriteByte(c)
+		case depth == 0 && (c == '>' || c == '+' || c == '~'):
+			flush()
+		case depth == 0 && (c == ' ' || c == '\t' || c == '\n' || c == '\r'):
+			flush()
+		default:
+			current.WriteByte(c)
+		}
+	}
+	flush()
+	return segments
+}
+
+// parseCompoundSelector reads one combinator-free compound selector
+// ("input.sr-only#field:focus[type=text]") into its tag, class list, and
+// id, discarding pseudo-classes/elements and attribute selectors -- this
+// check has no per-state or per-attribute information about an element to
+// match those against, so it deliberately widens the match rather than
+// silently mis-parsing one into a wrong tag/class/id.
+func parseCompoundSelector(s string) simpleSelector {
+	var sel simpleSelector
+	n := len(s)
+	i := 0
+	for i < n {
+		c := s[i]
+		switch {
+		case c == '.':
+			j := i + 1
+			for j < n && isCSSIdentChar(s[j]) {
+				j++
+			}
+			sel.classes = append(sel.classes, s[i+1:j])
+			i = j
+		case c == '#':
+			j := i + 1
+			for j < n && isCSSIdentChar(s[j]) {
+				j++
+			}
+			sel.id = s[i+1 : j]
+			i = j
+		case c == ':':
+			j := i + 1
+			if j < n && s[j] == ':' {
+				j++
+			}
+			for j < n && isCSSIdentChar(s[j]) {
+				j++
+			}
+			if j < n && s[j] == '(' {
+				depth := 1
+				j++
+				for j < n && depth > 0 {
+					if s[j] == '(' {
+						depth++
+					}
+					if s[j] == ')' {
+						depth--
+					}
+					j++
+				}
+			}
+			i = j
+		case c == '[':
+			depth := 1
+			j := i + 1
+			for j < n && depth > 0 {
+				if s[j] == '[' {
+					depth++
+				}
+				if s[j] == ']' {
+					depth--
+				}
+				j++
+			}
+			i = j
+		case c == '*':
+			i++
+		case isCSSIdentChar(c):
+			j := i
+			for j < n && isCSSIdentChar(s[j]) {
+				j++
+			}
+			sel.tag = s[i:j]
+			i = j
+		default:
+			i++
+		}
+	}
+	return sel
+}
+
+func isCSSIdentChar(c byte) bool {
+	return c == '-' || c == '_' ||
+		(c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+}

--- a/strictcheck/dataloader.go
+++ b/strictcheck/dataloader.go
@@ -1,0 +1,298 @@
+package strictcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"path/filepath"
+	"strings"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/transpile"
+)
+
+// validateDataLoaderKeysContract is strictcheck's check-time data-loader
+// key contract (gosx#249, check 4). A legacy file-routed page reads
+// data.someKey; the file router's reflective renderer binds "data" to
+// whatever this directory's FileModule.Load hook returns
+// (route/fileeval.go: env.values["data"] = ctx.Data). When Load's complete
+// key set is visible as a literal map[string]any{...}, a key the template
+// reads that never appears in it is guaranteed to evaluate to nil, every
+// request, forever -- no error, no crash, just an empty spot on the page.
+//
+// Warning severity, not error: even a fully literal Load can still be
+// legitimately incomplete from this scan's point of view (a key added by
+// a same-page FileModule.Bindings hook the map literal never mentions --
+// see bindingsMightOverrideData below), and gosx#249 asks that any
+// residual uncertainty in a heuristic ship as a warning with that
+// uncertainty stated, not as a build-failing error.
+func validateDataLoaderKeysContract(files []transpile.PackageFile, opts Options) {
+	if opts.Warnings == nil {
+		return
+	}
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		keys, ok := resolveDataKeysForFile(file.Path)
+		if !ok {
+			continue
+		}
+		addWarnings(opts, dataKeyDiagnosticsForFile(file, keys))
+	}
+}
+
+// resolveDataKeysForFile resolves gsxPath's complete data.X key set.
+// gsxPath's own directory and its immediate parent are both searched (see
+// candidateServerGoDirs) since a registration may name gsxPath explicitly
+// through route.FileModuleFor rather than only through the same-directory
+// RegisterFileModuleHere convention (gosx#249 confirmed this against
+// examples/goetrope-watch/app/watch/page.server.go, which registers for
+// app/watch/[code]/page.gsx this exact way). Three outcomes:
+//
+//   - Nothing registers for gsxPath at all: "data" is never assigned
+//     (route/fileeval.go's baseFileRenderValues starts it at nil and
+//     nothing overwrites it without a FileModule), so every data.X read
+//     is confidently, always nil -- an empty, resolved key set.
+//   - Every registration targeting gsxPath resolves (see resolveLoadKeys):
+//     their key sets are unioned.
+//   - Any registration's Bindings field might override "data", or its
+//     Load field cannot be resolved with confidence: the whole file
+//     abstains (ok=false), matching gosx#249's "only report with
+//     confidence" rule.
+func resolveDataKeysForFile(gsxPath string) (map[string]bool, bool) {
+	dirs := candidateServerGoDirs(filepath.Dir(gsxPath))
+	registrations, ok := collectFileModuleRegistrations(dirs)
+	if !ok {
+		return nil, false
+	}
+	funcs := funcDeclsAcrossDirs(dirs)
+	target := filepath.Clean(gsxPath)
+	keys := make(map[string]bool)
+	for _, reg := range registrations {
+		if reg.target != target {
+			continue
+		}
+		if bindingsMightOverrideData(reg.lit) {
+			// gosx#249's honesty rule: FileModule.Bindings can set
+			// env.values["data"] directly (route/fileeval.go's
+			// withBindings does a whole-value overwrite, not a merge),
+			// which this scan cannot trace, so it must not vouch for
+			// Load's key set alone -- abstain for the whole file.
+			return nil, false
+		}
+		litKeys, ok := resolveLoadKeys(reg.lit, funcs)
+		if !ok {
+			return nil, false
+		}
+		for key := range litKeys {
+			keys[key] = true
+		}
+	}
+	return keys, true
+}
+
+// bindingsMightOverrideData reports whether lit's Bindings field is
+// present and not explicitly nil.
+func bindingsMightOverrideData(lit *ast.CompositeLit) bool {
+	expr, present := fileModuleField(lit, "Bindings")
+	return present && !isNilExpr(expr)
+}
+
+// resolveLoadKeys resolves lit's Load field to the complete union of
+// literal string keys every "return map[string]any{...}, nil"-shaped exit
+// from that function can produce. ok is false whenever any exit point's
+// data is not confidently knowable: a missing Load field means data is
+// confidently always nil (an empty, resolved key set, not an abstention --
+// see below), but a Load field naming an unresolvable function, or a
+// function with any exit this scan cannot fully read, means the whole
+// directory abstains instead of risking a false positive on one branch it
+// could not see.
+func resolveLoadKeys(lit *ast.CompositeLit, funcs map[string]*ast.FuncDecl) (map[string]bool, bool) {
+	expr, present := fileModuleField(lit, "Load")
+	if !present || isNilExpr(expr) {
+		// No loader at all: ctx.Data is never assigned (route/fileeval.go's
+		// baseFileRenderValues starts "data" at nil and nothing overwrites
+		// it), so every data.X read in this page is confidently, always nil.
+		return map[string]bool{}, true
+	}
+	body := resolveLoadFuncBody(expr, funcs)
+	if body == nil {
+		return nil, false
+	}
+	return literalReturnMapKeys(body)
+}
+
+// resolveLoadFuncBody resolves expr -- an inline func literal or an
+// identifier naming a package-level function -- to its body block.
+// Anything else (a method value, a call, a variable holding a pre-built
+// closure) is unresolvable.
+func resolveLoadFuncBody(expr ast.Expr, funcs map[string]*ast.FuncDecl) *ast.BlockStmt {
+	switch e := expr.(type) {
+	case *ast.FuncLit:
+		return e.Body
+	case *ast.Ident:
+		if fn, ok := funcs[e.Name]; ok {
+			return fn.Body
+		}
+		return nil
+	default:
+		return nil
+	}
+}
+
+// literalReturnMapKeys walks every return statement reachable in body and
+// unions the literal string keys of every map[string]any{...} composite
+// literal returned as the first result. ok is false the moment any return
+// statement's first result is neither "nil" nor such a literal (a call, a
+// variable, a merge of two maps, a naked return) -- the complete key set
+// is then not something this scan can vouch for.
+func literalReturnMapKeys(body *ast.BlockStmt) (map[string]bool, bool) {
+	keys := make(map[string]bool)
+	ok := true
+	ast.Inspect(body, func(n ast.Node) bool {
+		if !ok {
+			return false
+		}
+		// A return inside a nested closure belongs to that closure, not to
+		// Load itself -- do not descend into one, or an unrelated inner
+		// func's return shape would wrongly abstain (or wrongly contribute
+		// keys to) the outer Load's own result.
+		if _, isFuncLit := n.(*ast.FuncLit); isFuncLit {
+			return false
+		}
+		ret, isReturn := n.(*ast.ReturnStmt)
+		if !isReturn {
+			return true
+		}
+		if len(ret.Results) == 0 {
+			// A naked return in a named-result function: this scan does not
+			// trace named-result assignment, so it cannot vouch for what
+			// ships. Abstain for the whole function.
+			ok = false
+			return false
+		}
+		first := ret.Results[0]
+		if isNilExpr(first) {
+			return true
+		}
+		lit, isLit := first.(*ast.CompositeLit)
+		if !isLit || !isMapStringAnyType(lit.Type) {
+			ok = false
+			return false
+		}
+		litKeys, litOK := literalStringMapKeys(lit)
+		if !litOK {
+			ok = false
+			return false
+		}
+		for key := range litKeys {
+			keys[key] = true
+		}
+		return true
+	})
+	if !ok {
+		return nil, false
+	}
+	return keys, true
+}
+
+// isMapStringAnyType reports whether t is written as "map[string]any" or
+// "map[string]interface{}" -- the only shape ctx.Data's reflective
+// binding and route.FileLoadFunc's own "(any, error)" result actually use
+// in every example this scan targets. A Load that returns some other
+// concrete type (a struct pointer, a named map type) is real, valid Go;
+// this scan simply has no data.X key list to offer for it, so it abstains
+// rather than guess a shape it was not given.
+func isMapStringAnyType(t ast.Expr) bool {
+	m, ok := t.(*ast.MapType)
+	if !ok {
+		return false
+	}
+	keyIdent, ok := m.Key.(*ast.Ident)
+	if !ok || keyIdent.Name != "string" {
+		return false
+	}
+	switch v := m.Value.(type) {
+	case *ast.Ident:
+		return v.Name == "any"
+	case *ast.InterfaceType:
+		return v.Methods == nil || len(v.Methods.List) == 0
+	default:
+		return false
+	}
+}
+
+// dataKeyDiagnosticsForFile scans file's whole IR tree for a top-level
+// "data.X" read whose X is missing from keys, reusing the same
+// legacy-template scope ir/validate.go's own ".length" rule targets: a
+// strict or island component has typed props, not this reflective "data"
+// binding, so neither is in scope here.
+func dataKeyDiagnosticsForFile(file transpile.PackageFile, keys map[string]bool) []ir.Diagnostic {
+	var diags []ir.Diagnostic
+	for _, comp := range file.Program.Components {
+		if comp.Syntax == ir.ComponentSyntaxStrict || comp.IsIsland {
+			continue
+		}
+		for _, id := range collectImageContractNodeIDs(file.Program, comp.Root) {
+			node := &file.Program.Nodes[id]
+			diags = append(diags, dataKeyNodeDiagnostics(file.Path, node, keys)...)
+		}
+	}
+	return diags
+}
+
+func dataKeyNodeDiagnostics(path string, node *ir.Node, keys map[string]bool) []ir.Diagnostic {
+	var diags []ir.Diagnostic
+	if node.Kind == ir.NodeExpr {
+		diags = append(diags, missingDataKeyDiagnostics(path, node.Span, node.Text, keys)...)
+	}
+	for _, attr := range node.Attrs {
+		switch attr.Kind {
+		case ir.AttrExpr, ir.AttrSpread:
+			diags = append(diags, missingDataKeyDiagnostics(path, node.Span, attr.Expr, keys)...)
+		}
+	}
+	return diags
+}
+
+// missingDataKeyDiagnostics parses one expression hole and reports every
+// top-level "data.X" selector (exactly one hop off the "data" identifier;
+// "data.picks.length" is out of scope here the same way it is for the
+// existing ".length" rule -- only the "picks" hop is a loader key) whose X
+// is absent from keys.
+func missingDataKeyDiagnostics(path string, span ir.Span, source string, keys map[string]bool) []ir.Diagnostic {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return nil
+	}
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return nil
+	}
+	var diags []ir.Diagnostic
+	ast.Inspect(expr, func(n ast.Node) bool {
+		sel, ok := n.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil {
+			return true
+		}
+		root, ok := sel.X.(*ast.Ident)
+		if !ok || root.Name != "data" {
+			return true
+		}
+		key := sel.Sel.Name
+		if keys[key] {
+			return true
+		}
+		fileSpan := span
+		fileSpan.File = path
+		diags = append(diags, ir.Diagnostic{
+			Span:     fileSpan,
+			Severity: ir.SeverityWarning,
+			Message:  fmt.Sprintf("gosx: data.%s is not a key this page's Load hook produces", key),
+			Hint:     `this page's data comes from no Load hook, or one whose complete literal map[string]any key set is known, and "` + key + `" is not in it, so it renders as nil; fix the key name, or add it to the loader if this is intentional`,
+		})
+		return true
+	})
+	return diags
+}

--- a/strictcheck/dataloader.go
+++ b/strictcheck/dataloader.go
@@ -60,8 +60,16 @@ func validateDataLoaderKeysContract(files []transpile.PackageFile, opts Options)
 //     Load field cannot be resolved with confidence: the whole file
 //     abstains (ok=false), matching gosx#249's "only report with
 //     confidence" rule.
+//
+// A "*.server.gotmpl" in either searched directory abstains first (see
+// hasUnrenderedServerGoTemplate): its real Load is template syntax this
+// scan cannot read, so "no *.server.go found" is not the same fact here
+// as "confidently, always nil".
 func resolveDataKeysForFile(gsxPath string) (map[string]bool, bool) {
 	dirs := candidateServerGoDirs(filepath.Dir(gsxPath))
+	if hasUnrenderedServerGoTemplate(dirs) {
+		return nil, false
+	}
 	registrations, ok := collectFileModuleRegistrations(dirs)
 	if !ok {
 		return nil, false

--- a/strictcheck/dataloader_test.go
+++ b/strictcheck/dataloader_test.go
@@ -1,0 +1,213 @@
+package strictcheck
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+// checkFileWarnings runs CheckFileWithOptions against path and returns
+// every warning-severity diagnostic collected, failing the test if the
+// check itself returns an error (every fixture in this file is expected
+// to be a clean, error-free page.gsx).
+func checkFileWarnings(t *testing.T, path string) []ir.Diagnostic {
+	t.Helper()
+	var warnings []ir.Diagnostic
+	if err := CheckFileWithOptions(context.Background(), path, Options{Warnings: &warnings}); err != nil {
+		t.Fatalf("CheckFileWithOptions: %v", err)
+	}
+	return warnings
+}
+
+func hasWarningContaining(warnings []ir.Diagnostic, substr string) bool {
+	for _, w := range warnings {
+		if strings.Contains(w.Message, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Rejects (warns) -----------------------------------------------------
+
+// TestDataLoaderKeysWarnsOnMissingKey is check 4's own proof: a page reads
+// data.open_seats, but Load's one, fully literal return only ever produces
+// "seats" -- a typo that renders silently empty forever, gosx#249's
+// largest defect class.
+func TestDataLoaderKeysWarnsOnMissingKey(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.open_seats}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]any{
+				"seats": 12,
+			}, nil
+		},
+	})
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if !hasWarningContaining(warnings, "data.open_seats") {
+		t.Fatalf("expected a warning naming data.open_seats, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysAcceptsPresentKey proves the same fixture shape
+// produces no warning once the key actually matches.
+func TestDataLoaderKeysAcceptsPresentKey(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.open_seats}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]any{
+				"open_seats": 12,
+			}, nil
+		},
+	})
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if hasWarningContaining(warnings, "data.open_seats") {
+		t.Fatalf("expected no warning for a present key, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysWarnsWhenNoLoadAtAll proves the confidently-empty case:
+// no Load hook exists anywhere, so "data" is always nil, and a data.X read
+// is certain to be a bug, not merely a guess.
+func TestDataLoaderKeysWarnsWhenNoLoadAtAll(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.anything}</p>`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if !hasWarningContaining(warnings, "data.anything") {
+		t.Fatalf("expected a warning for data.anything with no Load hook, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysAbstainsOnNonLiteralReturn proves the honesty rule
+// (gosx#249): a Load hook that returns anything this scan cannot read as a
+// complete literal map (here, a call to a helper) must not be flagged --
+// the true key set might include "open_seats" and this scan simply cannot
+// see it.
+func TestDataLoaderKeysAbstainsOnNonLiteralReturn(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.open_seats}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return fetchSeatData(), nil
+		},
+	})
+}
+
+func fetchSeatData() map[string]any {
+	return map[string]any{"open_seats": 12}
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if hasWarningContaining(warnings, "data.open_seats") {
+		t.Fatalf("expected a non-literal Load return to abstain, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysAbstainsWhenBindingsMightOverrideData proves the
+// FileModule.Bindings safety rule: withBindings does a whole-value
+// overwrite of "data" (route/fileeval.go), so a page that also sets
+// Bindings cannot be vouched for by Load's key set alone.
+func TestDataLoaderKeysAbstainsWhenBindingsMightOverrideData(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.open_seats}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]any{"seats": 12}, nil
+		},
+		Bindings: func(ctx *route.RouteContext, page route.FilePage, data any) route.FileTemplateBindings {
+			return route.FileTemplateBindings{}
+		},
+	})
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if hasWarningContaining(warnings, "data.open_seats") {
+		t.Fatalf("expected a page with Bindings set to abstain, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysAcceptsUnionOfBothReturnBranches proves keys are
+// unioned across every literal return branch, not just the first.
+func TestDataLoaderKeysAcceptsUnionOfBothReturnBranches(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.b}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			if page.Pattern == "/x" {
+				return map[string]any{"a": 1}, nil
+			}
+			return map[string]any{"b": 2}, nil
+		},
+	})
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if hasWarningContaining(warnings, "data.b") {
+		t.Fatalf("expected data.b to be accepted via the second branch, got: %+v", warnings)
+	}
+}
+
+// TestDataLoaderKeysIgnoresStrictComponents proves the reflective "data"
+// binding rule is scoped to legacy syntax only (route/fileeval.go binds
+// "data" only in the reflective file renderer); a strict component's own
+// typed props are out of scope for this check entirely, so a same-named
+// "data.whatever" read inside one strict-syntax fixture would be a
+// misleading test here -- this test instead just proves the legacy-only
+// scope by confirming a strict-syntax file with no Load produces no
+// data.X finding for an unrelated legacy field read elsewhere.
+func TestDataLoaderKeysIgnoresStrictComponents(t *testing.T) {
+	dir := newTestModule(t)
+	// "widget.gsx", not "page.gsx"/"index.gsx"/"layout.gsx": this proves
+	// the reflective "data" binding's own scope (a strict component has
+	// typed props, not this binding, regardless of file name), without
+	// also tripping validateStrictRenderEntries' unrelated file-routed
+	// zero-props rule, which only applies to a page/layout/index entry.
+	mustWrite(t, filepath.Join(dir, "widget.gsx"), `package main
+
+type WidgetProps struct {
+	Open int
+}
+
+component Widget(props: *WidgetProps) {
+	return <p>{props.Open}</p>
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "widget.gsx"))
+	if len(warnings) != 0 {
+		t.Fatalf("expected no data.X warnings for a strict component, got: %+v", warnings)
+	}
+}

--- a/strictcheck/dataloader_test.go
+++ b/strictcheck/dataloader_test.go
@@ -97,6 +97,34 @@ func TestDataLoaderKeysWarnsWhenNoLoadAtAll(t *testing.T) {
 	}
 }
 
+// TestDataLoaderKeysAbstainsOnUnrenderedServerGoTemplate reconstructs the
+// gosx#249 scaffold defect: cmd/gosx/templates/docs ships
+// "page.server.gotmpl" beside each "page.gsx" that needs one, never a
+// real "page.server.go". Before this test existed, the "no Load hook
+// exists" branch (see TestDataLoaderKeysWarnsWhenNoLoadAtAll) could not
+// tell that apart from a real, rendered project with no loader at all,
+// and reported the framework's own scaffold as broken.
+func TestDataLoaderKeysAbstainsOnUnrenderedServerGoTemplate(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<p>{data.features}</p>`))
+	mustWrite(t, filepath.Join(dir, "page.server.gotmpl"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Load: func(ctx *route.RouteContext, page route.FilePage) (any, error) {
+			return map[string]any{"features": nil}, nil
+		},
+	})
+}
+`)
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if hasWarningContaining(warnings, "data.features") {
+		t.Fatalf("expected a page.server.gotmpl sibling to abstain, got: %+v", warnings)
+	}
+}
+
 // TestDataLoaderKeysAbstainsOnNonLiteralReturn proves the honesty rule
 // (gosx#249): a Load hook that returns anything this scan cannot read as a
 // complete literal map (here, a call to a helper) must not be flagged --

--- a/strictcheck/formaction.go
+++ b/strictcheck/formaction.go
@@ -57,8 +57,17 @@ func validateFormActionContract(files []transpile.PackageFile, opts Options) err
 // (ok=true, empty map) is a real, meaningful finding: nothing registers
 // any action for gsxPath at all, so ANY actionPath(...) reference found in
 // it is unregistered.
+//
+// A "*.server.gotmpl" in either searched directory abstains first (see
+// hasUnrenderedServerGoTemplate): its real Actions are template syntax
+// this scan cannot read, so "no *.server.go found" is not the same fact
+// here as "confidently registers nothing".
 func registeredFileActionNamesForFile(gsxPath string) (map[string]bool, bool) {
-	registrations, ok := collectFileModuleRegistrations(candidateServerGoDirs(filepath.Dir(gsxPath)))
+	dirs := candidateServerGoDirs(filepath.Dir(gsxPath))
+	if hasUnrenderedServerGoTemplate(dirs) {
+		return nil, false
+	}
+	registrations, ok := collectFileModuleRegistrations(dirs)
 	if !ok {
 		return nil, false
 	}

--- a/strictcheck/formaction.go
+++ b/strictcheck/formaction.go
@@ -1,0 +1,168 @@
+package strictcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/transpile"
+)
+
+// validateFormActionContract is strictcheck's check-time form-action
+// registry contract (gosx#249, check 1). A .gsx element writes
+// action={actionPath("name")} or formaction={actionPath("name")};
+// route.RouteContext.ActionPath (route/route.go) builds the runtime URL
+// from that bare name with NO lookup against what is actually
+// registered -- so a name with no matching entry in this directory's
+// route.FileActions (registered through RegisterFileModuleHere and its
+// siblings in a "*.server.go" file, see route/filemodule.go) is a
+// guaranteed 404 the first time a real request reaches it. Both sides are
+// compile-time facts: the .gsx side from the IR, the Go side from a
+// composite literal in a "*.server.go" file. This exact shape shipped in
+// this repository's own examples/dashboard (gosx#249's premise table).
+//
+// Error severity: an unresolvable name is not a matter of interpretation
+// the way check 2's CSS heuristic or check 4's loader-key heuristic are --
+// either the name is registered or the request 404s.
+func validateFormActionContract(files []transpile.PackageFile, opts Options) error {
+	var diags []ir.Diagnostic
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		registered, resolved := registeredFileActionNamesForFile(file.Path)
+		if !resolved {
+			// A dynamic Actions construction, or an unresolvable
+			// registration call (gosx#249's "only report with confidence"
+			// rule): stay silent for this file rather than risk flagging a
+			// name this scan simply could not see.
+			continue
+		}
+		diags = append(diags, formActionDiagnostics(file, registered)...)
+	}
+	return ir.NewDiagnosticsError("form-action", diags)
+}
+
+// registeredFileActionNamesForFile returns the complete set of action
+// names any "*.server.go" registration targeting gsxPath registers, and
+// whether that set could be resolved with confidence. gsxPath's own
+// directory and its immediate parent are both searched (see
+// candidateServerGoDirs) since a registration may name gsxPath explicitly
+// through route.FileModuleFor rather than only through the same-directory
+// RegisterFileModuleHere convention. An empty-but-resolved result
+// (ok=true, empty map) is a real, meaningful finding: nothing registers
+// any action for gsxPath at all, so ANY actionPath(...) reference found in
+// it is unregistered.
+func registeredFileActionNamesForFile(gsxPath string) (map[string]bool, bool) {
+	registrations, ok := collectFileModuleRegistrations(candidateServerGoDirs(filepath.Dir(gsxPath)))
+	if !ok {
+		return nil, false
+	}
+	target := filepath.Clean(gsxPath)
+	registered := make(map[string]bool)
+	for _, reg := range registrations {
+		if reg.target != target {
+			continue
+		}
+		expr, present := fileModuleField(reg.lit, "Actions")
+		if !present || isNilExpr(expr) {
+			continue
+		}
+		keys, ok := resolveCompositeExpr(expr, reg.vars)
+		if !ok {
+			return nil, false
+		}
+		for name := range keys {
+			registered[name] = true
+		}
+	}
+	return registered, true
+}
+
+// resolveCompositeExpr resolves expr -- either an inline composite literal
+// or an identifier naming a package-level composite-literal variable in
+// vars -- to its complete literal string key set.
+func resolveCompositeExpr(expr ast.Expr, vars map[string]*ast.CompositeLit) (map[string]bool, bool) {
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		return literalStringMapKeys(e)
+	case *ast.Ident:
+		if lit, ok := vars[e.Name]; ok {
+			return literalStringMapKeys(lit)
+		}
+		return nil, false
+	default:
+		return nil, false
+	}
+}
+
+// formActionDiagnostics scans file's whole IR tree for a static "action" or
+// "formaction" attribute holding a bare actionPath("name") call, and
+// reports one it cannot find in registered.
+func formActionDiagnostics(file transpile.PackageFile, registered map[string]bool) []ir.Diagnostic {
+	var diags []ir.Diagnostic
+	for _, comp := range file.Program.Components {
+		for _, id := range collectImageContractNodeIDs(file.Program, comp.Root) {
+			node := &file.Program.Nodes[id]
+			for _, attr := range node.Attrs {
+				if attr.Name != "action" && attr.Name != "formaction" {
+					continue
+				}
+				if attr.Kind != ir.AttrExpr {
+					continue
+				}
+				name, ok := actionPathCallArg(attr.Expr)
+				if !ok || registered[name] {
+					continue
+				}
+				span := node.Span
+				span.File = file.Path
+				diags = append(diags, ir.Diagnostic{
+					Span:    span,
+					Message: fmt.Sprintf("gosx: %s references actionPath(%q), which is not registered in any FileActions reachable from this page", attr.Name, name),
+					Hint:    fmt.Sprintf("register it in a *.server.go beside this page, for example Actions: route.FileActions{%q: func(ctx *action.Context) error { ... }}, or fix the name if this is a typo", name),
+				})
+			}
+		}
+	}
+	return diags
+}
+
+// actionPathCallArg reports whether source is exactly a call to the
+// actionPath template function with one string-literal argument, and if
+// so, that argument's value. Any other shape (a variable, a concatenation,
+// a different function) is out of this check's reach and reported as
+// ok=false -- it cannot 404 against a name this scan can compare, but it
+// also is not something this check can vouch for; the node is simply
+// skipped, not flagged either way.
+func actionPathCallArg(source string) (string, bool) {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "", false
+	}
+	expr, err := parser.ParseExpr(source)
+	if err != nil {
+		return "", false
+	}
+	call, ok := expr.(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return "", false
+	}
+	fn, ok := call.Fun.(*ast.Ident)
+	if !ok || fn.Name != "actionPath" {
+		return "", false
+	}
+	basic, ok := call.Args[0].(*ast.BasicLit)
+	if !ok {
+		return "", false
+	}
+	name, err := strconv.Unquote(basic.Value)
+	if err != nil {
+		return "", false
+	}
+	return name, true
+}

--- a/strictcheck/formaction_test.go
+++ b/strictcheck/formaction_test.go
@@ -91,6 +91,34 @@ func TestFormActionContractRejectsUnregisteredAction(t *testing.T) {
 	}
 }
 
+// TestFormActionContractAbstainsOnUnrenderedServerGoTemplate reconstructs
+// the gosx#249 scaffold defect: cmd/gosx/templates/docs ships
+// "page.server.gotmpl" beside each "page.gsx" that needs one, never a
+// real "page.server.go" -- `gosx init` renders the template into a real
+// file only when scaffolding a new project. Before this test existed,
+// this scan read "no page.server.go here" as "confidently registers
+// nothing" and reported the framework's own scaffold as broken.
+func TestFormActionContractAbstainsOnUnrenderedServerGoTemplate(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<form method="post" action={actionPath("signIn")}></form>`))
+	mustWrite(t, filepath.Join(dir, "page.server.gotmpl"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Actions: route.FileActions{
+			"signIn": nil,
+		},
+	})
+}
+`)
+	if err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx")); err != nil {
+		t.Fatalf("expected a page.server.gotmpl sibling to abstain, got %v", err)
+	}
+}
+
 func TestFormActionContractRejectsUnregisteredFormactionOnButton(t *testing.T) {
 	dir := newTestModule(t)
 	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(

--- a/strictcheck/formaction_test.go
+++ b/strictcheck/formaction_test.go
@@ -1,0 +1,117 @@
+package strictcheck
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func formPageFixture(formTag string) string {
+	return "package main\n\nfunc Page() Node {\n\treturn " + formTag + "\n}\n"
+}
+
+// --- Accepts -----------------------------------------------------------
+
+func TestFormActionContractAcceptsRegisteredAction(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<form method="post" action={actionPath("createUser")}><button type="submit">Go</button></form>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Actions: route.FileActions{
+			"createUser": nil,
+		},
+	})
+}
+`)
+	if err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx")); err != nil {
+		t.Fatalf("expected a registered action to be accepted, got %v", err)
+	}
+}
+
+func TestFormActionContractAcceptsNoActionsAtAllOnAStaticForm(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(`<form method="get" action="/search"></form>`))
+	if err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx")); err != nil {
+		t.Fatalf("expected a plain static action to be out of scope, got %v", err)
+	}
+}
+
+// TestFormActionContractAbstainsOnDynamicActionsConstruction proves the
+// "only report with confidence" rule (gosx#249): a page.server.go that
+// builds its Actions map through a helper call, not a literal, must not be
+// flagged even though this scan cannot see "createUser" registered
+// anywhere.
+func TestFormActionContractAbstainsOnDynamicActionsConstruction(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<form method="post" action={actionPath("createUser")}></form>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Actions: buildActions(),
+	})
+}
+
+func buildActions() route.FileActions {
+	return route.FileActions{"createUser": nil}
+}
+`)
+	if err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx")); err != nil {
+		t.Fatalf("expected a dynamically built Actions map to abstain, got %v", err)
+	}
+}
+
+// --- Rejects -------------------------------------------------------------
+
+// TestFormActionContractRejectsUnregisteredAction reconstructs the
+// gosx#249 premise-table defect: a form posts to an action name that is
+// never registered anywhere (a guaranteed 404 the moment a real request
+// reaches it), the examples/dashboard defect that shipped in this
+// repository's own history.
+func TestFormActionContractRejectsUnregisteredAction(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<form method="post" action={actionPath("signup-claim")}><button type="submit">Claim</button></form>`))
+	// No page.server.go at all: nothing registers any action for this page.
+	err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx"))
+	if err == nil {
+		t.Fatal("expected an unregistered form action to be rejected")
+	}
+	if !strings.Contains(err.Error(), `actionPath("signup-claim")`) || !strings.Contains(err.Error(), "not registered") {
+		t.Fatalf("expected the diagnostic to name the unregistered action, got: %v", err)
+	}
+}
+
+func TestFormActionContractRejectsUnregisteredFormactionOnButton(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<button formaction={actionPath("signOut")}>Sign out</button>`))
+	mustWrite(t, filepath.Join(dir, "page.server.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func init() {
+	route.RegisterFileModuleHere(route.FileModuleOptions{
+		Actions: route.FileActions{
+			"signIn": nil,
+		},
+	})
+}
+`)
+	err := CheckFile(context.Background(), filepath.Join(dir, "page.gsx"))
+	if err == nil {
+		t.Fatal("expected an unregistered formaction to be rejected")
+	}
+	if !strings.Contains(err.Error(), `actionPath("signOut")`) {
+		t.Fatalf("expected the diagnostic to name signOut, got: %v", err)
+	}
+}

--- a/strictcheck/requiredreach.go
+++ b/strictcheck/requiredreach.go
@@ -1,0 +1,197 @@
+package strictcheck
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/transpile"
+)
+
+// validateRequiredReachabilityContract is strictcheck's check-time
+// required-control reachability heuristic (gosx#249, check 2). A form
+// control carrying "required" that the project's own stylesheet visually
+// hides makes the WHOLE form unsubmittable: a browser refuses to submit a
+// form containing a required control it cannot focus, silently -- no
+// request leaves the page, no console error, nothing. This is the signup
+// form defect from gosx#249's premise table: the markup and the stylesheet
+// were both in the repository the whole time.
+//
+// Warning severity, stated as a heuristic in every message this produces:
+// CSS resolution without a browser is approximate by construction (see
+// ruleMatchesElement's and hidingReason's doc comments for exactly what
+// this check does and does not model). A false positive here costs a
+// human one dismissed warning; a false negative here ships a form nobody
+// can submit.
+func validateRequiredReachabilityContract(files []transpile.PackageFile, root string, opts Options) {
+	if opts.Warnings == nil {
+		return
+	}
+	rules := loadPublicCSSHidingRules(root)
+	if len(rules) == 0 {
+		return
+	}
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		for _, comp := range file.Program.Components {
+			for _, id := range collectImageContractNodeIDs(file.Program, comp.Root) {
+				node := &file.Program.Nodes[id]
+				if diag, ok := requiredReachabilityDiagnostic(file.Path, node, rules); ok {
+					addWarnings(opts, []ir.Diagnostic{diag})
+				}
+			}
+		}
+	}
+}
+
+// requiredReachabilityDiagnostic reports whether node carries a static
+// "required" attribute AND has a static class or id matching one of
+// rules -- both class and id must be static (a dynamic {expr} class/id is
+// outside what this check can resolve, so it abstains for that node
+// rather than guess).
+func requiredReachabilityDiagnostic(path string, node *ir.Node, rules []cssHidingRule) (ir.Diagnostic, bool) {
+	if node.Kind != ir.NodeElement || !nodeHasStaticRequired(node) {
+		return ir.Diagnostic{}, false
+	}
+	class, classOK := staticAttrValue(node, "class")
+	id, idOK := staticAttrValue(node, "id")
+	if !classOK && !idOK {
+		return ir.Diagnostic{}, false
+	}
+	classes := strings.Fields(class)
+	for _, rule := range rules {
+		if !ruleMatchesElement(rule, node.Tag, classes, id) {
+			continue
+		}
+		span := node.Span
+		span.File = path
+		return ir.Diagnostic{
+			Span:     span,
+			Severity: ir.SeverityWarning,
+			Message:  fmt.Sprintf("gosx: heuristic: this required control matches CSS rule %q, which appears to hide it (%s)", rule.selector, rule.reason),
+			Hint:     "a browser refuses to submit a form containing a required control it cannot focus, silently; this is a static, non-cascade-aware match against public/*.css, so verify by hand -- remove required, or make the control focusable another way",
+		}, true
+	}
+	return ir.Diagnostic{}, false
+}
+
+func nodeHasStaticRequired(node *ir.Node) bool {
+	for _, attr := range node.Attrs {
+		if attr.Name != "required" {
+			continue
+		}
+		switch attr.Kind {
+		case ir.AttrBool:
+			return true
+		case ir.AttrStatic:
+			return !strings.EqualFold(strings.TrimSpace(attr.Value), "false")
+		}
+	}
+	return false
+}
+
+func staticAttrValue(node *ir.Node, name string) (string, bool) {
+	for _, attr := range node.Attrs {
+		if attr.Name == name && attr.Kind == ir.AttrStatic {
+			return attr.Value, true
+		}
+	}
+	return "", false
+}
+
+// cssHidingRule is one parsed CSS rule this check believes hides whatever
+// it matches, plus the raw selector list and the human-readable reason for
+// its own diagnostic message.
+type cssHidingRule struct {
+	selectors []simpleSelector
+	selector  string // original selector list text, for the message
+	reason    string
+}
+
+// simpleSelector is the rightmost compound selector of one comma-separated
+// entry in a rule's selector list: a tag name, and/or one or more classes,
+// and/or an id. ruleMatchesElement below matches ONLY this rightmost
+// compound against the element's own tag/class/id -- see its doc comment
+// for why ignoring ancestor combinators is a deliberate, documented
+// simplification rather than an oversight.
+type simpleSelector struct {
+	tag     string
+	classes []string
+	id      string
+}
+
+// ruleMatchesElement reports whether any of rule's selectors' rightmost
+// compound could match an element with tag/classes/id. This does not
+// model combinators (descendant, child, sibling), pseudo-classes,
+// attribute selectors, or specificity/cascade order at all -- it asks only
+// "does the element's own tag/class/id satisfy this compound's own
+// requirements", which is why gosx#249 ships this as a heuristic warning,
+// not an error: a rule like ".card.archived .required-field" matches an
+// element with class="required-field" by this rule's logic even outside
+// an actual ".card.archived" ancestor, a false positive a human dismisses
+// in seconds; the alternative -- silently missing an unsubmittable form --
+// costs much more.
+func ruleMatchesElement(rule cssHidingRule, tag string, classes []string, id string) bool {
+	for _, sel := range rule.selectors {
+		if sel.tag != "" && !strings.EqualFold(sel.tag, tag) {
+			continue
+		}
+		if sel.id != "" && sel.id != id {
+			continue
+		}
+		if !classSetContainsAll(classes, sel.classes) {
+			continue
+		}
+		if sel.tag == "" && sel.id == "" && len(sel.classes) == 0 {
+			continue // an empty compound (a bare combinator/universal) matches nothing usefully here
+		}
+		return true
+	}
+	return false
+}
+
+func classSetContainsAll(have, want []string) bool {
+	for _, w := range want {
+		found := false
+		for _, h := range have {
+			if h == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			return false
+		}
+	}
+	return true
+}
+
+// loadPublicCSSHidingRules reads every "*.css" file under root's public/
+// directory (the same convention validateImageContract's publicImageDirFor
+// already establishes) and returns every rule this check recognizes as
+// hiding whatever it matches. A missing or absent public/ directory
+// degrades to no rules found -- the same fail-quiet-not-fail-positive
+// posture publicImageDirFor documents for its own local-source rule.
+func loadPublicCSSHidingRules(root string) []cssHidingRule {
+	dir := publicImageDirFor(root)
+	if dir == "" {
+		return nil
+	}
+	var rules []cssHidingRule
+	_ = filepath.WalkDir(dir, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil || entry.IsDir() || !strings.EqualFold(filepath.Ext(entry.Name()), ".css") {
+			return nil
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil
+		}
+		rules = append(rules, parseCSSHidingRules(string(data))...)
+		return nil
+	})
+	return rules
+}

--- a/strictcheck/requiredreach_test.go
+++ b/strictcheck/requiredreach_test.go
@@ -1,0 +1,89 @@
+package strictcheck
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestRequiredReachabilityWarnsOnVisuallyHiddenRequiredControl
+// reconstructs the gosx#249 premise-table signup-form defect: a required
+// radio input carries a class the project's own stylesheet visually hides
+// with the classic "position: absolute; width: 1px; height: 1px" sr-only
+// idiom. A browser refuses to submit a form containing a required control
+// it cannot focus, so this makes the whole form unsubmittable, silently.
+func TestRequiredReachabilityWarnsOnVisuallyHiddenRequiredControl(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "styles.css"), `
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+`)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<input class="sr-only" type="radio" name="badge" required />`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if !hasWarningContaining(warnings, "heuristic") || !hasWarningContaining(warnings, ".sr-only") {
+		t.Fatalf("expected a heuristic warning naming .sr-only, got: %+v", warnings)
+	}
+}
+
+func TestRequiredReachabilityWarnsOnDisplayNone(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "styles.css"), `.hidden-field { display: none; }`)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<input class="hidden-field" type="text" name="honeypot" required />`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if !hasWarningContaining(warnings, "display: none") {
+		t.Fatalf("expected a warning citing display: none, got: %+v", warnings)
+	}
+}
+
+// TestRequiredReachabilityAcceptsVisibleRequiredControl proves an ordinary
+// required control with no matching hiding rule produces no warning.
+func TestRequiredReachabilityAcceptsVisibleRequiredControl(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "styles.css"), `
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.field { border: 1px solid #ccc; padding: 4px; }
+`)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<input class="field" type="text" name="email" required />`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning for a visible required control, got: %+v", warnings)
+	}
+}
+
+// TestRequiredReachabilityAcceptsRequiredControlWithNoPublicCSS proves the
+// check degrades to a no-op, not a false positive, when the project has no
+// public/*.css at all -- the same posture publicImageDirFor documents for
+// check 1's local-source rule.
+func TestRequiredReachabilityAcceptsRequiredControlWithNoPublicCSS(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<input class="sr-only" type="text" name="email" required />`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning with no public/ CSS present, got: %+v", warnings)
+	}
+}
+
+// TestRequiredReachabilityAcceptsRequiredControlWithDynamicClass proves a
+// dynamic {expr} class is out of scope rather than guessed at.
+func TestRequiredReachabilityAcceptsRequiredControlWithDynamicClass(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "public", "styles.css"), `.sr-only { display: none; }`)
+	mustWrite(t, filepath.Join(dir, "page.gsx"), formPageFixture(
+		`<input class={dynamicClassName()} type="text" name="email" required />`))
+	warnings := checkFileWarnings(t, filepath.Join(dir, "page.gsx"))
+	if len(warnings) != 0 {
+		t.Fatalf("expected no warning for a dynamic class, got: %+v", warnings)
+	}
+}

--- a/strictcheck/routemount.go
+++ b/strictcheck/routemount.go
@@ -51,12 +51,51 @@ func validateRouteMountContract(root string, sources []string, opts Options) {
 		if mounted[clean] {
 			continue
 		}
+		if hasUnrenderedMainTemplate(filepath.Dir(clean), root) {
+			// gosx#249: a "main.gotmpl" between this page and root is a
+			// scaffold's own unrendered Go source for what becomes the
+			// main.go that calls router.AddDir once rendered -- never
+			// before. This scan cannot read a router.AddDir call out of
+			// template syntax, so this page is not confidently unmounted;
+			// see hasUnrenderedMainTemplate's own doc comment.
+			continue
+		}
 		addWarnings(opts, []ir.Diagnostic{{
 			Span:     ir.Span{File: src, StartLine: 1, StartCol: 1},
 			Severity: ir.SeverityWarning,
 			Message:  fmt.Sprintf("gosx: %s is not reached by any router.AddDir mount found in this project", filepath.Base(src)),
 			Hint:     "mount its directory tree with router.AddDir, or remove/rename it if it is intentionally unrouted (a work-in-progress page, a scaffold template, and so on)",
 		}})
+	}
+}
+
+// hasUnrenderedMainTemplate walks from dir up to (and including) root
+// looking for a "main.gotmpl" file: a scaffold's own unrendered Go source
+// for what becomes the "main.go" that calls router.AddDir only once
+// rendered (by `gosx init`, or a project's own generator) -- gosx#249
+// confirmed this exact shape in cmd/gosx/templates/docs/main.gotmpl,
+// which sits two directories above the seven page.gsx files it would
+// mount once rendered. This scan cannot read a router.AddDir call out of
+// template syntax, so a page below a directory holding one of these is
+// not confidently unmounted -- the same "the Go side is templated here,
+// stay silent" rule hasUnrenderedServerGoTemplate applies to checks 1 and
+// 4 (servergo.go), applied to check 3's own missing fact (a mount, not a
+// registration).
+func hasUnrenderedMainTemplate(dir, root string) bool {
+	root = filepath.Clean(root)
+	dir = filepath.Clean(dir)
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "main.gotmpl")); err == nil && !info.IsDir() {
+			return true
+		}
+		if dir == root {
+			return false
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return false
+		}
+		dir = parent
 	}
 }
 

--- a/strictcheck/routemount.go
+++ b/strictcheck/routemount.go
@@ -1,0 +1,377 @@
+package strictcheck
+
+import (
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/route"
+)
+
+// validateRouteMountContract is strictcheck's whole-tree page-mount
+// contract (gosx#249, check 3): a "page.gsx" or "index.gsx" no
+// router.AddDir call reaches is dead code a reader mistakes for live code
+// -- exactly the examples/dashboard defect gosx#249's premise table
+// names (five file-routed pages main.go never mounted). Unlike checks 1,
+// 2, and 4, this one cannot be scoped to one package directory: knowing
+// whether a page is reached requires seeing every AddDir call in the
+// whole project, so CheckTreeWithOptions calls this once per run, not
+// once per package the way runBuiltinChecks' other checks do.
+//
+// Warning severity: a deliberate work-in-progress page (or a scaffold
+// template no main.go anywhere is meant to mount yet, such as
+// cmd/gosx/templates/) is legitimate, so this must never fail a build.
+func validateRouteMountContract(root string, sources []string, opts Options) {
+	if opts.Warnings == nil {
+		return
+	}
+	mountRoots, ok := resolveProjectAddDirRoots(root)
+	if !ok || len(mountRoots) == 0 {
+		// Either no AddDir call was found anywhere (a project that does not
+		// use file routing, or one this scan could not observe using it),
+		// or at least one call's target directory could not be resolved
+		// with confidence -- and an unresolvable call could mount any
+		// directory in the project, including one holding a page this scan
+		// would otherwise call unmounted. Stay silent rather than risk that
+		// false positive (gosx#249's "only report with confidence" rule).
+		return
+	}
+	mounted := mountedPageSet(mountRoots)
+	for _, src := range sources {
+		if !isRoutablePageFileName(src) {
+			continue
+		}
+		clean := filepath.Clean(src)
+		if mounted[clean] {
+			continue
+		}
+		addWarnings(opts, []ir.Diagnostic{{
+			Span:     ir.Span{File: src, StartLine: 1, StartCol: 1},
+			Severity: ir.SeverityWarning,
+			Message:  fmt.Sprintf("gosx: %s is not reached by any router.AddDir mount found in this project", filepath.Base(src)),
+			Hint:     "mount its directory tree with router.AddDir, or remove/rename it if it is intentionally unrouted (a work-in-progress page, a scaffold template, and so on)",
+		}})
+	}
+}
+
+// isRoutablePageFileName reports whether path's base name is one the file
+// router treats as a standalone page ("page.gsx"/"index.gsx" and their
+// ".html" sibling extension -- see route/filesystem.go's routeFileKind).
+// "layout.gsx", "not-found.gsx", and "error.gsx" are structural, not
+// routes of their own, so they are out of scope for "is this reachable".
+func isRoutablePageFileName(path string) bool {
+	name := strings.ToLower(strings.TrimSuffix(filepath.Base(path), filepath.Ext(path)))
+	return name == "page" || name == "index"
+}
+
+// mountedPageSet resolves every mount root through route.ScanDir -- the
+// framework's own file-route discovery, so this can never drift from what
+// AddDir would actually mount -- and returns the set of every page source
+// path (including special pages) it discovers, clean-path-normalized. A
+// root route.ScanDir itself fails to read is skipped, not fatal to the
+// whole set.
+func mountedPageSet(mountRoots []string) map[string]bool {
+	mounted := make(map[string]bool)
+	add := func(path string) {
+		if path != "" {
+			mounted[filepath.Clean(path)] = true
+		}
+	}
+	for _, mountRoot := range mountRoots {
+		routes, err := route.ScanDir(mountRoot)
+		if err != nil {
+			continue
+		}
+		for _, page := range routes.Pages {
+			add(page.FilePath)
+		}
+		if routes.NotFound != nil {
+			add(routes.NotFound.FilePath)
+		}
+		if routes.Error != nil {
+			add(routes.Error.FilePath)
+		}
+		for _, scope := range routes.NotFoundScopes {
+			add(scope.Page.FilePath)
+		}
+	}
+	return mounted
+}
+
+// resolveProjectAddDirRoots walks every non-test ".go" file under root
+// (using the same directory-skip rules as CheckTreeWithOptions's own .gsx
+// walk, so the two stay consistent about what is "in the project") and
+// resolves every router.AddDir call it finds to an absolute directory. ok
+// is false the moment any call's argument cannot be resolved with
+// confidence -- see resolveAddDirRootsInFile's doc comment for exactly
+// which shapes are resolvable.
+func resolveProjectAddDirRoots(root string) ([]string, bool) {
+	var roots []string
+	ok := true
+	_ = filepath.WalkDir(root, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return nil
+		}
+		if entry.IsDir() {
+			if shouldSkipDir(root, path, entry.Name()) {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		name := entry.Name()
+		if !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+			return nil
+		}
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		if err != nil {
+			// A file this package's own go/parser cannot read is a real Go
+			// syntax error the compiler will also reject elsewhere; it is
+			// not evidence one way or the other about AddDir mounts, so it
+			// is skipped rather than treated as an unresolved call.
+			return nil
+		}
+		fileRoots, unresolved := resolveAddDirRootsInFile(file, path)
+		if unresolved {
+			ok = false
+			return filepath.SkipAll
+		}
+		roots = append(roots, fileRoots...)
+		return nil
+	})
+	return roots, ok
+}
+
+// resolveAddDirRootsInFile finds every "<x>.AddDir(<dirExpr>, ...)" call in
+// file and resolves each dirExpr to an absolute directory. unresolved is
+// true the moment one call's argument is not one of the two shapes this
+// scan can resolve with confidence:
+//
+//  1. A string literal, resolved relative to file's own directory -- the
+//     conventional "AddDir("app", ...)" shape run from the source tree.
+//  2. filepath.Join(<X>, "seg", ...) (or a bare <X>) where X is, or
+//     resolves through filepath.Dir(...) to, the second result of a
+//     "runtime.Caller(0)" call earlier in the SAME file -- the
+//     "_, thisFile, _, _ := runtime.Caller(0); root :=
+//     filepath.Dir(thisFile)" idiom every real AddDir call in this
+//     repository actually uses (gosx#249 confirmed this against
+//     examples/basic, examples/dashboard, examples/goetrope-watch,
+//     examples/gosx-docs, and cmd/gosx/init.go's own scaffold template
+//     before relying on it).
+//
+// Any other shape -- a variable built some other way, a function
+// parameter, string concatenation, os.Getenv, and so on -- is unresolved:
+// this scan cannot rule out that call mounting a directory holding a page
+// it would otherwise call unmounted, so it must not proceed with a
+// possibly-incomplete mounted-page set.
+func resolveAddDirRootsInFile(file *ast.File, filePath string) (roots []string, unresolved bool) {
+	fileDir := filepath.Dir(filePath)
+	vars := resolvePathVarsInFile(file, filePath)
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, isCall := n.(*ast.CallExpr)
+		if !isCall {
+			return true
+		}
+		sel, isSel := call.Fun.(*ast.SelectorExpr)
+		if !isSel || sel.Sel == nil || sel.Sel.Name != "AddDir" || len(call.Args) == 0 {
+			return true
+		}
+		dir, ok := resolvePathExpr(call.Args[0], fileDir, vars)
+		if !ok {
+			unresolved = true
+			return false
+		}
+		roots = append(roots, dir)
+		return true
+	})
+	return roots, unresolved
+}
+
+// resolvePathVarsInFile computes, for every local or package-level
+// variable in file this scan can trace, the absolute path it resolves to
+// at build time. This is the single shared foundation both router.AddDir
+// target resolution (resolveAddDirRootsInFile above) and
+// route.FileModuleFor source resolution (servergo.go's
+// fileModuleRegistrationsInFile) build on: both idioms are ultimately
+// "start from runtime.Caller(0)'s own file, walk filepath.Dir/
+// filepath.Join calls, optionally through a named intermediate variable,
+// to a final directory or file path" -- see resolvePathExpr for exactly
+// which expression shapes resolve.
+func resolvePathVarsInFile(file *ast.File, filePath string) map[string]string {
+	vars := make(map[string]string)
+
+	// Pass 1: "_, thisFile, _, _ := runtime.Caller(0)" binds thisFile to
+	// this very file's own build-time path. Only skip level 0 counts --
+	// "runtime.Caller(1)" and above name a DIFFERENT file (the caller of
+	// the function this scan is reading), which this scan has no way to
+	// identify statically, so a non-zero or non-literal skip argument is
+	// simply not added.
+	ast.Inspect(file, func(n ast.Node) bool {
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) != 4 || len(assign.Rhs) != 1 {
+			return true
+		}
+		call, ok := assign.Rhs[0].(*ast.CallExpr)
+		if !ok || len(call.Args) != 1 {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil || sel.Sel.Name != "Caller" {
+			return true
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok || pkg.Name != "runtime" {
+			return true
+		}
+		skip, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || skip.Kind != token.INT || skip.Value != "0" {
+			return true
+		}
+		if ident, ok := assign.Lhs[1].(*ast.Ident); ok && ident.Name != "_" {
+			vars[ident.Name] = filePath
+		}
+		return true
+	})
+
+	// Pass 2+: fixed point over every plain single-value assignment
+	// (":=" or "=") whose right side resolvePathExpr can resolve given
+	// the variables resolved so far -- a chain like "root :=
+	// filepath.Dir(thisFile); source := filepath.Join(root, "[code]",
+	// "page.gsx")" resolves regardless of declaration order in the file.
+	fileDir := filepath.Dir(filePath)
+	for pass := 0; pass < 8; pass++ {
+		before := len(vars)
+		ast.Inspect(file, func(n ast.Node) bool {
+			assign, ok := n.(*ast.AssignStmt)
+			if !ok || len(assign.Lhs) != 1 || len(assign.Rhs) != 1 {
+				return true
+			}
+			name, ok := assign.Lhs[0].(*ast.Ident)
+			if !ok || name.Name == "_" {
+				return true
+			}
+			if _, already := vars[name.Name]; already {
+				return true
+			}
+			if resolved, ok := resolvePathExpr(assign.Rhs[0], fileDir, vars); ok {
+				vars[name.Name] = resolved
+			}
+			return true
+		})
+		if len(vars) == before {
+			break
+		}
+	}
+	return vars
+}
+
+// resolvePathExpr resolves one path-shaped expression to an absolute
+// path, given fileDir (the directory holding the file being scanned) and
+// vars (every already-resolved variable in that file; see
+// resolvePathVarsInFile). Four shapes resolve:
+//
+//  1. A string literal, resolved relative to fileDir -- the conventional
+//     "AddDir("app", ...)" shape run from the source tree.
+//  2. An identifier already present in vars.
+//  3. filepath.Dir(<expr>), where <expr> itself resolves.
+//  4. filepath.Join(<expr>, "seg", ...), where <expr> resolves and every
+//     later argument is a string literal -- covers both a directory
+//     target ("app") and a full file target ("[code]", "page.gsx"), since
+//     this function does not distinguish a directory from a file: it is
+//     shared by router.AddDir's directory argument and
+//     route.FileModuleFor's file argument alike.
+//
+// Anything else -- a function call other than filepath.Dir/Join, a
+// concatenation, os.Getenv, a struct field, a function parameter, and so
+// on -- is unresolved.
+func resolvePathExpr(expr ast.Expr, fileDir string, vars map[string]string) (string, bool) {
+	switch e := expr.(type) {
+	case *ast.BasicLit:
+		if e.Kind != token.STRING {
+			return "", false
+		}
+		value, err := strconv.Unquote(e.Value)
+		if err != nil {
+			return "", false
+		}
+		return filepath.Clean(filepath.Join(fileDir, value)), true
+	case *ast.Ident:
+		resolved, ok := vars[e.Name]
+		return resolved, ok
+	case *ast.CallExpr:
+		sel, ok := e.Fun.(*ast.SelectorExpr)
+		if !ok || sel.Sel == nil {
+			return "", false
+		}
+		pkg, ok := sel.X.(*ast.Ident)
+		if !ok {
+			return "", false
+		}
+		// server.ResolveAppRoot(callerFile) (server/approot.go) is a second
+		// real "find my own source directory" idiom this repository's own
+		// examples use beside the bare filepath.Dir(thisFile) one --
+		// examples/goetrope-watch and examples/gosx-docs both call it with
+		// runtime.Caller(0)'s own file. Its real resolution order also
+		// checks GOSX_APP_ROOT and the running executable's own directory
+		// first, so treating it as filepath.Dir(callerFile) is a documented
+		// assumption, not a certainty: it holds whenever neither override is
+		// in play, true for every ordinary `go run`/`gosx build`/`gosx dev`
+		// invocation this scan's own callers (gosx build's build gate, `gosx
+		// check`) run under. Accepting that bounded risk here roughly
+		// doubles this check's real coverage in this repository alone (2 of
+		// 4 example apps use it) — a worthwhile trade given check 3 is
+		// warning-severity, not error.
+		if pkg.Name == "server" && sel.Sel.Name == "ResolveAppRoot" && len(e.Args) == 1 {
+			base, ok := resolvePathExpr(e.Args[0], fileDir, vars)
+			if !ok {
+				return "", false
+			}
+			return filepath.Dir(base), true
+		}
+		if pkg.Name != "filepath" {
+			return "", false
+		}
+		switch sel.Sel.Name {
+		case "Dir":
+			if len(e.Args) != 1 {
+				return "", false
+			}
+			base, ok := resolvePathExpr(e.Args[0], fileDir, vars)
+			if !ok {
+				return "", false
+			}
+			return filepath.Dir(base), true
+		case "Join":
+			if len(e.Args) == 0 {
+				return "", false
+			}
+			base, ok := resolvePathExpr(e.Args[0], fileDir, vars)
+			if !ok {
+				return "", false
+			}
+			segments := []string{base}
+			for _, arg := range e.Args[1:] {
+				lit, ok := arg.(*ast.BasicLit)
+				if !ok || lit.Kind != token.STRING {
+					return "", false
+				}
+				value, err := strconv.Unquote(lit.Value)
+				if err != nil {
+					return "", false
+				}
+				segments = append(segments, value)
+			}
+			return filepath.Clean(filepath.Join(segments...)), true
+		default:
+			return "", false
+		}
+	default:
+		return "", false
+	}
+}

--- a/strictcheck/routemount_test.go
+++ b/strictcheck/routemount_test.go
@@ -1,0 +1,117 @@
+package strictcheck
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"m31labs.dev/gosx/ir"
+)
+
+func checkTreeWarnings(t *testing.T, dir string) []ir.Diagnostic {
+	t.Helper()
+	var warnings []ir.Diagnostic
+	if err := CheckTreeWithOptions(context.Background(), dir, Options{Warnings: &warnings}); err != nil {
+		t.Fatalf("CheckTreeWithOptions: %v", err)
+	}
+	return warnings
+}
+
+// mainGoWithAddDir writes the "_, thisFile, _, _ := runtime.Caller(0);
+// root := filepath.Dir(thisFile); router.AddDir(filepath.Join(root,
+// "app"), ...)" idiom every real AddDir call in this repository uses
+// (examples/basic, examples/dashboard, examples/goetrope-watch,
+// examples/gosx-docs, cmd/gosx/init.go's scaffold template).
+func mainGoWithAddDir() string {
+	return `package main
+
+import (
+	"path/filepath"
+	"runtime"
+
+	"m31labs.dev/gosx/route"
+)
+
+func main() {
+	_, thisFile, _, _ := runtime.Caller(0)
+	root := filepath.Dir(thisFile)
+	router := route.NewRouter()
+	if err := router.AddDir(filepath.Join(root, "app"), route.FileRoutesOptions{}); err != nil {
+		panic(err)
+	}
+}
+`
+}
+
+// TestRouteMountContractWarnsOnUnmountedPage reconstructs the gosx#249
+// premise-table examples/dashboard defect: a page.gsx sitting outside the
+// directory tree main.go's one router.AddDir call actually mounts is dead
+// code a reader mistakes for live code.
+func TestRouteMountContractWarnsOnUnmountedPage(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "main.go"), mainGoWithAddDir())
+	mustWrite(t, filepath.Join(dir, "app", "page.gsx"), formPageFixture(`<p>Home</p>`))
+	mustWrite(t, filepath.Join(dir, "orphan", "page.gsx"), formPageFixture(`<p>Orphaned</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if !hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected a warning for the unmounted orphan page, got: %+v", warnings)
+	}
+	for _, w := range warnings {
+		if w.Span.File == filepath.Join(dir, "app", "page.gsx") {
+			t.Fatalf("did not expect the mounted app/page.gsx to be flagged, got: %+v", warnings)
+		}
+	}
+}
+
+// TestRouteMountContractAcceptsFullyMountedTree proves a project where
+// every page.gsx sits under the AddDir root produces no warning.
+func TestRouteMountContractAcceptsFullyMountedTree(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "main.go"), mainGoWithAddDir())
+	mustWrite(t, filepath.Join(dir, "app", "page.gsx"), formPageFixture(`<p>Home</p>`))
+	mustWrite(t, filepath.Join(dir, "app", "settings", "page.gsx"), formPageFixture(`<p>Settings</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected no unmounted-page warning, got: %+v", warnings)
+	}
+}
+
+// TestRouteMountContractAbstainsWithNoAddDirCall proves a project with no
+// AddDir call anywhere (a project that does not use file routing, or one
+// this scan cannot see using it) produces no warning rather than assuming
+// every page.gsx is orphaned.
+func TestRouteMountContractAbstainsWithNoAddDirCall(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "app", "page.gsx"), formPageFixture(`<p>Home</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected no warning with no AddDir call anywhere, got: %+v", warnings)
+	}
+}
+
+// TestRouteMountContractAbstainsOnUnresolvableAddDirTarget proves the
+// "only report with confidence" rule: an AddDir call whose target this
+// scan cannot resolve (here, a directory named by a function parameter)
+// could mount any directory in the project, including one holding a page
+// this scan would otherwise call unmounted -- so the whole run abstains
+// rather than risk a false positive.
+func TestRouteMountContractAbstainsOnUnresolvableAddDirTarget(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "main.go"), `package main
+
+import "m31labs.dev/gosx/route"
+
+func mount(router *route.Router, dynamicDir string) {
+	router.AddDir(dynamicDir, route.FileRoutesOptions{})
+}
+`)
+	mustWrite(t, filepath.Join(dir, "orphan", "page.gsx"), formPageFixture(`<p>Orphaned</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected an unresolvable AddDir target to abstain the whole run, got: %+v", warnings)
+	}
+}

--- a/strictcheck/routemount_test.go
+++ b/strictcheck/routemount_test.go
@@ -115,3 +115,44 @@ func mount(router *route.Router, dynamicDir string) {
 		t.Fatalf("expected an unresolvable AddDir target to abstain the whole run, got: %+v", warnings)
 	}
 }
+
+// TestRouteMountContractAbstainsOnUnrenderedMainTemplate reconstructs the
+// gosx#249 scaffold defect: cmd/gosx/templates/docs ships "main.gotmpl"
+// at its root, never a real "main.go" -- `gosx init` renders the
+// template into a real file only when scaffolding a new project. Before
+// this test existed, this scan found no AddDir call anywhere under the
+// scaffold and reported every one of its pages as unmounted.
+func TestRouteMountContractAbstainsOnUnrenderedMainTemplate(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "main.gotmpl"), mainGoWithAddDir())
+	mustWrite(t, filepath.Join(dir, "app", "docs", "page.gsx"), formPageFixture(`<p>Docs</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected a main.gotmpl ancestor to abstain, got: %+v", warnings)
+	}
+}
+
+// TestRouteMountContractStillWarnsBesideAnUnrelatedMainTemplate proves
+// the abstention in TestRouteMountContractAbstainsOnUnrenderedMainTemplate
+// is scoped to pages actually below the templated directory: a page in a
+// resolvably-mounted tree elsewhere in the same project keeps being
+// checked normally.
+func TestRouteMountContractStillWarnsBesideAnUnrelatedMainTemplate(t *testing.T) {
+	dir := newTestModule(t)
+	mustWrite(t, filepath.Join(dir, "scaffold", "main.gotmpl"), mainGoWithAddDir())
+	mustWrite(t, filepath.Join(dir, "scaffold", "app", "page.gsx"), formPageFixture(`<p>Scaffold</p>`))
+	mustWrite(t, filepath.Join(dir, "main.go"), mainGoWithAddDir())
+	mustWrite(t, filepath.Join(dir, "app", "page.gsx"), formPageFixture(`<p>Home</p>`))
+	mustWrite(t, filepath.Join(dir, "orphan", "page.gsx"), formPageFixture(`<p>Orphaned</p>`))
+
+	warnings := checkTreeWarnings(t, dir)
+	if !hasWarningContaining(warnings, "not reached by any router.AddDir mount") {
+		t.Fatalf("expected the real orphan page to still be flagged, got: %+v", warnings)
+	}
+	for _, w := range warnings {
+		if w.Span.File == filepath.Join(dir, "scaffold", "app", "page.gsx") {
+			t.Fatalf("did not expect the templated scaffold's own page to be flagged, got: %+v", warnings)
+		}
+	}
+}

--- a/strictcheck/servergo.go
+++ b/strictcheck/servergo.go
@@ -1,0 +1,399 @@
+package strictcheck
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// serverGoDir holds every *.server.go file parsed from one file-routed page
+// directory. Both the form-action-registry check (gosx#249 check 1) and the
+// data-loader-keys check (gosx#249 check 4) read the same
+// route.FileModuleOptions / route.FileModule composite literal -- one
+// registered field (Actions) for check 1, two more (Load, Bindings) for
+// check 4 -- so this is one shared parse rather than two.
+//
+// Both checks fail closed on anything this type cannot represent
+// confidently: parseErr covers a *.server.go file this package's own
+// go/parser cannot read (a real syntax error the Go compiler will also
+// reject, so no check needs to diagnose it a second time).
+type serverGoDir struct {
+	dir      string
+	fset     *token.FileSet
+	files    []*ast.File
+	paths    []string
+	parseErr error
+}
+
+// loadServerGoDir parses every "*.server.go" file directly inside dir (no
+// recursion -- a file-routed page directory's own server file always sits
+// beside its .gsx page, never in a subdirectory). Files named "*_test.go"
+// are excluded; a "*.server.go" name never matches that suffix in practice,
+// but the exclusion costs nothing and keeps the scan test-safe.
+func loadServerGoDir(dir string) serverGoDir {
+	result := serverGoDir{dir: dir, fset: token.NewFileSet()}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		result.parseErr = err
+		return result
+	}
+	var names []string
+	for _, entry := range entries {
+		name := entry.Name()
+		if entry.IsDir() || !strings.HasSuffix(name, ".server.go") || strings.HasSuffix(name, "_test.go") {
+			continue
+		}
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		file, err := parser.ParseFile(result.fset, path, nil, 0)
+		if err != nil {
+			result.parseErr = err
+			return result
+		}
+		result.files = append(result.files, file)
+		result.paths = append(result.paths, path)
+	}
+	return result
+}
+
+// compositeLitTypeName returns the bare type name a composite literal
+// names, unqualified by any package selector ("route.FileModuleOptions"
+// and a dot-imported "FileModuleOptions" both return "FileModuleOptions").
+// An elided-type literal (legal only when nested inside another literal of
+// known element type, which is not a shape route.FileModuleOptions ever
+// appears in as a value) returns "".
+func compositeLitTypeName(lit *ast.CompositeLit) string {
+	switch t := lit.Type.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		return t.Sel.Name
+	default:
+		return ""
+	}
+}
+
+// fileModuleField returns the value expression assigned to name within
+// lit's fields, and whether that field was written at all. A field never
+// written is the same as an explicit Go zero value (nil) to every caller
+// here -- FileModuleOptions has no non-nil zero value for Actions, Load,
+// or Bindings, so "absent" and "present as nil" are one case, not two.
+func fileModuleField(lit *ast.CompositeLit, name string) (ast.Expr, bool) {
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			continue
+		}
+		key, ok := kv.Key.(*ast.Ident)
+		if !ok || key.Name != name {
+			continue
+		}
+		return kv.Value, true
+	}
+	return nil, false
+}
+
+// isNilExpr reports whether expr is the bare identifier "nil".
+func isNilExpr(expr ast.Expr) bool {
+	ident, ok := expr.(*ast.Ident)
+	return ok && ident.Name == "nil"
+}
+
+// literalStringMapKeys resolves a composite literal to its complete
+// literal string key set. ok is false when any element is not a
+// string-keyed key:value pair -- a spread-like bare-value element, a
+// non-literal (computed) key, or a non-string key -- since any of those
+// means the true key set is not what this function can read off the
+// syntax alone.
+func literalStringMapKeys(lit *ast.CompositeLit) (map[string]bool, bool) {
+	keys := make(map[string]bool, len(lit.Elts))
+	for _, elt := range lit.Elts {
+		kv, ok := elt.(*ast.KeyValueExpr)
+		if !ok {
+			return nil, false
+		}
+		basic, ok := kv.Key.(*ast.BasicLit)
+		if !ok || basic.Kind != token.STRING {
+			return nil, false
+		}
+		name, err := strconv.Unquote(basic.Value)
+		if err != nil {
+			return nil, false
+		}
+		keys[name] = true
+	}
+	return keys, true
+}
+
+// fileTopLevelCompositeVars maps every package-level "var name = <composite
+// literal>" (and "var name = TypeName{...}") declaration in file to that
+// literal, by name. This resolves the one indirection level real code
+// actually uses -- a FileActions or a data map built as its own named
+// variable next to the registration call -- without attempting to trace
+// assignment through arbitrary control flow, which is exactly the
+// unbounded-analysis shape gosx#249 says to abstain from instead of
+// guessing at.
+func fileTopLevelCompositeVars(file *ast.File) map[string]*ast.CompositeLit {
+	vars := make(map[string]*ast.CompositeLit)
+	for _, decl := range file.Decls {
+		gen, ok := decl.(*ast.GenDecl)
+		if !ok || gen.Tok != token.VAR {
+			continue
+		}
+		for _, spec := range gen.Specs {
+			value, ok := spec.(*ast.ValueSpec)
+			if !ok || len(value.Names) != len(value.Values) {
+				continue
+			}
+			for i, name := range value.Names {
+				if lit, ok := value.Values[i].(*ast.CompositeLit); ok {
+					vars[name.Name] = lit
+				}
+			}
+		}
+	}
+	return vars
+}
+
+// funcDeclsByName maps every top-level function name declared across
+// files to its declaration -- used to resolve a Load field written as a
+// bare identifier (Load: loadDashboardData) to the function it names, which
+// may live in a *.server.go file other than the one registering it.
+func funcDeclsByName(files []*ast.File) map[string]*ast.FuncDecl {
+	funcs := make(map[string]*ast.FuncDecl)
+	for _, file := range files {
+		for _, decl := range file.Decls {
+			if fn, ok := decl.(*ast.FuncDecl); ok && fn.Recv == nil && fn.Name != nil {
+				funcs[fn.Name.Name] = fn
+			}
+		}
+	}
+	return funcs
+}
+
+// funcDeclsAcrossDirs unions funcDeclsByName over every "*.server.go" file
+// in each of dirs -- a Load field written as a bare identifier can name a
+// function declared in a sibling "*.server.go" file, not only the one
+// holding the registration call itself. A directory whose files fail to
+// parse simply contributes nothing; it does not abort the scan, since an
+// unrelated directory's parse failure should not hide a resolvable
+// function declared in another.
+func funcDeclsAcrossDirs(dirs []string) map[string]*ast.FuncDecl {
+	funcs := make(map[string]*ast.FuncDecl)
+	for _, dir := range dirs {
+		parsed := loadServerGoDir(dir)
+		if parsed.parseErr != nil {
+			continue
+		}
+		for name, fn := range funcDeclsByName(parsed.files) {
+			funcs[name] = fn
+		}
+	}
+	return funcs
+}
+
+// fileModuleRegistration is one route.FileModuleOptions/FileModule
+// composite literal this scan found while reading "*.server.go" files,
+// resolved to the exact .gsx (or .html) source path it registers for.
+type fileModuleRegistration struct {
+	// target is the clean absolute path this literal registers for.
+	target string
+	lit    *ast.CompositeLit
+	// vars is the declaring file's own package-level composite-literal
+	// variables, needed to resolve an Actions/Load field written as a
+	// local identifier rather than an inline literal.
+	vars map[string]*ast.CompositeLit
+}
+
+// candidateServerGoDirs returns gsxDir and its immediate parent directory
+// (deduplicated, and only the parent when it differs from gsxDir) -- the
+// two places a "*.server.go" file registering gsxDir's page can live.
+// Beside gsxDir is the ordinary RegisterFileModuleHere convention; one
+// level up is the explicit route.FileModuleFor(source, opts) pattern a
+// shared parent server file uses to register for a dynamic child route
+// segment (gosx#249 confirmed this against
+// examples/goetrope-watch/app/watch/page.server.go, which registers for
+// app/watch/[code]/page.gsx this exact way). This scan does not search
+// beyond one level up: each additional level raises the chance of
+// wrongly attributing a distant, unrelated page's registration to this
+// one, which is exactly the false-positive risk gosx#249 asks every
+// check here to avoid.
+func candidateServerGoDirs(gsxDir string) []string {
+	parent := filepath.Dir(gsxDir)
+	if parent == gsxDir {
+		return []string{gsxDir}
+	}
+	return []string{gsxDir, parent}
+}
+
+// collectFileModuleRegistrations scans every "*.server.go" file in each of
+// dirs and resolves every route.FileModuleOptions/FileModule registration
+// it finds to its exact target .gsx path: RegisterFileModuleHere,
+// MustRegisterFileModuleHere, and FileModuleHere infer the sibling source
+// path from the calling file (see impliedFileModuleTarget); FileModuleFor
+// takes its target as an explicit first argument, resolved the same way
+// resolvePathExpr resolves a router.AddDir target (see that function's own
+// doc comment in routemount.go for exactly which source-expression shapes
+// resolve).
+//
+// ok is false if any "*.server.go" file in dirs failed to parse, OR if any
+// of them builds a route.FileModuleOptions/FileModule literal through a
+// call shape this scan does not recognize by name (a project's own helper
+// wrapping FileModuleOptions, for example) -- gosx#249 confirmed this
+// shape is real too, against
+// examples/gosx-docs/app/demos/water/page.server.go's
+// docsapp.RegisterStaticDocsPage helper. Such a literal is real evidence
+// of a registration this scan simply cannot target precisely, so treating
+// "found no recognized registration" as "confidently registers nothing"
+// would be a false positive waiting to happen for every directory holding
+// one -- ok=false here makes every caller abstain instead.
+func collectFileModuleRegistrations(dirs []string) ([]fileModuleRegistration, bool) {
+	var out []fileModuleRegistration
+	seen := make(map[string]bool, len(dirs))
+	for _, dir := range dirs {
+		if dir == "" || seen[dir] {
+			continue
+		}
+		seen[dir] = true
+		parsed := loadServerGoDir(dir)
+		if parsed.parseErr != nil {
+			return nil, false
+		}
+		for i, file := range parsed.files {
+			regs, orphan := fileModuleRegistrationsInFile(file, parsed.paths[i])
+			if orphan {
+				return nil, false
+			}
+			out = append(out, regs...)
+		}
+	}
+	return out, true
+}
+
+// fileModuleRegistrationsInFile scans one file for every recognized
+// FileModuleOptions/FileModule registration call, and separately for any
+// FileModuleOptions/FileModule composite literal this scan can find but
+// could not attribute to one of those recognized calls (orphan=true) --
+// see collectFileModuleRegistrations' own doc comment for why an orphan
+// forces every caller to abstain.
+func fileModuleRegistrationsInFile(file *ast.File, path string) (regs []fileModuleRegistration, orphan bool) {
+	vars := fileTopLevelCompositeVars(file)
+	pathVars := resolvePathVarsInFile(file, path)
+	fileDir := filepath.Dir(path)
+	consumed := make(map[*ast.CompositeLit]bool)
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		switch calleeName(call.Fun) {
+		case "RegisterFileModuleHere", "MustRegisterFileModuleHere", "FileModuleHere":
+			if len(call.Args) != 1 {
+				return true
+			}
+			lit, ok := asFileModuleOptionsLit(call.Args[0], vars)
+			if !ok {
+				return true
+			}
+			consumed[lit] = true
+			regs = append(regs, fileModuleRegistration{
+				target: impliedFileModuleTarget(path),
+				lit:    lit,
+				vars:   vars,
+			})
+		case "FileModuleFor":
+			if len(call.Args) != 2 {
+				return true
+			}
+			lit, ok := asFileModuleOptionsLit(call.Args[1], vars)
+			if !ok {
+				return true
+			}
+			consumed[lit] = true
+			target, ok := resolvePathExpr(call.Args[0], fileDir, pathVars)
+			if !ok {
+				return true
+			}
+			regs = append(regs, fileModuleRegistration{target: target, lit: lit, vars: vars})
+		}
+		return true
+	})
+
+	ast.Inspect(file, func(n ast.Node) bool {
+		lit, ok := n.(*ast.CompositeLit)
+		if !ok {
+			return true
+		}
+		switch compositeLitTypeName(lit) {
+		case "FileModuleOptions", "FileModule":
+			if !consumed[lit] {
+				orphan = true
+			}
+		}
+		return true
+	})
+	return regs, orphan
+}
+
+func calleeName(fun ast.Expr) string {
+	switch f := fun.(type) {
+	case *ast.Ident:
+		return f.Name
+	case *ast.SelectorExpr:
+		if f.Sel != nil {
+			return f.Sel.Name
+		}
+	}
+	return ""
+}
+
+// asFileModuleOptionsLit resolves expr -- an inline composite literal or
+// an identifier naming one of the declaring file's own package-level
+// composite-literal variables -- to a route.FileModuleOptions or
+// route.FileModule literal.
+func asFileModuleOptionsLit(expr ast.Expr, vars map[string]*ast.CompositeLit) (*ast.CompositeLit, bool) {
+	var lit *ast.CompositeLit
+	switch e := expr.(type) {
+	case *ast.CompositeLit:
+		lit = e
+	case *ast.Ident:
+		found, ok := vars[e.Name]
+		if !ok {
+			return nil, false
+		}
+		lit = found
+	default:
+		return nil, false
+	}
+	switch compositeLitTypeName(lit) {
+	case "FileModuleOptions", "FileModule":
+		return lit, true
+	default:
+		return nil, false
+	}
+}
+
+// impliedFileModuleTarget mirrors route/filemodule.go's own
+// fileModuleSourceFromFile: RegisterFileModuleHere and its siblings swap
+// a calling "X.server.go" file's own suffix for ".gsx" (preferring
+// ".html" when only that sibling exists on disk), registering for
+// whichever one is actually present beside it.
+func impliedFileModuleTarget(serverGoPath string) string {
+	base := strings.TrimSuffix(serverGoPath, ".server.go")
+	for _, ext := range []string{".gsx", ".html"} {
+		candidate := base + ext
+		if info, err := os.Stat(candidate); err == nil && !info.IsDir() {
+			return filepath.Clean(candidate)
+		}
+	}
+	return filepath.Clean(base + ".gsx")
+}

--- a/strictcheck/servergo.go
+++ b/strictcheck/servergo.go
@@ -234,6 +234,37 @@ func candidateServerGoDirs(gsxDir string) []string {
 	return []string{gsxDir, parent}
 }
 
+// hasUnrenderedServerGoTemplate reports whether any of dirs contains a
+// "*.server.gotmpl" file: a scaffold's own unrendered Go source for what
+// becomes a "*.server.go" file only once rendered (by `gosx init`, or a
+// project's own generator) -- never before. Its real Actions/Load content
+// is template syntax, not Go, so this scan cannot read it, and "found no
+// *.server.go here" must not be read as "confidently registers nothing"
+// when one of these sits right beside where that file would be.
+//
+// gosx#249 confirmed this exact shape in
+// cmd/gosx/templates/docs/app/docs/forms/page.server.gotmpl and its six
+// siblings: every one of them registers real Actions and a real Load once
+// `gosx init` renders it, and check 1 and check 4 were reporting all
+// fourteen of those pages as broken before this existed — a scaffold gosx
+// itself ships, found broken by the very tool meant to keep a real
+// application from shipping broken, is exactly the "first impression is a
+// wall of noise" outcome that gets a check turned off.
+func hasUnrenderedServerGoTemplate(dirs []string) bool {
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			continue
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".server.gotmpl") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // collectFileModuleRegistrations scans every "*.server.go" file in each of
 // dirs and resolves every route.FileModuleOptions/FileModule registration
 // it finds to its exact target .gsx path: RegisterFileModuleHere,

--- a/strictcheck/warnings.go
+++ b/strictcheck/warnings.go
@@ -1,0 +1,29 @@
+package strictcheck
+
+import (
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/transpile"
+)
+
+// addFileGosxWarnings runs ir.ValidateWarnings over every file's already-
+// compiled *ir.Program and appends its findings to opts.Warnings. This is
+// the check-time counterpart to lsp/symbols.go's own ir.ValidateWarnings
+// call: the LSP runs it per keystroke against one file with no path
+// attached (a document URI stands in for that); a whole-project check run
+// covers every file in the package and needs the path on each diagnostic
+// to be useful in a terminal, so this sets Span.File the same way
+// validateImageContract already does for its own findings.
+func addFileGosxWarnings(files []transpile.PackageFile, opts Options) {
+	if opts.Warnings == nil {
+		return
+	}
+	for _, file := range files {
+		if file.Program == nil {
+			continue
+		}
+		for _, diag := range ir.ValidateWarnings(file.Program) {
+			diag.Span.File = file.Path
+			addWarnings(opts, []ir.Diagnostic{diag})
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Introduce a warning severity channel for diagnostics and implement a suite of whole-application static correctness checks that run during `gosx check` and the build gate. Adds `ir.SeverityWarning`, `ir.ValidateWarnings`, and five new checks in `strictcheck` covering form actions, CSS reachability, route mounting, data loader keys, and `data-gosx-*` attribute typos, along with corresponding LSP integration and CLI output formatting.

## Changes

- Add `Severity` field to `ir.Diagnostic` with `SeverityError` (zero value) and `SeverityWarning`; preserves backward compatibility for existing diagnostic literals.
- Introduce `ir.ValidateWarnings` as a lightweight, no-I/O sibling to `ir.Validate` that performs the same IR pass and returns only non-fatal findings, safe to run on every keystroke.
- Extend `strictcheck.Options` with a `Warnings *[]ir.Diagnostic` field; checks append findings here instead of aborting, and both `cmd/gosx check` and the build gate print them to stderr while still exiting 0.
- Implement Check 1: verify form `action`/`formaction` attributes resolve to registered `FileActions` keys (error severity).
- Implement Check 2: detect required form controls hidden by common CSS patterns (`display: none`, `opacity: 0`, visually-hidden idiom) across project stylesheets (warning, heuristic).
- Implement Check 3: ensure every routable `.gsx` file is covered by at least one `router.AddDir` call by scanning the entire route tree (warning).
- Implement Check 4: flag `data.X` reads in legacy templates whose keys are missing from the page's fully literal `Load` hook map returns (warning, heuristic).
- Implement Check 5: flag likely misspellings of `data-gosx-*` navigation primitives using Levenshtein distance within a closed set, and add value-shape validation for interval/policy/link attributes.
- Wire warnings into LSP diagnostics, mapping them to LSP `SeverityWarning` (2) alongside fatal errors.
- Update CHANGELOG with detailed documentation of the new features, their design rationale, and expected findings.

## Testing

- Run `go test ./...` to verify all new unit tests in `ir`, `strictcheck`, and `lsp` pass.
- Create a temporary page with a misspelled `data-gosx-heartbeat` attribute or an unregistered `actionPath("missing")` and run `gosx check <path>/page.gsx` to confirm warnings/errors print to stderr with exit code 0.
- Open a `.gsx` file containing an invalid `data-gosx-link-current-policy` value in an editor with LSP enabled to verify a yellow squiggle (severity 2) appears inline.

## Review Focus

Pay close attention to the heuristic boundaries in Checks 2 and 4, and ensure the Levenshtein threshold in `validate_warnings.go` correctly filters out unrelated subsystem attributes like `data-gosx-motion`.