### PR TITLE
fix(perf): isolate route collection deadlines

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -349,6 +349,17 @@ jobs:
           CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
         run: make perf-budget-ci
 
+      - name: Upload perf budget failure diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-budget-diagnostics-${{ github.run_id }}-${{ github.run_attempt }}
+          path: |
+            build/perf-report.json
+            build/perf-server.log
+          if-no-files-found: ignore
+          retention-days: 7
+
   # test: kept as the lightweight aggregate required-check surface. It must
   # include release-gate so branch protection on the aggregate `test` check also
   # gates release policy and governed workflow topology.

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ GOFILES := $(shell find . -name '*.go' -not -path './dist/*' -not -path './build
 DMJFILES := $(shell find . -name '*.dmj' -not -path './dist/*' -not -path './build/*')
 DMJGOFILES := $(patsubst %.dmj,%_danmuji_test.go,$(DMJFILES))
 
-.PHONY: fmt fmt-check verify-fmt verify-danmuji canopy-index canopy-stats canopy-clean build-bootstrap test test-unit test-cli test-ci-partitions test-race test-race-pr test-fuzz-smoke test-js test-runtime-types test-editor test-wasm test-wasm-islands wasm-size-budget test-e2e test-perf-browser test-ouroboros-smoke test-water-prod test-water-profile-evidence water-profile-evidence test-desktop test-desktop-macos test-docs-deploy test-release-workflow test-release-ancestry test-repo-hygiene perf-budget perf-budget-ci build-cli build-desktop-windows build-desktop-macos build-runtime ci test-motion-parity test-physics-parity release-gate
+.PHONY: fmt fmt-check verify-fmt verify-danmuji canopy-index canopy-stats canopy-clean build-bootstrap test test-unit test-cli test-ci-partitions test-race test-race-pr test-fuzz-smoke test-js test-runtime-types test-editor test-wasm test-wasm-islands wasm-size-budget test-e2e test-perf-browser test-ouroboros-smoke test-water-prod test-water-profile-evidence water-profile-evidence test-desktop test-desktop-macos test-docs-deploy test-release-workflow test-release-ancestry test-repo-hygiene test-perf-budget-ci perf-budget perf-budget-ci build-cli build-desktop-windows build-desktop-macos build-runtime ci test-motion-parity test-physics-parity release-gate
 
 fmt:
 	$(GOFMT) -w $(GOFILES)
@@ -351,7 +351,9 @@ build-runtime:
 #      contract accepts canonical release commits and rejects side-branch tags.
 #   8. live release tag ancestry - when a release tag is present, that exact tag
 #      commit must already be reachable from the fresh remote default branch.
-#   9. module-zip smoke (`git archive --format=zip`) - reproduces the exact
+#   9. perf budget CI wrapper - proves browser-lane failures preserve the
+#      partial report/server log without hiding budget failures.
+#   10. module-zip smoke (`git archive --format=zip`) - reproduces the exact
 #      operation that broke v0.29.0 so a zip-breaking commit fails fast.
 test-docs-deploy:
 	sh scripts/deploy-gosx-docs-concurrency-test.sh
@@ -367,32 +369,37 @@ test-repo-hygiene:
 	sh scripts/check-repo-hygiene.sh --root .
 	sh scripts/check-repo-hygiene-test.sh
 
+test-perf-budget-ci:
+	sh scripts/perf-budget-ci-test.sh
+
 release-gate:
-	@echo "release-gate (1/9): go run ./cmd/gosx release check"
+	@echo "release-gate (1/10): go run ./cmd/gosx release check"
 	$(GO) run ./cmd/gosx release check
-	@echo "release-gate (2/9): go.mod replace-directive scan"
+	@echo "release-gate (2/10): go.mod replace-directive scan"
 	@if grep -E '^replace ' go.mod; then \
 		echo "release-gate: go.mod has a replace directive; 'go run mod@version' fails with any replace present (this is why v0.27.0 was a bad tag). Remove it before release."; \
 		exit 1; \
 	fi
-	@echo "release-gate (3/9): tracked-filename scan"
+	@echo "release-gate (3/10): tracked-filename scan"
 	@bad="$$(git ls-files | grep -E '[:"|<>?*[:cntrl:]]' || true)"; \
 	if [ -n "$$bad" ]; then \
 		echo "release-gate: tracked filenames contain characters Go's module zip format rejects (a file like this broke v0.29.0's module zip and forced its retraction):"; \
 		echo "$$bad"; \
 		exit 1; \
 	fi
-	@echo "release-gate (4/9): repository hygiene"
+	@echo "release-gate (4/10): repository hygiene"
 	@$(MAKE) --no-print-directory test-repo-hygiene
-	@echo "release-gate (5/9): docs deploy transaction regression"
+	@echo "release-gate (5/10): docs deploy transaction regression"
 	@$(MAKE) --no-print-directory test-docs-deploy
-	@echo "release-gate (6/9): governed release workflow topology"
+	@echo "release-gate (6/10): governed release workflow topology"
 	@$(MAKE) --no-print-directory test-release-workflow
-	@echo "release-gate (7/9): release tag ancestry regression"
+	@echo "release-gate (7/10): release tag ancestry regression"
 	@$(MAKE) --no-print-directory test-release-ancestry
-	@echo "release-gate (8/9): live release tag ancestry"
+	@echo "release-gate (8/10): live release tag ancestry"
 	@sh scripts/check-release-tag-ancestry.sh --root .
-	@echo "release-gate (9/9): module-zip smoke (git archive --format=zip)"
+	@echo "release-gate (9/10): perf budget CI wrapper regression"
+	@$(MAKE) --no-print-directory test-perf-budget-ci
+	@echo "release-gate (10/10): module-zip smoke (git archive --format=zip)"
 	@git archive --format=zip -o /dev/null HEAD
 	@echo "release-gate: all gates passed"
 

--- a/cmd/gosx/perf.go
+++ b/cmd/gosx/perf.go
@@ -88,6 +88,9 @@ func cmdPerf() {
 
 	report, err := perf.RunScenario(scenario)
 	if err != nil {
+		if *jsonOut {
+			emitPartialPerfReportJSON(report)
+		}
 		fatal("gosx perf: %v", err)
 	}
 
@@ -150,6 +153,18 @@ func cmdPerf() {
 			os.Exit(1)
 		}
 	}
+}
+
+func emitPartialPerfReportJSON(report *perf.Report) {
+	if report == nil || len(report.Pages) == 0 {
+		return
+	}
+	data, err := perf.FormatJSON(report)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "gosx perf: partial json: %v\n", err)
+		return
+	}
+	fmt.Println(string(data))
 }
 
 // cmdPerfCompare implements `gosx perf compare baseline.json candidate.json`.

