### PR TITLE
secure(release): govern tags from main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
         run: make test-fuzz-smoke
 
       # The desktop host holds 3520 lines behind a windows build tag against 62
-      # lines of windows-gated test, and this runner is Linux. release.yml
+      # lines of windows-gated test, and this runner is Linux. release-governed.yml
       # cross-compiles the binary, but nothing compiled the windows TEST
       # binaries, so a broken desktop test could not fail anywhere. This runs the
       # portable tests and links both windows test binaries.
@@ -349,16 +349,13 @@ jobs:
           CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: make perf-budget-ci
 
-  # test: kept as a lightweight aggregate so the `test` check name still
-  # exists for any external required-check configuration that references it
-  # by name. As of this split, `main` branch protection on this repo has no
-  # required_status_checks configured (verified via `gh api
-  # repos/odvcencio/gosx/branches/main/protection`), so nothing currently
-  # depends on this name — this job is defensive insurance, not a fix for a
-  # known break.
+  # test: kept as the lightweight aggregate required-check surface. It must
+  # include release-gate so branch protection on the aggregate `test` check also
+  # gates release policy and governed workflow topology.
   test:
     runs-on: ubuntu-latest
     needs:
+      - release-gate
       - go-tests
       - go-race-tests
       - go-cli-tests
@@ -369,7 +366,7 @@ jobs:
 
     steps:
       - name: All test jobs passed
-        run: echo "go-tests, go-race-tests, go-cli-tests, js-tests, wasm-tests, and browser-tests all passed"
+        run: echo "release-gate, go-tests, go-race-tests, go-cli-tests, js-tests, wasm-tests, and browser-tests all passed"
 
   # Opt-in certification for a self-hosted runner with a real GPU. Generic
   # GitHub runners use SwiftShader and cannot produce meaningful WebGPU frame

--- a/.github/workflows/release-governed.yml
+++ b/.github/workflows/release-governed.yml
@@ -1,90 +1,136 @@
 name: Release
 
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
     inputs:
       tag:
-        description: "Existing semantic-version tag to release"
+        description: "Stable vMAJOR.MINOR.PATCH tag to create or rerun"
         required: true
         type: string
 
 permissions:
-  contents: write
+  contents: read
 
 concurrency:
-  group: release-${{ inputs.tag || github.ref_name }}
+  group: release-${{ inputs.tag }}
   cancel-in-progress: false
 
 env:
-  RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
+  RELEASE_TAG: ${{ inputs.tag }}
+  RELEASE_DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
 
-# Verification is split into parallel jobs so release wall-clock tracks the
-# slowest partition instead of the serial sum. Platform builds start after
-# validate alone; publish is the gate that requires every test job.
+# The workflow file and release policy scripts are always evaluated from the
+# repository default branch. The release source is checked out separately under
+# source/ so historical tag reruns do not depend on policy files existing in the
+# historical tree.
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      mode: ${{ steps.prepare.outputs.mode }}
+      source_ref: ${{ steps.prepare.outputs.source_ref }}
+      commit: ${{ steps.prepare.outputs.commit }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - name: Require default-branch workflow dispatch
+        run: |
+          set -euo pipefail
+          sh scripts/check-release-workflow-ref.sh \
+            --workflow-ref-type "${GITHUB_REF_TYPE}" \
+            --workflow-ref-name "${GITHUB_REF_NAME}" \
+            --workflow-ref "${GITHUB_REF}" \
+            --default-branch "${RELEASE_DEFAULT_BRANCH}"
+
+      - name: Prepare release source ref
+        id: prepare
+        run: |
+          set -euo pipefail
+          sh scripts/prepare-release-tag.sh \
+            --tag "${RELEASE_TAG}" \
+            --default-branch "${RELEASE_DEFAULT_BRANCH}" \
+            --github-output "${GITHUB_OUTPUT}"
+
   validate:
+    needs: prepare
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref_name }}
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
           cache: true
 
-      - name: Validate tag, release truth, and vanity module path
-        env:
-          GITHUB_REF_TYPE: tag
-          GITHUB_REF_NAME: ${{ env.RELEASE_TAG }}
+      - name: Validate release source truth and vanity module path
         run: |
           set -euo pipefail
