### PR TITLE
secure(docs): gate deploy source and identity

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -343,8 +343,9 @@ build-runtime:
 #      Go module zip creation and forced the v0.29.0 retraction.
 #   4. repository hygiene - rejects tracked build artifacts, top-level scratch
 #      outputs, and accidental binary/manifests that should not ship in the module.
-#   5. docs deploy transaction - prevents an overlapping deployment or rollback
-#      from overwriting a newer successful docs release.
+#   5. docs deploy identity and transaction - prevents stale docs revisions,
+#      overlapping deployment, or rollback from overwriting a newer successful
+#      docs release.
 #   6. governed release workflow topology - proves deploy-key material is scoped
 #      to the tag step and the retired release workflow stays retired.
 #   7. release tag ancestry regression - proves the default-branch lineage
@@ -358,6 +359,10 @@ build-runtime:
 test-docs-deploy:
 	sh scripts/deploy-gosx-docs-concurrency-test.sh
 	sh scripts/deploy-gosx-docs-public-test.sh
+	sh scripts/check-gosx-docs-deploy-source-test.sh
+	sh scripts/check-gosx-docs-built-identity-test.sh
+	sh scripts/deploy-gosx-docs-order-test.sh
+	sh scripts/deploy-gosx-docs-gate-test.sh
 
 test-release-workflow:
 	sh scripts/check-release-workflow-topology.sh
@@ -389,7 +394,7 @@ release-gate:
 	fi
 	@echo "release-gate (4/10): repository hygiene"
 	@$(MAKE) --no-print-directory test-repo-hygiene
-	@echo "release-gate (5/10): docs deploy transaction regression"
+	@echo "release-gate (5/10): docs deploy identity and transaction regression"
 	@$(MAKE) --no-print-directory test-docs-deploy
 	@echo "release-gate (6/10): governed release workflow topology"
 	@$(MAKE) --no-print-directory test-release-workflow

--- a/scripts/check-gosx-docs-built-identity-test.sh
+++ b/scripts/check-gosx-docs-built-identity-test.sh
@@ -1,0 +1,183 @@
+#!/usr/bin/env sh
+set -eu
+
+for command_name in curl dirname jq mktemp ps python3 sleep true; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "gosx docs built identity test: required command is unavailable: ${command_name}" >&2
+		exit 1
+	fi
+done
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+identity_script="${script_dir}/check-gosx-docs-built-identity.sh"
+fake_curl="${script_dir}/testdata/fake-gosx-docs-built-identity-curl.sh"
+fake_app="${script_dir}/testdata/fake-gosx-docs-built-identity-app.py"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+framework_version="v0.53.9"
+revision="1111111111111111111111111111111111111111"
+built_at="2026-08-30T00:00:00Z"
+public_url="https://gosx.m31labs.dev"
+
+run_identity() {
+	GOSX_DOCS_FAKE_IDENTITY_MODE="$1" \
+		GOSX_DOCS_FAKE_FRAMEWORK_VERSION="$framework_version" \
+		GOSX_DOCS_FAKE_REVISION="$revision" \
+		GOSX_DOCS_FAKE_BUILT_AT="$built_at" \
+		GOSX_DOCS_FAKE_PUBLIC_URL="$public_url" \
+		CURL="$fake_curl" SLEEP=true \
+		sh "$identity_script" \
+			--root "$tmp_dir" \
+			--app "$tmp_dir/fake-app" \
+			--framework-version "$framework_version" \
+			--revision "$revision" \
+			--built-at "$built_at" \
+			--public-url "$public_url" \
+			--base-url "http://127.0.0.1:65535"
+}
+
+run_identity ok >/dev/null
+
+run_real_identity() {
+	mode="$1"
+	shift
+	GOSX_FAKE_IDENTITY_APP_MODE="$mode" \
+		GOSX_DOCS_REVISION_FRAMEWORK_VERSION="$framework_version" \
+		GOSX_DOCS_IDENTITY_PORT="${GOSX_DOCS_IDENTITY_PORT:-}" \
+		sh "$identity_script" \
+			--root "$tmp_dir" \
+			--app "$fake_app" \
+			--framework-version "$framework_version" \
+			--revision "$revision" \
+			--built-at "$built_at" \
+			--public-url "$public_url" \
+			"$@"
+}
+
+pid_file="${tmp_dir}/identity.pid"
+secret_log="${tmp_dir}/identity-secret.log"
+GOSX_FAKE_IDENTITY_APP_PID_FILE="$pid_file" \
+	GOSX_FAKE_IDENTITY_APP_SECRET_LOG="$secret_log" \
+	SESSION_SECRET="disposable-test-secret" \
+	run_real_identity ok >/dev/null
+identity_pid="$(cat "$pid_file")"
+if kill -0 "$identity_pid" >/dev/null 2>&1; then
+	echo "gosx docs built identity test: successful local identity server was not cleaned up" >&2
+	exit 1
+fi
+if ! grep -Fx "disposable-test-secret" "$secret_log" >/dev/null; then
+	echo "gosx docs built identity test: local identity server did not receive the disposable secret" >&2
+	exit 1
+fi
+
+if GOSX_FAKE_IDENTITY_APP_MODE=exit-after-site \
+	GOSX_DOCS_REVISION_FRAMEWORK_VERSION="$framework_version" \
+	GOSX_DOCS_IDENTITY_LIVENESS_DELAY=1 \
+	sh "$identity_script" \
+		--root "$tmp_dir" \
+		--app "$fake_app" \
+		--framework-version "$framework_version" \
+		--revision "$revision" \
+		--built-at "$built_at" \
+		--public-url "$public_url" >"${tmp_dir}/exit-after-site.out" 2>&1; then
+	echo "gosx docs built identity test: server exit after successful probe unexpectedly passed" >&2
+	cat "${tmp_dir}/exit-after-site.out" >&2
+	exit 1
+fi
+if ! grep -F "built docs server exited after successful /api/site request" "${tmp_dir}/exit-after-site.out" >/dev/null; then
+	echo "gosx docs built identity test: server exit failure did not prove post-request liveness" >&2
+	cat "${tmp_dir}/exit-after-site.out" >&2
+	exit 1
+fi
+
+port="$(python3 -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+GOSX_FAKE_IDENTITY_APP_MODE=wrong-responder \
+	GOSX_DOCS_REVISION_FRAMEWORK_VERSION="$framework_version" \
+	PORT="127.0.0.1:${port}" \
+	"$fake_app" >"${tmp_dir}/wrong-responder.log" 2>&1 &
+wrong_pid="$!"
+wrong_ready=0
+wrong_attempt=1
+while [ "$wrong_attempt" -le 30 ]; do
+	if curl --fail --silent --show-error "http://127.0.0.1:${port}/readyz" >/dev/null 2>&1; then
+		wrong_ready=1
+		break
+	fi
+	if ! kill -0 "$wrong_pid" >/dev/null 2>&1; then
+		echo "gosx docs built identity test: wrong responder exited before readiness" >&2
+		cat "${tmp_dir}/wrong-responder.log" >&2
+		exit 1
+	fi
+	sleep 1
+	wrong_attempt=$((wrong_attempt + 1))
+done
+if [ "$wrong_ready" -ne 1 ]; then
+	echo "gosx docs built identity test: wrong responder did not become ready" >&2
+	cat "${tmp_dir}/wrong-responder.log" >&2
+	exit 1
+fi
+if GOSX_DOCS_IDENTITY_PORT="$port" \
+	GOSX_DOCS_IDENTITY_LIVENESS_DELAY=1 \
+	GOSX_FAKE_IDENTITY_APP_MODE=ok \
+	GOSX_DOCS_REVISION_FRAMEWORK_VERSION="$framework_version" \
+	sh "$identity_script" \
+		--root "$tmp_dir" \
+		--app "$fake_app" \
+		--framework-version "$framework_version" \
+		--revision "$revision" \
+		--built-at "$built_at" \
+		--public-url "$public_url" >"${tmp_dir}/port-collision.out" 2>&1; then
+	kill "$wrong_pid" >/dev/null 2>&1 || true
+	wait "$wrong_pid" >/dev/null 2>&1 || true
+	echo "gosx docs built identity test: port collision with wrong responder unexpectedly passed" >&2
+	cat "${tmp_dir}/port-collision.out" >&2
+	exit 1
+fi
+kill "$wrong_pid" >/dev/null 2>&1 || true
+wait "$wrong_pid" >/dev/null 2>&1 || true
+if ! grep -E "built docs server exited after successful /readyz request|/api/site does not match the intended deployment identity" "${tmp_dir}/port-collision.out" >/dev/null; then
+	echo "gosx docs built identity test: port collision with wrong responder was not rejected by liveness or identity" >&2
+	cat "${tmp_dir}/port-collision.out" >&2
+	exit 1
+fi
+
+if GOSX_DOCS_IDENTITY_PORT="-1" run_real_identity ok >"${tmp_dir}/bad-port.out" 2>&1; then
+	echo "gosx docs built identity test: option-like identity port unexpectedly passed" >&2
+	cat "${tmp_dir}/bad-port.out" >&2
+	exit 1
+fi
+if ! grep -F "GOSX_DOCS_IDENTITY_PORT must be a numeric TCP port" "${tmp_dir}/bad-port.out" >/dev/null; then
+	echo "gosx docs built identity test: bad port failure did not explain numeric requirement" >&2
+	cat "${tmp_dir}/bad-port.out" >&2
+	exit 1
+fi
+
+for mode in stale-revision unknown-revision wrong-framework wrong-built-at wrong-public-url unhealthy unready malformed-site; do
+	if run_identity "$mode" >"${tmp_dir}/${mode}.out" 2>&1; then
+		echo "gosx docs built identity test: ${mode} unexpectedly passed" >&2
+		cat "${tmp_dir}/${mode}.out" >&2
+		exit 1
+	fi
+	case "$mode" in
+		unhealthy)
+			want="/healthz is not healthy"
+			;;
+		unready)
+			want="/readyz is not ready"
+			;;
+		*)
+			want="/api/site does not match"
+			;;
+	esac
+	if ! grep -F "$want" "${tmp_dir}/${mode}.out" >/dev/null; then
+		echo "gosx docs built identity test: ${mode} failure did not explain ${want}" >&2
+		cat "${tmp_dir}/${mode}.out" >&2
+		exit 1
+	fi
+done
+
+echo "gosx docs built identity test: all checks passed"

