### PR TITLE
Archive orphaned PR142 scene and page-state blobs

### DIFF
--- a/scene/scene_ir.go
+++ b/scene/scene_ir.go
@@ -433,6 +433,12 @@ type HTMLIR struct {
 	X                float64      `json:"x,omitempty"`
 	Y                float64      `json:"y,omitempty"`
 	Z                float64      `json:"z,omitempty"`
+	RotationX        float64      `json:"rotationX,omitempty"`
+	RotationY        float64      `json:"rotationY,omitempty"`
+	RotationZ        float64      `json:"rotationZ,omitempty"`
+	SpinX            float64      `json:"spinX,omitempty"`
+	SpinY            float64      `json:"spinY,omitempty"`
+	SpinZ            float64      `json:"spinZ,omitempty"`
 	Priority         float64      `json:"priority,omitempty"`
 	ShiftX           float64      `json:"shiftX,omitempty"`
 	ShiftY           float64      `json:"shiftY,omitempty"`
@@ -1023,6 +1029,7 @@ type EnvironmentIR struct {
 	GroundIntensity  float64        `json:"groundIntensity,omitempty"`
 	EnvMap           string         `json:"envMap,omitempty"`
 	IBL              EnvironmentIBL `json:"ibl,omitzero"`
+	Sky              *Sky           `json:"sky,omitempty"`
 	EnvIntensity     float64        `json:"envIntensity,omitempty"`
 	EnvRotation      float64        `json:"envRotation,omitempty"`
 	Exposure         float64        `json:"exposure,omitempty"`
@@ -2975,6 +2982,7 @@ func (item EnvironmentIR) IsZero() bool {
 		item.GroundIntensity == 0 &&
 		item.EnvMap == "" &&
 		item.IBL.IsZero() &&
+		item.Sky == nil &&
 		item.EnvIntensity == 0 &&
 		item.EnvRotation == 0 &&
 		item.Exposure == 0 &&
@@ -3002,6 +3010,9 @@ func (item EnvironmentIR) legacyProps() map[string]any {
 	if !item.IBL.IsZero() {
 		record["ibl"] = item.IBL
 	}
+	if item.Sky != nil {
+		record["sky"] = item.Sky
+	}
 	setNumeric(record, "envIntensity", item.EnvIntensity)
 	setNumeric(record, "envRotation", item.EnvRotation)
 	setNumeric(record, "exposure", item.Exposure)
@@ -3022,6 +3033,7 @@ func (environment Environment) sceneIR() EnvironmentIR {
 		GroundIntensity:  environment.GroundIntensity,
 		EnvMap:           strings.TrimSpace(environment.EnvironmentMap),
 		IBL:              normalizeEnvironmentIBL(environment.IBL),
+		Sky:              normalizeSky(environment.Sky),
 		EnvIntensity:     environment.EnvIntensity,
 		EnvRotation:      environment.EnvRotation,
 		Exposure:         environment.Exposure,
@@ -3059,6 +3071,7 @@ var collectFeatureOrder = []capability.Feature{
 	capability.FeatureWaterSim,
 	capability.FeatureIBL,
 	capability.FeatureEnvironmentMap,
+	capability.FeatureSkyEnvironment,
 	capability.FeatureGPUPicking,
 	capability.FeatureLineDashed,
 	capability.FeatureSkinning,
@@ -3134,16 +3147,30 @@ func collectFeatures(ir SceneIR) []capability.Feature {
 	// ibl and environment-map: the environment carries a non-empty env-map.
 	//
 	// One authored field raises two features because the two questions differ.
-	// ibl asks whether a backend runs a split-sum fit; no backend does, so both
-	// its cells are false. environment-map asks whether a backend opens the
-	// image at all; WebGL2 does and WebGPU does not. Raising only ibl reported
-	// the two backends as equal, and they are not.
+	// ibl asks whether a backend runs a split-sum fit: WebGPU does
+	// (syncEnvironmentIBL consumes the prefiltered products unconditionally);
+	// WebGL2 only above the 18-fragment-texture-unit gate, so its cell stays
+	// false. environment-map asks whether a backend opens the legacy equirect
+	// image at all: both backends do now. See capability.go's ibl and
+	// environment-map rows.
+	//
+	// Pairing a bare EnvMap with ibl is conservative: an env-map-only scene now
+	// degrades on WebGL2 even though it authored no split-sum descriptor. See
+	// the open question this raises in specs/scene3d-parity/cluster-a-
+	// environment.md section 4, Q7; this cluster does not resolve it.
 	if strings.TrimSpace(ir.Environment.EnvMap) != "" {
 		seen[capability.FeatureIBL] = true
 		seen[capability.FeatureEnvironmentMap] = true
 	}
 	if !ir.Environment.IBL.IsZero() {
 		seen[capability.FeatureIBL] = true
+	}
+
+	// sky-environment: the environment mode of an authored Sky. Gradient sky
+	// (the default and the degrade target) draws on every backend and raises
+	// nothing; see the row's doc comment in capability.go.
+	if skyRaisesEnvironmentFeature(ir.Environment.Sky) {
+		seen[capability.FeatureSkyEnvironment] = true
 	}
 
 	// gpu-picking: any ObjectIR or InstancedGLBMeshIR is explicitly pickable.

--- a/server/page_state.go
+++ b/server/page_state.go
@@ -13,14 +13,15 @@ import (
 // PageState carries shared request-scoped page response state used by both
 // server.Context and route.RouteContext.
 type PageState struct {
-	headers  http.Header
-	status   int
-	metadata Metadata
-	head     []gosx.Node
-	deferred *DeferredRegistry
-	cache    *CacheState
-	runtime  *PageRuntime
-	nonce    string
+	requestPath string
+	headers     http.Header
+	status      int
+	metadata    Metadata
+	head        []gosx.Node
+	deferred    *DeferredRegistry
+	cache       *CacheState
+	runtime     *PageRuntime
+	nonce       string
 }
 
 // NewPageState creates an empty shared page-state container.
@@ -33,6 +34,17 @@ type PageState struct {
 // passthrough.
 func NewPageState() *PageState {
 	return &PageState{}
+}
+
+// NewPageStateForRequest creates page state whose automatic metadata URLs use
+// the request's route path. NewPageState intentionally remains pathless so
+// standalone metadata rendering keeps its root-path default.
+func NewPageStateForRequest(r *http.Request) *PageState {
+	state := NewPageState()
+	if r != nil && r.URL != nil {
+		state.requestPath = r.URL.Path
+	}
+	return state
 }
 
 // Header returns the response headers to apply when the request completes.


### PR DESCRIPTION
Preservation-only draft carrying two exact historical blobs on top of the archived PR142 convergence oracle.

- Carrier commit: `99a0dec67a448a61d3701600917cb2fc129f837b`
- Exact parent: `6eba7ce296b3ae603c6d09d826d05110a113131d`
- `scene/scene_ir.go`: `f875687083b252018c2b31b229c178e156dc304f`
- `server/page_state.go`: `6adcf903b6b3c8ecf02a7fb1d578e59593bf63bd`

Validation:
- Root license at the parent is MIT.
- Focused gitleaks scans passed for both blobs and the staged diff.
- `git diff --check` passed.
- `go test ./scene ./server` does not compile because these orphan snapshots reference companion historical objects that are not present in the convergence oracle; no compatibility edits were made because exact object preservation is the purpose of this carrier.

This draft is archival evidence and is not intended to be merged as-is.