### PR TITLE
WIP: preserve semantic-whitespace formatter slice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## Unreleased
 
+### Fixed: gosx fmt preserves GSX child whitespace
+
+- The formatter now keeps zero-whitespace adjacency and intentional
+  whitespace between text, expression, element, component, self-closing, and
+  fragment children, while only wrapping at whitespace-only child boundaries.
+  Formatted source therefore renders the same HTML as the source, including
+  punctuation adjacency, prose, and raw text elements.
+
 ### Added: a shared component call executes end to end for a strict caller
 
 - **A strict caller's shared component call now renders.** WP4 (v0.49.0)

--- a/cmd/gosx/fmt_test.go
+++ b/cmd/gosx/fmt_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
 )
 
 func TestRunFmtFormatsSingleGSXFile(t *testing.T) {
@@ -14,7 +15,11 @@ func TestRunFmtFormatsSingleGSXFile(t *testing.T) {
 	writeTempFile(t, dir, "page.gsx", `package main
 
 func Page() Node {
-	return <main><section><h1>Hi</h1></section></main>
+	return <main>
+		<section>
+			<h1>Hi</h1>
+		</section>
+	</main>
 }
 `)
 	path := filepath.Join(dir, "page.gsx")
@@ -32,8 +37,8 @@ func Page() Node {
 	if !strings.Contains(formatted, "<section>") || !strings.Contains(formatted, "<h1>Hi</h1>") {
 		t.Fatalf("unexpected formatted output %q", formatted)
 	}
-	if strings.Contains(formatted, "<main><section>") {
-		t.Fatalf("expected formatter to expand nested GSX elements, got %q", formatted)
+	if strings.Contains(formatted, "<main><section>") || strings.Contains(formatted, "<section><h1>") {
+		t.Fatalf("expected formatter to preserve source whitespace for readable nesting, got %q", formatted)
 	}
 }
 
@@ -42,7 +47,9 @@ func TestRunFmtFormatsOnlyGSXFilesInDirectory(t *testing.T) {
 	writeTempFile(t, dir, "app/page.gsx", `package main
 
 func Page() Node {
-	return <div><span>Hi</span></div>
+	return <div>
+		<span>Hi</span>
+	</div>
 }
 `)
 	writeTempFile(t, dir, "app/page.server.go", `package main
@@ -64,7 +71,7 @@ func Loader() string { return "ok" }
 
 	formatted := readFile(t, filepath.Join(dir, "app", "page.gsx"))
 	if strings.Contains(formatted, "<div><span>") {
-		t.Fatalf("expected formatted GSX output, got %q", formatted)
+		t.Fatalf("expected formatted GSX output to retain readable source whitespace, got %q", formatted)
 	}
 	goFile := readFile(t, filepath.Join(dir, "app", "page.server.go"))
 	if !strings.Contains(goFile, `func Loader() string { return "ok" }`) {
@@ -124,7 +131,11 @@ func TestRunFmtCheckReportsUnformattedGSXFile(t *testing.T) {
 	writeTempFile(t, dir, "page.gsx", `package main
 
 func Page() Node {
-	return <main><section><h1>Hi</h1></section></main>
+	return <main>
+	<section>
+	<h1>Hi</h1>
+	</section>
+	</main>
 }
 `)
 	path := filepath.Join(dir, "page.gsx")
@@ -147,7 +158,9 @@ func TestRunFmtCheckVerifiesFormattedDirectory(t *testing.T) {
 	writeTempFile(t, dir, "app/page.gsx", `package main
 
 func Page() Node {
-	return <div><span>Hi</span></div>
+	return <div>
+	<span>Hi</span>
+	</div>
 }
 `)
 
@@ -169,7 +182,7 @@ func Page() Node {
 	}
 }
 
-func TestRunFmtCheckHandlesWrappedTextWithoutDrift(t *testing.T) {
+func TestRunFmtCheckPreservesWrappedTextWithoutDrift(t *testing.T) {
 	dir := t.TempDir()
 	writeTempFile(t, dir, "page.gsx", `package main
 
@@ -196,11 +209,21 @@ func Page() Node {
 	}
 
 	formatted := readFile(t, path)
-	if strings.Contains(formatted, "\n\t\t\t\t\t\t") {
-		t.Fatalf("expected wrapped text indentation drift to be removed, got:\n%s", formatted)
+	for _, snippet := range []string{
+		"This example is a real GoSX app, not a brochure hung next to one.",
+		"Routes, server actions, auth, client navigation, and Scene3D all live in the same",
+		"codebase.",
+	} {
+		if !strings.Contains(formatted, snippet) {
+			t.Fatalf("expected wrapped prose to survive formatting, missing %q:\n%s", snippet, formatted)
+		}
 	}
-	if !strings.Contains(formatted, "Routes, server actions, auth, client navigation, and Scene3D all live in the same codebase.") {
-		t.Fatalf("expected wrapped text to normalize to a single logical line, got:\n%s", formatted)
+	beforeSecondPass := formatted
+	if _, err := RunFmt(path, &stderr); err != nil {
+		t.Fatalf("RunFmt second pass (%s): %v", path, err)
+	}
+	if afterSecondPass := readFile(t, path); afterSecondPass != beforeSecondPass {
+		t.Fatalf("wrapped text formatting is not idempotent\nfirst:\n%s\nsecond:\n%s", beforeSecondPass, afterSecondPass)
 	}
 }
 
@@ -239,5 +262,61 @@ func TestRunFmtCheckLeavesRawStringCodeExamplesStable(t *testing.T) {
 	}
 	if afterSecondPass := readFile(t, path); afterSecondPass != beforeSecondPass {
 		t.Fatalf("raw string formatting is not idempotent\nfirst:\n%s\nsecond:\n%s", beforeSecondPass, afterSecondPass)
+	}
+}
+
+func TestRunFmtPreservesRenderedSemanticWhitespaceAndCheck(t *testing.T) {
+	dir := t.TempDir()
+	source := []byte(`package main
+
+func Page() Node {
+	return <main>
+		<p>({"ABC"})</p>
+		<p>{"support"}@stablekernel.com</p>
+		<p><b>A</b><i>B</i></p>
+		<p><b>A</b> <i>B</i></p>
+	</main>
+}
+`)
+	path := filepath.Join(dir, "page.gsx")
+	writeTempFile(t, dir, "page.gsx", string(source))
+
+	wantProg, err := gosx.Compile(source)
+	if err != nil {
+		t.Fatalf("Compile(source): %v", err)
+	}
+	wantHTML, err := route.RenderProgramComponent(wantProg, "Page", route.ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent(source): %v", err)
+	}
+
+	var stderr bytes.Buffer
+	if count, err := RunFmt(path, &stderr); err != nil || count != 1 {
+		t.Fatalf("RunFmt(%s) = (%d, %v)", path, count, err)
+	}
+	formatted := []byte(readFile(t, path))
+	gotProg, err := gosx.Compile(formatted)
+	if err != nil {
+		t.Fatalf("Compile(formatted): %v\n%s", err, formatted)
+	}
+	gotHTML, err := route.RenderProgramComponent(gotProg, "Page", route.ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent(formatted): %v", err)
+	}
+	if gotHTML != wantHTML {
+		t.Fatalf("gosx fmt changed rendered HTML\nwant: %q\ngot:  %q\nformatted:\n%s", wantHTML, gotHTML, formatted)
+	}
+
+	stderr.Reset()
+	if count, err := RunFmtCheck(path, &stderr); err != nil || count != 1 {
+		t.Fatalf("RunFmtCheck(%s) = (%d, %v), stderr=%q", path, count, err, stderr.String())
+	}
+	beforeSecondPass := string(formatted)
+	stderr.Reset()
+	if count, err := RunFmt(path, &stderr); err != nil || count != 1 {
+		t.Fatalf("RunFmt second pass (%s) = (%d, %v)", path, count, err)
+	}
+	if afterSecondPass := readFile(t, path); afterSecondPass != beforeSecondPass {
+		t.Fatalf("RunFmt is not idempotent\nfirst:\n%s\nsecond:\n%s", beforeSecondPass, afterSecondPass)
 	}
 }

--- a/examples/gosx-docs/app/docs/layout.gsx
+++ b/examples/gosx-docs/app/docs/layout.gsx
@@ -10,7 +10,12 @@ func Layout() Node {
 						class="docs-guide-navigation docs-guide-navigation--desktop"
 						aria-label="All documentation guides"
 					>
-						<a href="/docs" data-gosx-link="true" class={docsIndexClassName} aria-current={docsIndexCurrent}>
+						<a
+							href="/docs"
+							data-gosx-link="true"
+							class={docsIndexClassName}
+							aria-current={docsIndexCurrent}
+						>
 							<span>Search &amp; guide index</span>
 							<small>All documentation</small>
 						</a>
@@ -94,7 +99,11 @@ func Layout() Node {
 							</a>
 						</If>
 						<If cond={docsNext != nil}>
-							<a href={docsNext.href} data-gosx-link="true" class="docs-footer__link docs-footer__link--next">
+							<a
+								href={docsNext.href}
+								data-gosx-link="true"
+								class="docs-footer__link docs-footer__link--next"
+							>
 								{docsNext.label}
 							</a>
 						</If>

--- a/format/comment_test.go
+++ b/format/comment_test.go
@@ -1,0 +1,104 @@
+package format
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+)
+
+func TestSourcePreservesExpressionContainerComments(t *testing.T) {
+	tests := []struct {
+		name     string
+		source   string
+		comments []string
+	}{
+		{
+			name: "leading and trailing block comments",
+			source: `package main
+
+func Page() Node {
+	return <p>{/* leading */ "A" /* trailing */}</p>
+}
+`,
+			comments: []string{"/* leading */", "/* trailing */"},
+		},
+		{
+			name: "trailing line comment",
+			source: `package main
+
+func Page() Node {
+	return <p>{"A" // trailing
+}</p>
+}
+`,
+			comments: []string{"// trailing"},
+		},
+		{
+			name: "comment between sibling expressions",
+			source: `package main
+
+func Page() Node {
+	return <p><b>A</b>{/* between */ " "}<i>B</i></p>
+}
+`,
+			comments: []string{"/* between */"},
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			formatted, err := Source([]byte(tc.source))
+			if err != nil {
+				t.Fatalf("Source: %v", err)
+			}
+			for _, comment := range tc.comments {
+				if !bytes.Contains(formatted, []byte(comment)) {
+					t.Fatalf("formatter dropped %q:\n%s", comment, formatted)
+				}
+			}
+			twice, err := Source(formatted)
+			if err != nil {
+				t.Fatalf("Source (second pass): %v\n%s", err, formatted)
+			}
+			if !bytes.Equal(formatted, twice) {
+				t.Fatalf("formatter is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, twice)
+			}
+			want := renderFormatterFixture(t, []byte(tc.source))
+			if got := renderFormatterFixture(t, formatted); got != want {
+				t.Fatalf("formatted source changed rendered HTML\nwant: %q\ngot:  %q\nformatted:\n%s", want, got, formatted)
+			}
+			if got := renderFormatterFixture(t, twice); got != want {
+				t.Fatalf("twice-formatted source changed rendered HTML\nwant: %q\ngot:  %q", want, got)
+			}
+		})
+	}
+}
+
+func TestSourceRetainsCommentOnlyExpressionBeforeCompile(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <p>{/* comment-only */}</p>
+}
+`)
+	if _, err := gosx.Compile(source); err == nil || !strings.Contains(err.Error(), "missing identifier") {
+		t.Fatalf("expected the grammar to reject a comment-only expression with missing identifier, got %v", err)
+	}
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	if !bytes.Equal(formatted, source) {
+		t.Fatalf("formatter dropped unsupported comment-only expression\nsource:\n%s\nformatted:\n%s", source, formatted)
+	}
+	twice, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source (second pass): %v", err)
+	}
+	if !bytes.Equal(twice, source) {
+		t.Fatalf("comment-only expression changed on second pass\nsource:\n%s\ntwice:\n%s", source, twice)
+	}
+}

--- a/format/format.go
+++ b/format/format.go
@@ -110,22 +110,8 @@ func (f *formatter) formatElement(n *gotreesitter.Node, depth int) string {
 	// Format children
 	if len(children) == 0 {
 		// Empty: <tag></tag>
-	} else if len(children) == 1 && f.isInlineChild(children[0]) {
-		// Single inline child: <tag>text</tag>
-		b.WriteString(f.format(children[0], depth))
 	} else {
-		// Multi-line children
-		for _, child := range children {
-			childStr := f.format(child, depth+1)
-			if strings.TrimSpace(childStr) == "" {
-				continue
-			}
-			b.WriteByte('\n')
-			b.WriteString(strings.Repeat(f.indent, depth+1))
-			b.WriteString(strings.TrimSpace(childStr))
-		}
-		b.WriteByte('\n')
-		b.WriteString(strings.Repeat(f.indent, depth))
+		b.WriteString(f.formatChildren(children, depth))
 	}
 
 	// Closing tag
@@ -166,19 +152,9 @@ func (f *formatter) formatFragment(n *gotreesitter.Node, depth int) string {
 
 	var b strings.Builder
 	b.WriteString("<>")
-
-	for _, child := range children {
-		childStr := f.format(child, depth+1)
-		if strings.TrimSpace(childStr) == "" {
-			continue
-		}
-		b.WriteByte('\n')
-		b.WriteString(strings.Repeat(f.indent, depth+1))
-		b.WriteString(strings.TrimSpace(childStr))
+	if len(children) > 0 {
+		b.WriteString(f.formatChildren(children, depth))
 	}
-
-	b.WriteByte('\n')
-	b.WriteString(strings.Repeat(f.indent, depth))
 	b.WriteString("</>")
 	return b.String()
 }
@@ -186,7 +162,26 @@ func (f *formatter) formatFragment(n *gotreesitter.Node, depth int) string {
 func (f *formatter) formatExprContainer(n *gotreesitter.Node) string {
 	exprNode := f.childByField(n, "expression")
 	if exprNode == nil {
-		return "{}"
+		// The grammar requires an expression, but a comment-only container
+		// can still reach the formatter before Compile reports the missing
+		// expression. Keep the source intact instead of deleting its comment.
+		return f.text(n)
+	}
+
+	// Go comments are extras rather than part of the expression node span.
+	// Preserve a leading/trailing comment together with its surrounding
+	// container; rebuilding from only exprNode would silently erase it.
+	innerStart := int(n.StartByte()) + 1
+	innerEnd := int(n.EndByte()) - 1
+	exprStart := int(exprNode.StartByte())
+	exprEnd := int(exprNode.EndByte())
+	if exprStart >= innerStart && exprEnd <= innerEnd {
+		prefix := string(f.src[innerStart:exprStart])
+		suffix := string(f.src[exprEnd:innerEnd])
+		if strings.Contains(prefix, "//") || strings.Contains(prefix, "/*") ||
+			strings.Contains(suffix, "//") || strings.Contains(suffix, "/*") {
+			return f.text(n)
+		}
 	}
 	expr := f.text(exprNode)
 	if strings.Contains(expr, "\n") && f.containsStringLiteral(exprNode) {
@@ -197,11 +192,96 @@ func (f *formatter) formatExprContainer(n *gotreesitter.Node) string {
 
 func (f *formatter) formatText(n *gotreesitter.Node) string {
 	text := f.text(n)
-	fields := strings.Fields(text)
-	if len(fields) == 0 {
+	if strings.TrimSpace(text) == "" {
+		// The compiler lowers every whitespace-only jsx_text node to one
+		// semantic space. Keep that canonical spelling when the node stays
+		// inline; formatChildren may replace it with a source-approved line
+		// break when the surrounding child stream is multiline.
+		return " "
+	}
+	// Non-empty text is rendered verbatim by the compiler and renderer. In
+	// particular, a line break or a run of spaces inside prose is not merely
+	// formatter indentation: it belongs to the output text node. Returning it
+	// unchanged keeps source, formatted source, and repeated formatting on the
+	// same rendered HTML.
+	return text
+}
+
+// formatChildren formats the direct GSX child stream without inventing a
+// separator between adjacent children. A newline in a formatted GSX body is
+// itself a jsx_text child and therefore renders as a space; inserting one
+// around every child changes `(<expr>)` into `( <expr> )` and joins such as
+// `<b>A</b><i>B</i>` into a spaced sequence. The only safe place to break is
+// a standalone whitespace-only child that was already present in the source.
+// That child is represented by the formatter's line break and indentation,
+// preserving the compiler's one-space rendering contract.
+func (f *formatter) formatChildren(children []*gotreesitter.Node, depth int) string {
+	if len(children) == 0 {
 		return ""
 	}
-	return strings.Join(fields, " ")
+
+	type childInfo struct {
+		node           *gotreesitter.Node
+		whitespaceOnly bool
+	}
+	infos := make([]childInfo, 0, len(children))
+	nonWhitespace := 0
+	hasWhitespaceBoundary := false
+	for _, child := range children {
+		info := childInfo{node: child}
+		if f.nodeType(child) == "jsx_text" {
+			info.whitespaceOnly = strings.TrimSpace(f.text(child)) == ""
+		}
+		if info.whitespaceOnly {
+			hasWhitespaceBoundary = true
+		}
+		if !info.whitespaceOnly {
+			nonWhitespace++
+		}
+		infos = append(infos, info)
+	}
+
+	// A whitespace-only child is the source-level permission to make a
+	// structural line break. Keep a body made solely of whitespace inline
+	// (`<p> </p>`); there is no useful wrapping to do and the inline spelling
+	// is the least surprising canonical result.
+	multiline := hasWhitespaceBoundary && nonWhitespace > 0
+	if !multiline {
+		var b strings.Builder
+		for _, info := range infos {
+			b.WriteString(f.format(info.node, depth))
+		}
+		return b.String()
+	}
+
+	var b strings.Builder
+	pendingBreak := false
+	for _, info := range infos {
+		if info.whitespaceOnly {
+			// The whitespace-only child is emitted either as a literal space
+			// (when the run remains inline) or as this pending source-approved
+			// line break. Consecutive whitespace-only nodes coalesce here
+			// without quadratic concatenation.
+			pendingBreak = true
+			continue
+		}
+
+		childDepth := depth
+		if pendingBreak {
+			b.WriteByte('\n')
+			b.WriteString(strings.Repeat(f.indent, depth+1))
+			childDepth = depth + 1
+			pendingBreak = false
+		}
+		b.WriteString(f.format(info.node, childDepth))
+	}
+	if pendingBreak {
+		// A trailing whitespace-only child is retained as a source-approved
+		// newline. Align the closing tag with this element/fragment's depth.
+		b.WriteByte('\n')
+		b.WriteString(strings.Repeat(f.indent, depth))
+	}
+	return b.String()
 }
 
 func (f *formatter) formatDefault(n *gotreesitter.Node, depth int) string {
@@ -220,9 +300,14 @@ func (f *formatter) formatDefault(n *gotreesitter.Node, depth int) string {
 		}
 
 		childType := f.nodeType(child)
-		if childType == "jsx_element" || childType == "jsx_self_closing_element" || childType == "jsx_fragment" {
-			childStr := f.format(child, depth)
-			b.WriteString(f.indentEmbedded(childStr, f.lineLeadingWhitespace(child.StartByte())))
+		if childType == "jsx_element" || childType == "jsx_raw_text_element" ||
+			childType == "jsx_self_closing_element" || childType == "jsx_fragment" {
+			// Format the embedded GSX node at the next structural depth so
+			// its own child lines have the right code indentation. Do not
+			// prefix every rendered line afterwards: a multiline jsx_text node
+			// is output verbatim, and adding Go indentation to it changes the
+			// rendered prose (and compounds on every formatter pass).
+			b.WriteString(f.format(child, depth+1))
 		} else {
 			b.WriteString(f.formatDefault(child, depth))
 		}
@@ -237,44 +322,6 @@ func (f *formatter) formatDefault(n *gotreesitter.Node, depth int) string {
 	return b.String()
 }
 
-func (f *formatter) indentEmbedded(text string, prefix string) string {
-	if prefix == "" || !strings.Contains(text, "\n") {
-		return text
-	}
-	lines := strings.Split(text, "\n")
-	for i := 1; i < len(lines); i++ {
-		if strings.TrimSpace(lines[i]) == "" {
-			lines[i] = ""
-			continue
-		}
-		lines[i] = prefix + lines[i]
-	}
-	return strings.Join(lines, "\n")
-}
-
-func (f *formatter) lineLeadingWhitespace(pos uint32) string {
-	if pos == 0 || len(f.src) == 0 {
-		return ""
-	}
-	idx := int(pos)
-	if idx > len(f.src) {
-		idx = len(f.src)
-	}
-	lineStart := idx - 1
-	for lineStart >= 0 && f.src[lineStart] != '\n' {
-		lineStart--
-	}
-	lineStart++
-	lineEnd := lineStart
-	for lineEnd < idx {
-		if f.src[lineEnd] != ' ' && f.src[lineEnd] != '\t' {
-			break
-		}
-		lineEnd++
-	}
-	return string(f.src[lineStart:lineEnd])
-}
-
 func (f *formatter) normalizeMultilineExpr(expr string) string {
 	lines := strings.Split(expr, "\n")
 	if len(lines) < 2 {
@@ -287,7 +334,16 @@ func (f *formatter) normalizeMultilineExpr(expr string) string {
 		if line == "" {
 			continue
 		}
-		if strings.HasPrefix(line, f.indent) {
+		if strings.TrimSpace(line) == "" {
+			lines[i] = ""
+			changed = true
+			continue
+		}
+		// One leading indent belongs to the Go expression that contains
+		// this multiline literal. Leave the literal's own first indent in
+		// place so a second formatter pass does not keep shifting its
+		// contents left.
+		if strings.HasPrefix(line, f.indent+f.indent) {
 			lines[i] = strings.TrimPrefix(line, f.indent)
 			changed = true
 		}
@@ -383,15 +439,4 @@ func (f *formatter) extractTagName(n *gotreesitter.Node) string {
 		return ""
 	}
 	return f.text(nameNode)
-}
-
-func (f *formatter) isInlineChild(n *gotreesitter.Node) bool {
-	typ := f.nodeType(n)
-	if typ == "jsx_text" {
-		return len(strings.TrimSpace(f.text(n))) < 40
-	}
-	if typ == "jsx_expression_container" {
-		return len(f.text(n)) < 40
-	}
-	return false
 }

--- a/format/format_test.go
+++ b/format/format_test.go
@@ -11,7 +11,11 @@ func TestSourceFormatsNestedElements(t *testing.T) {
 	formatted, err := Source([]byte(`package main
 
 func Page() Node {
-	return <main><section><h1>Hi</h1></section></main>
+	return <main>
+		<section>
+			<h1>Hi</h1>
+		</section>
+	</main>
 }
 `))
 	if err != nil {
@@ -19,13 +23,29 @@ func Page() Node {
 	}
 
 	output := string(formatted)
-	if strings.Contains(output, "<main><section>") {
-		t.Fatalf("expected nested elements to expand, got:\n%s", output)
+	if strings.Contains(output, "<main><section>") || strings.Contains(output, "<section><h1>") {
+		t.Fatalf("expected source whitespace to remain readable, got:\n%s", output)
 	}
 	for _, snippet := range []string{"<main>", "<section>", "<h1>Hi</h1>"} {
 		if !strings.Contains(output, snippet) {
 			t.Fatalf("expected %q in formatted output:\n%s", snippet, output)
 		}
+	}
+}
+
+func TestSourceKeepsZeroWhitespaceNestedAdjacency(t *testing.T) {
+	source := []byte(`package main
+
+func Page() Node {
+	return <main><section><h1>Hi</h1></section></main>
+}
+`)
+	formatted, err := Source(source)
+	if err != nil {
+		t.Fatalf("Source: %v", err)
+	}
+	if string(formatted) != string(source) {
+		t.Fatalf("formatter inserted layout into zero-whitespace child stream\nsource:\n%s\nformatted:\n%s", source, formatted)
 	}
 }
 
@@ -56,8 +76,8 @@ func NavLink(props any) Node {
 	}
 }
 
-func TestSourceNormalizesWrappedTextWithoutDrift(t *testing.T) {
-	formatted, err := Source([]byte(`package main
+func TestSourcePreservesWrappedTextWithoutDrift(t *testing.T) {
+	source := []byte(`package main
 
 func Page() Node {
 	return <article>
@@ -68,17 +88,28 @@ func Page() Node {
 		</p>
 	</article>
 }
-`))
+`)
+	formatted, err := Source(source)
 	if err != nil {
 		t.Fatalf("Source: %v", err)
 	}
 
 	output := string(formatted)
-	if strings.Contains(output, "\n\t\t\t\t\t\t") {
-		t.Fatalf("expected wrapped text indentation drift to be removed, got:\n%s", output)
+	second, err := Source(formatted)
+	if err != nil {
+		t.Fatalf("Source second pass: %v", err)
 	}
-	if !strings.Contains(output, "Routes, server actions, auth, client navigation, and Scene3D all live in the same codebase.") {
-		t.Fatalf("expected wrapped text to normalize to one logical line, got:\n%s", output)
+	if string(second) != output {
+		t.Fatalf("wrapped prose formatting is not idempotent\nfirst:\n%s\nsecond:\n%s", output, second)
+	}
+	for _, snippet := range []string{
+		"This example is a real GoSX app, not a brochure hung next to one.",
+		"Routes, server actions, auth, client navigation, and Scene3D all live in the same",
+		"codebase.",
+	} {
+		if !strings.Contains(output, snippet) {
+			t.Fatalf("expected wrapped prose to survive formatting, missing %q:\n%s", snippet, output)
+		}
 	}
 }
 

--- a/format/semantic_whitespace_test.go
+++ b/format/semantic_whitespace_test.go
@@ -1,0 +1,190 @@
+package format
+
+import (
+	"bytes"
+	"testing"
+
+	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/route"
+)
+
+func TestSourcePreservesRenderedSemanticWhitespace(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		source string
+	}{
+		{
+			name: "mixed text hole parentheses",
+			source: `package main
+
+func Page() Node {
+	return <p>({"ABC"})</p>
+}
+`,
+		},
+		{
+			name: "at domain adjacency",
+			source: `package main
+
+func Page() Node {
+	return <p>{"support"}@stablekernel.com</p>
+}
+`,
+		},
+		{
+			name: "punctuation adjacency",
+			source: `package main
+
+func Page() Node {
+	return <p>/range:{"value"},next.</p>
+}
+`,
+		},
+		{
+			name: "intentional one space boundaries",
+			source: `package main
+
+func Page() Node {
+	return <p>before {"middle"} after</p>
+}
+`,
+		},
+		{
+			name: "adjacent inline elements without space",
+			source: `package main
+
+func Page() Node {
+	return <p><b>A</b><i>B</i></p>
+}
+`,
+		},
+		{
+			name: "adjacent inline elements with space",
+			source: `package main
+
+func Page() Node {
+	return <p><b>A</b> <i>B</i></p>
+}
+`,
+		},
+		{
+			name: "expression element expression",
+			source: `package main
+
+func Page() Node {
+	return <p>{"A"}<b>B</b>{"C"}</p>
+}
+`,
+		},
+		{
+			name: "local component self closing fragment adjacency",
+			source: `package main
+
+func Badge(props any) Node {
+	return <b>badge</b>
+}
+
+func Page() Node {
+	return <><Badge /><i>!</i><Badge /></>
+}
+`,
+		},
+		{
+			name: "long mixed run wraps at supplied spaces",
+			source: `package main
+
+func Page() Node {
+	return <p><b>A</b> <b>B</b> <b>C</b> <b>D</b> <b>E</b> <b>F</b></p>
+}
+`,
+		},
+		{
+			name:   "multiline prose",
+			source: "package main\n\nfunc Page() Node {\n\treturn <p>\n\t\tThis is a long\n\t\tparagraph with UTF-8 café text.\n\t</p>\n}\n",
+		},
+		{
+			name: "whitespace only boundary",
+			source: `package main
+
+func Page() Node {
+	return <p><b>A</b>   <i>B</i></p>
+}
+`,
+		},
+		{
+			name: "utf8 and entities",
+			source: `package main
+
+func Page() Node {
+	return <p>café &amp; naïve → ok</p>
+}
+`,
+		},
+		{
+			name: "attributes stay byte stable",
+			source: `package main
+
+func Page() Node {
+	return <p data-label="a  b" data-utf8="café" aria-label="(ABC)">text</p>
+}
+`,
+		},
+		{
+			name: "raw script and style",
+			source: `package main
+
+func Page() Node {
+	return <div><script>if (a < b) { go(); }</script><style>.a > .b { color: red; }</style></div>
+}
+`,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			formatted, err := Source([]byte(tc.source))
+			if err != nil {
+				t.Fatalf("Source: %v", err)
+			}
+			twice, err := Source(formatted)
+			if err != nil {
+				t.Fatalf("Source (second pass): %v\n%s", err, formatted)
+			}
+			if !bytes.Equal(formatted, twice) {
+				t.Fatalf("formatter is not idempotent\nfirst:\n%s\nsecond:\n%s", formatted, twice)
+			}
+
+			want := renderFormatterFixture(t, []byte(tc.source))
+			got := renderFormatterFixture(t, formatted)
+			if got != want {
+				t.Fatalf("formatted source changed rendered HTML\nwant: %q\ngot:  %q\nformatted:\n%s", want, got, formatted)
+			}
+			gotTwice := renderFormatterFixture(t, twice)
+			if gotTwice != want {
+				t.Fatalf("twice-formatted source changed rendered HTML\nwant: %q\ngot:  %q", want, gotTwice)
+			}
+
+			if tc.name == "long mixed run wraps at supplied spaces" &&
+				!bytes.Contains(formatted, []byte("</b>\n\t\t<b>B</b>\n\t\t<b>C</b>")) {
+				t.Fatalf("expected a child-boundary wrap at supplied spaces:\n%s", formatted)
+			}
+		})
+	}
+}
+
+func renderFormatterFixture(t *testing.T, source []byte) string {
+	t.Helper()
+	prog, err := gosx.Compile(source)
+	if err != nil {
+		t.Fatalf("Compile: %v\n%s", err, source)
+	}
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v\n%s", err, source)
+	}
+	return html
+}


### PR DESCRIPTION
Durable archival checkpoint of the semantic-whitespace formatter worktree.

- Authored source, tests, docs example, and changelog only.
- Staged secret scan: clean.
- Buckley generated and validated the commit through OpenRouter/Luna.
- This draft preserves work remotely and does not imply acceptance or merge readiness.