--- a/scripts/check-gosx-docs-built-identity.sh
+++ b/scripts/check-gosx-docs-built-identity.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-gosx-docs-built-identity.sh --root DIST --app APP --framework-version VERSION --revision SHA --built-at RFC3339 --public-url URL [--base-url URL]" >&2
+}
+
+dist_root=""
+app_path=""
+framework_version=""
+revision=""
+built_at=""
+public_url=""
+base_url=""
+curl_cmd="${CURL:-curl}"
+sleep_cmd="${SLEEP:-sleep}"
+python_cmd="${PYTHON:-python3}"
+identity_port="${GOSX_DOCS_IDENTITY_PORT:-}"
+liveness_delay="${GOSX_DOCS_IDENTITY_LIVENESS_DELAY:-}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			dist_root="$2"
+			shift 2
+			;;
+		--app)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			app_path="$2"
+			shift 2
+			;;
+		--framework-version)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			framework_version="$2"
+			shift 2
+			;;
+		--revision)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			revision="$2"
+			shift 2
+			;;
+		--built-at)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			built_at="$2"
+			shift 2
+			;;
+		--public-url)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			public_url="${2%/}"
+			shift 2
+			;;
+		--base-url)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			base_url="${2%/}"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "gosx docs built identity: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+for pair in "root:$dist_root" "app:$app_path" "framework version:$framework_version" "revision:$revision" "built at:$built_at" "public url:$public_url"; do
+	label="${pair%%:*}"
+	value="${pair#*:}"
+	if [ -z "$value" ]; then
+		echo "gosx docs built identity: ${label} is required" >&2
+		exit 2
+	fi
+done
+
+for command_name in "$curl_cmd" jq; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "gosx docs built identity: required command is unavailable: ${command_name}" >&2
+		exit 2
+	fi
+done
+
+tmp_dir="$(mktemp -d)"
+pid=""
+started_server=0
+cleanup() {
+	if [ -n "$pid" ]; then
+		kill "$pid" >/dev/null 2>&1 || true
+		wait "$pid" >/dev/null 2>&1 || true
+	fi
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+if [ -z "$base_url" ]; then
+	for command_name in "$python_cmd" "$sleep_cmd" ps; do
+		if ! command -v "$command_name" >/dev/null 2>&1; then
+			echo "gosx docs built identity: required command is unavailable: ${command_name}" >&2
+			exit 2
+		fi
+	done
+	if [ ! -x "$app_path" ]; then
+		echo "gosx docs built identity: app is not executable: ${app_path}" >&2
+		exit 1
+	fi
+	if [ ! -d "$dist_root" ]; then
+		echo "gosx docs built identity: dist root is missing: ${dist_root}" >&2
+		exit 1
+	fi
+	if [ -n "$identity_port" ]; then
+		case "$identity_port" in
+			*[!0123456789]*)
+				echo "gosx docs built identity: GOSX_DOCS_IDENTITY_PORT must be a numeric TCP port" >&2
+				exit 2
+				;;
+		esac
+		port="$identity_port"
+	else
+		port="$("$python_cmd" -c 'import socket; s=socket.socket(); s.bind(("127.0.0.1", 0)); print(s.getsockname()[1]); s.close()')"
+	fi
+	base_url="http://127.0.0.1:${port}"
+	GOSX_APP_ROOT="$dist_root" \
+		PORT="127.0.0.1:${port}" \
+		PUBLIC_URL="$public_url" \
+		GOSX_DOCS_REVISION="$revision" \
+		GOSX_DOCS_BUILT_AT="$built_at" \
+		SESSION_SECRET="${SESSION_SECRET:-gosx-docs-local-identity-secret}" \
+		"$app_path" >"${tmp_dir}/server.log" 2>&1 &
+	pid="$!"
+	started_server=1
+fi
+
+fetch_json() {
+	path="$1"
+	output="$2"
+	if ! "$curl_cmd" --fail --silent --show-error --connect-timeout 2 --max-time 5 \
+		--header 'cache-control: no-cache' "${base_url}${path}" >"$output"; then
+		if [ -s "${tmp_dir}/server.log" ]; then
+			tail -n 20 "${tmp_dir}/server.log" >&2 || true
+		fi
+		return 1
+	fi
+	assert_server_alive "$path"
+}
+
+assert_server_alive() {
+	probe_name="$1"
+	if [ -n "$liveness_delay" ]; then
+		"$sleep_cmd" "$liveness_delay"
+	fi
+	server_dead=0
+	if [ "$started_server" -eq 1 ]; then
+		if ! kill -0 "$pid" >/dev/null 2>&1; then
+			server_dead=1
+		else
+			server_state="$(ps -p "$pid" -o stat= 2>/dev/null || true)"
+			case "$server_state" in
+				Z*) server_dead=1 ;;
+			esac
+		fi
+	fi
+	if [ "$server_dead" -eq 1 ]; then
+		echo "gosx docs built identity: built docs server exited after successful ${probe_name} request" >&2
+		if [ -s "${tmp_dir}/server.log" ]; then
+			tail -n 40 "${tmp_dir}/server.log" >&2 || true
+		fi
+		exit 1
+	fi
+}
+
+if [ "$started_server" -eq 1 ]; then
+	ready=0
+	attempt=1
+	while [ "$attempt" -le 30 ]; do
+		if "$curl_cmd" --fail --silent --show-error --connect-timeout 2 --max-time 5 \
+			--header 'cache-control: no-cache' "${base_url}/readyz" >"${tmp_dir}/ready-probe.json" 2>/dev/null; then
+			assert_server_alive "/readyz"
+			if jq -e '.ok == true' "${tmp_dir}/ready-probe.json" >/dev/null 2>&1; then
+				ready=1
+				break
+			fi
+		fi
+		if [ -n "$pid" ] && ! kill -0 "$pid" >/dev/null 2>&1; then
+			echo "gosx docs built identity: built docs server exited before readiness" >&2
+			if [ -s "${tmp_dir}/server.log" ]; then
+				tail -n 40 "${tmp_dir}/server.log" >&2 || true
+			fi
+			exit 1
+		fi
+		"$sleep_cmd" 1
+		attempt=$((attempt + 1))
+	done
+	if [ "$ready" -ne 1 ]; then
+		echo "gosx docs built identity: built docs server did not become ready" >&2
+		exit 1
+	fi
+fi
+
+fetch_json "/api/site" "${tmp_dir}/site.json"
+fetch_json "/healthz" "${tmp_dir}/health.json"
+fetch_json "/readyz" "${tmp_dir}/ready.json"
+
+if ! jq -e \
+	--arg frameworkVersion "$framework_version" \
+	--arg revision "$revision" \
+	--arg builtAt "$built_at" \
+	--arg publicURL "$public_url" \
+	'.site == "gosx-docs" and .status == "ok" and
+	 .apiVersion == "1" and .framework == "GoSX" and
+	 .frameworkVersion == $frameworkVersion and
+	 .revision == $revision and .builtAt == $builtAt and
+	 (.publicURL | rtrimstr("/")) == $publicURL' \
+	"${tmp_dir}/site.json" >/dev/null; then
+	echo "gosx docs built identity: /api/site does not match the intended deployment identity" >&2
+	cat "${tmp_dir}/site.json" >&2
+	exit 1
+fi
+if ! jq -e '.ok == true' "${tmp_dir}/health.json" >/dev/null; then
+	echo "gosx docs built identity: /healthz is not healthy" >&2
+	cat "${tmp_dir}/health.json" >&2
+	exit 1
+fi
+if ! jq -e '.ok == true' "${tmp_dir}/ready.json" >/dev/null; then
+	echo "gosx docs built identity: /readyz is not ready" >&2
+	cat "${tmp_dir}/ready.json" >&2
+	exit 1
+fi
+
+echo "gosx docs built identity: ${framework_version} ${revision} ${built_at} is locally ready"