-          if [[ ! "${RELEASE_TAG}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+([+-][0-9A-Za-z.-]+)?$ ]]; then
-            echo "release tag must be semantic versioning: ${RELEASE_TAG}" >&2
-            exit 1
-          fi
-          test "$(git describe --tags --exact-match)" = "${RELEASE_TAG}"
+          sh scripts/check-release-tag-grammar.sh "${RELEASE_TAG}"
+          sh scripts/check-release-source-truth.sh --root source --tag "${RELEASE_TAG}"
+          cd source
+          GITHUB_REF_TYPE=tag \
+            GITHUB_REF_NAME="${RELEASE_TAG}" \
+            GITHUB_REF="refs/tags/${RELEASE_TAG}" \
+            go run ./cmd/gosx release check --root .
           test "$(go list -m)" = "m31labs.dev/gosx"
-          go run ./cmd/gosx release check --root .
           curl --fail --silent --show-error 'https://m31labs.dev/gosx?go-get=1' \
             | grep -F 'm31labs.dev/gosx git https://github.com/odvcencio/gosx'
 
   test-unit:
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     timeout-minutes: 25
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
           cache: true
 
       # Keep release verification aligned with the CI package partition.
       - name: Partition validation and unit tests
+        working-directory: source
         run: |
           set -euo pipefail
           make test-ci-partitions
           make test-unit
 
   test-cli:
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
           cache: true
 
       - name: Install TinyGo
@@ -120,26 +166,31 @@ jobs:
       # 15-minute Go timeout carried by test-cli; a plain `go test ./...`
       # silently restores Go's 10-minute package timeout.
       - name: CLI production-build tests
+        working-directory: source
         run: |
           set -euo pipefail
           make test-cli
           CGO_ENABLED=0 go build ./cmd/gosx
 
   vet:
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
           cache: true
 
       # Generated Danmuji test cases run under go test; vet production files only.
       - name: Vet production files
+        working-directory: source
         run: |
           set -euo pipefail
           while IFS= read -r pkg; do
@@ -151,7 +202,7 @@ jobs:
           done < <(GOFLAGS=-buildvcs=false go list ./...)
 
   build:
-    needs: validate
+    needs: [prepare, validate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     strategy:
@@ -162,13 +213,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
 
       - name: Build gosx
+        working-directory: source
         env:
           GOOS: ${{ matrix.goos }}
           GOARCH: ${{ matrix.goarch }}
@@ -184,16 +238,79 @@ jobs:
         with:
           name: gosx-${{ matrix.goos }}-${{ matrix.goarch }}
           retention-days: 7
-          path: release-artifacts/
+          path: source/release-artifacts/
 
   publish:
-    needs: [validate, test-unit, test-cli, vet, build]
+    needs: [prepare, validate, test-unit, test-cli, vet, build]
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    environment: governed-release
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ inputs.tag || github.ref_name }}
+          fetch-depth: 0
+          persist-credentials: false
+          ref: ${{ github.event.repository.default_branch }}
+
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          path: source
+          persist-credentials: false
+          ref: ${{ needs.prepare.outputs.source_ref }}
+
+      - name: Ensure release tag exists
+        env:
+          GOSX_RELEASE_TAG_DEPLOY_KEY: ${{ secrets.GOSX_RELEASE_TAG_DEPLOY_KEY }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${GOSX_RELEASE_TAG_DEPLOY_KEY}" ]]; then
+            echo "release tag deploy key secret is empty" >&2
+            exit 1
+          fi
+          if [[ -z "${RUNNER_TEMP:-}" ]]; then
+            echo "RUNNER_TEMP is required for release SSH material" >&2
+            exit 1
+          fi
+          if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+            echo "GITHUB_REPOSITORY is required for release SSH remote" >&2
+            exit 1
+          fi
+          release_ssh_dir="$(mktemp -d "${RUNNER_TEMP}/gosx-release-ssh.XXXXXX")"
+          key_file="${release_ssh_dir}/deploy_key"
+          known_hosts_file="${release_ssh_dir}/known_hosts"
+          cleanup_release_ssh() {
+            git -C source remote remove release-origin >/dev/null 2>&1 || true
+            if [[ -f "${key_file}" ]]; then
+              chmod 600 "${key_file}" >/dev/null 2>&1 || true
+              shred -u "${key_file}" >/dev/null 2>&1 || rm -f "${key_file}"
+            fi
+            rm -f "${known_hosts_file}"
+            rmdir "${release_ssh_dir}" >/dev/null 2>&1 || rm -rf "${release_ssh_dir}"
+          }
+          trap cleanup_release_ssh EXIT
+          chmod 700 "${release_ssh_dir}"
+          umask 077
+          printf '%s\n' "${GOSX_RELEASE_TAG_DEPLOY_KEY}" >"${key_file}"
+          chmod 600 "${key_file}"
+          test -s "${key_file}"
+          curl --fail --silent --show-error --location https://api.github.com/meta \
+            | python3 -c 'import json, sys; data=json.load(sys.stdin); keys=[k.strip() for k in (data.get("ssh_keys") or []) if k.strip()]; sys.exit("github meta response did not include ssh_keys") if not keys else None; print("\n".join("github.com " + key for key in keys))' >"${known_hosts_file}"
+          test -s "${known_hosts_file}"
+          chmod 600 "${known_hosts_file}"
+          git -C source remote add release-origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          git -C source config user.name "github-actions[bot]"
+          git -C source config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          GIT_SSH_COMMAND="ssh -i ${key_file} -o IdentitiesOnly=yes -o UserKnownHostsFile=${known_hosts_file} -o StrictHostKeyChecking=yes" \
+            sh scripts/prepare-release-tag.sh \
+            --root source \
+            --remote release-origin \
+            --tag "${RELEASE_TAG}" \
+            --default-branch "${RELEASE_DEFAULT_BRANCH}" \
+            --expected-commit "${{ needs.prepare.outputs.commit }}" \
+            --create
 
       - uses: actions/download-artifact@v4
         with:
@@ -234,7 +351,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version-file: source/go.mod
 
       - name: Verify vanity-path install
         env:

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOFILES := $(shell find . -name '*.go' -not -path './dist/*' -not -path './build
 DMJFILES := $(shell find . -name '*.dmj' -not -path './dist/*' -not -path './build/*')
 DMJGOFILES := $(patsubst %.dmj,%_danmuji_test.go,$(DMJFILES))
 
-.PHONY: fmt fmt-check verify-fmt verify-danmuji canopy-index canopy-stats canopy-clean build-bootstrap test test-unit test-cli test-ci-partitions test-race test-race-pr test-fuzz-smoke test-js test-runtime-types test-editor test-wasm test-wasm-islands wasm-size-budget test-e2e test-perf-browser test-ouroboros-smoke test-water-prod test-water-profile-evidence water-profile-evidence test-desktop test-desktop-macos test-docs-deploy perf-budget perf-budget-ci build-cli build-desktop-windows build-desktop-macos build-runtime ci test-motion-parity test-physics-parity release-gate
+.PHONY: fmt fmt-check verify-fmt verify-danmuji canopy-index canopy-stats canopy-clean build-bootstrap test test-unit test-cli test-ci-partitions test-race test-race-pr test-fuzz-smoke test-js test-runtime-types test-editor test-wasm test-wasm-islands wasm-size-budget test-e2e test-perf-browser test-ouroboros-smoke test-water-prod test-water-profile-evidence water-profile-evidence test-desktop test-desktop-macos test-docs-deploy test-release-workflow test-release-ancestry perf-budget perf-budget-ci build-cli build-desktop-windows build-desktop-macos build-runtime ci test-motion-parity test-physics-parity release-gate
 
 fmt:
 	$(GOFMT) -w $(GOFILES)
@@ -343,30 +343,48 @@ build-runtime:
 #      Go module zip creation and forced the v0.29.0 retraction.
 #   4. docs deploy transaction - prevents an overlapping deployment or rollback
 #      from overwriting a newer successful docs release.
-#   5. module-zip smoke (`git archive --format=zip`) - reproduces the exact
+#   5. governed release workflow topology - proves deploy-key material is scoped
+#      to the tag step and the retired release workflow stays retired.
+#   6. release tag ancestry regression - proves the default-branch lineage
+#      contract accepts canonical release commits and rejects side-branch tags.
+#   7. live release tag ancestry - when a release tag is present, that exact tag
+#      commit must already be reachable from the fresh remote default branch.
+#   8. module-zip smoke (`git archive --format=zip`) - reproduces the exact
 #      operation that broke v0.29.0 so a zip-breaking commit fails fast.
 test-docs-deploy:
 	sh scripts/deploy-gosx-docs-concurrency-test.sh
 	sh scripts/deploy-gosx-docs-public-test.sh
 
+test-release-workflow:
+	sh scripts/check-release-workflow-topology.sh
+
+test-release-ancestry:
+	sh scripts/check-release-tag-ancestry-test.sh
+
 release-gate:
-	@echo "release-gate (1/5): go run ./cmd/gosx release check"
+	@echo "release-gate (1/8): go run ./cmd/gosx release check"
 	$(GO) run ./cmd/gosx release check
-	@echo "release-gate (2/5): go.mod replace-directive scan"
+	@echo "release-gate (2/8): go.mod replace-directive scan"
 	@if grep -E '^replace ' go.mod; then \
 		echo "release-gate: go.mod has a replace directive; 'go run mod@version' fails with any replace present (this is why v0.27.0 was a bad tag). Remove it before release."; \
 		exit 1; \
 	fi
-	@echo "release-gate (3/5): tracked-filename scan"
+	@echo "release-gate (3/8): tracked-filename scan"
 	@bad="$$(git ls-files | grep -E '[:"|<>?*[:cntrl:]]' || true)"; \
 	if [ -n "$$bad" ]; then \
 		echo "release-gate: tracked filenames contain characters Go's module zip format rejects (a file like this broke v0.29.0's module zip and forced its retraction):"; \
 		echo "$$bad"; \
 		exit 1; \
 	fi
-	@echo "release-gate (4/5): docs deploy transaction regression"
+	@echo "release-gate (4/8): docs deploy transaction regression"
 	@$(MAKE) --no-print-directory test-docs-deploy
-	@echo "release-gate (5/5): module-zip smoke (git archive --format=zip)"
+	@echo "release-gate (5/8): governed release workflow topology"
+	@$(MAKE) --no-print-directory test-release-workflow
+	@echo "release-gate (6/8): release tag ancestry regression"
+	@$(MAKE) --no-print-directory test-release-ancestry
+	@echo "release-gate (7/8): live release tag ancestry"
+	@sh scripts/check-release-tag-ancestry.sh --root .
+	@echo "release-gate (8/8): module-zip smoke (git archive --format=zip)"
 	@git archive --format=zip -o /dev/null HEAD
 	@echo "release-gate: all gates passed"
 

--- a/scripts/check-release-source-truth.sh
+++ b/scripts/check-release-source-truth.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-release-source-truth.sh --root DIR --tag vX.Y.Z" >&2
+}
+
+repo_root="."
+release_tag=""
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			repo_root="$2"
+			shift 2
+			;;
+		--tag)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			release_tag="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "check-release-source-truth: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ -z "$release_tag" ]; then
+	echo "check-release-source-truth: release tag is required" >&2
+	exit 1
+fi
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+sh "${script_dir}/check-release-tag-grammar.sh" "$release_tag" || exit 1
+
+release_number="${release_tag#v}"
+
+if ! grep -E '^module m31labs\.dev/gosx$' "${repo_root}/go.mod" >/dev/null; then
+	echo "check-release-source-truth: go.mod must declare module m31labs.dev/gosx" >&2
+	exit 1
+fi
+if ! grep -F "const Current = \"${release_tag}\"" "${repo_root}/internal/version/version.go" >/dev/null; then
+	echo "check-release-source-truth: internal/version.Current must equal ${release_tag}" >&2
+	exit 1
+fi
+if ! grep -F "const Number = \"${release_number}\"" "${repo_root}/internal/version/version.go" >/dev/null; then
+	echo "check-release-source-truth: internal/version.Number must equal ${release_number}" >&2
+	exit 1
+fi
+readme_releases="$(grep -Eio 'current release([[:space:]]+is|:)?[[:space:]]+\*\*v[0-9]+\.[0-9]+\.[0-9]+\*\*' "${repo_root}/README.md" || true)"
+if [ -z "$readme_releases" ]; then
+	echo "check-release-source-truth: README.md must state current release ${release_tag}" >&2
+	exit 1
+fi
+stale_readme="$(printf '%s\n' "$readme_releases" | grep -Fv "**${release_tag}**" || true)"
+if [ -n "$stale_readme" ]; then
+	echo "check-release-source-truth: README.md contains a stale current-release statement" >&2
+	printf '%s\n' "$stale_readme" >&2
+	exit 1
+fi
+if ! grep -E "^##[[:space:]]+\\[?${release_tag}\\]?([[:space:]]|$)" "${repo_root}/CHANGELOG.md" >/dev/null; then
+	echo "check-release-source-truth: CHANGELOG.md must contain section ${release_tag}" >&2
+	exit 1
+fi
+
+echo "check-release-source-truth: ${release_tag} source truth passed"

