### PR TITLE
Reuse runtime feature preloads

### DIFF
--- a/island/island.go
+++ b/island/island.go
@@ -1816,7 +1816,7 @@ func (r *Renderer) PreloadHints() gosx.Node {
 			if strings.TrimSpace(path) == "" || emittedScriptSrcs[path] {
 				continue
 			}
-			b.WriteString(fmt.Sprintf(`<link rel="preload" href="%s" as="script">`, path))
+			b.WriteString(fmt.Sprintf(`<link rel="preload" href="%s" as="script" crossorigin="anonymous" referrerpolicy="no-referrer">`, path))
 			b.WriteByte('\n')
 		}
 	}

--- a/island/island_test.go
+++ b/island/island_test.go
@@ -846,6 +846,12 @@ func TestPreloadHintsSkipScene3DAlreadyEmittedAsScriptTag(t *testing.T) {
 		t.Fatalf("engines bundle preload must be preserved (client-side fetched, never a same-document script tag): %s", preloads)
 	}
 
+	path := r.selectedBootstrapFeaturePath("engines")
+	expected := `<link rel="preload" href="` + path + `" as="script" crossorigin="anonymous" referrerpolicy="no-referrer">`
+	if !strings.Contains(preloads, expected) {
+		t.Fatalf("regression: preload for engines path %q missing exact link tag (needs crossorigin and referrerpolicy in order)\nwant: %s\ngot:  %s", path, expected, preloads)
+	}
+
 	scripts := gosx.RenderHTML(r.BootstrapScript())
 	if !strings.Contains(scripts, `data-gosx-script="feature-scene3d"`) || !strings.Contains(scripts, "bootstrap-feature-scene3d") {
 		t.Fatalf("scene3d bundle must still be emitted as a deferred <script> tag: %s", scripts)


### PR DESCRIPTION
## Summary

- Match script-preload CORS and referrer-policy attributes to the dynamic script loader.
- Keep early feature preloads, custom asset paths, and the existing Scene3D script policy.
- Prevent a second transfer of the engines bundle without changing performance budgets.

## Validation

- `GOWORK=off go test ./island ./server` passes.
- The focused preload regression fails against the old renderer and passes with the fix. Existing Scene3D preload/script assertions remain intact.
- Real served-page performance check passes with existing budgets.
- Docs network payload: 1,603.82 → 1,496.29 KiB.
- Water network payload: 1,533.85 → 1,426.33 KiB in the same local browser setup.
- Resource traces show one engines-bundle transfer per page, down from two (110,106 bytes saved).
- The docs failure also reproduces at the base commit; this is independent of the static morph-target changes in #279.

Exact remote checkpoint: `1e0654e3edfed842d5a7947572adf2e7f09ec9f0`. Remote JavaScript, CLI, race, release, WASM, and browser jobs passed, including the unchanged performance budgets. The Go job timed out starting Chrome in `TestWaterDiagRendersQueryAndAttributeValuesAsText`; that exact test passed three local repetitions. The failed Go job passed its targeted rerun. Final CI is green at the exact head SHA above; independent review found no remaining issue in this two-file change.