--- a/scripts/check-gosx-docs-deploy-source-test.sh
+++ b/scripts/check-gosx-docs-deploy-source-test.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env sh
+set -eu
+
+for command_name in git mktemp; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "gosx docs deploy source test: required command is unavailable: ${command_name}" >&2
+		exit 1
+	fi
+done
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+source_script="${script_dir}/check-gosx-docs-deploy-source.sh"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+remote_dir="${tmp_dir}/remote.git"
+repo_dir="${tmp_dir}/repo"
+git init --bare --initial-branch=main "$remote_dir" >/dev/null
+git init --initial-branch=main "$repo_dir" >/dev/null
+git -C "$repo_dir" config user.email "docs-deploy-test@example.invalid"
+git -C "$repo_dir" config user.name "Docs Deploy Test"
+git -C "$repo_dir" remote add origin "$remote_dir"
+
+printf '%s\n' "base" >"${repo_dir}/file.txt"
+git -C "$repo_dir" add file.txt
+git -C "$repo_dir" commit -m "base" >/dev/null
+git -C "$repo_dir" push -u origin main >/dev/null
+base_commit="$(git -C "$repo_dir" rev-parse HEAD)"
+
+output="$("$source_script" --root "$repo_dir" --branch main)"
+case "$output" in
+	"revision=${base_commit}") ;;
+	*)
+		echo "gosx docs deploy source test: exact main did not report the approved revision" >&2
+		echo "$output" >&2
+		exit 1
+		;;
+esac
+"$source_script" --root "$repo_dir" --branch main --expected-revision "$base_commit" >/dev/null
+
+expect_reject() {
+	label="$1"
+	want="$2"
+	shift 2
+	if "$source_script" "$@" >"${tmp_dir}/${label}.out" 2>&1; then
+		echo "gosx docs deploy source test: ${label} unexpectedly passed" >&2
+		cat "${tmp_dir}/${label}.out" >&2
+		exit 1
+	fi
+	if ! grep -F -- "$want" "${tmp_dir}/${label}.out" >/dev/null; then
+		echo "gosx docs deploy source test: ${label} failure did not explain ${want}" >&2
+		cat "${tmp_dir}/${label}.out" >&2
+		exit 1
+	fi
+}
+
+expect_reject option-like-remote "remote must not be option-like" \
+	--root "$repo_dir" --remote "-origin" --branch main
+expect_reject option-like-branch "branch must be a simple branch name" \
+	--root "$repo_dir" --branch "-main"
+expect_reject parent-traversal-branch "branch must be a simple branch name" \
+	--root "$repo_dir" --branch "release..main"
+newline_branch="$(printf 'main\njunk')"
+expect_reject newline-branch "branch must not contain a newline" \
+	--root "$repo_dir" --branch "$newline_branch"
+cr_branch="$(printf 'main\r')"
+expect_reject carriage-return-branch "branch must not contain a carriage return" \
+	--root "$repo_dir" --branch "$cr_branch"
+newline_expected="$(printf '%s\njunk' "$base_commit")"
+expect_reject newline-expected "expected revision must not contain a newline" \
+	--root "$repo_dir" --branch main --expected-revision "$newline_expected"
+expect_reject option-like-allow-fetch "--allow-fetch must be 0 or 1" \
+	--root "$repo_dir" --branch main --allow-fetch "-1"
+
+wrong_expected="2222222222222222222222222222222222222222"
+expect_reject wrong-expected "does not match expected revision" \
+	--root "$repo_dir" --branch main --expected-revision "$wrong_expected"
+
+printf '%s\n' "remote advances" >>"${repo_dir}/file.txt"
+git -C "$repo_dir" commit -am "remote advance" >/dev/null
+git -C "$repo_dir" push origin main >/dev/null
+remote_ahead_commit="$(git -C "$repo_dir" rev-parse HEAD)"
+git -C "$repo_dir" reset --hard "$base_commit" >/dev/null
+expect_reject behind-main "must equal fresh origin/main" --root "$repo_dir" --branch main
+
+git -C "$repo_dir" reset --hard "$remote_ahead_commit" >/dev/null
+git -C "$repo_dir" checkout -b docs-preview >/dev/null 2>&1
+expect_reject wrong-branch "must run from branch main" --root "$repo_dir" --branch main
+git -C "$repo_dir" checkout main >/dev/null 2>&1
+
+printf '%s\n' "local only" >>"${repo_dir}/file.txt"
+git -C "$repo_dir" commit -am "local ahead" >/dev/null
+local_ahead_commit="$(git -C "$repo_dir" rev-parse HEAD)"
+expect_reject ahead-main "must equal fresh origin/main" --root "$repo_dir" --branch main
+
+git -C "$repo_dir" checkout --detach "$base_commit" >/dev/null 2>&1
+expect_reject detached-history "must run from branch main" --root "$repo_dir" --branch main
+
+git -C "$repo_dir" checkout main >/dev/null 2>&1
+git -C "$repo_dir" reset --hard "$remote_ahead_commit" >/dev/null
+printf '%s\n' "dirty" >>"${repo_dir}/file.txt"
+expect_reject dirty-tracked "refusing a dirty worktree" --root "$repo_dir" --branch main
+git -C "$repo_dir" checkout -- file.txt
+
+printf '%s\n' "untracked" >"${repo_dir}/scratch.txt"
+expect_reject dirty-untracked "refusing a dirty worktree" --root "$repo_dir" --branch main
+rm -f "${repo_dir}/scratch.txt"
+
+mkdir -p "${repo_dir}/examples/gosx-docs/dist"
+printf '%s\n' "generated" >"${repo_dir}/examples/gosx-docs/dist/build.json"
+"$source_script" --root "$repo_dir" --branch main >/dev/null
+rm -rf "${repo_dir}/examples"
+
+git -C "$repo_dir" remote set-url origin "${tmp_dir}/missing.git"
+git -C "$repo_dir" reset --hard "$remote_ahead_commit" >/dev/null
+expect_reject fetch-failure "must be checked against a fresh default-branch ref" --root "$repo_dir" --branch main
+GOSX_DOCS_DEPLOY_ALLOW_FETCH=0 "$source_script" --root "$repo_dir" --branch main >/dev/null
+git -C "$repo_dir" remote set-url origin "$remote_dir"
+
+if "$source_script" --root "$repo_dir" --branch main --expected-revision "$local_ahead_commit" --allow-fetch 0 >"${tmp_dir}/local-wrong-expected.out" 2>&1; then
+	echo "gosx docs deploy source test: local-only wrong expected revision unexpectedly passed" >&2
+	cat "${tmp_dir}/local-wrong-expected.out" >&2
+	exit 1
+fi
+
+echo "gosx docs deploy source test: all checks passed"