--- a/scripts/check-release-tag-ancestry-test.sh
+++ b/scripts/check-release-tag-ancestry-test.sh
@@ -1,0 +1,384 @@
+#!/usr/bin/env sh
+set -eu
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+ancestry_script="${script_dir}/check-release-tag-ancestry.sh"
+prepare_script="${script_dir}/prepare-release-tag.sh"
+workflow_ref_script="${script_dir}/check-release-workflow-ref.sh"
+tag_grammar_script="${script_dir}/check-release-tag-grammar.sh"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+assert_grammar_rejects() {
+	label="$1"
+	tag="$2"
+	out="${tmp_dir}/grammar-${label}.out"
+	if "$tag_grammar_script" "$tag" >"$out" 2>&1; then
+		echo "check-release-tag-ancestry-test: ${label} unexpectedly passed canonical tag grammar" >&2
+		cat "$out" >&2
+		exit 1
+	fi
+	if ! grep -F "canonical stable vMAJOR.MINOR.PATCH" "$out" >/dev/null; then
+		echo "check-release-tag-ancestry-test: ${label} failure did not explain canonical stable grammar" >&2
+		cat "$out" >&2
+		exit 1
+	fi
+}
+
+for valid_tag in v0.0.0 v0.2.3 v1.0.3 v1.2.0; do
+	"$tag_grammar_script" "$valid_tag"
+done
+for invalid_tag in v01.2.3 v1.02.3 v1.2.03 v2.0 v2.0.0-rc.1 v2.0.0+build.1; do
+	assert_grammar_rejects "$invalid_tag" "$invalid_tag"
+done
+assert_grammar_rejects "lf-suffix" "$(printf 'v1.2.3\njunk')"
+assert_grammar_rejects "lf-prefix" "$(printf 'junk\nv1.2.3')"
+assert_grammar_rejects "lf-two-tags" "$(printf 'v1.2.3\nv2.3.4')"
+assert_grammar_rejects "cr-suffix" "$(printf 'v1.2.3\rjunk')"
+assert_grammar_rejects "cr-prefix" "$(printf 'junk\rv1.2.3')"
+assert_grammar_rejects "cr-trailing" "$(printf 'v1.2.3\r')"
+assert_grammar_rejects "leading-space" " v1.2.3"
+assert_grammar_rejects "trailing-space" "v1.2.3 "
+assert_grammar_rejects "tab-in-tag" "$(printf 'v1.2\t.3')"
+assert_grammar_rejects "escape-in-tag" "$(printf 'v1.2.3\033')"
+
+remote_dir="${tmp_dir}/remote.git"
+repo_dir="${tmp_dir}/repo"
+
+git init --bare --initial-branch=trunk "$remote_dir" >/dev/null
+git init --initial-branch=trunk "$repo_dir" >/dev/null
+git -C "$repo_dir" config user.email "release-test@example.invalid"
+git -C "$repo_dir" config user.name "Release Test"
+
+printf '%s\n' "base" >"${repo_dir}/file.txt"
+git -C "$repo_dir" add file.txt
+git -C "$repo_dir" commit -m "base" >/dev/null
+git -C "$repo_dir" tag v1.0.0
+v1_commit="$(git -C "$repo_dir" rev-parse HEAD)"
+
+printf '%s\n' "default branch continues" >>"${repo_dir}/file.txt"
+git -C "$repo_dir" commit -am "default branch commit" >/dev/null
+git -C "$repo_dir" remote add origin "$remote_dir"
+git -C "$repo_dir" push -u origin trunk --tags >/dev/null
+
+assert_prepare_create_rejects_without_refs() {
+	label="$1"
+	tag="$2"
+	local_before="$(git -C "$repo_dir" tag -l | LC_ALL=C sort)"
+	remote_before="$(git --git-dir="$remote_dir" for-each-ref --format='%(refname)' refs/tags | LC_ALL=C sort)"
+	out="${tmp_dir}/prepare-invalid-${label}.out"
+	if "$prepare_script" --root "$repo_dir" --tag "$tag" --default-branch trunk --create --expected-commit "$v1_commit" >"$out" 2>&1; then
+		echo "check-release-tag-ancestry-test: ${label} unexpectedly passed create preparation" >&2
+		cat "$out" >&2
+		exit 1
+	fi
+	if ! grep -F "canonical stable vMAJOR.MINOR.PATCH" "$out" >/dev/null; then
+		echo "check-release-tag-ancestry-test: ${label} failure did not explain canonical stable grammar" >&2
+		cat "$out" >&2
+		exit 1
+	fi
+	local_after="$(git -C "$repo_dir" tag -l | LC_ALL=C sort)"
+	remote_after="$(git --git-dir="$remote_dir" for-each-ref --format='%(refname)' refs/tags | LC_ALL=C sort)"
+	if [ "$local_before" != "$local_after" ] || [ "$remote_before" != "$remote_after" ]; then
+		echo "check-release-tag-ancestry-test: ${label} mutated local or remote tags before canonical validation rejected it" >&2
+		exit 1
+	fi
+}
+
+assert_prepare_create_rejects_without_refs "lf-suffix" "$(printf 'v1.2.3\njunk')"
+assert_prepare_create_rejects_without_refs "lf-prefix" "$(printf 'junk\nv1.2.3')"
+assert_prepare_create_rejects_without_refs "lf-two-tags" "$(printf 'v1.2.3\nv2.3.4')"
+assert_prepare_create_rejects_without_refs "cr-suffix" "$(printf 'v1.2.3\rjunk')"
+assert_prepare_create_rejects_without_refs "cr-prefix" "$(printf 'junk\rv1.2.3')"
+assert_prepare_create_rejects_without_refs "cr-trailing" "$(printf 'v1.2.3\r')"
+assert_prepare_create_rejects_without_refs "leading-space" " v1.2.3"
+assert_prepare_create_rejects_without_refs "trailing-space" "v1.2.3 "
+assert_prepare_create_rejects_without_refs "tab-in-tag" "$(printf 'v1.2\t.3')"
+assert_prepare_create_rejects_without_refs "escape-in-tag" "$(printf 'v1.2.3\033')"
+
+git -C "$repo_dir" remote set-url origin "${tmp_dir}/missing-remote-before-grammar.git"
+assert_prepare_create_rejects_without_refs "invalid-before-fetch" "$(printf 'v1.2.3\njunk')"
+git -C "$repo_dir" remote set-url origin "$remote_dir"
+
+output="$("$ancestry_script" --root "$repo_dir" --tag v1.0.0 --default-branch trunk)"
+case "$output" in
+	*"v1.0.0"*"reachable from origin/trunk"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: ancestor tag did not report success" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+
+output="$("$prepare_script" --root "$repo_dir" --tag v1.0.0 --default-branch trunk)"
+case "$output" in
+	*"mode=existing"*"tag=v1.0.0"*"source_ref=${v1_commit}"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: historical in-line tag was not accepted as immutable commit source" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+
+for valid_tag in v0.0.0 v0.2.3 v1.0.3 v1.2.0; do
+	git -C "$repo_dir" tag "$valid_tag" "$v1_commit"
+	output="$("$ancestry_script" --root "$repo_dir" --tag "$valid_tag" --default-branch trunk)"
+	case "$output" in
+		*"${valid_tag}"*"reachable from origin/trunk"*) ;;
+		*)
+			echo "check-release-tag-ancestry-test: canonical edge tag ${valid_tag} did not pass ancestry" >&2
+			echo "$output" >&2
+			exit 1
+			;;
+	esac
+	output="$("$prepare_script" --root "$repo_dir" --tag "$valid_tag" --default-branch trunk)"
+	case "$output" in
+		*"mode=existing"*"tag=${valid_tag}"*"source_ref=${v1_commit}"*) ;;
+		*)
+			echo "check-release-tag-ancestry-test: canonical edge tag ${valid_tag} did not pass prepare" >&2
+			echo "$output" >&2
+			exit 1
+			;;
+	esac
+done
+
+git -C "$repo_dir" checkout --orphan release-only >/dev/null
+git -C "$repo_dir" rm -rf . >/dev/null 2>&1 || true
+printf '%s\n' "off default branch" >"${repo_dir}/release.txt"
+git -C "$repo_dir" add release.txt
+git -C "$repo_dir" commit -m "off-main release" >/dev/null
+git -C "$repo_dir" tag v2.0.0
+
+if "$ancestry_script" --root "$repo_dir" --tag v2.0.0 --default-branch trunk >"${tmp_dir}/off-main.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: off-default-branch tag unexpectedly passed" >&2
+	cat "${tmp_dir}/off-main.out" >&2
+	exit 1
+fi
+if ! grep -F "is not reachable from origin/trunk" "${tmp_dir}/off-main.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: off-default-branch failure did not explain ancestry" >&2
+	cat "${tmp_dir}/off-main.out" >&2
+	exit 1
+fi
+
+if "$prepare_script" --root "$repo_dir" --tag v2.0.0 --default-branch trunk >"${tmp_dir}/prepare-off-main.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: prepare accepted off-default-branch tag" >&2
+	cat "${tmp_dir}/prepare-off-main.out" >&2
+	exit 1
+fi
+if ! grep -F "canonical default-branch lineage" "${tmp_dir}/prepare-off-main.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: prepare off-branch failure did not explain lineage" >&2
+	cat "${tmp_dir}/prepare-off-main.out" >&2
+	exit 1
+fi
+
+for invalid_tag in v01.2.3 v1.02.3 v1.2.03 v2.0 v2.0.0-rc.1 v2.0.0+build.1; do
+	if "$ancestry_script" --root "$repo_dir" --tag "$invalid_tag" --default-branch trunk >"${tmp_dir}/ancestry-invalid-${invalid_tag}.out" 2>&1; then
+		echo "check-release-tag-ancestry-test: ${invalid_tag} unexpectedly passed ancestry grammar" >&2
+		cat "${tmp_dir}/ancestry-invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+	if ! grep -F "canonical stable vMAJOR.MINOR.PATCH" "${tmp_dir}/ancestry-invalid-${invalid_tag}.out" >/dev/null; then
+		echo "check-release-tag-ancestry-test: ${invalid_tag} ancestry failure did not explain canonical stable grammar" >&2
+		cat "${tmp_dir}/ancestry-invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+	if "$prepare_script" --root "$repo_dir" --tag "$invalid_tag" --default-branch trunk --create --expected-commit "$v1_commit" >"${tmp_dir}/invalid-${invalid_tag}.out" 2>&1; then
+		echo "check-release-tag-ancestry-test: ${invalid_tag} unexpectedly passed create preparation" >&2
+		cat "${tmp_dir}/invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+	if ! grep -F "canonical stable vMAJOR.MINOR.PATCH" "${tmp_dir}/invalid-${invalid_tag}.out" >/dev/null; then
+		echo "check-release-tag-ancestry-test: ${invalid_tag} failure did not explain canonical stable grammar" >&2
+		cat "${tmp_dir}/invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+	if git -C "$repo_dir" rev-parse -q --verify "refs/tags/${invalid_tag}" >/dev/null; then
+		echo "check-release-tag-ancestry-test: invalid tag ${invalid_tag} was created before canonical validation rejected it" >&2
+		exit 1
+	fi
+done
+
+git -C "$repo_dir" checkout trunk >/dev/null
+git -C "$repo_dir" remote set-head origin -a >/dev/null
+output="$("$ancestry_script" --root "$repo_dir" --tag v1.0.0)"
+case "$output" in
+	*"v1.0.0"*"reachable from origin/trunk"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: origin/HEAD discovery did not report success" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+
+git -C "$repo_dir" remote set-url origin "${tmp_dir}/missing-remote.git"
+if "$ancestry_script" --root "$repo_dir" --tag v1.0.0 --default-branch trunk >"${tmp_dir}/fetch-fails.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: failed fetch with stale local ref unexpectedly passed" >&2
+	cat "${tmp_dir}/fetch-fails.out" >&2
+	exit 1
+fi
+if ! grep -F "could not fetch origin/trunk" "${tmp_dir}/fetch-fails.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: failed fetch did not explain fresh-ref requirement" >&2
+	cat "${tmp_dir}/fetch-fails.out" >&2
+	exit 1
+fi
+
+if "$prepare_script" --root "$repo_dir" --tag v1.0.0 --default-branch trunk >"${tmp_dir}/prepare-fetch-fails.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: prepare accepted stale ref after fetch failure" >&2
+	cat "${tmp_dir}/prepare-fetch-fails.out" >&2
+	exit 1
+fi
+if ! grep -F "must use fresh remote refs" "${tmp_dir}/prepare-fetch-fails.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: prepare fetch failure did not explain fresh-ref requirement" >&2
+	cat "${tmp_dir}/prepare-fetch-fails.out" >&2
+	exit 1
+fi
+
+output="$(GOSX_RELEASE_ANCESTRY_FETCH=0 "$ancestry_script" --root "$repo_dir" --tag v1.0.0 --default-branch trunk)"
+case "$output" in
+	*"v1.0.0"*"reachable from origin/trunk"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: explicit local-only mode did not use stale local ref" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+
+git -C "$repo_dir" remote set-url origin "$remote_dir"
+mkdir -p "${repo_dir}/internal/version"
+printf '%s\n' "module m31labs.dev/gosx" >"${repo_dir}/go.mod"
+printf '%s\n' "package version" "" "const Current = \"v3.0.0\"" "const Number = \"3.0.0\"" >"${repo_dir}/internal/version/version.go"
+printf '%s\n' "Current release: **v3.0.0**." >"${repo_dir}/README.md"
+printf '%s\n' "## v3.0.0" >"${repo_dir}/CHANGELOG.md"
+git -C "$repo_dir" add go.mod internal/version/version.go README.md CHANGELOG.md
+git -C "$repo_dir" commit -m "prepare v3.0.0 release truth" >/dev/null
+git -C "$repo_dir" push origin trunk >/dev/null
+trunk_head="$(git -C "$repo_dir" rev-parse HEAD)"
+
+output="$("$prepare_script" --root "$repo_dir" --tag v3.0.0 --default-branch trunk --create --expected-commit "$trunk_head")"
+case "$output" in
+	*"mode=created"*"tag=v3.0.0"*"source_ref=${trunk_head}"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: new default-head tag was not created" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+created_commit="$(git -C "$repo_dir" rev-parse "refs/tags/v3.0.0^{commit}")"
+remote_created_commit="$(git --git-dir="$remote_dir" rev-parse "refs/tags/v3.0.0^{commit}")"
+if [ "$created_commit" != "$trunk_head" ] || [ "$remote_created_commit" != "$trunk_head" ]; then
+	echo "check-release-tag-ancestry-test: new tag was not created at fresh default HEAD" >&2
+	exit 1
+fi
+
+output="$("$prepare_script" --root "$repo_dir" --tag v3.0.0 --default-branch trunk --create --expected-commit "$trunk_head")"
+case "$output" in
+	*"mode=existing"*"tag=v3.0.0"*) ;;
+	*)
+		echo "check-release-tag-ancestry-test: rerun did not treat existing tag idempotently" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+
+printf '%s\n' "default branch still advances" >>"${repo_dir}/file.txt"
+git -C "$repo_dir" add file.txt
+git -C "$repo_dir" commit -m "advance default after v3.0.0" >/dev/null
+git -C "$repo_dir" push origin trunk >/dev/null
+moved_tag_commit="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" tag -f -a v3.0.0 "$moved_tag_commit" -m "Moved v3.0.0" >/dev/null
+git -C "$repo_dir" push --force origin "refs/tags/v3.0.0" >/dev/null
+if "$prepare_script" --root "$repo_dir" --tag v3.0.0 --default-branch trunk --create --expected-commit "$trunk_head" >"${tmp_dir}/moved-tag.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: forced in-line tag move unexpectedly passed" >&2
+	cat "${tmp_dir}/moved-tag.out" >&2
+	exit 1
+fi
+if ! grep -F "release tag state changed after preparation" "${tmp_dir}/moved-tag.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: forced tag move failure did not explain prepared commit mismatch" >&2
+	cat "${tmp_dir}/moved-tag.out" >&2
+	exit 1
+fi
+
+printf '%s\n' "package version" "" "const Current = \"v4.0.0\"" "const Number = \"4.0.0\"" >"${repo_dir}/internal/version/version.go"
+printf '%s\n' "Current release: **v4.0.0**." >"${repo_dir}/README.md"
+printf '%s\n' "## v4.0.0" >"${repo_dir}/CHANGELOG.md"
+git -C "$repo_dir" add internal/version/version.go README.md CHANGELOG.md
+git -C "$repo_dir" commit -m "local unpushed v4.0.0 release truth" >/dev/null
+if "$prepare_script" --root "$repo_dir" --tag v4.0.0 --default-branch trunk --create --expected-commit "$moved_tag_commit" >"${tmp_dir}/not-default-head.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: new tag from non-default HEAD unexpectedly passed" >&2
+	cat "${tmp_dir}/not-default-head.out" >&2
+	exit 1
+fi
+if ! grep -F "must be created at origin/trunk HEAD" "${tmp_dir}/not-default-head.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: non-default HEAD failure did not explain exact HEAD requirement" >&2
+	cat "${tmp_dir}/not-default-head.out" >&2
+	exit 1
+fi
+
+printf '%s\n' "Current release: **v4.0.0**." "Current release: **v3.0.0**." >"${repo_dir}/README.md"
+if "$script_dir/check-release-source-truth.sh" --root "$repo_dir" --tag v4.0.0 >"${tmp_dir}/stale-readme.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: stale duplicate README release unexpectedly passed" >&2
+	cat "${tmp_dir}/stale-readme.out" >&2
+	exit 1
+fi
+if ! grep -F "stale current-release statement" "${tmp_dir}/stale-readme.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: stale README failure did not explain duplicate release truth" >&2
+	cat "${tmp_dir}/stale-readme.out" >&2
+	exit 1
+fi
+
+for valid_tag in v0.0.0 v0.2.3 v1.0.3 v1.2.0; do
+	valid_number="${valid_tag#v}"
+	printf '%s\n' "package version" "" "const Current = \"${valid_tag}\"" "const Number = \"${valid_number}\"" >"${repo_dir}/internal/version/version.go"
+	printf '%s\n' "Current release: **${valid_tag}**." >"${repo_dir}/README.md"
+	printf '%s\n' "## ${valid_tag}" >"${repo_dir}/CHANGELOG.md"
+	"$script_dir/check-release-source-truth.sh" --root "$repo_dir" --tag "$valid_tag" >/dev/null
+done
+for invalid_tag in v01.2.3 v1.02.3 v1.2.03; do
+	if "$script_dir/check-release-source-truth.sh" --root "$repo_dir" --tag "$invalid_tag" >"${tmp_dir}/source-invalid-${invalid_tag}.out" 2>&1; then
+		echo "check-release-tag-ancestry-test: source truth accepted non-canonical tag ${invalid_tag}" >&2
+		cat "${tmp_dir}/source-invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+	if ! grep -F "canonical stable vMAJOR.MINOR.PATCH" "${tmp_dir}/source-invalid-${invalid_tag}.out" >/dev/null; then
+		echo "check-release-tag-ancestry-test: source truth ${invalid_tag} failure did not explain canonical grammar" >&2
+		cat "${tmp_dir}/source-invalid-${invalid_tag}.out" >&2
+		exit 1
+	fi
+done
+
+if "$workflow_ref_script" --workflow-ref-type branch --workflow-ref-name release/v3 --workflow-ref refs/heads/release/v3 --default-branch trunk >"${tmp_dir}/workflow-ref-name.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: non-default workflow ref unexpectedly passed" >&2
+	cat "${tmp_dir}/workflow-ref-name.out" >&2
+	exit 1
+fi
+if ! grep -F "ref name must be trunk" "${tmp_dir}/workflow-ref-name.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: workflow ref failure did not explain default branch requirement" >&2
+	cat "${tmp_dir}/workflow-ref-name.out" >&2
+	exit 1
+fi
+if "$workflow_ref_script" --workflow-ref-type tag --workflow-ref-name main --workflow-ref refs/tags/main --default-branch main >"${tmp_dir}/workflow-ref-type.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: tag workflow ref named main unexpectedly passed" >&2
+	cat "${tmp_dir}/workflow-ref-type.out" >&2
+	exit 1
+fi
+if ! grep -F "must run from a branch ref" "${tmp_dir}/workflow-ref-type.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: tag ref failure did not explain branch type requirement" >&2
+	cat "${tmp_dir}/workflow-ref-type.out" >&2
+	exit 1
+fi
+if "$workflow_ref_script" --workflow-ref-type branch --workflow-ref-name main --workflow-ref refs/tags/main --default-branch main >"${tmp_dir}/workflow-ref-full.out" 2>&1; then
+	echo "check-release-tag-ancestry-test: wrong full workflow ref unexpectedly passed" >&2
+	cat "${tmp_dir}/workflow-ref-full.out" >&2
+	exit 1
+fi
+if ! grep -F "ref must be refs/heads/main" "${tmp_dir}/workflow-ref-full.out" >/dev/null; then
+	echo "check-release-tag-ancestry-test: full ref failure did not explain refs/heads requirement" >&2
+	cat "${tmp_dir}/workflow-ref-full.out" >&2
+	exit 1
+fi
+"$workflow_ref_script" --workflow-ref-type branch --workflow-ref-name trunk --workflow-ref refs/heads/trunk --default-branch trunk >/dev/null
+
+echo "check-release-tag-ancestry-test: all checks passed"