--- a/cmd/gosx/perf_browser_test.go
+++ b/cmd/gosx/perf_browser_test.go
@@ -1,0 +1,93 @@
+//go:build browser
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"m31labs.dev/gosx/perf"
+)
+
+func TestPerfCLIPrintsPartialJSONOnCollectionFailure(t *testing.T) {
+	requireChromeForPerfCLI(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/ok":
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><h1>ok</h1></body></html>`)
+		case "/slow":
+			time.Sleep(2 * time.Second)
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprint(w, `<html><body><h1>slow</h1></body></html>`)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	cmd := exec.Command("go", "run", "./cmd/gosx", "perf",
+		"--json",
+		"--timeout", "750ms",
+		srv.URL+"/ok",
+		srv.URL+"/slow",
+	)
+	cmd.Dir = moduleRootForPerfCLITest(t)
+	cmd.Env = append(os.Environ(), "GOSX_CHROME_NO_SANDBOX=1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gosx perf unexpectedly succeeded:\n%s", string(out))
+	}
+	text := string(out)
+	start := strings.Index(text, "{")
+	if start < 0 {
+		t.Fatalf("expected partial JSON on stdout/stderr, got:\n%s", text)
+	}
+	end := strings.LastIndex(text, "}")
+	if end < start {
+		t.Fatalf("expected complete partial JSON object, got:\n%s", text)
+	}
+	var report perf.Report
+	if err := json.Unmarshal([]byte(text[start:end+1]), &report); err != nil {
+		t.Fatalf("partial JSON is not parseable: %v\n%s", err, text[start:end+1])
+	}
+	if len(report.Pages) != 1 || report.Pages[0].URL != srv.URL+"/ok" {
+		t.Fatalf("expected exactly the completed first route in partial JSON, got %#v", report.Pages)
+	}
+	if !strings.Contains(text, "route 2/2 "+srv.URL+"/slow") ||
+		!strings.Contains(text, "context deadline exceeded") {
+		t.Fatalf("expected failing route identity in CLI output, got:\n%s", text)
+	}
+}
+
+func requireChromeForPerfCLI(t *testing.T) {
+	t.Helper()
+	if _, err := perf.FindChrome(); err != nil {
+		if os.Getenv("GOSX_REQUIRE_CHROME") != "" {
+			t.Fatalf("GOSX_REQUIRE_CHROME is set, so Chrome is required for perf CLI regression: %v", err)
+		}
+		t.Skipf("skipping perf CLI regression: %v", err)
+	}
+}
+
+func moduleRootForPerfCLITest(t *testing.T) string {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	root := filepath.Clean(filepath.Join(wd, "..", ".."))
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("resolve module root from %s: %v", wd, err)
+	}
+	return root
+}

--- a/perf/driver.go
+++ b/perf/driver.go
@@ -221,10 +221,27 @@ func (d *Driver) BindTarget() error {
 
 // WithOperationContext returns a shallow Driver that uses a derived CDP context.
 func (d *Driver) WithOperationContext(parent context.Context, timeout time.Duration) (*Driver, context.CancelFunc) {
-	opCtx := d.ctx
-	var cancel context.CancelFunc
+	if parent == nil {
+		parent = context.Background()
+	}
+	baseCtx := d.ctx
+	if baseCtx == nil {
+		baseCtx = context.Background()
+	}
+	now := time.Now()
+	deadline, hasDeadline := earliestContextDeadline(baseCtx, parent)
 	if timeout > 0 {
-		opCtx, cancel = context.WithTimeout(opCtx, timeout)
+		timeoutDeadline := now.Add(timeout)
+		if !hasDeadline || timeoutDeadline.Before(deadline) {
+			deadline = timeoutDeadline
+			hasDeadline = true
+		}
+	}
+
+	opCtx := baseCtx
+	var cancel context.CancelFunc
+	if hasDeadline {
+		opCtx, cancel = context.WithDeadline(opCtx, deadline)
 	} else {
 		opCtx, cancel = context.WithCancel(opCtx)
 	}
@@ -232,6 +249,12 @@ func (d *Driver) WithOperationContext(parent context.Context, timeout time.Durat
 	go func() {
 		select {
 		case <-parent.Done():
+			if parentDeadline, ok := parent.Deadline(); ok &&
+				parent.Err() == context.DeadlineExceeded &&
+				hasDeadline &&
+				parentDeadline.Equal(deadline) {
+				return
+			}
 			cancel()
 		case <-opCtx.Done():
 		case <-done:
@@ -248,6 +271,25 @@ func (d *Driver) WithOperationContext(parent context.Context, timeout time.Durat
 			cancel()
 		})
 	}
+}
+
+func earliestContextDeadline(contexts ...context.Context) (time.Time, bool) {
+	var earliest time.Time
+	found := false
+	for _, ctx := range contexts {
+		if ctx == nil {
+			continue
+		}
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			continue
+		}
+		if !found || deadline.Before(earliest) {
+			earliest = deadline
+			found = true
+		}
+	}
+	return earliest, found
 }
 
 // Close shuts down the browser and cleans up all contexts.

--- a/perf/driver_context_test.go
+++ b/perf/driver_context_test.go
@@ -1,0 +1,150 @@
+package perf
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+type driverContextValueKey string
+
+func TestWithOperationContextEffectiveDeadlineAndCancellation(t *testing.T) {
+	tests := []struct {
+		name          string
+		driverTimeout time.Duration
+		parentTimeout time.Duration
+		opTimeout     time.Duration
+		cancelParent  bool
+		cancelDriver  bool
+		wantErr       error
+		maxWait       time.Duration
+	}{
+		{
+			name:          "timeout zero inherits parent deadline",
+			parentTimeout: 25 * time.Millisecond,
+			wantErr:       context.DeadlineExceeded,
+			maxWait:       250 * time.Millisecond,
+		},
+		{
+			name:          "parent deadline beats longer operation timeout",
+			parentTimeout: 25 * time.Millisecond,
+			opTimeout:     time.Second,
+			wantErr:       context.DeadlineExceeded,
+			maxWait:       250 * time.Millisecond,
+		},
+		{
+			name:          "shorter operation timeout beats parent deadline",
+			parentTimeout: time.Second,
+			opTimeout:     25 * time.Millisecond,
+			wantErr:       context.DeadlineExceeded,
+			maxWait:       250 * time.Millisecond,
+		},
+		{
+			name:          "driver deadline beats parent and operation timeout",
+			driverTimeout: 25 * time.Millisecond,
+			parentTimeout: time.Second,
+			opTimeout:     time.Second,
+			wantErr:       context.DeadlineExceeded,
+			maxWait:       250 * time.Millisecond,
+		},
+		{
+			name:         "manual parent cancellation wins promptly",
+			opTimeout:    time.Second,
+			cancelParent: true,
+			wantErr:      context.Canceled,
+			maxWait:      250 * time.Millisecond,
+		},
+		{
+			name:          "driver cancellation always wins",
+			parentTimeout: time.Second,
+			opTimeout:     time.Second,
+			cancelDriver:  true,
+			wantErr:       context.Canceled,
+			maxWait:       250 * time.Millisecond,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			driverCtx := context.WithValue(context.Background(), driverContextValueKey("driver"), "preserved")
+			driverCancel := func() {}
+			if tt.driverTimeout > 0 {
+				driverCtx, driverCancel = context.WithTimeout(driverCtx, tt.driverTimeout)
+			} else {
+				driverCtx, driverCancel = context.WithCancel(driverCtx)
+			}
+			defer driverCancel()
+
+			parentCtx := context.WithValue(context.Background(), driverContextValueKey("parent"), "external")
+			parentCancel := func() {}
+			if tt.parentTimeout > 0 {
+				parentCtx, parentCancel = context.WithTimeout(parentCtx, tt.parentTimeout)
+			} else {
+				parentCtx, parentCancel = context.WithCancel(parentCtx)
+			}
+			defer parentCancel()
+
+			d := &Driver{ctx: driverCtx}
+			opD, cancel := d.WithOperationContext(parentCtx, tt.opTimeout)
+			defer cancel()
+
+			if got := opD.Context().Value(driverContextValueKey("driver")); got != "preserved" {
+				t.Fatalf("operation context lost driver/chromedp values: got %v", got)
+			}
+			if got := opD.Context().Value(driverContextValueKey("parent")); got != nil {
+				t.Fatalf("operation context should not be derived from external parent values, got %v", got)
+			}
+
+			if tt.cancelParent {
+				parentCancel()
+			}
+			if tt.cancelDriver {
+				driverCancel()
+			}
+
+			err := waitForContextErr(t, opD.Context(), tt.maxWait)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("operation context err = %v, want %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWithOperationContextPreviousParentDeadlineProbe(t *testing.T) {
+	parent, parentCancel := context.WithTimeout(context.Background(), 25*time.Millisecond)
+	defer parentCancel()
+
+	d := &Driver{ctx: context.Background()}
+	opD, cancel := d.WithOperationContext(parent, time.Second)
+	defer cancel()
+
+	err := waitForContextErr(t, opD.Context(), 250*time.Millisecond)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("operation context err = %v, want deadline exceeded", err)
+	}
+}
+
+func TestWithOperationContextReturnedCancelStopsOperation(t *testing.T) {
+	d := &Driver{ctx: context.Background()}
+	opD, cancel := d.WithOperationContext(context.Background(), time.Second)
+	cancel()
+
+	err := waitForContextErr(t, opD.Context(), 250*time.Millisecond)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("operation context err = %v, want canceled", err)
+	}
+}
+
+func waitForContextErr(t *testing.T, ctx context.Context, maxWait time.Duration) error {
+	t.Helper()
+	timer := time.NewTimer(maxWait)
+	defer timer.Stop()
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-timer.C:
+		t.Fatalf("operation context still live after %s", maxWait)
+		return nil
+	}
+}

--- a/perf/metrics.go
+++ b/perf/metrics.go
@@ -1,6 +1,7 @@
 package perf
 
 import (
+	"fmt"
 	"math"
 	"sort"
 	"strconv"
@@ -258,14 +259,67 @@ type InteractionMetric struct {
 	PatchCount int     `json:"patchCount"`
 }
 
+type pageReportQueryRunner func(phase string, required bool, query func() error) error
+
+type pageReportQueries struct {
+	navigationTiming    func(*Driver) (NavigationTiming, error)
+	heapSize            func(*Driver) (float64, error)
+	hydrationLog        func(*Driver) ([]HydrationEntry, error)
+	performanceMeasures func(*Driver, string) ([]PerfEntry, error)
+	sceneTelemetry      func(*Driver) (SceneTelemetrySnapshot, error)
+	runtimeState        func(*Driver) (RuntimeState, error)
+	dispatchLog         func(*Driver) ([]DispatchEntry, error)
+	evaluate            func(*Driver, string, interface{}) error
+	resourceWaterfall   func(*Driver) ([]ResourceEntry, error)
+}
+
+func defaultPageReportQueries() pageReportQueries {
+	return pageReportQueries{
+		navigationTiming:    QueryNavigationTiming,
+		heapSize:            QueryHeapSize,
+		hydrationLog:        QueryHydrationLog,
+		performanceMeasures: QueryPerformanceMeasures,
+		sceneTelemetry:      QuerySceneTelemetry,
+		runtimeState:        QueryRuntimeState,
+		dispatchLog:         QueryDispatchLog,
+		evaluate:            (*Driver).Evaluate,
+		resourceWaterfall:   QueryResourceWaterfall,
+	}
+}
+
+func runPageReportQuery(runner pageReportQueryRunner, phase string, required bool, query func() error) error {
+	var err error
+	if runner != nil {
+		err = runner(phase, required, query)
+	} else {
+		err = query()
+	}
+	if err != nil {
+		return fmt.Errorf("%s: %w", phase, err)
+	}
+	return nil
+}
+
 // CollectPageReport queries all performance data from the driver and assembles
 // a PageReport for the given URL.
 func CollectPageReport(d *Driver, url string) (*PageReport, error) {
+	return collectPageReport(d, url, defaultPageReportQueries(), nil)
+}
+
+func collectPageReportWithQueryRunner(d *Driver, url string, runner pageReportQueryRunner) (*PageReport, error) {
+	return collectPageReport(d, url, defaultPageReportQueries(), runner)
+}
+
+func collectPageReport(d *Driver, url string, queries pageReportQueries, runner pageReportQueryRunner) (*PageReport, error) {
 	pr := &PageReport{URL: url}
 
 	// Navigation timing
-	nav, err := QueryNavigationTiming(d)
-	if err != nil {
+	var nav NavigationTiming
+	if err := runPageReportQuery(runner, "collect/navigation-timing", true, func() error {
+		var err error
+		nav, err = queries.navigationTiming(d)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	pr.TTFBMs = nav.TTFB
@@ -273,15 +327,23 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 	pr.FullyLoadedMs = nav.FullyLoaded
 
 	// Heap size
-	heap, err := QueryHeapSize(d)
-	if err != nil {
+	var heap float64
+	if err := runPageReportQuery(runner, "collect/heap-size", true, func() error {
+		var err error
+		heap, err = queries.heapSize(d)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	pr.JSHeapSizeMB = heap
 
 	// Hydration log
-	hydLog, err := QueryHydrationLog(d)
-	if err != nil {
+	var hydLog []HydrationEntry
+	if err := runPageReportQuery(runner, "collect/hydration-log", true, func() error {
+		var err error
+		hydLog, err = queries.hydrationLog(d)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	var totalHydration float64
@@ -297,25 +359,41 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 	// Scene3D CPU measures and renderer-published telemetry. scene3d-render
 	// measures CPU command planning/submission; rAF and GPU timings remain
 	// separate sources throughout the report.
-	sceneMeasures, err := QueryPerformanceMeasures(d, "scene3d-")
-	if err != nil {
+	var sceneMeasures []PerfEntry
+	if err := runPageReportQuery(runner, "collect/scene-measures", true, func() error {
+		var err error
+		sceneMeasures, err = queries.performanceMeasures(d, "scene3d-")
+		return err
+	}); err != nil {
 		return nil, err
 	}
-	snapshot, err := QuerySceneTelemetry(d)
-	if err != nil {
+	var snapshot SceneTelemetrySnapshot
+	if err := runPageReportQuery(runner, "collect/scene-telemetry", true, func() error {
+		var err error
+		snapshot, err = queries.sceneTelemetry(d)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	if snapshot.Available || len(sceneMeasures) > 0 {
-		rs, err := QueryRuntimeState(d)
-		if err != nil {
+		var rs RuntimeState
+		if err := runPageReportQuery(runner, "collect/runtime-state", true, func() error {
+			var err error
+			rs, err = queries.runtimeState(d)
+			return err
+		}); err != nil {
 			return nil, err
 		}
 		pr.Scene = BuildSceneMetric(sceneMeasures, snapshot, rs.FrameCount)
 	}
 
 	// Dispatch log → interactions
-	dispLog, err := QueryDispatchLog(d)
-	if err != nil {
+	var dispLog []DispatchEntry
+	if err := runPageReportQuery(runner, "collect/dispatch-log", true, func() error {
+		var err error
+		dispLog, err = queries.dispatchLog(d)
+		return err
+	}); err != nil {
 		return nil, err
 	}
 	for _, dl := range dispLog {
@@ -337,7 +415,8 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 		HubMessageBytes int     `json:"hubMessageBytes"`
 		HubSendCount    int     `json:"hubSendCount"`
 	}
-	_ = d.Evaluate(`(function() {
+	_ = runPageReportQuery(runner, "collect/vitals", false, func() error {
+		return queries.evaluate(d, `(function() {
 		var p = window.__gosx_perf || {};
 		return {
 			lcp: p.largestContentfulPaint || 0,
@@ -350,6 +429,7 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 			hubSendCount: p.hubSendCount || 0
 		};
 	})()`, &vitals)
+	})
 	pr.LargestContentfulPaintMs = vitals.LCP
 	pr.CumulativeLayoutShift = vitals.CLS
 	pr.FirstInputDelayMs = vitals.FID
@@ -365,7 +445,9 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 		StartTime float64 `json:"startTime"`
 		Duration  float64 `json:"duration"`
 	}
-	_ = d.Evaluate(`(window.__gosx_perf && window.__gosx_perf.longTasks) || []`, &longTasks)
+	_ = runPageReportQuery(runner, "collect/long-tasks", false, func() error {
+		return queries.evaluate(d, `(window.__gosx_perf && window.__gosx_perf.longTasks) || []`, &longTasks)
+	})
 	for _, lt := range longTasks {
 		pr.LongTasks = append(pr.LongTasks, LongTaskMetric{
 			Name:       lt.Name,
@@ -383,14 +465,21 @@ func CollectPageReport(d *Driver, url string) (*PageReport, error) {
 	// GPU context info (tier + caps). Captured even when no canvas is
 	// present so the report can show browser capabilities.
 	var webgl WebGLInfo
-	err = d.Evaluate(`(typeof window.__gosx_perf_webgl_info === "function") ? window.__gosx_perf_webgl_info() : null`, &webgl)
-	if err == nil && webgl.Tier != "" {
+	webglErr := runPageReportQuery(runner, "collect/webgl-info", false, func() error {
+		return queries.evaluate(d, `(typeof window.__gosx_perf_webgl_info === "function") ? window.__gosx_perf_webgl_info() : null`, &webgl)
+	})
+	if webglErr == nil && webgl.Tier != "" {
 		pr.WebGL = &webgl
 	}
 
 	// Resource waterfall
-	resources, err := QueryResourceWaterfall(d)
-	if err == nil {
+	var resources []ResourceEntry
+	resourcesErr := runPageReportQuery(runner, "collect/resource-waterfall", false, func() error {
+		var err error
+		resources, err = queries.resourceWaterfall(d)
+		return err
+	})
+	if resourcesErr == nil {
 		pr.Resources = resources
 		for _, r := range resources {
 			pr.TotalBytesTransferred += int64(r.TransferSize)

--- a/perf/metrics_collect_browser_test.go
+++ b/perf/metrics_collect_browser_test.go
@@ -1,0 +1,86 @@
+//go:build browser
+
+package perf
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCollectPageReportBusyMainThreadAttributesFirstQuery(t *testing.T) {
+	d := requireDriver(t, 5*time.Second)
+	busyStarted := make(chan struct{}, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/busy-started" {
+			select {
+			case busyStarted <- struct{}{}:
+			default:
+			}
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<!doctype html><html><body><script>
+			setTimeout(function() {
+				navigator.sendBeacon('/busy-started', 'busy');
+				var until = performance.now() + 1500;
+				while (performance.now() < until) {}
+			}, 50);
+		</script></body></html>`)
+	}))
+	defer srv.Close()
+
+	if err := d.Navigate(srv.URL); err != nil {
+		t.Fatalf("Navigate: %v", err)
+	}
+	if err := d.WaitReady(); err != nil {
+		t.Fatalf("WaitReady: %v", err)
+	}
+	select {
+	case <-busyStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("page did not enter the synchronized busy-main-thread section")
+	}
+
+	const queryTimeout = 150 * time.Millisecond
+	routeCtx, routeCancel := context.WithTimeout(context.Background(), queryTimeout)
+	defer routeCancel()
+	routeD, driverCancel := d.WithOperationContext(routeCtx, 0)
+	defer driverCancel()
+
+	var diagnostics bytes.Buffer
+	report, err := collectPageReportWithQueryRunner(
+		routeD,
+		srv.URL,
+		diagnosticPageReportQueryRunner(&diagnostics, 0, 1, srv.URL, queryTimeout),
+	)
+	if report != nil {
+		t.Fatalf("busy page returned a report: %+v", report)
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("busy page error = %v, want context deadline exceeded", err)
+	}
+	if !strings.Contains(err.Error(), "collect/navigation-timing") {
+		t.Fatalf("busy page error lacks exact first-query attribution: %v", err)
+	}
+
+	log := diagnostics.String()
+	if !strings.Contains(log, "phase=collect/navigation-timing start required=true timeout=150ms") {
+		t.Fatalf("missing attributed query start:\n%s", log)
+	}
+	if !strings.Contains(log, "phase=collect/navigation-timing failed") ||
+		!strings.Contains(log, "required=true action=fail: context deadline exceeded") {
+		t.Fatalf("missing attributed query failure:\n%s", log)
+	}
+	if strings.Contains(log, "phase=collect/heap-size start") {
+		t.Fatalf("collector advanced after required query cancellation:\n%s", log)
+	}
+}

--- a/perf/metrics_collect_test.go
+++ b/perf/metrics_collect_test.go
@@ -1,0 +1,172 @@
+package perf
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+)
+
+type pageReportQueryInvocation struct {
+	phase    string
+	required bool
+}
+
+func successfulPageReportQueries() pageReportQueries {
+	return pageReportQueries{
+		navigationTiming: func(*Driver) (NavigationTiming, error) {
+			return NavigationTiming{TTFB: 1, DOMContentLoaded: 2, FullyLoaded: 3}, nil
+		},
+		heapSize: func(*Driver) (float64, error) {
+			return 4, nil
+		},
+		hydrationLog: func(*Driver) ([]HydrationEntry, error) {
+			return []HydrationEntry{{ID: "island", Ms: 5}}, nil
+		},
+		performanceMeasures: func(*Driver, string) ([]PerfEntry, error) {
+			return []PerfEntry{{Name: "scene3d-render", Duration: 6}}, nil
+		},
+		sceneTelemetry: func(*Driver) (SceneTelemetrySnapshot, error) {
+			return SceneTelemetrySnapshot{Available: true}, nil
+		},
+		runtimeState: func(*Driver) (RuntimeState, error) {
+			return RuntimeState{FrameCount: 1}, nil
+		},
+		dispatchLog: func(*Driver) ([]DispatchEntry, error) {
+			return []DispatchEntry{{Island: "island", Handler: "click", Ms: 7, Patches: 1}}, nil
+		},
+		evaluate: func(*Driver, string, interface{}) error {
+			return nil
+		},
+		resourceWaterfall: func(*Driver) ([]ResourceEntry, error) {
+			return []ResourceEntry{{Name: "app.js", InitiatorType: "script", TransferSize: 8, ResponseEnd: 9}}, nil
+		},
+	}
+}
+
+func TestCollectPageReportQueryOrderAndOptionalFailures(t *testing.T) {
+	queries := successfulPageReportQueries()
+	optionalErr := errors.New("optional query unavailable")
+	queries.evaluate = func(*Driver, string, interface{}) error { return optionalErr }
+	queries.resourceWaterfall = func(*Driver) ([]ResourceEntry, error) { return nil, optionalErr }
+
+	var got []pageReportQueryInvocation
+	runner := func(phase string, required bool, query func() error) error {
+		got = append(got, pageReportQueryInvocation{phase: phase, required: required})
+		return query()
+	}
+
+	report, err := collectPageReport(nil, "https://example.test/", queries, runner)
+	if err != nil {
+		t.Fatalf("collectPageReport returned an optional error: %v", err)
+	}
+	want := []pageReportQueryInvocation{
+		{phase: "collect/navigation-timing", required: true},
+		{phase: "collect/heap-size", required: true},
+		{phase: "collect/hydration-log", required: true},
+		{phase: "collect/scene-measures", required: true},
+		{phase: "collect/scene-telemetry", required: true},
+		{phase: "collect/runtime-state", required: true},
+		{phase: "collect/dispatch-log", required: true},
+		{phase: "collect/vitals", required: false},
+		{phase: "collect/long-tasks", required: false},
+		{phase: "collect/webgl-info", required: false},
+		{phase: "collect/resource-waterfall", required: false},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("query order/requiredness mismatch:\n got: %#v\nwant: %#v", got, want)
+	}
+	if report.URL != "https://example.test/" || report.TTFBMs != 1 || report.JSHeapSizeMB != 4 {
+		t.Fatalf("required results were not retained: %+v", report)
+	}
+	if report.WebGL != nil || len(report.Resources) != 0 {
+		t.Fatalf("failed optional results must remain absent: webgl=%+v resources=%+v", report.WebGL, report.Resources)
+	}
+}
+
+func TestCollectPageReportRequiredFailureAttribution(t *testing.T) {
+	requiredPhases := []string{
+		"collect/navigation-timing",
+		"collect/heap-size",
+		"collect/hydration-log",
+		"collect/scene-measures",
+		"collect/scene-telemetry",
+		"collect/runtime-state",
+		"collect/dispatch-log",
+	}
+	for _, failPhase := range requiredPhases {
+		t.Run(failPhase, func(t *testing.T) {
+			sentinel := errors.New("sentinel")
+			var phases []string
+			runner := func(phase string, required bool, query func() error) error {
+				phases = append(phases, phase)
+				if phase == failPhase {
+					if !required {
+						t.Fatalf("%s unexpectedly marked optional", phase)
+					}
+					return sentinel
+				}
+				return query()
+			}
+
+			report, err := collectPageReport(nil, "https://example.test/", successfulPageReportQueries(), runner)
+			if report != nil {
+				t.Fatalf("required failure returned a report: %+v", report)
+			}
+			if !errors.Is(err, sentinel) {
+				t.Fatalf("error lost sentinel: %v", err)
+			}
+			wantError := failPhase + ": sentinel"
+			if err.Error() != wantError {
+				t.Fatalf("error = %q, want %q", err, wantError)
+			}
+			if got := phases[len(phases)-1]; got != failPhase {
+				t.Fatalf("last query = %q, want %q", got, failPhase)
+			}
+		})
+	}
+}
+
+func TestCollectPageReportCancellationRemainsAttributedAndFatal(t *testing.T) {
+	runner := func(phase string, _ bool, query func() error) error {
+		if phase == "collect/scene-measures" {
+			return fmt.Errorf("Runtime.evaluate: %w", context.Canceled)
+		}
+		return query()
+	}
+
+	report, err := collectPageReport(nil, "https://example.test/", successfulPageReportQueries(), runner)
+	if report != nil {
+		t.Fatalf("cancellation returned a report: %+v", report)
+	}
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancellation cause was lost: %v", err)
+	}
+	want := "collect/scene-measures: Runtime.evaluate: context canceled"
+	if err.Error() != want {
+		t.Fatalf("error = %q, want %q", err, want)
+	}
+}
+
+func TestDiagnosticPageReportQueryRunnerLabelsOptionalFailure(t *testing.T) {
+	var diagnostics bytes.Buffer
+	sentinel := errors.New("optional unavailable")
+	runner := diagnosticPageReportQueryRunner(&diagnostics, 1, 3, "https://example.test/", 45*time.Second)
+
+	err := runner("collect/vitals", false, func() error { return sentinel })
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("runner lost optional error: %v", err)
+	}
+	log := diagnostics.String()
+	if !strings.Contains(log, "route 2/3 https://example.test/ phase=collect/vitals start required=false timeout=45s") {
+		t.Fatalf("missing stable optional start attribution:\n%s", log)
+	}
+	if !strings.Contains(log, "phase=collect/vitals failed") ||
+		!strings.Contains(log, "required=false action=continue: optional unavailable") {
+		t.Fatalf("missing stable optional failure attribution:\n%s", log)
+	}
+}

--- a/perf/scenario.go
+++ b/perf/scenario.go
@@ -165,6 +165,7 @@ func RunScenario(s *Scenario) (*Report, error) {
 					return nil
 				})
 			}
+			runCollectQuery := diagnosticPageReportQueryRunner(diagnostics, i, total, url, s.Timeout)
 
 			navigate := func() error {
 				if err := runPhase("navigate", func() error { return routeD.Navigate(url) }); err != nil {
@@ -241,7 +242,7 @@ func RunScenario(s *Scenario) (*Report, error) {
 			var page *PageReport
 			if err := runPhase("collect", func() error {
 				var err error
-				page, err = CollectPageReport(routeD, url)
+				page, err = collectPageReportWithQueryRunner(routeD, url, runCollectQuery)
 				return err
 			}); err != nil {
 				return nil, fmt.Errorf("phase %s: %w", routePhase, err)
@@ -376,6 +377,25 @@ func formatPerfTimeout(timeout time.Duration) string {
 		return "none"
 	}
 	return timeout.String()
+}
+
+func diagnosticPageReportQueryRunner(diagnostics io.Writer, index, total int, url string, timeout time.Duration) pageReportQueryRunner {
+	return func(phase string, required bool, query func() error) error {
+		start := time.Now()
+		fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s start required=%t timeout=%s\n", index+1, total, url, phase, required, formatPerfTimeout(timeout))
+		err := query()
+		elapsed := time.Since(start).Round(time.Millisecond)
+		if err != nil {
+			action := "continue"
+			if required {
+				action = "fail"
+			}
+			fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s failed elapsed=%s required=%t action=%s: %v\n", index+1, total, url, phase, elapsed, required, action, err)
+			return err
+		}
+		fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s done elapsed=%s required=%t\n", index+1, total, url, phase, elapsed, required)
+		return nil
+	}
 }
 
 func captureCoverageForRoute(enabled bool, index int) bool {

--- a/perf/scenario.go
+++ b/perf/scenario.go
@@ -1,7 +1,9 @@
 package perf
 
 import (
+	"context"
 	"fmt"
+	"io"
 	"os"
 	"time"
 )
@@ -28,7 +30,12 @@ type Scenario struct {
 	// interactions have run. GC runs first so the snapshot reflects
 	// live retention, not ephemeral churn.
 	HeapSnapshotPath string
+
+	routeRunner scenarioRouteRunner
+	diagnostics io.Writer
 }
+
+type scenarioRouteRunner func(ctx context.Context, url string, index int, total int) (*PageReport, error)
 
 // Interaction is a user action to execute during profiling.
 type Interaction struct {
@@ -39,10 +46,7 @@ type Interaction struct {
 
 // RunScenario executes a full profiling session and returns a Report.
 func RunScenario(s *Scenario) (*Report, error) {
-	opts := []Option{WithHeadless(s.Headless)}
-	if s.Timeout > 0 {
-		opts = append(opts, WithTimeout(s.Timeout))
-	}
+	opts := []Option{WithHeadless(s.Headless), WithTimeout(0)}
 
 	d, err := New(opts...)
 	if err != nil {
@@ -105,84 +109,157 @@ func RunScenario(s *Scenario) (*Report, error) {
 	// capturing across a full multi-page scenario would produce an
 	// oversized file. The trace is written after the run completes.
 	var traceBytes []byte
-	for i, url := range s.URLs {
-		navigate := func() error {
-			if err := d.Navigate(url); err != nil {
-				return fmt.Errorf("navigate %s: %w", url, err)
-			}
-			if err := d.WaitReady(); err != nil {
-				return fmt.Errorf("wait ready %s: %w", url, err)
-			}
-			// Allow instrumentation + initial renders to settle.
-			time.Sleep(300 * time.Millisecond)
-			return nil
-		}
+	diagnostics := s.diagnostics
+	if diagnostics == nil {
+		diagnostics = os.Stderr
+	}
+	routeRunner := s.routeRunner
+	if routeRunner == nil {
+		routeRunner = func(routeCtx context.Context, url string, i int, total int) (*PageReport, error) {
+			routeD, routeCancel := d.WithOperationContext(routeCtx, 0)
+			defer routeCancel()
 
-		// If coverage and trace are both requested, coverage wraps the
-		// trace capture so a single navigate yields both signals.
-		var coverageEntries []CoverageEntry
-		runNav := navigate
-		if s.TracePath != "" && i == 0 {
-			runNav = func() error {
-				tb, err := CaptureTrace(d, navigate)
+			var routePhase string
+			runPhase := func(name string, fn func() error) error {
+				routePhase = name
+				start := time.Now()
+				fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s start timeout=%s\n", i+1, total, url, name, formatPerfTimeout(s.Timeout))
+				err := fn()
+				elapsed := time.Since(start)
 				if err != nil {
-					return fmt.Errorf("capture trace: %w", err)
+					fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s failed elapsed=%s: %v\n", i+1, total, url, name, elapsed.Round(time.Millisecond), err)
+					return fmt.Errorf("%s %s: %w", name, url, err)
 				}
-				traceBytes = tb
+				fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s done elapsed=%s\n", i+1, total, url, name, elapsed.Round(time.Millisecond))
 				return nil
 			}
-		}
-		if s.Coverage && i == 0 {
-			entries, err := CaptureCoverage(d, runNav)
-			if err != nil {
-				return nil, fmt.Errorf("capture coverage: %w", err)
-			}
-			coverageEntries = entries
-		} else if err := runNav(); err != nil {
-			return nil, err
-		}
 
-		// Scene3D engines can initialize after the generic GoSX ready mark,
-		// especially when large model/runtime chunks are involved. If the
-		// route declared a Scene3D surface, wait for the requested render sample
-		// before the first collection so missing scene metrics mean "no frames",
-		// not "sampled too early".
-		if scene3DSurfacePresent(d) {
-			waitForSceneFrames(d, frames)
-		}
-
-		page, err := CollectPageReport(d, url)
-		if err != nil {
-			return nil, fmt.Errorf("collect %s: %w", url, err)
-		}
-
-		// If scene detected, wait for frames then re-collect scene metrics.
-		if page.Scene != nil {
-			waitForSceneFrames(d, frames)
-			sceneEntries, _ := QuerySceneFrames(d)
-			if len(sceneEntries) > 0 {
-				durations := make([]float64, len(sceneEntries))
-				for i, e := range sceneEntries {
-					durations[i] = e.Duration
+			navigate := func() error {
+				if err := runPhase("navigate", func() error { return routeD.Navigate(url) }); err != nil {
+					return err
 				}
-				page.Scene.FrameStats = ComputeFrameStats(durations)
-				page.Scene.FrameCount = len(sceneEntries)
+				if err := runPhase("wait-ready", routeD.WaitReady); err != nil {
+					return err
+				}
+				if err := runPhase("settle", func() error {
+					select {
+					case <-time.After(300 * time.Millisecond):
+						return nil
+					case <-routeCtx.Done():
+						return routeCtx.Err()
+					case <-routeD.Context().Done():
+						return routeD.Context().Err()
+					}
+				}); err != nil {
+					return err
+				}
+				return nil
 			}
+
+			// If coverage and trace are both requested, coverage wraps the
+			// trace capture so a single navigate yields both signals.
+			var coverageEntries []CoverageEntry
+			runNav := navigate
+			if s.TracePath != "" && i == 0 {
+				runNav = func() error {
+					return runPhase("trace", func() error {
+						tb, err := CaptureTrace(routeD, navigate)
+						if err != nil {
+							return err
+						}
+						traceBytes = tb
+						return nil
+					})
+				}
+			}
+			if captureCoverageForRoute(s.Coverage, i) {
+				err := runPhase("coverage", func() error {
+					entries, err := CaptureCoverage(routeD, runNav)
+					if err != nil {
+						return err
+					}
+					coverageEntries = entries
+					return nil
+				})
+				if err != nil {
+					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+				}
+			} else if err := runNav(); err != nil {
+				return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+			}
+
+			// Scene3D engines can initialize after the generic GoSX ready mark,
+			// especially when large model/runtime chunks are involved. If the
+			// route declared a Scene3D surface, wait for the requested render sample
+			// before the first collection so missing scene metrics mean "no frames",
+			// not "sampled too early".
+			scenePresent := false
+			if err := runPhase("detect-scene3d", func() error {
+				scenePresent = scene3DSurfacePresent(routeD)
+				return nil
+			}); err != nil {
+				return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+			}
+			if scenePresent {
+				if err := runPhase("scene3d-wait", func() error {
+					return waitForSceneFrames(routeD, frames)
+				}); err != nil {
+					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+				}
+			}
+
+			var page *PageReport
+			if err := runPhase("collect", func() error {
+				var err error
+				page, err = CollectPageReport(routeD, url)
+				return err
+			}); err != nil {
+				return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+			}
+
+			// If scene detected, wait for frames then re-collect scene metrics.
+			if page.Scene != nil {
+				if err := runPhase("scene3d-rewait", func() error {
+					return waitForSceneFrames(routeD, frames)
+				}); err != nil {
+					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+				}
+				var sceneEntries []PerfEntry
+				if err := runPhase("scene3d-recollect", func() error {
+					var err error
+					sceneEntries, err = QuerySceneFrames(routeD)
+					return err
+				}); err != nil {
+					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
+				}
+				if len(sceneEntries) > 0 {
+					durations := make([]float64, len(sceneEntries))
+					for i, e := range sceneEntries {
+						durations[i] = e.Duration
+					}
+					page.Scene.FrameStats = ComputeFrameStats(durations)
+					page.Scene.FrameCount = len(sceneEntries)
+				}
+			}
+
+			// Attach console entries captured so far to this page. For
+			// multi-page scenarios we clear between pages so each page
+			// reports only its own errors.
+			page.ConsoleEntries = console.Entries()
+			console.Clear()
+
+			// Attach coverage if captured for this (first) page.
+			if captureCoverageForRoute(s.Coverage, i) {
+				page.CoverageCaptured = true
+				page.Coverage = coverageEntries
+			}
+			return page, nil
 		}
+	}
 
-		// Attach console entries captured so far to this page. For
-		// multi-page scenarios we clear between pages so each page
-		// reports only its own errors.
-		page.ConsoleEntries = console.Entries()
-		console.Clear()
-
-		// Attach coverage if captured for this (first) page.
-		if s.Coverage && i == 0 {
-			page.CoverageCaptured = true
-			page.Coverage = coverageEntries
-		}
-
-		report.Pages = append(report.Pages, *page)
+	if err := runScenarioRoutes(s, report, routeRunner, diagnostics); err != nil {
+		finalizeScenarioReport(report)
+		return report, err
 	}
 
 	// Run interactions on the LAST navigated page.
@@ -191,24 +268,19 @@ func RunScenario(s *Scenario) (*Report, error) {
 		for _, inter := range s.Interactions {
 			metric, err := runInteraction(d, inter)
 			if err != nil {
-				return nil, fmt.Errorf("interaction %s %s: %w", inter.Kind, inter.Selector, err)
+				finalizeScenarioReport(report)
+				return report, fmt.Errorf("interaction %s %s: %w", inter.Kind, inter.Selector, err)
 			}
 			report.Pages[lastIdx].Interactions = append(report.Pages[lastIdx].Interactions, *metric)
 		}
 	}
 
-	// Single-page mode: copy into embedded PageReport for backward compat.
-	if len(report.Pages) == 1 {
-		report.PageReport = report.Pages[0]
-		report.URL = report.Pages[0].URL
-	} else if len(report.Pages) > 0 {
-		report.URL = report.Pages[0].URL
-	}
+	finalizeScenarioReport(report)
 
 	// Stop recording and write file.
 	if recorder != nil {
 		if err := recorder.Stop(d, s.RecordPath); err != nil {
-			return nil, fmt.Errorf("stop recording: %w", err)
+			return report, fmt.Errorf("stop recording: %w", err)
 		}
 	}
 
@@ -216,7 +288,7 @@ func RunScenario(s *Scenario) (*Report, error) {
 	// mid-run error doesn't leave a partial file around.
 	if len(traceBytes) > 0 && s.TracePath != "" {
 		if err := os.WriteFile(s.TracePath, traceBytes, 0o644); err != nil {
-			return nil, fmt.Errorf("write trace: %w", err)
+			return report, fmt.Errorf("write trace: %w", err)
 		}
 	}
 
@@ -226,26 +298,88 @@ func RunScenario(s *Scenario) (*Report, error) {
 	if s.HeapSnapshotPath != "" {
 		snap, err := TakeHeapSnapshotAfterGC(d)
 		if err != nil {
-			return nil, fmt.Errorf("heap snapshot: %w", err)
+			return report, fmt.Errorf("heap snapshot: %w", err)
 		}
 		if err := os.WriteFile(s.HeapSnapshotPath, snap, 0o644); err != nil {
-			return nil, fmt.Errorf("write heap snapshot: %w", err)
+			return report, fmt.Errorf("write heap snapshot: %w", err)
 		}
 	}
 
 	return report, nil
 }
 
-func waitForSceneFrames(d *Driver, target int) {
-	// Poll frameCount until we have enough frames or timeout.
-	js := fmt.Sprintf(`window.__gosx_perf && window.__gosx_perf.frameCount >= %d`, target)
-	deadline := time.Now().Add(10 * time.Second)
-	for time.Now().Before(deadline) {
-		var done bool
-		if err := d.Evaluate(js, &done); err != nil || done {
-			return
+func runScenarioRoutes(s *Scenario, report *Report, runRoute scenarioRouteRunner, diagnostics io.Writer) error {
+	total := len(s.URLs)
+	for i, url := range s.URLs {
+		routeStart := time.Now()
+		fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s start timeout=%s\n", i+1, total, url, formatPerfTimeout(s.Timeout))
+		ctx := context.Background()
+		var cancel context.CancelFunc
+		if s.Timeout > 0 {
+			ctx, cancel = context.WithTimeout(ctx, s.Timeout)
+		} else {
+			ctx, cancel = context.WithCancel(ctx)
 		}
-		time.Sleep(50 * time.Millisecond)
+		page, err := runRoute(ctx, url, i, total)
+		cancel()
+		elapsed := time.Since(routeStart).Round(time.Millisecond)
+		if err != nil {
+			fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s failed elapsed=%s: %v\n", i+1, total, url, elapsed, err)
+			return fmt.Errorf("route %d/%d %s: %w", i+1, total, url, err)
+		}
+		report.Pages = append(report.Pages, *page)
+		fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s done elapsed=%s\n", i+1, total, url, elapsed)
+	}
+	return nil
+}
+
+func finalizeScenarioReport(report *Report) {
+	// Single-page mode: copy into embedded PageReport for backward compat.
+	if len(report.Pages) == 1 {
+		report.PageReport = report.Pages[0]
+		report.URL = report.Pages[0].URL
+	} else if len(report.Pages) > 0 {
+		report.URL = report.Pages[0].URL
+	}
+}
+
+func formatPerfTimeout(timeout time.Duration) string {
+	if timeout <= 0 {
+		return "none"
+	}
+	return timeout.String()
+}
+
+func captureCoverageForRoute(enabled bool, index int) bool {
+	return enabled && index == 0
+}
+
+func waitForSceneFrames(d *Driver, target int) error {
+	// Poll frameCount until we have enough frames or timeout.
+	if target <= 0 {
+		return nil
+	}
+	js := fmt.Sprintf(`window.__gosx_perf && window.__gosx_perf.frameCount >= %d`, target)
+	waitD, cancel := d.WithOperationContext(d.Context(), 10*time.Second)
+	defer cancel()
+	ticker := time.NewTicker(50 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		var done bool
+		if err := waitD.Evaluate(js, &done); err != nil {
+			if waitD.Context().Err() != nil {
+				return waitD.Context().Err()
+			}
+			return err
+		}
+		if done {
+			return nil
+		}
+		select {
+		case <-waitD.Context().Done():
+			return waitD.Context().Err()
+		case <-ticker.C:
+		}
 	}
 }
 

--- a/perf/scenario.go
+++ b/perf/scenario.go
@@ -2,10 +2,16 @@ package perf
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"time"
+)
+
+const (
+	defaultSceneFrameSampleWindow = 10 * time.Second
+	defaultSceneFramePollInterval = 50 * time.Millisecond
 )
 
 // Scenario describes a profiling session.
@@ -33,6 +39,12 @@ type Scenario struct {
 
 	routeRunner scenarioRouteRunner
 	diagnostics io.Writer
+
+	// Test-only sampling overrides. Production scenarios use the bounded
+	// defaults above; keeping these private prevents them from becoming part of
+	// the perf command's public contract.
+	sceneFrameSampleWindow time.Duration
+	sceneFramePollInterval time.Duration
 }
 
 type scenarioRouteRunner func(ctx context.Context, url string, index int, total int) (*PageReport, error)
@@ -88,6 +100,14 @@ func RunScenario(s *Scenario) (*Report, error) {
 	if frames <= 0 {
 		frames = 120
 	}
+	sceneFrameSampleWindow := s.sceneFrameSampleWindow
+	if sceneFrameSampleWindow <= 0 {
+		sceneFrameSampleWindow = defaultSceneFrameSampleWindow
+	}
+	sceneFramePollInterval := s.sceneFramePollInterval
+	if sceneFramePollInterval <= 0 {
+		sceneFramePollInterval = defaultSceneFramePollInterval
+	}
 
 	// Start recording if requested.
 	var recorder *Recorder
@@ -132,6 +152,18 @@ func RunScenario(s *Scenario) (*Report, error) {
 				}
 				fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s done elapsed=%s\n", i+1, total, url, name, elapsed.Round(time.Millisecond))
 				return nil
+			}
+			runSceneFrameSamplePhase := func(name string) error {
+				return runPhase(name, func() error {
+					sample, err := waitForSceneFrames(routeD, frames, sceneFrameSampleWindow, sceneFramePollInterval)
+					if err != nil {
+						return err
+					}
+					if sample.Exhausted {
+						fmt.Fprintf(diagnostics, "gosx perf: route %d/%d %s phase=%s sample-window-exhausted target=%d observed=%d window=%s action=continue-with-partial-metrics\n", i+1, total, url, name, sample.Target, sample.Observed, sceneFrameSampleWindow)
+					}
+					return nil
+				})
 			}
 
 			navigate := func() error {
@@ -201,9 +233,7 @@ func RunScenario(s *Scenario) (*Report, error) {
 				return nil, fmt.Errorf("phase %s: %w", routePhase, err)
 			}
 			if scenePresent {
-				if err := runPhase("scene3d-wait", func() error {
-					return waitForSceneFrames(routeD, frames)
-				}); err != nil {
+				if err := runSceneFrameSamplePhase("scene3d-wait"); err != nil {
 					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
 				}
 			}
@@ -219,9 +249,7 @@ func RunScenario(s *Scenario) (*Report, error) {
 
 			// If scene detected, wait for frames then re-collect scene metrics.
 			if page.Scene != nil {
-				if err := runPhase("scene3d-rewait", func() error {
-					return waitForSceneFrames(routeD, frames)
-				}); err != nil {
+				if err := runSceneFrameSamplePhase("scene3d-rewait"); err != nil {
 					return nil, fmt.Errorf("phase %s: %w", routePhase, err)
 				}
 				var sceneEntries []PerfEntry
@@ -354,33 +382,124 @@ func captureCoverageForRoute(enabled bool, index int) bool {
 	return enabled && index == 0
 }
 
-func waitForSceneFrames(d *Driver, target int) error {
-	// Poll frameCount until we have enough frames or timeout.
+type sceneFrameSampleResult struct {
+	Target    int
+	Observed  int
+	Exhausted bool
+}
+
+func waitForSceneFrames(d *Driver, target int, window, pollInterval time.Duration) (sceneFrameSampleResult, error) {
+	result := sceneFrameSampleResult{Target: target}
 	if target <= 0 {
-		return nil
+		return result, nil
 	}
-	js := fmt.Sprintf(`window.__gosx_perf && window.__gosx_perf.frameCount >= %d`, target)
-	waitD, cancel := d.WithOperationContext(d.Context(), 10*time.Second)
+	if window <= 0 {
+		window = defaultSceneFrameSampleWindow
+	}
+	if pollInterval <= 0 {
+		pollInterval = defaultSceneFramePollInterval
+	}
+
+	waitD, cancel := d.WithOperationContext(d.Context(), window)
 	defer cancel()
-	ticker := time.NewTicker(50 * time.Millisecond)
+
+	// WithOperationContext preserves the earliest enclosing deadline. An equal
+	// deadline therefore belongs to the route/parent and remains fatal; only a
+	// strictly earlier deadline introduced by this helper is best-effort.
+	internalDeadline := true
+	if waitDeadline, ok := waitD.Context().Deadline(); ok {
+		if parentDeadline, parentOK := d.Context().Deadline(); parentOK && !waitDeadline.Before(parentDeadline) {
+			internalDeadline = false
+		}
+	}
+
+	return pollSceneFrameSamples(d.Context(), waitD.Context(), internalDeadline, target, pollInterval, func() (int, error) {
+		var observed int
+		err := waitD.Evaluate(`(function(){
+			var perf = window.__gosx_perf;
+			var count = perf ? Number(perf.frameCount) : 0;
+			return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0;
+		})()`, &observed)
+		return observed, err
+	})
+}
+
+func pollSceneFrameSamples(parentCtx, sampleCtx context.Context, internalDeadline bool, target int, pollInterval time.Duration, probe func() (int, error)) (sceneFrameSampleResult, error) {
+	result := sceneFrameSampleResult{Target: target}
+	if target <= 0 {
+		return result, nil
+	}
+	if pollInterval <= 0 {
+		pollInterval = defaultSceneFramePollInterval
+	}
+
+	ticker := time.NewTicker(pollInterval)
 	defer ticker.Stop()
 	for {
-		var done bool
-		if err := waitD.Evaluate(js, &done); err != nil {
-			if waitD.Context().Err() != nil {
-				return waitD.Context().Err()
+		observed, err := probe()
+		if observed > result.Observed {
+			result.Observed = observed
+		}
+		if err != nil {
+			// A completed sample context must not erase an independent CDP or
+			// protocol failure returned by the probe. Only an error whose entire
+			// unwrap chain terminates in context cancellation/deadline can be
+			// attributed to the sampling context below.
+			if !isSolelyContextTerminationError(err) {
+				return result, err
 			}
-			return err
+			if parentCtx.Err() != nil || sampleCtx.Err() != nil {
+				return finishSceneFrameSampling(parentCtx, sampleCtx, internalDeadline, result)
+			}
+			return result, err
 		}
-		if done {
-			return nil
+		if result.Observed >= target {
+			return result, nil
 		}
+
 		select {
-		case <-waitD.Context().Done():
-			return waitD.Context().Err()
+		case <-sampleCtx.Done():
+			return finishSceneFrameSampling(parentCtx, sampleCtx, internalDeadline, result)
 		case <-ticker.C:
 		}
 	}
+}
+
+func isSolelyContextTerminationError(err error) bool {
+	if err == context.Canceled || err == context.DeadlineExceeded {
+		return true
+	}
+	if multi, ok := err.(interface{ Unwrap() []error }); ok {
+		causes := multi.Unwrap()
+		if len(causes) == 0 {
+			return false
+		}
+		for _, cause := range causes {
+			if !isSolelyContextTerminationError(cause) {
+				return false
+			}
+		}
+		return true
+	}
+	if single, ok := err.(interface{ Unwrap() error }); ok {
+		return isSolelyContextTerminationError(single.Unwrap())
+	}
+	return false
+}
+
+func finishSceneFrameSampling(parentCtx, sampleCtx context.Context, internalDeadline bool, result sceneFrameSampleResult) (sceneFrameSampleResult, error) {
+	if err := parentCtx.Err(); err != nil {
+		return result, err
+	}
+	sampleErr := sampleCtx.Err()
+	if internalDeadline && errors.Is(sampleErr, context.DeadlineExceeded) {
+		result.Exhausted = true
+		return result, nil
+	}
+	if sampleErr != nil {
+		return result, sampleErr
+	}
+	return result, errors.New("scene frame sample context ended without a cancellation cause")
 }
 
 func scene3DSurfacePresent(d *Driver) bool {

--- a/perf/scenario_browser_test.go
+++ b/perf/scenario_browser_test.go
@@ -1,0 +1,99 @@
+//go:build browser
+
+package perf
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunScenarioUsesFreshTimeoutForEachRealDriverRoute(t *testing.T) {
+	requireChromeAvailableForScenario(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/first", "/second":
+			time.Sleep(17 * time.Second)
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body><h1>%s</h1></body></html>`, r.URL.Path)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	start := time.Now()
+	report, err := RunScenario(&Scenario{
+		URLs:        []string{srv.URL + "/first", srv.URL + "/second"},
+		Timeout:     22 * time.Second,
+		Headless:    true,
+		diagnostics: &diagnostics,
+	})
+	elapsed := time.Since(start)
+	if err != nil {
+		t.Fatalf("RunScenario should let each route use its own timeout, elapsed=%s err=%v\ndiagnostics:\n%s", elapsed, err, diagnostics.String())
+	}
+	if elapsed < 30*time.Second {
+		t.Fatalf("test did not exceed the old default global 30s cap; elapsed=%s", elapsed)
+	}
+	if len(report.Pages) != 2 {
+		t.Fatalf("expected reports for both routes, got %d", len(report.Pages))
+	}
+	if report.Pages[0].URL != srv.URL+"/first" || report.Pages[1].URL != srv.URL+"/second" {
+		t.Fatalf("URL order changed: %#v", []string{report.Pages[0].URL, report.Pages[1].URL})
+	}
+	log := diagnostics.String()
+	if !strings.Contains(log, "route 2/2 "+srv.URL+"/second phase=navigate start timeout=22s") ||
+		!strings.Contains(log, "route 2/2 "+srv.URL+"/second phase=navigate done elapsed=") {
+		t.Fatalf("missing route 2 timing diagnostics:\n%s", log)
+	}
+}
+
+func TestRunScenarioAttributesScene3DFrameWaitTimeoutToScenePhase(t *testing.T) {
+	requireChromeAvailableForScenario(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body><div data-gosx-scene3d="true"></div></body></html>`)
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	report, err := RunScenario(&Scenario{
+		URLs:        []string{srv.URL},
+		Frames:      999,
+		Timeout:     600 * time.Millisecond,
+		Headless:    true,
+		diagnostics: &diagnostics,
+	})
+	if err == nil {
+		t.Fatalf("RunScenario unexpectedly succeeded with report %#v", report)
+	}
+	text := err.Error()
+	if !strings.Contains(text, "phase scene3d-wait") || !strings.Contains(text, "context deadline exceeded") {
+		t.Fatalf("expected scene3d-wait deadline attribution, got %v\ndiagnostics:\n%s", err, diagnostics.String())
+	}
+	if strings.Contains(text, "phase collect") {
+		t.Fatalf("scene3d wait timeout was misattributed to collect: %v", err)
+	}
+	if !strings.Contains(diagnostics.String(), "phase=scene3d-wait failed") {
+		t.Fatalf("missing scene3d-wait failure diagnostics:\n%s", diagnostics.String())
+	}
+}
+
+func requireChromeAvailableForScenario(t *testing.T) {
+	t.Helper()
+	if _, err := FindChrome(); err != nil {
+		if os.Getenv(requireChromeEnv) != "" {
+			t.Fatalf("%s is set, so Chrome is required for this scenario regression: %v", requireChromeEnv, err)
+		}
+		t.Skipf("skipping scenario regression: %v", err)
+	}
+}

--- a/perf/scenario_browser_test.go
+++ b/perf/scenario_browser_test.go
@@ -56,7 +56,108 @@ func TestRunScenarioUsesFreshTimeoutForEachRealDriverRoute(t *testing.T) {
 	}
 }
 
-func TestRunScenarioAttributesScene3DFrameWaitTimeoutToScenePhase(t *testing.T) {
+func TestRunScenarioStaticWebGPUFallbackSampleWindowIsBestEffort(t *testing.T) {
+	requireChromeAvailableForScenario(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>
+<div id="scene" data-gosx-scene3d="true" data-gosx-scene3d-mounted="true" data-gosx-scene3d-backend="webgl" data-gosx-scene3d-renderer="webgl" data-gosx-scene3d-renderer-fallback="webgpu-feature-gap">
+<canvas data-gosx-scene3d-canvas="true" width="320" height="180"></canvas>
+</div>
+</body></html>`)
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	report, err := RunScenario(&Scenario{
+		URLs:                   []string{srv.URL},
+		Timeout:                5 * time.Second,
+		Headless:               true,
+		diagnostics:            &diagnostics,
+		sceneFrameSampleWindow: 50 * time.Millisecond,
+		sceneFramePollInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("static WebGPU-to-WebGL fallback should retain available metrics: %v\ndiagnostics:\n%s", err, diagnostics.String())
+	}
+	if len(report.Pages) != 1 || report.Pages[0].Scene == nil {
+		t.Fatalf("expected one page with available Scene3D telemetry, got %#v", report.Pages)
+	}
+	scene := report.Pages[0].Scene
+	if scene.FrameCount != 0 {
+		t.Fatalf("static fallback unexpectedly reported rendered frames: %#v", scene)
+	}
+	if len(scene.Mounts) != 1 || scene.Mounts[0].Renderer != "webgl" || scene.Mounts[0].Fallback != "webgpu-feature-gap" {
+		t.Fatalf("fallback telemetry was not preserved: %#v", scene.Mounts)
+	}
+	log := diagnostics.String()
+	if strings.Count(log, "sample-window-exhausted") != 2 {
+		t.Fatalf("expected one bounded exhaustion diagnostic for wait and rewait, got:\n%s", log)
+	}
+	for _, want := range []string{
+		"phase=scene3d-wait sample-window-exhausted target=120 observed=0 window=50ms action=continue-with-partial-metrics",
+		"phase=scene3d-rewait sample-window-exhausted target=120 observed=0 window=50ms action=continue-with-partial-metrics",
+		"phase=collect done",
+		"phase=scene3d-recollect done",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("missing %q in diagnostics:\n%s", want, log)
+		}
+	}
+	if strings.Contains(log, "phase=scene3d-wait failed") || strings.Contains(log, "phase=scene3d-rewait failed") {
+		t.Fatalf("local sample exhaustion was logged as a fatal phase:\n%s", log)
+	}
+}
+
+func TestRunScenarioCollectsPartialScene3DSamplesAfterWindowExhaustion(t *testing.T) {
+	requireChromeAvailableForScenario(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprint(w, `<html><body>
+<div data-gosx-scene3d="true" data-gosx-scene3d-mounted="true" data-gosx-scene3d-renderer="webgl"><canvas></canvas></div>
+<script>
+for (var i = 0; i < 3; i++) {
+  var start = "scene-start-" + i;
+  var end = "scene-end-" + i;
+  performance.mark(start);
+  performance.mark(end);
+  performance.measure("scene3d-render", start, end);
+}
+</script>
+</body></html>`)
+	}))
+	defer srv.Close()
+
+	var diagnostics bytes.Buffer
+	report, err := RunScenario(&Scenario{
+		URLs:                   []string{srv.URL},
+		Frames:                 10,
+		Timeout:                5 * time.Second,
+		Headless:               true,
+		diagnostics:            &diagnostics,
+		sceneFrameSampleWindow: 50 * time.Millisecond,
+		sceneFramePollInterval: 5 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("partial Scene3D samples should remain reportable: %v\ndiagnostics:\n%s", err, diagnostics.String())
+	}
+	if len(report.Pages) != 1 || report.Pages[0].Scene == nil {
+		t.Fatalf("expected one page with partial Scene3D metrics, got %#v", report.Pages)
+	}
+	scene := report.Pages[0].Scene
+	if scene.FrameCount != 3 || scene.FrameStats.Count != 3 {
+		t.Fatalf("partial frame samples were not retained: %#v", scene)
+	}
+	log := diagnostics.String()
+	if !strings.Contains(log, "phase=scene3d-wait sample-window-exhausted target=10 observed=3") ||
+		!strings.Contains(log, "phase=scene3d-rewait sample-window-exhausted target=10 observed=3") {
+		t.Fatalf("partial sample diagnostics were not explicit:\n%s", log)
+	}
+}
+
+func TestRunScenarioAttributesScene3DRouteDeadlineToScenePhase(t *testing.T) {
 	requireChromeAvailableForScenario(t)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -85,6 +186,9 @@ func TestRunScenarioAttributesScene3DFrameWaitTimeoutToScenePhase(t *testing.T) 
 	}
 	if !strings.Contains(diagnostics.String(), "phase=scene3d-wait failed") {
 		t.Fatalf("missing scene3d-wait failure diagnostics:\n%s", diagnostics.String())
+	}
+	if strings.Contains(diagnostics.String(), "sample-window-exhausted") {
+		t.Fatalf("route deadline was misclassified as local sample exhaustion:\n%s", diagnostics.String())
 	}
 }
 

--- a/perf/scenario_test.go
+++ b/perf/scenario_test.go
@@ -1,0 +1,133 @@
+package perf
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRunScenarioRoutesGivesEachURLFreshTimeout(t *testing.T) {
+	var diagnostics bytes.Buffer
+	report := &Report{}
+	scenario := &Scenario{
+		URLs:        []string{"http://127.0.0.1/first", "http://127.0.0.1/second"},
+		Timeout:     200 * time.Millisecond,
+		diagnostics: &diagnostics,
+	}
+
+	err := runScenarioRoutes(scenario, report, func(ctx context.Context, url string, index int, total int) (*PageReport, error) {
+		deadline, ok := ctx.Deadline()
+		if !ok {
+			t.Fatalf("route %d did not receive a deadline", index)
+		}
+		remaining := time.Until(deadline)
+		if index == 0 {
+			time.Sleep(125 * time.Millisecond)
+		}
+		if index == 1 && remaining < 150*time.Millisecond {
+			t.Fatalf("second route inherited an exhausted deadline: remaining=%s", remaining)
+		}
+		return &PageReport{URL: url, FullyLoadedMs: float64(index + 1)}, nil
+	}, &diagnostics)
+	if err != nil {
+		t.Fatalf("runScenarioRoutes: %v", err)
+	}
+	if len(report.Pages) != 2 {
+		t.Fatalf("expected 2 page reports, got %d", len(report.Pages))
+	}
+	log := diagnostics.String()
+	if !strings.Contains(log, "route 1/2 http://127.0.0.1/first start timeout=200ms") ||
+		!strings.Contains(log, "route 2/2 http://127.0.0.1/second start timeout=200ms") {
+		t.Fatalf("expected per-route diagnostics, got:\n%s", log)
+	}
+}
+
+func TestRunScenarioRoutesTimeoutIdentifiesURLAndKeepsPartialReport(t *testing.T) {
+	var diagnostics bytes.Buffer
+	report := &Report{}
+	scenario := &Scenario{
+		URLs:    []string{"http://127.0.0.1/fast", "http://127.0.0.1/slow"},
+		Timeout: 25 * time.Millisecond,
+	}
+
+	err := runScenarioRoutes(scenario, report, func(ctx context.Context, url string, index int, total int) (*PageReport, error) {
+		if index == 0 {
+			return &PageReport{URL: url, FullyLoadedMs: 10}, nil
+		}
+		<-ctx.Done()
+		return nil, ctx.Err()
+	}, &diagnostics)
+	if err == nil {
+		t.Fatal("expected route timeout failure")
+	}
+	text := err.Error()
+	if !strings.Contains(text, "route 2/2 http://127.0.0.1/slow") ||
+		!strings.Contains(text, "context deadline exceeded") {
+		t.Fatalf("timeout error did not identify URL and cause: %v", err)
+	}
+	if len(report.Pages) != 1 || report.Pages[0].URL != "http://127.0.0.1/fast" {
+		t.Fatalf("expected partial report for completed first route, got %#v", report.Pages)
+	}
+	finalizeScenarioReport(report)
+	data, jsonErr := FormatJSON(report)
+	if jsonErr != nil {
+		t.Fatalf("FormatJSON partial report: %v", jsonErr)
+	}
+	var decoded Report
+	if jsonErr := json.Unmarshal(data, &decoded); jsonErr != nil {
+		t.Fatalf("partial report was not valid JSON: %v\n%s", jsonErr, string(data))
+	}
+	log := diagnostics.String()
+	if !strings.Contains(log, "route 2/2 http://127.0.0.1/slow failed") {
+		t.Fatalf("expected failure diagnostics for timed-out URL, got:\n%s", log)
+	}
+}
+
+func TestCaptureCoverageForRouteStaysFirstRouteOnly(t *testing.T) {
+	cases := []struct {
+		name    string
+		enabled bool
+		index   int
+		want    bool
+	}{
+		{name: "disabled first route", enabled: false, index: 0, want: false},
+		{name: "enabled first route", enabled: true, index: 0, want: true},
+		{name: "enabled second route", enabled: true, index: 1, want: false},
+		{name: "enabled later route", enabled: true, index: 4, want: false},
+	}
+	for _, tt := range cases {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := captureCoverageForRoute(tt.enabled, tt.index); got != tt.want {
+				t.Fatalf("captureCoverageForRoute(%v, %d) = %v, want %v", tt.enabled, tt.index, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPerfBudgetFailureRemainsAuthoritativeAfterRouteIsolation(t *testing.T) {
+	report := &Report{Pages: []PageReport{{
+		URL:                   "http://127.0.0.1/docs/getting-started",
+		FullyLoadedMs:         2000,
+		TotalBytesTransferred: 1,
+	}}}
+	budget := &BudgetFile{
+		DefaultProfile: "strict",
+		Profiles: map[string]BudgetProfile{
+			"strict": {Assertions: []string{"fully_loaded <= 1"}},
+		},
+	}
+
+	result, err := EvaluateBudget(report, budget, "")
+	if err != nil {
+		t.Fatalf("EvaluateBudget: %v", err)
+	}
+	if result.Passed {
+		t.Fatal("expected failing budget to remain authoritative")
+	}
+	if len(result.Pages) != 1 || len(result.Pages[0].Assertions) != 1 || result.Pages[0].Assertions[0].Passed {
+		t.Fatalf("unexpected budget result: %#v", result)
+	}
+}

--- a/perf/scenario_test.go
+++ b/perf/scenario_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -129,5 +131,150 @@ func TestPerfBudgetFailureRemainsAuthoritativeAfterRouteIsolation(t *testing.T) 
 	}
 	if len(result.Pages) != 1 || len(result.Pages[0].Assertions) != 1 || result.Pages[0].Assertions[0].Passed {
 		t.Fatalf("unexpected budget result: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesInternalWindowReturnsPartialResult(t *testing.T) {
+	parentCtx := context.Background()
+	sampleCtx, cancel := context.WithTimeout(parentCtx, 30*time.Millisecond)
+	defer cancel()
+
+	observations := []int{1, 3}
+	probeCount := 0
+	result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+		index := probeCount
+		probeCount++
+		if index >= len(observations) {
+			index = len(observations) - 1
+		}
+		return observations[index], nil
+	})
+	if err != nil {
+		t.Fatalf("internal sample-window exhaustion should be best-effort: %v", err)
+	}
+	if !result.Exhausted || result.Target != 10 || result.Observed != 3 {
+		t.Fatalf("unexpected partial sample result: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesExternalCancellationRemainsFatal(t *testing.T) {
+	parentCtx, cancelParent := context.WithCancel(context.Background())
+	sampleCtx, cancelSample := context.WithTimeout(parentCtx, time.Second)
+	defer cancelSample()
+
+	result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+		cancelParent()
+		return 2, fmt.Errorf("evaluate: %w", context.Canceled)
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("external cancellation should remain fatal, got result=%#v err=%v", result, err)
+	}
+	if result.Exhausted {
+		t.Fatalf("external cancellation was misclassified as local exhaustion: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesRouteDeadlineRemainsFatal(t *testing.T) {
+	parentCtx, cancelParent := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancelParent()
+	sampleCtx, cancelSample := context.WithTimeout(parentCtx, time.Second)
+	defer cancelSample()
+
+	result, err := pollSceneFrameSamples(parentCtx, sampleCtx, false, 10, time.Millisecond, func() (int, error) {
+		return 2, nil
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("route deadline should remain fatal, got result=%#v err=%v", result, err)
+	}
+	if result.Exhausted {
+		t.Fatalf("route deadline was misclassified as local exhaustion: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesCDPErrorRemainsFatal(t *testing.T) {
+	parentCtx := context.Background()
+	sampleCtx, cancelSample := context.WithTimeout(parentCtx, time.Second)
+	defer cancelSample()
+	wantErr := errors.New("cdp evaluation failed")
+
+	result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+		return 2, wantErr
+	})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CDP error should remain fatal, got result=%#v err=%v", result, err)
+	}
+	if result.Exhausted {
+		t.Fatalf("CDP error was misclassified as local exhaustion: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesAlreadyExpiredInternalContextIsExhausted(t *testing.T) {
+	parentCtx := context.Background()
+	sampleCtx, cancelSample := context.WithDeadline(parentCtx, time.Now().Add(-time.Second))
+	defer cancelSample()
+
+	result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+		return 3, context.DeadlineExceeded
+	})
+	if err != nil {
+		t.Fatalf("expired internal sample context should be best-effort: %v", err)
+	}
+	if !result.Exhausted || result.Observed != 3 {
+		t.Fatalf("unexpected expired-context result: %#v", result)
+	}
+}
+
+func TestPollSceneFrameSamplesConcurrentExpiryDoesNotSwallowCDPError(t *testing.T) {
+	wantErr := errors.New("execution context destroyed")
+	for _, tt := range []struct {
+		name     string
+		probeErr error
+	}{
+		{name: "sentinel", probeErr: wantErr},
+		{name: "sentinel joined with context", probeErr: errors.Join(context.DeadlineExceeded, wantErr)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parentCtx := context.Background()
+			sampleCtx, cancelSample := context.WithTimeout(parentCtx, 10*time.Millisecond)
+			defer cancelSample()
+
+			result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+				<-sampleCtx.Done()
+				return 3, tt.probeErr
+			})
+			if !errors.Is(err, wantErr) {
+				t.Fatalf("concurrent sample expiry swallowed CDP error: result=%#v err=%v", result, err)
+			}
+			if result.Exhausted {
+				t.Fatalf("concurrent CDP error was misclassified as local exhaustion: %#v", result)
+			}
+		})
+	}
+}
+
+func TestPollSceneFrameSamplesWrappedInternalContextErrorsAreExhausted(t *testing.T) {
+	for _, tt := range []struct {
+		name       string
+		contextErr error
+	}{
+		{name: "deadline", contextErr: context.DeadlineExceeded},
+		{name: "canceled", contextErr: context.Canceled},
+		{name: "joined context errors", contextErr: errors.Join(context.DeadlineExceeded, context.Canceled)},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			parentCtx := context.Background()
+			sampleCtx, cancelSample := context.WithDeadline(parentCtx, time.Now().Add(-time.Second))
+			defer cancelSample()
+
+			result, err := pollSceneFrameSamples(parentCtx, sampleCtx, true, 10, time.Millisecond, func() (int, error) {
+				return 3, fmt.Errorf("evaluate: %w", tt.contextErr)
+			})
+			if err != nil {
+				t.Fatalf("wrapped internal context error should be best-effort: %v", err)
+			}
+			if !result.Exhausted || result.Observed != 3 {
+				t.Fatalf("unexpected wrapped-context result: %#v", result)
+			}
+		})
 	}
 }

--- a/scripts/perf-budget-ci-test.sh
+++ b/scripts/perf-budget-ci-test.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env sh
+set -eu
+
+repo_root="$(CDPATH= cd -- "$(dirname "$0")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+
+cleanup() {
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+fake_go="$tmp_dir/fake-go"
+cat >"$fake_go" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -ge 4 ] && [ "$1" = "run" ] && [ "$2" = "./cmd/gosx" ] && [ "$3" = "dev" ]; then
+	if [ "$*" != "run ./cmd/gosx dev ./examples/gosx-docs" ]; then
+		echo "unexpected dev invocation: $*" >&2
+		exit 98
+	fi
+	trap 'if [ -n "${FAKE_SERVER_STOP_FILE:-}" ]; then echo stopped >"$FAKE_SERVER_STOP_FILE"; fi; exit 0' TERM INT
+	echo "fake docs server starting"
+	while :; do sleep 1; done
+fi
+
+if [ "$#" -ge 4 ] && [ "$1" = "run" ] && [ "$2" = "./cmd/gosx" ] && [ "$3" = "perf" ]; then
+	expected="run ./cmd/gosx perf --mobile pixel7 --throttle 4 --coverage --timeout 45s --budget perf/budgets/default.json --json http://127.0.0.1:3971/docs/getting-started http://127.0.0.1:3971/demos/water"
+	if [ "$*" != "$expected" ]; then
+		echo "unexpected perf invocation: $*" >&2
+		echo "expected: $expected" >&2
+		exit 97
+	fi
+	printf '{"url":"http://127.0.0.1:3971/docs/getting-started","timestamp":"2026-08-30T00:00:00Z","pages":[{"url":"http://127.0.0.1:3971/docs/getting-started","fullyLoadedMs":1}]}\n'
+	exit "${FAKE_PERF_STATUS:-0}"
+fi
+
+echo "unexpected fake go invocation: $*" >&2
+exit 99
+EOF
+chmod 700 "$fake_go"
+
+fake_curl="$tmp_dir/curl"
+cat >"$fake_curl" <<'EOF'
+#!/usr/bin/env sh
+set -eu
+exit 0
+EOF
+chmod 700 "$fake_curl"
+
+run_case() {
+	name="$1"
+	status="$2"
+	want_status="$3"
+	case_dir="$tmp_dir/$name"
+	mkdir -p "$case_dir"
+	out="$case_dir/perf-report.json"
+	log="$case_dir/perf-server.log"
+	err="$case_dir/stderr.txt"
+	stopped="$case_dir/server-stopped.txt"
+	if (
+		cd "$repo_root"
+		PATH="$tmp_dir:$PATH" \
+		GO="$fake_go" \
+		FAKE_PERF_STATUS="$status" \
+		FAKE_SERVER_STOP_FILE="$stopped" \
+		PERF_PORT=3971 \
+		PERF_BASE_URL=http://127.0.0.1:3971 \
+		PERF_URLS="http://127.0.0.1:3971/docs/getting-started http://127.0.0.1:3971/demos/water" \
+		PERF_FLAGS="--mobile pixel7 --throttle 4 --coverage --timeout 45s" \
+		PERF_OUT="$out" \
+		PERF_LOG="$log" \
+		sh scripts/perf-budget-ci.sh
+	) 2>"$err"; then
+		got_status=0
+	else
+		got_status=$?
+	fi
+	if [ "$got_status" -ne "$want_status" ]; then
+		echo "perf-budget-ci-test: $name got status $got_status, want $want_status" >&2
+		cat "$err" >&2 || true
+		exit 1
+	fi
+	wait_count=0
+	while [ ! -s "$stopped" ] && [ "$wait_count" -lt 20 ]; do
+		sleep 0.1
+		wait_count=$((wait_count + 1))
+	done
+	if [ ! -s "$stopped" ]; then
+		echo "perf-budget-ci-test: $name did not clean up the docs server" >&2
+		cat "$err" >&2 || true
+		exit 1
+	fi
+	if [ ! -s "$out" ]; then
+		echo "perf-budget-ci-test: $name did not preserve a JSON report" >&2
+		exit 1
+	fi
+	if [ "$want_status" -ne 0 ]; then
+		if ! grep -q "preserved JSON report" "$err"; then
+			echo "perf-budget-ci-test: $name did not report preserved JSON" >&2
+			cat "$err" >&2 || true
+			exit 1
+		fi
+		if ! grep -q "server log tail" "$err"; then
+			echo "perf-budget-ci-test: $name did not print server log tail" >&2
+			cat "$err" >&2 || true
+			exit 1
+		fi
+	fi
+}
+
+run_case success 0 0
+run_case budget_failure 7 7
+
+if ! grep -q "Upload perf budget failure diagnostics" "$repo_root/.github/workflows/ci.yml" ||
+	! grep -q "if: failure()" "$repo_root/.github/workflows/ci.yml" ||
+	! grep -q "actions/upload-artifact@v4" "$repo_root/.github/workflows/ci.yml" ||
+	! grep -q "retention-days: 7" "$repo_root/.github/workflows/ci.yml"; then
+	echo "perf-budget-ci-test: CI workflow no longer uploads bounded failure diagnostics" >&2
+	exit 1
+fi
+
+echo "perf-budget-ci-test: ok"

--- a/scripts/perf-budget-ci.sh
+++ b/scripts/perf-budget-ci.sh
@@ -51,5 +51,27 @@ fi
 # PERF_FLAGS and PERF_URLS intentionally split on shell words so callers can
 # pass the same flag and URL lists used by `make perf-budget`.
 # shellcheck disable=SC2086
-GOSX_CHROME_NO_SANDBOX="${GOSX_CHROME_NO_SANDBOX:-1}" \
-	"$go_cmd" run ./cmd/gosx perf $flags --budget "$budget" --json $urls >"$out"
+if GOSX_CHROME_NO_SANDBOX="${GOSX_CHROME_NO_SANDBOX:-1}" \
+	"$go_cmd" run ./cmd/gosx perf $flags --budget "$budget" --json $urls >"$out"; then
+	exit 0
+else
+	status=$?
+	echo "gosx perf-budget-ci: perf collection or budget gate failed with status ${status}" >&2
+	if [ -s "$out" ]; then
+		echo "gosx perf-budget-ci: preserved JSON report at ${out}" >&2
+		if command -v jq >/dev/null 2>&1; then
+			if jq empty "$out" >/dev/null 2>&1; then
+				echo "gosx perf-budget-ci: report JSON is parseable" >&2
+			else
+				echo "gosx perf-budget-ci: report JSON is not parseable" >&2
+			fi
+		fi
+	else
+		echo "gosx perf-budget-ci: no perf report was written to ${out}" >&2
+	fi
+	if [ -s "$log" ]; then
+		echo "gosx perf-budget-ci: server log tail from ${log}" >&2
+		tail -n 200 "$log" >&2 || true
+	fi
+	exit "$status"
+fi


### PR DESCRIPTION
## Summary

This PR fixes the browser perf gate failure mode where a multi-route `gosx perf` run spent one shared Chrome operation deadline across all URLs. The CI budget path still uses the same URLs, order, budgets, mobile emulation, CPU throttle, first-route-only coverage semantics, and output schema; it just gives each route its own collection deadline.

## What changed

- Creates the perf scenario base driver with `WithTimeout(0)` so the driver's default 30s global cap does not constrain a multi-route run.
- Gives every URL a fresh per-route timeout while preserving URL order.
- Tightens exported `Driver.WithOperationContext(parent, timeout)` semantics:
  - derive from the driver/chromedp context so session values are preserved;
  - effective deadline is the minimum of driver/base deadline, parent deadline, and positive operation timeout;
  - parent cancellation terminates promptly;
  - parent deadline yields deadline semantics;
  - shorter positive operation timeout wins;
  - driver cancellation always wins.
- Makes Scene3D frame waits context-aware and error-returning, so frame wait timeouts are attributed to `scene3d-wait` instead of a later `collect` phase.
- Emits parseable partial JSON from `gosx perf --json` on collection failure when earlier routes have completed.
- Preserves CI failure diagnostics by uploading only `build/perf-report.json` and `build/perf-server.log` on browser-lane failure with 7-day retention.
- Adds an offline wrapper regression and wires it into the existing release gate, preserving hygiene main's complete gate and yielding a 10-step `release-gate`.

## Evidence

Recurring second-route deadline evidence:

- Real Chrome regression: two ~17s routes with `Timeout=22s` passed in `35.682s`, proving total runtime can exceed the old 30s default while route 2 still receives its own budget.

Actual CLI/partial report evidence:

- `go test -tags browser ./cmd/gosx -run '^TestPerfCLIPrintsPartialJSONOnCollectionFailure$' -count=1` passed, proving `go run ./cmd/gosx perf --json` emits parseable partial JSON before exiting nonzero on a second-route collection timeout.

Other verification run post-rebase:

- `go test ./perf -count=1`
- `go test -race ./perf -count=1`
- `go test -race ./perf -run '^TestWithOperationContext' -count=1`
- `go test ./cmd/gosx -run '^TestInterspersedPerfArgs' -count=1`
- `go test ./cmd/gosx -run '^$' -count=1`
- `go test -tags browser ./perf -run 'TestRunScenarioUsesFreshTimeoutForEachRealDriverRoute|TestRunScenarioAttributesScene3DFrameWaitTimeoutToScenePhase' -count=1`
- `go test -tags browser ./perf -count=1`
- `go test ./perf/ouroboros -run 'Browser|RuntimeJSONProbe|CompareSmoke|Remote' -count=1`
- `sh -n scripts/perf-budget-ci.sh scripts/perf-budget-ci-test.sh`
- `make test-perf-budget-ci`
- `make test-repo-hygiene`
- `make release-gate`
- `actionlint`
- `git diff --check`

## Explicit non-changes

- No perf thresholds or runtime budgets were loosened.
- No whole-command retries were added.
- No timeout was raised to hide the failure mode.
- Coverage remains first-route-only.
- The CI budget route list and mobile/throttle behavior remain unchanged.
- No tag, release, deploy, or external control change was made by this PR.

## Rollback

Revert this single commit to restore the previous shared-driver-timeout behavior and remove the new perf wrapper release-gate step and CI failure artifact upload. The rollback is code-only and does not require changing release controls, secrets, tags, or deployments.
