### PR TITLE
test(perf): synchronize busy-main-thread attribution

### DIFF
--- a/perf/metrics_collect_browser_test.go
+++ b/perf/metrics_collect_browser_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -17,26 +18,37 @@ import (
 func TestCollectPageReportBusyMainThreadAttributesFirstQuery(t *testing.T) {
 	d := requireDriver(t, 5*time.Second)
 	busyStarted := make(chan struct{}, 1)
+	releaseBusy := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseBusy)
+		})
+	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/busy-started" {
+		if r.URL.Path == "/busy-block" {
 			select {
 			case busyStarted <- struct{}{}:
 			default:
 			}
+			<-releaseBusy
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		w.Header().Set("Content-Type", "text/html")
 		fmt.Fprint(w, `<!doctype html><html><body><script>
-			setTimeout(function() {
-				navigator.sendBeacon('/busy-started', 'busy');
-				var until = performance.now() + 1500;
-				while (performance.now() < until) {}
-			}, 50);
+			window.blockMainThreadForPerfTest = function() {
+				var xhr = new XMLHttpRequest();
+				xhr.open('GET', '/busy-block', false);
+				xhr.send();
+			};
 		</script></body></html>`)
 	}))
-	defer srv.Close()
+	defer func() {
+		release()
+		srv.Close()
+	}()
 
 	if err := d.Navigate(srv.URL); err != nil {
 		t.Fatalf("Navigate: %v", err)
@@ -44,6 +56,12 @@ func TestCollectPageReportBusyMainThreadAttributesFirstQuery(t *testing.T) {
 	if err := d.WaitReady(); err != nil {
 		t.Fatalf("WaitReady: %v", err)
 	}
+
+	blockErr := make(chan error, 1)
+	go func() {
+		var ignored any
+		blockErr <- d.Evaluate(`window.blockMainThreadForPerfTest()`, &ignored)
+	}()
 	select {
 	case <-busyStarted:
 	case <-time.After(2 * time.Second):
@@ -63,11 +81,14 @@ func TestCollectPageReportBusyMainThreadAttributesFirstQuery(t *testing.T) {
 		diagnosticPageReportQueryRunner(&diagnostics, 0, 1, srv.URL, queryTimeout),
 	)
 	if report != nil {
+		release()
 		t.Fatalf("busy page returned a report: %+v", report)
 	}
 	if !errors.Is(err, context.DeadlineExceeded) {
+		release()
 		t.Fatalf("busy page error = %v, want context deadline exceeded", err)
 	}
+	release()
 	if !strings.Contains(err.Error(), "collect/navigation-timing") {
 		t.Fatalf("busy page error lacks exact first-query attribution: %v", err)
 	}
@@ -82,5 +103,8 @@ func TestCollectPageReportBusyMainThreadAttributesFirstQuery(t *testing.T) {
 	}
 	if strings.Contains(log, "phase=collect/heap-size start") {
 		t.Fatalf("collector advanced after required query cancellation:\n%s", log)
+	}
+	if err := <-blockErr; err != nil {
+		t.Fatalf("release synchronized busy-main-thread section: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

This is a test-only repair for the false main-branch browser failure in run 33298697973.

The failing fixture, TestCollectPageReportBusyMainThreadAttributesFirstQuery, synchronized on navigator.sendBeacon before a timed CPU loop. In CI, that synchronization could observe the beacon after Chrome was no longer blocking the relevant DevTools query path, so collection returned a full report instead of exercising the intended first-query deadline path.

This patch replaces that with a deterministic server-held synchronous XHR barrier:

- the page exposes window.blockMainThreadForPerfTest();
- the test invokes it from Go after Navigate/WaitReady;
- the /busy-block handler signals busyStarted, then blocks its response on a release channel;
- the 150ms collection context runs while the synchronous XHR keeps Chrome main thread blocked;
- cleanup idempotently releases the handler before closing the test server.

## Scope

- Changes only perf/metrics_collect_browser_test.go.
- No production code changes.
- No timeout, budget, route, schema, perf collection, or CI behavior changes.
- Preserves the exact attribution assertions for collect/navigation-timing and errors.Is(err, context.DeadlineExceeded).

## Evidence

Main-run false failure:

- Run: https://github.com/odvcencio/gosx/actions/runs/33298697973
- Failed before Perf budget gate, inside Perf driver browser tests.
- Failure: TestCollectPageReportBusyMainThreadAttributesFirstQuery unexpectedly returned a full report.

Verification after this patch:

- Focused repeat passed independently at 30x.
- Race repeat passed independently at 10x.
- Local worker run also passed the same focused browser test at 20x and race repeat at 5x.
- git diff --check passed.

Additional local worker evidence/caveats:

- make test-perf-browser passed the edited m31labs.dev/gosx/perf package, then timed out in unrelated perf/ouroboros test TestBuildSizeEvidenceRecordsNoncanonicalSymlinkEscapedAsset.
- make perf-budget-ci completed collection for both routes/all 11 probes without collection deadline recurrence, but failed local water LCP variance: actual 2904 > 2000.

Those caveats are outside this one-file test-only fix and do not indicate a production collection-deadline regression.

## Rollback

Revert this commit to restore the prior beacon/timed-loop fixture. Production behavior is unaffected either way.