--- a/scripts/check-release-tag-ancestry.sh
+++ b/scripts/check-release-tag-ancestry.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-release-tag-ancestry.sh [--root DIR] [--tag vX.Y.Z] [--default-branch BRANCH] [--remote REMOTE]" >&2
+}
+
+repo_root="."
+release_tag=""
+default_branch="${RELEASE_DEFAULT_BRANCH:-${GITHUB_DEFAULT_BRANCH:-}}"
+remote_name="${GOSX_RELEASE_REMOTE:-origin}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			repo_root="$2"
+			shift 2
+			;;
+		--tag)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			release_tag="$2"
+			shift 2
+			;;
+		--default-branch)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			default_branch="$2"
+			shift 2
+			;;
+		--remote)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			remote_name="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "check-release-tag-ancestry: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ -z "$release_tag" ]; then
+	if [ "${GITHUB_REF_TYPE:-}" = "tag" ]; then
+		release_tag="${GITHUB_REF_NAME:-}"
+	fi
+fi
+if [ -z "$release_tag" ] && [ -n "${GITHUB_REF:-}" ]; then
+	case "$GITHUB_REF" in
+		refs/tags/*) release_tag="${GITHUB_REF#refs/tags/}" ;;
+	esac
+fi
+if [ -z "$release_tag" ]; then
+	release_tag="${RELEASE_TAG:-${CI_COMMIT_TAG:-}}"
+fi
+if [ -z "$release_tag" ]; then
+	echo "check-release-tag-ancestry: no release tag in this environment; skipping"
+	exit 0
+fi
+
+if [ -z "$default_branch" ]; then
+	default_ref="$(git -C "$repo_root" symbolic-ref -q --short "refs/remotes/${remote_name}/HEAD" || true)"
+	if [ -n "$default_ref" ]; then
+		default_branch="${default_ref#${remote_name}/}"
+	fi
+fi
+if [ -z "$default_branch" ] && command -v gh >/dev/null 2>&1; then
+	default_branch="$(gh repo view --json defaultBranchRef --jq '.defaultBranchRef.name' 2>/dev/null || true)"
+fi
+if [ -z "$default_branch" ]; then
+	echo "check-release-tag-ancestry: could not determine the repository default branch" >&2
+	echo "set RELEASE_DEFAULT_BRANCH or pass --default-branch" >&2
+	exit 1
+fi
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+sh "${script_dir}/check-release-tag-grammar.sh" "$release_tag" || exit 1
+
+tag_commit="$(git -C "$repo_root" rev-parse -q --verify "refs/tags/${release_tag}^{commit}" || true)"
+if [ -z "$tag_commit" ]; then
+	echo "check-release-tag-ancestry: tag does not resolve to a commit: ${release_tag}" >&2
+	exit 1
+fi
+
+default_remote_ref="refs/remotes/${remote_name}/${default_branch}"
+if [ "${GOSX_RELEASE_ANCESTRY_FETCH:-1}" != "0" ]; then
+	if ! git -C "$repo_root" fetch --no-tags "$remote_name" "+refs/heads/${default_branch}:${default_remote_ref}"; then
+		echo "check-release-tag-ancestry: could not fetch ${remote_name}/${default_branch}" >&2
+		echo "release ancestry must be checked against a fresh default-branch ref" >&2
+		exit 1
+	fi
+fi
+
+default_commit="$(git -C "$repo_root" rev-parse -q --verify "${default_remote_ref}^{commit}" || true)"
+if [ -z "$default_commit" ]; then
+	echo "check-release-tag-ancestry: default branch ref is missing: ${default_remote_ref}" >&2
+	exit 1
+fi
+
+if ! git -C "$repo_root" merge-base --is-ancestor "$tag_commit" "$default_commit"; then
+	echo "check-release-tag-ancestry: ${release_tag} (${tag_commit}) is not reachable from ${remote_name}/${default_branch} (${default_commit})" >&2
+	echo "merge the exact tag commit into the default branch before creating or rerunning the release" >&2
+	exit 1
+fi
+
+echo "check-release-tag-ancestry: ${release_tag} (${tag_commit}) is reachable from ${remote_name}/${default_branch} (${default_commit})"

--- a/scripts/check-release-tag-grammar.sh
+++ b/scripts/check-release-tag-grammar.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-release-tag-grammar.sh TAG" >&2
+}
+
+if [ "$#" -ne 1 ]; then
+	usage
+	exit 2
+fi
+
+release_tag="$1"
+
+reject() {
+	echo "release tag must be canonical stable vMAJOR.MINOR.PATCH with no leading numeric zeroes" >&2
+	exit 1
+}
+
+case "$release_tag" in
+	*'
+'*) reject ;;
+esac
+carriage_return="$(printf '\r')"
+case "$release_tag" in
+	*"$carriage_return"*) reject ;;
+esac
+
+case "$release_tag" in
+	v*.*.*) ;;
+	*) reject ;;
+esac
+
+version="${release_tag#v}"
+major="${version%%.*}"
+rest="${version#*.}"
+minor="${rest%%.*}"
+patch="${rest#*.}"
+
+case "$patch" in
+	*.*) reject ;;
+esac
+
+check_component() {
+	component="$1"
+	case "$component" in
+		"") reject ;;
+		*[!0123456789]*) reject ;;
+		0) return 0 ;;
+		0*) reject ;;
+	esac
+}
+
+check_component "$major"
+check_component "$minor"
+check_component "$patch"

--- a/scripts/check-release-workflow-ref.sh
+++ b/scripts/check-release-workflow-ref.sh
@@ -1,0 +1,77 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-release-workflow-ref.sh [--workflow-ref-type TYPE] [--workflow-ref-name NAME] [--workflow-ref REF] [--default-branch BRANCH]" >&2
+}
+
+workflow_ref_type="${GITHUB_REF_TYPE:-}"
+workflow_ref_name="${GITHUB_REF_NAME:-}"
+workflow_ref="${GITHUB_REF:-}"
+default_branch="${RELEASE_DEFAULT_BRANCH:-${GITHUB_DEFAULT_BRANCH:-}}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--workflow-ref-type)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			workflow_ref_type="$2"
+			shift 2
+			;;
+		--workflow-ref-name)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			workflow_ref_name="$2"
+			shift 2
+			;;
+		--workflow-ref)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			workflow_ref="$2"
+			shift 2
+			;;
+		--default-branch)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			default_branch="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "check-release-workflow-ref: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ -z "$workflow_ref_type" ]; then
+	echo "check-release-workflow-ref: workflow ref type is required" >&2
+	exit 1
+fi
+if [ -z "$workflow_ref_name" ]; then
+	echo "check-release-workflow-ref: workflow ref name is required" >&2
+	exit 1
+fi
+if [ -z "$workflow_ref" ]; then
+	echo "check-release-workflow-ref: full workflow ref is required" >&2
+	exit 1
+fi
+if [ -z "$default_branch" ]; then
+	echo "check-release-workflow-ref: default branch is required" >&2
+	exit 1
+fi
+if [ "$workflow_ref_type" != "branch" ]; then
+	echo "check-release-workflow-ref: release workflow must run from a branch ref, got type ${workflow_ref_type}" >&2
+	exit 1
+fi
+if [ "$workflow_ref_name" != "$default_branch" ]; then
+	echo "check-release-workflow-ref: release workflow ref name must be ${default_branch}, got ${workflow_ref_name}" >&2
+	exit 1
+fi
+expected_ref="refs/heads/${default_branch}"
+if [ "$workflow_ref" != "$expected_ref" ]; then
+	echo "check-release-workflow-ref: release workflow ref must be ${expected_ref}, got ${workflow_ref}" >&2
+	exit 1
+fi
+
+echo "check-release-workflow-ref: release workflow ref ${workflow_ref_type} ${workflow_ref_name} ${workflow_ref} matches default branch"

--- a/scripts/check-release-workflow-topology.sh
+++ b/scripts/check-release-workflow-topology.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env sh
+set -eu
+
+workflow="${1:-.github/workflows/release-governed.yml}"
+
+if grep -n 'ssh-key:' "$workflow" >/dev/null; then
+	echo "check-release-workflow-topology: release workflow checkout must not use ssh-key" >&2
+	exit 1
+fi
+if ! grep -n 'environment: governed-release' "$workflow" >/dev/null; then
+	echo "check-release-workflow-topology: publish job must use governed-release environment" >&2
+	exit 1
+fi
+
+tag_step="$(awk '
+	/- name: Ensure release tag exists/ { in_step = 1 }
+	/- uses: actions\/download-artifact/ { in_step = 0 }
+	in_step { print }
+' "$workflow")"
+if [ -z "$tag_step" ]; then
+	echo "check-release-workflow-topology: could not locate tag creation step" >&2
+	exit 1
+fi
+
+total_secret_count="$(grep -c 'GOSX_RELEASE_TAG_DEPLOY_KEY' "$workflow" || true)"
+tag_secret_count="$(printf '%s\n' "$tag_step" | grep -c 'GOSX_RELEASE_TAG_DEPLOY_KEY' || true)"
+if [ "$total_secret_count" -eq 0 ] || [ "$total_secret_count" -ne "$tag_secret_count" ]; then
+	echo "check-release-workflow-topology: deploy-key secret must occur only in the tag step" >&2
+	exit 1
+fi
+environment_line="$(grep -n 'environment: governed-release' "$workflow" | cut -d: -f1 | head -n 1)"
+first_secret_line="$(grep -n 'GOSX_RELEASE_TAG_DEPLOY_KEY' "$workflow" | cut -d: -f1 | head -n 1)"
+if [ -z "$environment_line" ] || [ -z "$first_secret_line" ] || [ "$environment_line" -ge "$first_secret_line" ]; then
+	echo "check-release-workflow-topology: deploy-key secret must be inside environment-gated publish job" >&2
+	exit 1
+fi
+
+for pattern in \
+	'mktemp -d "${RUNNER_TEMP}/gosx-release-ssh.' \
+	'chmod 700 "${release_ssh_dir}"' \
+	'chmod 600 "${key_file}"' \
+	'https://api.github.com/meta' \
+	'test -s "${known_hosts_file}"' \
+	'remote add release-origin' \
+	'remote remove release-origin' \
+	'shred -u "${key_file}"' \
+	'GIT_SSH_COMMAND=' \
+	'--remote release-origin'
+do
+	if ! printf '%s\n' "$tag_step" | grep -F -- "$pattern" >/dev/null; then
+		echo "check-release-workflow-topology: missing tag-step pattern: $pattern" >&2
+		exit 1
+	fi
+done
+
+download_line="$(grep -n -- '- uses: actions/download-artifact' "$workflow" | cut -d: -f1 | head -n 1)"
+trap_line="$(grep -n 'trap cleanup_release_ssh EXIT' "$workflow" | cut -d: -f1 | head -n 1)"
+remote_remove_line="$(grep -n 'remote remove release-origin' "$workflow" | cut -d: -f1 | head -n 1)"
+if [ -z "$download_line" ] || [ -z "$trap_line" ] || [ -z "$remote_remove_line" ]; then
+	echo "check-release-workflow-topology: could not prove cleanup ordering" >&2
+	exit 1
+fi
+if [ "$trap_line" -ge "$download_line" ] || [ "$remote_remove_line" -ge "$download_line" ]; then
+	echo "check-release-workflow-topology: cleanup must be defined before download/release actions" >&2
+	exit 1
+fi
+
+echo "check-release-workflow-topology: governed workflow topology passed"

--- a/scripts/prepare-release-tag.sh
+++ b/scripts/prepare-release-tag.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: prepare-release-tag.sh --tag vX.Y.Z --default-branch BRANCH [--root DIR] [--remote REMOTE] [--create --expected-commit SHA] [--github-output FILE]" >&2
+}
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repo_root=""
+release_tag=""
+default_branch="${RELEASE_DEFAULT_BRANCH:-${GITHUB_DEFAULT_BRANCH:-}}"
+remote_name="${GOSX_RELEASE_REMOTE:-origin}"
+create_tag=0
+github_output=""
+expected_commit=""
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			repo_root="$2"
+			shift 2
+			;;
+		--tag)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			release_tag="$2"
+			shift 2
+			;;
+		--default-branch)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			default_branch="$2"
+			shift 2
+			;;
+		--remote)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			remote_name="$2"
+			shift 2
+			;;
+		--create)
+			create_tag=1
+			shift
+			;;
+		--expected-commit)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			expected_commit="$2"
+			shift 2
+			;;
+		--github-output)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			github_output="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "prepare-release-tag: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+if [ -z "$release_tag" ]; then
+	echo "prepare-release-tag: release tag is required" >&2
+	exit 1
+fi
+if [ -z "$default_branch" ]; then
+	echo "prepare-release-tag: default branch is required" >&2
+	exit 1
+fi
+sh "${script_dir}/check-release-tag-grammar.sh" "$release_tag" || exit 1
+if [ "$create_tag" -eq 1 ] && [ -z "$expected_commit" ]; then
+	echo "prepare-release-tag: --expected-commit is required with --create" >&2
+	exit 1
+fi
+
+git_root="${repo_root:-.}"
+default_remote_ref="refs/remotes/${remote_name}/${default_branch}"
+if ! git -C "$git_root" fetch --tags --force "$remote_name" "+refs/heads/${default_branch}:${default_remote_ref}"; then
+	echo "prepare-release-tag: could not fetch ${remote_name}/${default_branch} and tags" >&2
+	echo "release tag preparation must use fresh remote refs" >&2
+	exit 1
+fi
+
+default_commit="$(git -C "$git_root" rev-parse -q --verify "${default_remote_ref}^{commit}" || true)"
+if [ -z "$default_commit" ]; then
+	echo "prepare-release-tag: default branch ref is missing: ${default_remote_ref}" >&2
+	exit 1
+fi
+
+tag_commit="$(git -C "$git_root" rev-parse -q --verify "refs/tags/${release_tag}^{commit}" || true)"
+mode="create"
+source_ref="$default_commit"
+release_commit="$default_commit"
+
+if [ -n "$tag_commit" ]; then
+	if [ -n "$expected_commit" ] && [ "$tag_commit" != "$expected_commit" ]; then
+		echo "prepare-release-tag: ${release_tag} now resolves to ${tag_commit}, expected ${expected_commit}" >&2
+		echo "release tag state changed after preparation" >&2
+		exit 1
+	fi
+	if ! git -C "$git_root" merge-base --is-ancestor "$tag_commit" "$default_commit"; then
+		echo "prepare-release-tag: ${release_tag} (${tag_commit}) is not reachable from ${remote_name}/${default_branch} (${default_commit})" >&2
+		echo "release tags must belong to canonical default-branch lineage" >&2
+		exit 1
+	fi
+	mode="existing"
+	source_ref="$tag_commit"
+	release_commit="$tag_commit"
+elif [ "$create_tag" -eq 1 ]; then
+	if [ -z "$repo_root" ]; then
+		echo "prepare-release-tag: --root is required when creating a tag" >&2
+		exit 1
+	fi
+	source_head="$(git -C "$repo_root" rev-parse -q --verify HEAD || true)"
+	if [ "$source_head" != "$default_commit" ]; then
+		echo "prepare-release-tag: new tag ${release_tag} must be created at ${remote_name}/${default_branch} HEAD ${default_commit}, got ${source_head}" >&2
+		exit 1
+	fi
+	if [ "$expected_commit" != "$default_commit" ]; then
+		echo "prepare-release-tag: fresh ${remote_name}/${default_branch} HEAD ${default_commit} does not match prepared commit ${expected_commit}" >&2
+		exit 1
+	fi
+	sh "${script_dir}/check-release-source-truth.sh" --root "$repo_root" --tag "$release_tag" >/dev/null
+	git -C "$repo_root" tag -a "$release_tag" "$default_commit" -m "Release ${release_tag}"
+	git -C "$repo_root" push "$remote_name" "refs/tags/${release_tag}"
+	mode="created"
+	source_ref="$default_commit"
+	release_commit="$default_commit"
+fi
+
+if [ -n "$github_output" ]; then
+	{
+		printf 'mode=%s\n' "$mode"
+		printf 'source_ref=%s\n' "$source_ref"
+		printf 'commit=%s\n' "$release_commit"
+	} >>"$github_output"
+fi
+
+echo "prepare-release-tag: mode=${mode} tag=${release_tag} commit=${release_commit} source_ref=${source_ref}"


### PR DESCRIPTION
## Summary

This PR moves GoSX release orchestration under the repository default branch and closes the stale tag-push/manual-dispatch release paths without rewriting historical tags.

- Adds a new default-branch-only governed workflow identity at `.github/workflows/release-governed.yml`.
- Removes the legacy `.github/workflows/release.yml` identity from current main. The live legacy workflow id `317758615` is already `disabled_manually`.
- Removes automatic `push.tags` release triggering; releases are `workflow_dispatch` only with an explicit `tag` input.
- Hard-fails unless the workflow run ref is the repository default branch by checking all three of `GITHUB_REF_TYPE=branch`, `GITHUB_REF_NAME == github.event.repository.default_branch`, and `GITHUB_REF == refs/heads/<default>`.

## Release integrity

- Keeps policy scripts on the default-branch checkout and checks release source out separately under `source/`, preserving historical tag reruns even if the historical tag lacks current policy scripts.
- Emits immutable source refs as resolved commit SHAs, not mutable tag names.
- Re-fetches default/tag state at publish time to prevent TOCTOU races:
  - existing tags must still resolve to the prepared commit;
  - new tags can be created only at the exact fresh default-branch HEAD;
  - source HEAD, fresh default HEAD, and prepared commit must all match.
- Restores the full Go release checker in validation via `go run ./cmd/gosx release check --root .` from `source/` with explicit tag env, while policy-side shell checks cover module/version/README/changelog truth.

## Release authority and companion controls

- Scopes `contents: write` to the publish job only; top-level permissions remain `contents: read`.
- Uses environment `governed-release` for publish so the deploy key secret is available only to environment-approved main-ref runs.
- Keeps every checkout credentialless with `persist-credentials:false`; the publish source checkout has no `ssh-key`.
- Exposes `GOSX_RELEASE_TAG_DEPLOY_KEY` only in the single `Ensure release tag exists` step, writes it to a temporary `0600` key file under `RUNNER_TEMP`, uses GitHub SSH host keys from the TLS-authenticated `/meta` endpoint, adds a temporary `release-origin` remote, scopes `GIT_SSH_COMMAND` to the tag preparation command, and removes the remote/key/known_hosts/temp dir via an `EXIT` trap before later release steps.
- Companion GitHub control is live outside this PR: tag ruleset id `21831147` (`Governed semantic releases`) restricts create/update/delete of `refs/tags/v*` to the verified write deploy key. The environment is `governed-release` id `20856976314`, with `can_admins_bypass=false`; the environment secret exists and the repository-level secret has been deleted.

## Canonical tag grammar

- Centralizes canonical stable Go SemVer validation in `scripts/check-release-tag-grammar.sh`.
- Accepts only `vMAJOR.MINOR.PATCH`, where each numeric component is either literal `0` or a nonzero digit followed by digits.
- Rejects leading-zero numeric components, prerelease suffixes, build metadata, CR/LF, multiline payloads, whitespace, and control-character payloads before fetch or tag creation can run.

## CI governance

- Wires deterministic release-lineage and governed-workflow topology fixtures into `release-gate`.
- Updates the aggregate `test` job so it depends on `release-gate`; branch protection that requires only aggregate `test` now also gates release policy.

## Test evidence

Passed locally in `/home/draco/worktrees/codex-gosx-release-truth-20260829`:

- `make release-gate`
- `make test-release-workflow`
- `sh scripts/check-release-tag-ancestry-test.sh`
- `actionlint .github/workflows/ci.yml .github/workflows/release-governed.yml`
- `sh -n` on all release-governance scripts
- `git diff --check`
- `sh scripts/check-release-source-truth.sh --root . --tag v0.53.9`
- `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.53.9 GITHUB_REF=refs/tags/v0.53.9 go run ./cmd/gosx release check --root .`
- `go test ./cmd/gosx -run 'TestRunReleaseCheckCommandPassesCurrentRepo|TestCheckCITag|TestReleaseCheck'`
- `RELEASE_DEFAULT_BRANCH=main RELEASE_TAG=v0.53.9 sh scripts/check-release-tag-ancestry.sh --root .`

No tag or GitHub release was created by this PR work.

## Rollback note

If this needs to be backed out, revert this PR and keep the external tag ruleset/environment/deploy-key controls in place until a replacement governed release workflow is merged. Removing the companion controls first would reopen stale or human-created `refs/tags/v*` release paths.