--- a/scripts/check-gosx-docs-deploy-source.sh
+++ b/scripts/check-gosx-docs-deploy-source.sh
@@ -1,0 +1,163 @@
+#!/usr/bin/env sh
+set -eu
+
+usage() {
+	echo "usage: check-gosx-docs-deploy-source.sh [--root DIR] [--remote REMOTE] [--branch BRANCH] [--expected-revision SHA] [--allow-fetch 0|1]" >&2
+}
+
+repo_root="."
+remote_name="${GOSX_DOCS_DEPLOY_REMOTE:-origin}"
+default_branch="${GOSX_DOCS_DEPLOY_BRANCH:-main}"
+expected_revision="${GOSX_DOCS_DEPLOY_EXPECT_REVISION:-}"
+allow_fetch="${GOSX_DOCS_DEPLOY_ALLOW_FETCH:-1}"
+
+while [ "$#" -gt 0 ]; do
+	case "$1" in
+		--root)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			repo_root="$2"
+			shift 2
+			;;
+		--remote)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			remote_name="$2"
+			shift 2
+			;;
+		--branch)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			default_branch="$2"
+			shift 2
+			;;
+		--expected-revision)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			expected_revision="$2"
+			shift 2
+			;;
+		--allow-fetch)
+			if [ "$#" -lt 2 ]; then usage; exit 2; fi
+			allow_fetch="$2"
+			shift 2
+			;;
+		-h|--help)
+			usage
+			exit 0
+			;;
+		*)
+			usage
+			echo "gosx docs deploy source: unexpected argument: $1" >&2
+			exit 2
+			;;
+	esac
+done
+
+reject_control() {
+	label="$1"
+	value="$2"
+	case "$value" in
+		*'
+'*)
+			echo "gosx docs deploy source: ${label} must not contain a newline" >&2
+			exit 1
+			;;
+	esac
+	cr="$(printf '\r')"
+	case "$value" in
+		*"$cr"*)
+			echo "gosx docs deploy source: ${label} must not contain a carriage return" >&2
+			exit 1
+			;;
+	esac
+}
+
+for pair in "root:$repo_root" "remote:$remote_name" "branch:$default_branch"; do
+	label="${pair%%:*}"
+	value="${pair#*:}"
+	if [ -z "$value" ]; then
+		echo "gosx docs deploy source: ${label} is required" >&2
+		exit 1
+	fi
+	reject_control "$label" "$value"
+done
+case "$remote_name" in
+	-*)
+		echo "gosx docs deploy source: remote must not be option-like" >&2
+		exit 1
+		;;
+esac
+case "$default_branch" in
+	-*|*..*|*//*|/*|*/)
+		echo "gosx docs deploy source: branch must be a simple branch name" >&2
+		exit 1
+		;;
+esac
+
+case "$allow_fetch" in
+	0|1) ;;
+	*)
+		echo "gosx docs deploy source: --allow-fetch must be 0 or 1" >&2
+		exit 2
+		;;
+esac
+
+if [ -n "$expected_revision" ]; then
+	reject_control "expected revision" "$expected_revision"
+	case "$expected_revision" in
+		????????????????????????????????????????) ;;
+		*)
+			echo "gosx docs deploy source: expected revision must be a full 40-hex commit SHA" >&2
+			exit 1
+			;;
+	esac
+	case "$expected_revision" in
+		*[!0123456789abcdefABCDEF]*)
+			echo "gosx docs deploy source: expected revision must be a full 40-hex commit SHA" >&2
+			exit 1
+			;;
+	esac
+fi
+
+if ! git -C "$repo_root" rev-parse --is-inside-work-tree >/dev/null 2>&1; then
+	echo "gosx docs deploy source: root is not a git worktree: ${repo_root}" >&2
+	exit 1
+fi
+
+worktree_changes="$(git -C "$repo_root" status --porcelain --untracked-files=normal -- . ':(exclude)examples/gosx-docs/dist')"
+if [ -n "$worktree_changes" ]; then
+	echo "gosx docs deploy source: refusing a dirty worktree outside examples/gosx-docs/dist" >&2
+	printf '%s\n' "$worktree_changes" >&2
+	exit 1
+fi
+
+current_branch="$(git -C "$repo_root" symbolic-ref -q --short HEAD || true)"
+if [ "$current_branch" != "$default_branch" ]; then
+	echo "gosx docs deploy source: deployment must run from branch ${default_branch}, got ${current_branch:-detached HEAD}" >&2
+	exit 1
+fi
+
+remote_ref="refs/remotes/${remote_name}/${default_branch}"
+if [ "$allow_fetch" -eq 1 ]; then
+	if ! git -C "$repo_root" fetch --no-tags "$remote_name" "+refs/heads/${default_branch}:${remote_ref}"; then
+		echo "gosx docs deploy source: could not fetch ${remote_name}/${default_branch}" >&2
+		echo "gosx docs deploy source: deployment source must be checked against a fresh default-branch ref" >&2
+		exit 1
+	fi
+fi
+
+head_commit="$(git -C "$repo_root" rev-parse -q --verify HEAD^{commit} || true)"
+remote_commit="$(git -C "$repo_root" rev-parse -q --verify "${remote_ref}^{commit}" || true)"
+if [ -z "$head_commit" ] || [ -z "$remote_commit" ]; then
+	echo "gosx docs deploy source: could not resolve HEAD or ${remote_ref}" >&2
+	exit 1
+fi
+
+if [ "$head_commit" != "$remote_commit" ]; then
+	echo "gosx docs deploy source: HEAD ${head_commit} must equal fresh ${remote_name}/${default_branch} ${remote_commit}" >&2
+	exit 1
+fi
+
+if [ -n "$expected_revision" ] && [ "$expected_revision" != "$head_commit" ]; then
+	echo "gosx docs deploy source: HEAD ${head_commit} does not match expected revision ${expected_revision}" >&2
+	exit 1
+fi
+
+printf 'revision=%s\n' "$head_commit"

--- a/scripts/deploy-gosx-docs-gate-test.sh
+++ b/scripts/deploy-gosx-docs-gate-test.sh
@@ -1,0 +1,287 @@
+#!/usr/bin/env sh
+set -eu
+
+for command_name in cp git grep mkdir mktemp python3 rm sed sleep; do
+	if ! command -v "$command_name" >/dev/null 2>&1; then
+		echo "gosx docs deploy gate test: required command is unavailable: ${command_name}" >&2
+		exit 1
+	fi
+done
+
+script_dir="$(CDPATH= cd "$(dirname "$0")" && pwd)"
+repo_source="$(CDPATH= cd "${script_dir}/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+cleanup() {
+	rm -rf "$tmp_dir"
+}
+trap cleanup EXIT INT TERM
+
+write_file() {
+	file_path="$1"
+	shift
+	mkdir -p "$(dirname "$file_path")"
+	printf '%s\n' "$@" >"$file_path"
+}
+
+write_fake_tools() {
+	tools_dir="$1"
+	mkdir -p "$tools_dir"
+	write_file "${tools_dir}/go" \
+		'#!/usr/bin/env sh' \
+		'set -eu' \
+		'printf "%s\n" "go:$*" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'if [ "$#" -ge 2 ] && [ "$1" = "env" ] && [ "$2" = "GOHOSTOS" ]; then echo linux; exit 0; fi' \
+		'if [ "$#" -ge 2 ] && [ "$1" = "env" ] && [ "$2" = "GOHOSTARCH" ]; then echo amd64; exit 0; fi' \
+		'if [ "$#" -ge 1 ] && [ "$1" = "version" ]; then echo "go version go1.25.5 linux/amd64"; exit 0; fi' \
+		'if [ "$#" -ge 1 ] && [ "$1" = "build" ]; then' \
+		'  out=""' \
+		'  while [ "$#" -gt 0 ]; do' \
+		'    if [ "$1" = "-o" ]; then out="$2"; shift 2; continue; fi' \
+		'    shift' \
+		'  done' \
+		'  if [ -z "$out" ]; then echo "fake go: missing -o" >&2; exit 1; fi' \
+		'  cat >"$out" <<'"'"'GOSX_FAKE_CLI'"'"'' \
+		'#!/usr/bin/env sh' \
+		'set -eu' \
+		'printf "%s\n" "gosx:$*" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'if [ "$#" -ge 1 ] && [ "$1" = "version" ]; then echo "gosx v0.53.9"; exit 0; fi' \
+		'if [ "$#" -ge 2 ] && [ "$1" = "build" ] && [ "$2" = "--prod" ]; then' \
+		'  dist="examples/gosx-docs/dist"' \
+		'  mkdir -p "${dist}/server"' \
+		'  printf "{}\n" >"${dist}/build.json"' \
+		'  printf "#!/usr/bin/env sh\n" >"${dist}/run.sh"' \
+		'  cp "${GOSX_FAKE_IDENTITY_APP_SRC}" "${dist}/server/app"' \
+		'  chmod +x "${dist}/server/app"' \
+		'  case "${GOSX_FAKE_TOCTOU:-}" in' \
+		'    local-commit)' \
+		'      printf "%s\n" "local clean commit" > toctou-local.txt' \
+		'      git add toctou-local.txt' \
+		'      git commit -m "local clean docs toctou" >/dev/null' \
+		'      ;;' \
+		'    branch-switch)' \
+		'      git switch -c docs-toctou >/dev/null 2>&1' \
+		'      ;;' \
+		'    remote-advance)' \
+		'      advance_dir="$(mktemp -d)"' \
+		'      git clone "$(git remote get-url origin)" "${advance_dir}/repo" >/dev/null 2>&1' \
+		'      git -C "${advance_dir}/repo" config user.email "docs-gate@example.invalid"' \
+		'      git -C "${advance_dir}/repo" config user.name "Docs Gate"' \
+		'      printf "%s\n" "remote advance" >>"${advance_dir}/repo/file.txt"' \
+		'      git -C "${advance_dir}/repo" commit -am "remote advance" >/dev/null' \
+		'      git -C "${advance_dir}/repo" push origin main >/dev/null' \
+		'      rm -rf "${advance_dir}"' \
+		'      ;;' \
+		'  esac' \
+		'  exit 0' \
+		'fi' \
+		'echo "fake gosx: unexpected args: $*" >&2' \
+		'exit 1' \
+		'GOSX_FAKE_CLI' \
+		'  chmod +x "$out"' \
+		'  exit 0' \
+		'fi' \
+		'echo "fake go: unexpected args: $*" >&2' \
+		'exit 1'
+	chmod +x "${tools_dir}/go"
+	write_file "${tools_dir}/tinygo" \
+		'#!/usr/bin/env sh' \
+		'set -eu' \
+		'printf "%s\n" "tinygo:$*" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'if [ "$#" -ge 1 ] && [ "$1" = "version" ]; then echo "tinygo version 0.41.1 linux/amd64"; exit 0; fi' \
+		'echo "fake tinygo: unexpected args: $*" >&2' \
+		'exit 1'
+	chmod +x "${tools_dir}/tinygo"
+	write_file "${tools_dir}/docker" \
+		'#!/usr/bin/env sh' \
+		'set -eu' \
+		'case "$1" in' \
+		'  version) printf "%s\n" "docker-read:version" >>"${GOSX_FAKE_DEPLOY_LOG}"; echo "linux/amd64" ;;' \
+		'  build) printf "%s\n" "docker-mutation:build" >>"${GOSX_FAKE_DEPLOY_LOG}" ;;' \
+		'  push) printf "%s\n" "registry-mutation:push" >>"${GOSX_FAKE_DEPLOY_LOG}"; echo "digest: sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" ;;' \
+		'  image) printf "%s\n" "docker-read:image inspect" >>"${GOSX_FAKE_DEPLOY_LOG}"; echo "linux/amd64" ;;' \
+		'  buildx) printf "%s\n" "registry-read:imagetools" >>"${GOSX_FAKE_DEPLOY_LOG}"; echo "\"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" ;;' \
+		'  *) echo "fake docker: unexpected args: $*" >&2; exit 1 ;;' \
+		'esac'
+	chmod +x "${tools_dir}/docker"
+	write_file "${tools_dir}/kubectl" \
+		'#!/usr/bin/env sh' \
+		'set -eu' \
+		'if [ "$1" = "get" ]; then' \
+		'  case "$4" in' \
+		'    deployment/gosx-docs)' \
+		'      printf "%s\n" "kubectl-read:deployment" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'      printf "%s\n" "{\"metadata\":{\"uid\":\"uid-1\",\"generation\":1,\"annotations\":{}},\"spec\":{\"template\":{\"spec\":{\"containers\":[]}}}}"' \
+		'      exit 0' \
+		'      ;;' \
+		'    secret/gosx-docs)' \
+		'      printf "%s\n" "kubectl-read:secret" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'      printf "%s\n" "{\"data\":{\"session-secret\":\"cmVhbC1jbHVzdGVyLXNlY3JldA==\"}}"' \
+		'      exit 0' \
+		'      ;;' \
+		'  esac' \
+		'fi' \
+		'printf "%s\n" "kubectl-mutation:$*" >>"${GOSX_FAKE_DEPLOY_LOG}"' \
+		'echo "fake kubectl: unexpected or mutating args: $*" >&2' \
+		'exit 1'
+	chmod +x "${tools_dir}/kubectl"
+}
+
+setup_repo() {
+	label="$1"
+	remote_dir="${tmp_dir}/${label}-remote.git"
+	repo_dir="${tmp_dir}/${label}-repo"
+	git init --bare --initial-branch=main "$remote_dir" >/dev/null
+	git init --initial-branch=main "$repo_dir" >/dev/null
+	git -C "$repo_dir" config user.email "docs-gate@example.invalid"
+	git -C "$repo_dir" config user.name "Docs Gate"
+	git -C "$repo_dir" remote add origin "$remote_dir"
+	mkdir -p "${repo_dir}/scripts/testdata" "${repo_dir}/examples/gosx-docs" "${repo_dir}/deploy"
+	cp "${repo_source}/scripts/deploy-gosx-docs.sh" "${repo_dir}/scripts/deploy-gosx-docs.sh"
+	cp "${repo_source}/scripts/check-gosx-docs-deploy-source.sh" "${repo_dir}/scripts/check-gosx-docs-deploy-source.sh"
+	cp "${repo_source}/scripts/check-gosx-docs-built-identity.sh" "${repo_dir}/scripts/check-gosx-docs-built-identity.sh"
+	cp "${repo_source}/scripts/testdata/fake-gosx-docs-built-identity-app.py" "${repo_dir}/scripts/testdata/fake-gosx-docs-built-identity-app.py"
+	write_file "${repo_dir}/scripts/deploy-gosx-docs-transaction.sh" '# transaction stub for pre-mutation gate tests'
+	write_file "${repo_dir}/scripts/deploy-gosx-docs-public.sh" '# public verification stub for pre-mutation gate tests'
+	write_file "${repo_dir}/examples/gosx-docs/main.go" 'package main'
+	write_file "${repo_dir}/examples/gosx-docs/Dockerfile.runtime" 'FROM scratch'
+	write_file "${repo_dir}/deploy/gosx-docs.yaml" 'image: __IMAGE_DIGEST__' 'revision: __GIT_REVISION__' 'builtAt: __BUILT_AT__'
+	write_file "${repo_dir}/file.txt" 'base'
+	git -C "$repo_dir" add .
+	git -C "$repo_dir" commit -m "base" >/dev/null
+	git -C "$repo_dir" push -u origin main >/dev/null
+	printf '%s\n' "$repo_dir"
+}
+
+run_deploy() {
+	label="$1"
+	repo_dir="$2"
+	shift 2
+	tools_dir="${tmp_dir}/${label}-tools"
+	log_file="${tmp_dir}/${label}.log"
+	out_file="${tmp_dir}/${label}.out"
+	fake_go_root="${tmp_dir}/${label}-go-root"
+	write_fake_tools "$tools_dir"
+	mkdir -p "${fake_go_root}/bin"
+	cp "${tools_dir}/go" "${fake_go_root}/bin/go"
+	if (cd "$repo_dir" && \
+		PATH="${tools_dir}:$PATH" \
+		GO="${tools_dir}/go" \
+		DOCKER="${tools_dir}/docker" \
+		KUBECTL="${tools_dir}/kubectl" \
+		TINYGO="${tools_dir}/tinygo" \
+		GOSX_TINYGO_GOROOT="$fake_go_root" \
+		GOSX_FAKE_DEPLOY_LOG="$log_file" \
+		GOSX_FAKE_IDENTITY_APP_SRC="${repo_dir}/scripts/testdata/fake-gosx-docs-built-identity-app.py" \
+		"$@" \
+		sh scripts/deploy-gosx-docs.sh >"$out_file" 2>&1); then
+		printf 'pass:%s:%s:%s\n' "$label" "$log_file" "$out_file"
+	else
+		printf 'fail:%s:%s:%s\n' "$label" "$log_file" "$out_file"
+	fi
+}
+
+assert_failed() {
+	result="$1"
+	label="${result#*:}"
+	label="${label%%:*}"
+	case "$result" in
+		fail:*) ;;
+		*)
+			echo "gosx docs deploy gate test: ${label} unexpectedly passed" >&2
+			exit 1
+			;;
+	esac
+}
+
+result_log() {
+	result="$1"
+	rest="${result#*:}"
+	rest="${rest#*:}"
+	printf '%s\n' "${rest%%:*}"
+}
+
+result_out() {
+	result="$1"
+	rest="${result#*:}"
+	rest="${rest#*:}"
+	printf '%s\n' "${rest#*:}"
+}
+
+assert_no_side_effects() {
+	log_file="$1"
+	if [ -s "$log_file" ] && grep -E 'go:|tinygo:|docker-|registry-|kubectl-' "$log_file" >/dev/null; then
+		echo "gosx docs deploy gate test: source gate failure reached side-effect-capable commands" >&2
+		cat "$log_file" >&2
+		exit 1
+	fi
+}
+
+assert_no_mutations() {
+	log_file="$1"
+	if [ -s "$log_file" ] && grep -E 'docker-mutation|registry-mutation|kubectl-mutation' "$log_file" >/dev/null; then
+		echo "gosx docs deploy gate test: gate failure reached a deploy mutation" >&2
+		cat "$log_file" >&2
+		exit 1
+	fi
+}
+
+assert_output_contains() {
+	result="$1"
+	want="$2"
+	out_file="$(result_out "$result")"
+	if ! grep -F "$want" "$out_file" >/dev/null; then
+		echo "gosx docs deploy gate test: failure did not explain ${want}" >&2
+		cat "$out_file" >&2
+		exit 1
+	fi
+}
+
+repo_fetch="$(setup_repo fetch-failure)"
+git -C "$repo_fetch" remote set-url origin "${tmp_dir}/missing.git"
+result="$(run_deploy fetch-failure "$repo_fetch" env GOSX_DOCS_DEPLOY_REMOTE="$tmp_dir/nope.git" GOSX_DOCS_DEPLOY_BRANCH=evil GOSX_DOCS_DEPLOY_ALLOW_FETCH=0)"
+assert_failed "$result"
+assert_output_contains "$result" "deployment source must be checked against a fresh default-branch ref"
+assert_no_side_effects "$(result_log "$result")"
+
+repo_env="$(setup_repo env-bypass)"
+result="$(run_deploy env-bypass "$repo_env" env GOSX_DOCS_DEPLOY_REMOTE="$tmp_dir/nope.git" GOSX_DOCS_DEPLOY_BRANCH=evil GOSX_DOCS_DEPLOY_ALLOW_FETCH=0 GOSX_FAKE_IDENTITY_APP_MODE=bad-identity)"
+assert_failed "$result"
+assert_output_contains "$result" "/api/site does not match the intended deployment identity"
+if grep -F "evil" "$(result_out "$result")" >/dev/null; then
+	echo "gosx docs deploy gate test: entry script honored environment branch override" >&2
+	cat "$(result_out "$result")" >&2
+	exit 1
+fi
+assert_no_mutations "$(result_log "$result")"
+
+repo_identity="$(setup_repo identity-failure)"
+identity_secret_log="${tmp_dir}/identity-secret.log"
+result="$(run_deploy identity-failure "$repo_identity" env GOSX_FAKE_IDENTITY_APP_MODE=bad-identity GOSX_FAKE_IDENTITY_APP_SECRET_LOG="$identity_secret_log")"
+assert_failed "$result"
+assert_output_contains "$result" "/api/site does not match the intended deployment identity"
+assert_no_mutations "$(result_log "$result")"
+if grep -F "real-cluster-secret" "$identity_secret_log" >/dev/null; then
+	echo "gosx docs deploy gate test: real cluster secret reached the local identity process" >&2
+	cat "$identity_secret_log" >&2
+	exit 1
+fi
+if ! grep -F "gosx-docs-local-identity-" "$identity_secret_log" >/dev/null; then
+	echo "gosx docs deploy gate test: local identity process did not receive a disposable secret" >&2
+	cat "$identity_secret_log" >&2
+	exit 1
+fi
+
+for toctou_mode in local-commit branch-switch remote-advance; do
+	repo_toctou="$(setup_repo "toctou-${toctou_mode}")"
+	result="$(run_deploy "toctou-${toctou_mode}" "$repo_toctou" env GOSX_FAKE_TOCTOU="$toctou_mode")"
+	assert_failed "$result"
+	assert_output_contains "$result" "gosx docs deploy source:"
+	assert_no_mutations "$(result_log "$result")"
+	if ! grep -F "gosx:build --prod ./examples/gosx-docs" "$(result_log "$result")" >/dev/null; then
+		echo "gosx docs deploy gate test: ${toctou_mode} did not reach the post-build source gate" >&2
+		cat "$(result_log "$result")" >&2
+		exit 1
+	fi
+done
+
+echo "gosx docs deploy gate test: fail-closed gate ordering passed"

--- a/scripts/deploy-gosx-docs-order-test.sh
+++ b/scripts/deploy-gosx-docs-order-test.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env sh
+set -eu
+
+script="scripts/deploy-gosx-docs.sh"
+
+line_of() {
+	pattern="$1"
+	line="$(grep -n -F "$pattern" "$script" | sed -n '1s/:.*//p')"
+	if [ -z "$line" ]; then
+		echo "gosx docs deploy order test: missing pattern: ${pattern}" >&2
+		exit 1
+	fi
+	printf '%s\n' "$line"
+}
+
+require_before() {
+	first_label="$1"
+	first_line="$2"
+	second_label="$3"
+	second_line="$4"
+	if [ "$first_line" -ge "$second_line" ]; then
+		echo "gosx docs deploy order test: ${first_label} must run before ${second_label}" >&2
+		echo "gosx docs deploy order test: ${first_label} line ${first_line}; ${second_label} line ${second_line}" >&2
+		exit 1
+	fi
+}
+
+source_gate_line="$(line_of 'check-gosx-docs-deploy-source.sh')"
+deployment_read_line="$(line_of 'build_base_deployment_json="$($kubectl_cmd get')"
+secret_read_line="$(line_of 'session_secret_present="$($kubectl_cmd get')"
+cli_build_line="$(line_of 'build -o "$gosx_cli" ./cmd/gosx')"
+docs_build_line="$(line_of '"$gosx_cli" build --prod ./examples/gosx-docs')"
+identity_gate_line="$(line_of 'check-gosx-docs-built-identity.sh')"
+docker_build_line="$(line_of '"$docker_cmd" build \')"
+docker_push_line="$(line_of '"$docker_cmd" push "$image"')"
+
+require_before "source authority gate" "$source_gate_line" "Deployment read" "$deployment_read_line"
+require_before "source authority gate" "$source_gate_line" "secret read" "$secret_read_line"
+require_before "source authority gate" "$source_gate_line" "CLI build" "$cli_build_line"
+require_before "source authority gate" "$source_gate_line" "docs build" "$docs_build_line"
+require_before "identity gate" "$identity_gate_line" "Docker build" "$docker_build_line"
+require_before "identity gate" "$identity_gate_line" "Docker push" "$docker_push_line"
+require_before "docs build" "$docs_build_line" "identity gate" "$identity_gate_line"
+
+if ! grep -F 'namespace="draco-quest"' "$script" >/dev/null; then
+	echo "gosx docs deploy order test: deployment namespace must remain draco-quest" >&2
+	exit 1
+fi
+if ! grep -F 'deployment="gosx-docs"' "$script" >/dev/null; then
+	echo "gosx docs deploy order test: deployment name must remain gosx-docs" >&2
+	exit 1
+fi
+if grep -F 'm31labs' "$script" | grep -v -F 'gosx.m31labs.dev' >/dev/null; then
+	echo "gosx docs deploy order test: stale m31labs namespace/path surfaced in deploy script" >&2
+	exit 1
+fi
+
+echo "gosx docs deploy order test: source and identity gates precede deploy side effects"

--- a/scripts/deploy-gosx-docs.sh
+++ b/scripts/deploy-gosx-docs.sh
@@ -16,6 +16,7 @@ expected_tinygo="0.41.1"
 expected_tinygo_go="go1.25.5"
 tinygo_go_root="${GOSX_TINYGO_GOROOT:-}"
 curl_cmd="${CURL:-curl}"
+expected_revision="${GOSX_DOCS_DEPLOY_EXPECT_REVISION:-}"
 
 require_command() {
 	command_name="$1"
@@ -29,13 +30,41 @@ worktree_changes() {
 	git status --porcelain --untracked-files=normal -- . ':(exclude)examples/gosx-docs/dist'
 }
 
-for command_name in git "$go_cmd" "$docker_cmd" "$kubectl_cmd" "$tinygo_cmd" "$curl_cmd" \
-	base64 date dirname find grep jq mktemp sed tail tr; do
+for command_name in git; do
 	require_command "$command_name"
 done
 
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
+approve_source_revision() {
+	source_expected_revision="$1"
+	if [ -n "$source_expected_revision" ]; then
+		sh scripts/check-gosx-docs-deploy-source.sh \
+			--root "$repo_root" \
+			--remote origin \
+			--branch main \
+			--allow-fetch 1 \
+			--expected-revision "$source_expected_revision"
+	else
+		sh scripts/check-gosx-docs-deploy-source.sh \
+			--root "$repo_root" \
+			--remote origin \
+			--branch main \
+			--allow-fetch 1
+	fi
+}
+approved_revision_from_line() {
+	approved_line="$1"
+	approved_revision="${approved_line#revision=}"
+	if [ "$approved_line" = "$approved_revision" ] || [ -z "$approved_revision" ]; then
+		echo "gosx docs deploy: source authority gate did not return an approved revision" >&2
+		exit 1
+	fi
+	printf '%s\n' "$approved_revision"
+}
+approved_revision_line="$(approve_source_revision "$expected_revision")"
+revision="$(approved_revision_from_line "$approved_revision_line")"
+
 transaction_lib="${repo_root}/scripts/deploy-gosx-docs-transaction.sh"
 if [ ! -f "$transaction_lib" ]; then
 	echo "gosx docs deploy: transaction helper is missing: ${transaction_lib}" >&2
@@ -51,6 +80,11 @@ fi
 # shellcheck source=deploy-gosx-docs-public.sh
 . "$public_lib"
 
+for command_name in "$go_cmd" "$docker_cmd" "$kubectl_cmd" "$tinygo_cmd" "$curl_cmd" \
+	date dirname find grep jq mktemp sed tail tr; do
+	require_command "$command_name"
+done
+
 host_goos="$($go_cmd env GOHOSTOS)"
 host_goarch="$($go_cmd env GOHOSTARCH)"
 if [ "$host_goos/$host_goarch" != "linux/amd64" ]; then
@@ -60,11 +94,6 @@ fi
 docker_platform="$($docker_cmd version --format '{{.Server.Os}}/{{.Server.Arch}}' 2>/dev/null || true)"
 if [ "$docker_platform" != "linux/amd64" ]; then
 	echo "gosx docs deploy: the Docker builder must be linux/amd64; got ${docker_platform:-unavailable}" >&2
-	exit 1
-fi
-
-if [ -n "$(worktree_changes)" ]; then
-	echo "gosx docs deploy: refusing a dirty worktree" >&2
 	exit 1
 fi
 
@@ -90,7 +119,6 @@ case "$compat_go_version" in
 		;;
 esac
 
-revision="$(git rev-parse HEAD)"
 built_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 if [ ! -r /proc/sys/kernel/random/uuid ]; then
 	echo "gosx docs deploy: kernel UUID source is unavailable" >&2
@@ -104,6 +132,7 @@ if [ "${#transaction_id}" -ne 32 ]; then
 	echo "gosx docs deploy: could not create a unique deployment transaction ID" >&2
 	exit 1
 fi
+local_identity_secret="gosx-docs-local-identity-${transaction_id}"
 tag="${GOSX_DOCS_TAG:-git-${revision}}"
 image="${registry}:${tag}"
 
@@ -126,11 +155,9 @@ if [ -z "$build_base_deployment_uid" ] || [ -z "$build_base_spec" ] || \
 	echo "gosx docs deploy: starting Deployment identity is unavailable" >&2
 	exit 1
 fi
-session_secret_b64="$($kubectl_cmd get -n "$namespace" "secret/${secret}" -o json | jq -er '.data["session-secret"]')"
-session_secret="$(printf '%s' "$session_secret_b64" | base64 --decode)"
-session_secret_b64=""
-if [ -z "$session_secret" ]; then
-	echo "gosx docs deploy: secret/${secret} has an empty session-secret" >&2
+session_secret_present="$($kubectl_cmd get -n "$namespace" "secret/${secret}" -o json | jq -er '.data["session-secret"] | strings | length > 0')"
+if [ "$session_secret_present" != "true" ]; then
+	echo "gosx docs deploy: secret/${secret} session-secret is missing or empty" >&2
 	exit 1
 fi
 
@@ -207,10 +234,9 @@ PATH="${tinygo_dir}:${PATH}" \
 	PUBLIC_URL="$public_url" \
 	GOSX_DOCS_REVISION="$revision" \
 	GOSX_DOCS_BUILT_AT="$built_at" \
-	SESSION_SECRET="$session_secret" \
+	SESSION_SECRET="$local_identity_secret" \
 	GOOS=linux GOARCH=amd64 CGO_ENABLED=0 \
 	"$gosx_cli" build --prod ./examples/gosx-docs
-session_secret=""
 for required_output in build.json run.sh server/app; do
 	if [ ! -s "${dist_dir}/${required_output}" ]; then
 		echo "gosx docs deploy: production build did not create dist/${required_output}" >&2
@@ -219,6 +245,19 @@ for required_output in build.json run.sh server/app; do
 done
 if [ -n "$(worktree_changes)" ]; then
 	echo "gosx docs deploy: production build changed the worktree" >&2
+	exit 1
+fi
+SESSION_SECRET="$local_identity_secret" sh scripts/check-gosx-docs-built-identity.sh \
+	--root "$dist_dir" \
+	--app "${dist_dir}/server/app" \
+	--framework-version "$framework_version" \
+	--revision "$revision" \
+	--built-at "$built_at" \
+	--public-url "$public_url"
+approved_mutation_revision_line="$(approve_source_revision "$revision")"
+mutation_revision="$(approved_revision_from_line "$approved_mutation_revision_line")"
+if [ "$mutation_revision" != "$revision" ]; then
+	echo "gosx docs deploy: source authority changed before deployment mutation" >&2
 	exit 1
 fi
 

--- a/scripts/testdata/fake-gosx-docs-built-identity-app.py
+++ b/scripts/testdata/fake-gosx-docs-built-identity-app.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+import json
+import os
+import sys
+import threading
+import time
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+def listen_addr():
+    raw = os.environ.get("PORT", "")
+    if not raw:
+        raise SystemExit("PORT is required")
+    if ":" in raw:
+        host, port = raw.rsplit(":", 1)
+    else:
+        host, port = "127.0.0.1", raw
+    if host != "127.0.0.1":
+        raise SystemExit(f"expected loopback bind, got {host}")
+    return host, int(port)
+
+
+MODE = os.environ.get("GOSX_FAKE_IDENTITY_APP_MODE", "ok")
+FRAMEWORK_VERSION = os.environ.get("GOSX_DOCS_REVISION_FRAMEWORK_VERSION", "v0.53.9")
+REVISION = os.environ.get("GOSX_DOCS_REVISION", "1111111111111111111111111111111111111111")
+BUILT_AT = os.environ.get("GOSX_DOCS_BUILT_AT", "2026-08-30T00:00:00Z")
+PUBLIC_URL = os.environ.get("PUBLIC_URL", "https://gosx.m31labs.dev").rstrip("/")
+
+pid_file = os.environ.get("GOSX_FAKE_IDENTITY_APP_PID_FILE")
+if pid_file:
+    with open(pid_file, "w", encoding="utf-8") as handle:
+        handle.write(str(os.getpid()))
+
+secret_log = os.environ.get("GOSX_FAKE_IDENTITY_APP_SECRET_LOG")
+if secret_log:
+    with open(secret_log, "a", encoding="utf-8") as handle:
+        handle.write(os.environ.get("SESSION_SECRET", "") + "\n")
+
+
+class Handler(BaseHTTPRequestHandler):
+    def log_message(self, fmt, *args):
+        return
+
+    def write_json(self, payload):
+        body = json.dumps(payload).encode("utf-8")
+        self.send_response(200)
+        self.send_header("content-type", "application/json")
+        self.send_header("content-length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        self.wfile.flush()
+
+    def do_GET(self):
+        if self.path == "/api/site":
+            revision = REVISION
+            if MODE in ("bad-identity", "wrong-responder"):
+                revision = "2222222222222222222222222222222222222222"
+            self.write_json({
+                "site": "gosx-docs",
+                "status": "ok",
+                "apiVersion": "1",
+                "framework": "GoSX",
+                "frameworkVersion": FRAMEWORK_VERSION,
+                "revision": revision,
+                "builtAt": BUILT_AT,
+                "publicURL": PUBLIC_URL,
+            })
+            if MODE == "exit-after-site":
+                threading.Thread(target=lambda: (time.sleep(0.1), os._exit(0)), daemon=True).start()
+            return
+        if self.path == "/healthz":
+            self.write_json({"ok": True})
+            return
+        if self.path == "/readyz":
+            self.write_json({"ok": True})
+            return
+        self.send_response(404)
+        self.end_headers()
+
+
+if __name__ == "__main__":
+    try:
+        server = HTTPServer(listen_addr(), Handler)
+    except OSError as exc:
+        print(f"fake identity app bind failed: {exc}", file=sys.stderr)
+        raise SystemExit(1)
+    server.serve_forever()

--- a/scripts/testdata/fake-gosx-docs-built-identity-curl.sh
+++ b/scripts/testdata/fake-gosx-docs-built-identity-curl.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env sh
+set -eu
+
+mode="${GOSX_DOCS_FAKE_IDENTITY_MODE:?}"
+framework_version="${GOSX_DOCS_FAKE_FRAMEWORK_VERSION:-v0.53.9}"
+revision="${GOSX_DOCS_FAKE_REVISION:-1111111111111111111111111111111111111111}"
+built_at="${GOSX_DOCS_FAKE_BUILT_AT:-2026-08-30T00:00:00Z}"
+public_url="${GOSX_DOCS_FAKE_PUBLIC_URL:-https://gosx.m31labs.dev}"
+
+request_url=""
+for request_arg in "$@"; do
+	request_url="$request_arg"
+done
+
+site_json() {
+	printf '{"site":"gosx-docs","status":"ok","apiVersion":"1","framework":"GoSX","frameworkVersion":"%s","revision":"%s","builtAt":"%s","runtime":"go1.26.0","publicURL":"%s"}\n' \
+		"$1" "$2" "$3" "$4"
+}
+
+case "$request_url" in
+	*/api/site)
+		case "$mode" in
+			ok) site_json "$framework_version" "$revision" "$built_at" "$public_url" ;;
+			stale-revision) site_json "$framework_version" "2222222222222222222222222222222222222222" "$built_at" "$public_url" ;;
+			unknown-revision) site_json "$framework_version" "unknown" "$built_at" "$public_url" ;;
+			wrong-framework) site_json "v0.1.0" "$revision" "$built_at" "$public_url" ;;
+			wrong-built-at) site_json "$framework_version" "$revision" "2026-08-29T00:00:00Z" "$public_url" ;;
+			wrong-public-url) site_json "$framework_version" "$revision" "$built_at" "https://wrong.example.test" ;;
+			malformed-site) printf '%s\n' 'not json' ;;
+			*) site_json "$framework_version" "$revision" "$built_at" "$public_url" ;;
+		esac
+		;;
+	*/healthz)
+		case "$mode" in
+			unhealthy) printf '%s\n' '{"ok":false}' ;;
+			*) printf '%s\n' '{"ok":true}' ;;
+		esac
+		;;
+	*/readyz)
+		case "$mode" in
+			unready) printf '%s\n' '{"ok":false}' ;;
+			*) printf '%s\n' '{"ok":true}' ;;
+		esac
+		;;
+	*)
+		echo "fake identity curl: unexpected URL ${request_url}" >&2
+		exit 2
+		;;
+esac


### PR DESCRIPTION
## Summary

Public docs could be built and published from a clean but stale, detached, or local-only revision while consistently advertising that wrong identity. This change makes the deploy lane fail closed.

- Require a fresh, clean origin/main source identity before build and re-check the approved revision immediately before the first Docker, registry, or Kubernetes mutation.
- Verify the freshly built loopback docs server advertises the exact framework version, revision, build time, public URL, health, and readiness before image publication, without exposing the real cluster session secret.
- Preserve the guarded deployment transaction, compare-and-swap, and rollback behavior, plus default-branch and tag ancestry governance.
- Wire deterministic source, identity, ordering, and fail-closed fixtures into release gate 5 alongside repository hygiene (4), workflow and ancestry controls (6-8), the perf wrapper (9), and module-zip verification (10).

## Verification

- make test-docs-deploy (all six docs deploy fixtures)
- make test-repo-hygiene
- make test-perf-budget-ci
- make fmt-check
- make release-gate (all 10 steps)
- sh -n on the relevant deploy scripts
- actionlint
- git diff --check origin/main..HEAD

This PR does not deploy docs or mutate the registry, Kubernetes, tags, or releases.