### PR TITLE
add(scene3d): govern renderer architecture

### DIFF
--- a/assetpipe/ibl/consumer_test.go
+++ b/assetpipe/ibl/consumer_test.go
@@ -5,21 +5,18 @@ import (
 	"strings"
 	"testing"
 
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 	"m31labs.dev/gosx/scene/capability"
 )
 
-const (
-	webglRendererPath  = "../../client/runtime/scene3d/webgl.ts"
-	webgpuRendererPath = "../../client/runtime/scene3d/webgpu.ts"
+var (
+	webglRendererPath  = scene3drenderersource.BackendLabel("webgl")
+	webgpuRendererPath = scene3drenderersource.BackendLabel("webgpu")
 )
 
-func readRenderer(t *testing.T, path string) string {
+func readRenderer(t *testing.T, label string) string {
 	t.Helper()
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
-	}
-	return string(data)
+	return scene3drenderersource.ReadSource(t, label)
 }
 
 // TestWebGLEnvironmentPathConsumesPrefilteredIBL corroborates the real,

--- a/client/js/16a-scene-webgpu-bundle.test.mjs
+++ b/client/js/16a-scene-webgpu-bundle.test.mjs
@@ -24,6 +24,9 @@ import fs from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
@@ -32,7 +35,7 @@ function readSource(name) {
   return fs.readFileSync(name.startsWith("../") ? path.join(__dirname, name) : path.join(srcDir, name), "utf8");
 }
 
-const webgpuSource = readSource("../runtime/scene3d/webgpu.ts");
+const webgpuSource = readSceneRendererBackendSrc("webgpu");
 const computeSource = readSource("../runtime/scene3d/compute.ts");
 const computeBridgeSource = readSource("26e1-feature-scene3d-webgpu-compute-bridge.ts");
 

--- a/client/js/16a-scene-webgpu-f16.test.mjs
+++ b/client/js/16a-scene-webgpu-f16.test.mjs
@@ -24,10 +24,13 @@ import path from "node:path";
 import vm from "node:vm";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
-const webgpuSource = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+const webgpuSource = readSceneRendererBackendSrc("webgpu");
 
 // loadShaderVariants evaluates the preamble helper and the two shader bodies out
 // of the shipped source, then builds all four variants exactly as the renderer

--- a/client/js/16a-scene-webgpu-lights.test.mjs
+++ b/client/js/16a-scene-webgpu-lights.test.mjs
@@ -24,6 +24,9 @@ import path from "node:path";
 import vm from "node:vm";
 import { execFileSync } from "node:child_process";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
@@ -32,8 +35,8 @@ function readSource(name) {
   return fs.readFileSync(name.startsWith("../") ? path.join(__dirname, name) : path.join(srcDir, name), "utf8");
 }
 
-const webgpuSource = readSource("../runtime/scene3d/webgpu.ts");
-const webglSource = readSource("../runtime/scene3d/webgl.ts");
+const webgpuSource = readSceneRendererBackendSrc("webgpu");
+const webglSource = readSceneRendererBackendSrc("webgl");
 
 // --- Bundle-shaped VM context ----------------------------------------------
 

--- a/client/js/16a-scene-webgpu-pick.test.mjs
+++ b/client/js/16a-scene-webgpu-pick.test.mjs
@@ -21,6 +21,9 @@ import fs from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
@@ -282,7 +285,7 @@ function createContext() {
   vm.runInContext(prelude, context, { filename: "prelude.js" });
   vm.runInContext(readSource("11-scene-math.ts"), context, { filename: "11-scene-math.ts" });
   vm.runInContext(readSource("17-scene-input.ts"), context, { filename: "17-scene-input.ts" });
-  vm.runInContext(readSource("../runtime/scene3d/webgpu.ts"), context, { filename: "webgpu.ts" });
+  vm.runInContext(readSceneRendererBackendSrc("webgpu"), context, { filename: "webgpu.ts" });
   return { context, sandbox };
 }
 

--- a/client/js/runtime-03-scene-models-animation.test.js
+++ b/client/js/runtime-03-scene-models-animation.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Declarative Scene3D model loading: glTF and GLB parsing, point and line
 // primitives, skinning, animation playback and the Selena skin material.
 //
@@ -988,7 +990,7 @@ test("bootstrap renders a skinned GLB through the Selena material (default flip 
 });
 
 test("scenePBRSelenaSkinAugmentVertex renames position/normal, injects joint-skin GPU code, and validates as GLSL", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   const match = webgl.match(/function scenePBRSelenaSkinAugmentVertex\(source\)\s*\{([\s\S]*?)\n  \}/);
   assert.ok(match, "scenePBRSelenaSkinAugmentVertex must be extractable from 16-scene-webgl.js source");
 

--- a/client/js/runtime-05-scene-camera-planner.test.js
+++ b/client/js/runtime-05-scene-camera-planner.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Scene3D camera math and the shared draw planner: projection, view matrices,
 // depth conventions, screen-to-ray, draw sorting and bounds culling.
 //
@@ -275,8 +277,8 @@ test("bootstrap Scene3D WebGL shaders use shared camera depth contract", () => {
 });
 
 test("bootstrap Scene3D WebGL and WebGPU consume shared PBR view matrix", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgl, /scenePBRViewMatrix\(cam, scratchViewMatrix\)/);
   assert.match(webgl, /gl\.uniformMatrix4fv\(uniforms\.viewMatrix, false, viewMatrix\)/);
@@ -286,8 +288,8 @@ test("bootstrap Scene3D WebGL and WebGPU consume shared PBR view matrix", () => 
 });
 
 test("bootstrap Scene3D PBR cameraPos uniforms use world eye position", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgl, /vec3 V = normalize\(u_cameraPosition - v_worldPosition\);/);
   assert.match(webgl, /gl\.uniform3f\(uniforms\.cameraPosition, cam\.x, cam\.y, cam\.z\)/);

--- a/client/js/runtime-06-scene-webgpu-water.test.js
+++ b/client/js/runtime-06-scene-webgpu-water.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // WebGPU buffer packing, point rendering, post-effect passes, custom Selena
 // materials and the WebGPU / WebGL2 water renderers.
 //
@@ -22,11 +24,10 @@ const {
   loadSceneWaterClockAPI,
   createAdaptiveQualityHarness,
   readSceneMountSrc,
-  readWebGPUBackendSrc,
 } = require("./runtime-test-harness.js");
 
 test("bootstrap keeps WebGPU Scene3D points on per-entry cached GPU buffers", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /function ensurePointsUniformGPUBuffer\(owner, uniformData\)/);
   assert.match(source, /function ensurePointsParticleGPUBuffer\(entry, particleData\)/);
@@ -40,7 +41,7 @@ test("bootstrap keeps WebGPU Scene3D points on per-entry cached GPU buffers", ()
 });
 
 test("bootstrap keeps WebGPU Scene3D PBR mesh attributes on packed scene GPU buffers", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
   const sceneBuffers = source.slice(source.indexOf("function ensurePBRSceneAttributeBuffers"), source.indexOf("function webGPUBindSceneMeshVertexBuffer"));
   const bindSceneBuffer = source.slice(source.indexOf("function webGPUBindSceneMeshVertexBuffer"), source.indexOf("// -----------------------------------------------------------------------\n    // Draw list construction"));
   const shadowPass = source.slice(source.indexOf("function renderShadowPass"), source.indexOf("// -----------------------------------------------------------------------\n    // PBR object drawing"));
@@ -86,7 +87,7 @@ test("bootstrap keeps WebGPU Scene3D PBR mesh attributes on packed scene GPU buf
 });
 
 test("bootstrap renders WebGPU Scene3D static points from instanced vertex buffers", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /var WGSL_POINTS_INSTANCED_VERTEX = \[/);
   assert.match(source, /var WGPU_POINTS_INSTANCE_VERTEX_LAYOUT = \[/);
@@ -100,7 +101,7 @@ test("bootstrap renders WebGPU Scene3D static points from instanced vertex buffe
 });
 
 test("bootstrap renders WebGPU Scene3D glow points with radial alpha", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /points\.flags\.w == 2u/);
   assert.match(source, /let radial = length\(centered\) \* 2\.0/);
@@ -112,7 +113,7 @@ test("bootstrap renders WebGPU Scene3D glow points with radial alpha", () => {
 });
 
 test("bootstrap keeps WebGPU Scene3D point uniforms vec4-aligned", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /defaultColorAndSize: vec4f/);
   assert.match(source, /flags: vec4u/);
@@ -132,8 +133,8 @@ test("bootstrap keeps WebGPU Scene3D point uniforms vec4-aligned", () => {
 });
 
 test("bootstrap keeps WebGL and WebGPU Scene3D point size clamps in parity", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgl, /uniform float u_minPixelSize;/);
   assert.match(webgl, /uniform float u_maxPixelSize;/);
@@ -208,7 +209,7 @@ test("bootstrap preserves Scene3D point maxPixelSize from GLB extras", () => {
 });
 
 test("bootstrap exposes WebGPU Scene3D planned draw stats on the mount", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /function publishWebGPUFrameStats\(stats\)/);
   assert.match(source, /var webGPUFrameSeq = 0/);
@@ -243,7 +244,7 @@ test("bootstrap exposes WebGPU Scene3D planned draw stats on the mount", () => {
 });
 
 test("Scene3D WebGPU ignores popErrorScope lifecycle drops", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /function isWebGPUErrorScopeLifecycleMessage\(message\)/);
   assert.match(source, /function wgpuPopScopedErrorScope\(scopedDevice\)/);
@@ -254,7 +255,7 @@ test("Scene3D WebGPU ignores popErrorScope lifecycle drops", () => {
 });
 
 test("Scene3D WebGPU skinning is driven by Elio compute output buffers", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, /SCENE_ELIO_SKIN_LBS_SOURCE/);
   assert.match(source, /Emitted by m31labs\.dev\/elio\/emit\/wgsl from stdlib\.Skin\(\)/);
@@ -270,7 +271,7 @@ test("Scene3D WebGPU skinning is driven by Elio compute output buffers", () => {
 });
 
 test("Scene3D WebGPU water supports compound sphere object displacement", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const core = fs.readFileSync(path.join(__dirname, "bootstrap-src", "10-runtime-scene-core.ts"), "utf8");
 
   // The hand-written data-prop-authored compute pipeline tier
@@ -387,7 +388,7 @@ test("Scene3D WebGPU water supports compound sphere object displacement", () => 
 });
 
 test("Scene3D WebGPU water clips rounded box surfaces with a shader SDF", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /cornerRadius: f32/);
   assert.match(webgpu, /poolShape: f32/);
@@ -406,7 +407,7 @@ test("Scene3D WebGPU water clips rounded box surfaces with a shader SDF", () => 
 });
 
 test("Scene3D WebGPU water renders upstream-style above and below surface passes", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /SCENE_WATER_RENDER_FRAGMENT_SOURCE/);
   assert.match(webgpu, /SCENE_WATER_RENDER_BELOW_FRAGMENT_SOURCE/);
@@ -519,7 +520,7 @@ test("Scene3D WebGPU water renders upstream-style above and below surface passes
 });
 
 test("Scene3D WebGPU water renders an upstream-style pool pass with caustics and tile texture", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /SCENE_WATER_POOL_VERTEX_SOURCE/);
   assert.match(webgpu, /SCENE_WATER_POOL_FRAGMENT_SOURCE/);
@@ -948,7 +949,7 @@ test("Scene3D orbit controls expose focused keyboard exploration and authored re
 });
 
 test("Scene3D WebGPU water consumes caustic reflection refraction optics flags", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /opticsFlags: vec4f/);
   assert.match(webgpu, /function sceneWaterOpticsFlags/);
@@ -971,7 +972,7 @@ test("Scene3D WebGPU water consumes caustic reflection refraction optics flags",
 });
 
 test("Scene3D WebGPU water renders dynamic caustics to a sampled texture", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const core = fs.readFileSync(path.join(__dirname, "bootstrap-src", "10-runtime-scene-core.ts"), "utf8");
   const mount = readSceneMountSrc();
 
@@ -1061,7 +1062,7 @@ test("Scene3D WebGPU water renders dynamic caustics to a sampled texture", () =>
 });
 
 test("Scene3D WebGPU water renders upstream-style object texture targets", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const core = fs.readFileSync(path.join(__dirname, "bootstrap-src", "10-runtime-scene-core.ts"), "utf8");
   const mount = readSceneMountSrc();
   const geometry = fs.readFileSync(path.join(__dirname, "bootstrap-src", "12-scene-geometry.ts"), "utf8");
@@ -1453,8 +1454,8 @@ test("bootstrap bridges clamp01 into the WebGPU Scene3D sub-feature", () => {
 });
 
 test("Scene3D postfx tonemap modes are honored by WebGL and WebGPU", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgl, /uniform int u_toneMapMode/);
   assert.match(webgl, /u_toneMapMode == 2[\s\S]*reinhard\(color\)/);
@@ -1468,7 +1469,7 @@ test("Scene3D postfx tonemap modes are honored by WebGL and WebGPU", () => {
 });
 
 test("Scene3D WebGPU bloom blur avoids sparse radius tap grids", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /let radiusStep = clamp\(params\.radius \* 0\.35, 1\.0, 4\.0\)/);
   assert.match(webgpu, /offsets\[i\] \* radiusStep/);
@@ -1476,7 +1477,7 @@ test("Scene3D WebGPU bloom blur avoids sparse radius tap grids", () => {
 });
 
 test("Scene3D WebGPU SSAO uses a depth-backed post pass", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /var WGSL_POST_SSAO_FRAGMENT = \[/);
   assert.match(webgpu, /var WGSL_POST_DOF_FRAGMENT = \[/);
@@ -1493,9 +1494,9 @@ test("Scene3D WebGPU SSAO uses a depth-backed post pass", () => {
 });
 
 test("Scene3D FXAA is wired as the chain-end postfx pass in WebGL and WebGPU", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   const shared = fs.readFileSync(path.join(__dirname, "bootstrap-src", "16c-scene-shared-pbr.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // WebGL: GLSL fullscreen pass, dedicated program, wired into the effect switch.
   // The SCENE_POST_* kind constants live in 16c because 10-runtime-scene-core.js
@@ -1521,7 +1522,7 @@ test("Scene3D FXAA is wired as the chain-end postfx pass in WebGL and WebGPU", (
 });
 
 test("Scene3D WebGPU material uniforms cover physical PBR fields", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   for (const field of ["clearcoat", "sheen", "transmission", "iridescence", "anisotropy"]) {
     assert.match(webgpu, new RegExp(`${field}: f32`));
@@ -1544,7 +1545,7 @@ test("Scene3D WebGPU material uniforms cover physical PBR fields", () => {
 });
 
 test("Scene3D WebGPU reports custom material fallback diagnostics", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /function webGPUCustomMaterialStats\(materials\)/);
   assert.match(webgpu, /material\.customVertexWGSL/);
@@ -1556,8 +1557,8 @@ test("Scene3D WebGPU reports custom material fallback diagnostics", () => {
 });
 
 test("Scene3D executes Selena custom shader materials in WebGL and WebGPU", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = readWebGPUBackendSrc();
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgl, /function createSceneSelenaProgram\(gl, material, skinned\)/);
   assert.match(webgl, /ensureSelenaProgram\(mat, isSkinned\)/);
@@ -1581,8 +1582,8 @@ test("Scene3D executes Selena custom shader materials in WebGL and WebGPU", () =
 });
 
 test("Scene3D selena time auto-uniform: both backends declare the clock var and assign it before draws", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = readWebGPUBackendSrc();
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // WebGL keeps the per-frame clock in its renderer closure. WebGPU keeps the
   // same value on selenaFrame, the object it hands to the module-scope uniform
@@ -1605,8 +1606,8 @@ test("Scene3D selena time auto-uniform: both backends declare the clock var and 
 });
 
 test("Scene3D selena time auto-uniform: time is forced before customUniforms (reserved name)", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = readWebGPUBackendSrc();
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // The time branch must appear BEFORE the customUniforms early-return in both
   // resolvers (mirrors mvp/normalMatrix), so a compiled `param time` default
@@ -1628,7 +1629,7 @@ test("Scene3D selena time auto-uniform: time is forced before customUniforms (re
 });
 
 test("Scene3D WebGL2 water renderer wires the compound-object shadow pass", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // The compound-shadow program (compound-shadow.sel GLES) is compiled
   // alongside the sphere/cube object-shadow program, and both are disposed on
@@ -1655,8 +1656,8 @@ test("Scene3D WebGL2 water renderer wires the compound-object shadow pass", () =
 });
 
 test("Scene3D water renderers use one scheduler and bounded balanced-quality work", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // The mount owns animation. A backend-private rAF doubles WebGL work when
   // the mount also animates a WaterSystem and bypasses pause/offscreen policy.
@@ -1739,8 +1740,8 @@ test("Scene3D shared water clock is fixed-rate across display cadence and lifecy
 });
 
 test("Scene3D fixed-clock backend contracts skip zero-tick work and retain event IDs while paused", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const mount = readSceneMountSrc();
 
   assert.match(webgl, /var pendingDropEvents = new Map\(\)/);
@@ -1778,7 +1779,7 @@ test("Scene3D fixed-clock backend contracts skip zero-tick work and retain event
 });
 
 test("Scene3D WebGPU timing initialization failure unlocks CPU-rAF fallback", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const timingInit = webgpu.match(/function ensureGPUTiming\(\) \{[\s\S]*?\n    \}/);
   assert.ok(timingInit, "WebGPU timing initialization seam should exist");
   assert.match(timingInit[0], /catch \(error\) \{[\s\S]*candidateQuerySet\.destroy\(\)[\s\S]*candidateBuffer\.destroy\(\)[\s\S]*gpuTiming = false;\s*gpuTimingFailed = true;/);
@@ -1795,7 +1796,7 @@ test("Scene3D WebGPU timing initialization failure unlocks CPU-rAF fallback", ()
 });
 
 test("Scene3D WebGPU quality allocation retries with bounded backoff and publishes telemetry", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const applyQuality = webgpu.match(/function applySceneWaterQualityProfile\([\s\S]*?\n    \}\n\n    function retireWaterSystem/);
   assert.ok(applyQuality, "WebGPU quality allocation seam should exist");
   assert.match(applyQuality[0], /system\.qualityAllocationPending && webGPUFrameSeq < system\.qualityAllocationNextFrame/);
@@ -1808,7 +1809,7 @@ test("Scene3D WebGPU quality allocation retries with bounded backoff and publish
 });
 
 test("Scene3D WebGL2 water caches uniform locations and bounds retained-pass work", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // Cache hits and misses per WebGLProgram. Weak keys plus explicit disposal
   // keep renderer replacement from retaining deleted programs.
@@ -1845,7 +1846,7 @@ test("Scene3D WebGL2 water caches uniform locations and bounds retained-pass wor
 });
 
 test("Scene3D WebGL2 water seeds only the authored initial ripples", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   const primeRipples = webgl.match(/function primeRipples\(\) \{[\s\S]*?\n    \}/);
   assert.ok(primeRipples, "forced WebGL water renderer should prime authored state");
 
@@ -1855,7 +1856,7 @@ test("Scene3D WebGL2 water seeds only the authored initial ripples", () => {
 });
 
 test("Scene3D WebGL2 water consumes live events and renderer inputs", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   const forcedWater = webgl.match(/function createSceneWaterRendererWebGL[\s\S]*?return \{\s*\n\s*kind: "webgl"/);
   assert.ok(forcedWater, "forced WebGL water renderer should exist");
 
@@ -1871,14 +1872,14 @@ test("Scene3D WebGL2 water consumes live events and renderer inputs", () => {
 });
 
 test("Scene3D WebGL2 water refreshes analytic meshes by live transform signature", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   assert.match(webgl, /function refreshAnalyticMesh\(kind, center, radius, half, livePoolWidth, livePoolLength\)/);
   assert.match(webgl, /signature !== analyticMeshSignature[\s\S]{0,220}deleteAnalyticMesh\(sphereMesh\);[\s\S]{0,120}deleteAnalyticMesh\(boxMesh\);/);
   assert.match(webgl, /objectMesh = refreshAnalyticMesh\(liveKindNum, liveCenter, liveRadius, liveHalf, livePoolWidth, livePoolLength\)/);
 });
 
 test("Scene3D WebGL2 water pool pass wires the rounded-corner pool geometry (mirrors WebGPU)", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // Mirrors 16a-scene-webgpu.js's sceneWaterPoolShapeRounded verbatim, keyed
   // off entry.poolShape ("Rounded Box" / "rounded" / "roundbox").
@@ -1924,7 +1925,7 @@ test("Scene3D WebGL2 water pool pass wires the rounded-corner pool geometry (mir
 });
 
 test("Scene3D WebGPU Selena materials can bind live water resources", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /function sceneSelenaResourceRef\(material, descriptor\)/);
   assert.match(webgpu, /trimmed\.indexOf\("gosx:"\) === 0/);
@@ -1942,7 +1943,7 @@ test("Scene3D WebGPU Selena materials can bind live water resources", () => {
 });
 
 test("Scene3D WebGPU Selena materials expose object matrices as auto-uniforms", () => {
-  const webgpu = readWebGPUBackendSrc();
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const resolver = webgpu.match(/function sceneSelenaUniformValue[\s\S]{0,900}/)[0];
 
   // mvp and viewProjectionMatrix read the live matrix off selenaFrame, which

--- a/client/js/runtime-07-scene-webgpu-probe.test.js
+++ b/client/js/runtime-07-scene-webgpu-probe.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // The WebGPU adapter and device probe: optional-feature negotiation, retry
 // after an empty or failed device request, and lost-device reacquisition.
 //
@@ -35,8 +37,8 @@ test("Scene3D animation loop supports foreground frame caps", () => {
 
 test("Scene3D resource readiness is canvas-scoped and detach-safe", () => {
   const mount = readSceneMountSrc();
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(mount, /target\.addEventListener\("gosx:scene3d:resource-ready", onSceneResourceReady\)/);
   assert.match(mount, /target\.removeEventListener\("gosx:scene3d:resource-ready", onSceneResourceReady\)/);
@@ -46,7 +48,7 @@ test("Scene3D resource readiness is canvas-scoped and detach-safe", () => {
 });
 
 test("Scene3D instanced meshes are WebGPU-native", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const mount = readSceneMountSrc();
 
   assert.match(webgpu, /var WGSL_PBR_INSTANCED_VERTEX = \[/);
@@ -63,7 +65,7 @@ test("Scene3D instanced meshes are WebGPU-native", () => {
 });
 
 test("Scene3D WebGPU PBR meshes do not cull double-sided GLB surfaces", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /function wgpuCreatePBRPipeline/);
   assert.match(webgpu, /label: "gosx-pbr-" \+ blendMode[\s\S]*primitive: \{ topology: "triangle-list", cullMode: "none" \}/);
@@ -74,7 +76,7 @@ test("Scene3D WebGPU PBR meshes do not cull double-sided GLB surfaces", () => {
 });
 
 test("Scene3D WebGPU Selena mesh pipeline honors obj.doubleSided (cullMode: none)", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // getSelenaPipeline's own default stays "back" (unchanged) when the
   // caller passes no cullMode option -- drawPBRObjects is the caller that
@@ -86,7 +88,7 @@ test("Scene3D WebGPU Selena mesh pipeline honors obj.doubleSided (cullMode: none
 });
 
 test("Scene3D world lines and textured surfaces are WebGPU-native", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const mount = readSceneMountSrc();
 
   assert.match(webgpu, /var WGSL_SCENE_WORLD_COLOR_VERTEX = \[/);
@@ -115,7 +117,7 @@ test("Scene3D world lines and textured surfaces are WebGPU-native", () => {
 });
 
 test("Scene3D WebGPU supports tiered MSAA render targets", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   const mount = readSceneMountSrc();
   const probe = fs.readFileSync(path.join(__dirname, "bootstrap-src", "16z-scene-webgpu-probe.ts"), "utf8");
 

--- a/client/js/runtime-08-scene-materials-particles.test.js
+++ b/client/js/runtime-08-scene-materials-particles.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Scene3D scene normalization: named materials, material profiles, CPU compute
 // particles, live point buffers, update transitions and mesh raycasting.
 //
@@ -34,7 +36,7 @@ test("bootstrap guards WebGPU points shaders against zero/stale viewport uniform
   // shaders adopt the same clamp-to-1 form the thick-line shader uses, and
   // that neither still divides by the unguarded frame.viewportWidth /
   // frame.viewportHeight fields directly.
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   const pointsVertexStart = source.indexOf("var WGSL_POINTS_VERTEX = [");
   const pointsInstancedStart = source.indexOf("var WGSL_POINTS_INSTANCED_VERTEX = [");

--- a/client/js/runtime-10-scene-webgl-buffers-labels.test.js
+++ b/client/js/runtime-10-scene-webgl-buffers-labels.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // WebGL2 buffer reuse and invalidation, pass caches, native Scene3D engines,
 // projected labels, renderer preference and the custom post-effect passes.
 //
@@ -2048,7 +2050,7 @@ test("WebGL customPost receives reserved auto-uniforms: time is nonzero and adva
 });
 
 test("WebGL post processor is constructed with the Selena uniform resolver injected", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   // The injection is what supplies reserved auto-uniforms to custom post
   // passes; without it applyCustomPost silently falls back to author values
   // only. Mirrors the WebGPU side's wgpuCreatePostProcessor(..., sceneSelenaUniformData).

--- a/client/js/runtime-16-selective-capability.test.js
+++ b/client/js/runtime-16-selective-capability.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Selective feature-bundle loading, browser capability gates, the engine
 // factory contract, backend honesty gating and the video sync parity vector.
 //
@@ -864,7 +866,7 @@ test("Scene3D fallbackSceneRenderer honors window.__gosx_scene3d_require_gpu wit
 });
 
 test("Scene3D WebGPU water debug gates isolate update and draw stages", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgpu");
   assert.match(source, /new URLSearchParams\(window\.location\.search\)\.get\("gosx-water-debug"\)/);
   assert.match(source, /function sceneWebGPUWaterDebugSkipsUpdate\(mode\) \{[\s\S]*no-water[\s\S]*no-update/);
   assert.match(source, /function sceneWebGPUWaterDebugSkipsDraw\(mode\) \{[\s\S]*compute-only[\s\S]*no-draw/);

--- a/client/js/runtime-17-scene-canvas2d-board.test.js
+++ b/client/js/runtime-17-scene-canvas2d-board.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // The canvas2d surface kind: placeholder discovery, the paint loop, the 2D
 // painter and the orthographic 2D camera golden vectors.
 //
@@ -327,10 +329,7 @@ test("bootstrap Scene3D ortho-2D helpers apply the native defaults (zoom<=0→1,
 });
 
 test("bootstrap 16a uploadFrameUniforms takes the ortho-2D branch before the 3D camera normalizer", () => {
-  const source = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"),
-    "utf8",
-  );
+  const source = readSceneRendererBackendSrc("webgpu");
   const start = source.indexOf("function uploadFrameUniforms(");
   const end = source.indexOf("function uploadLights(");
   assert.notEqual(start, -1, "uploadFrameUniforms must exist in 16a");

--- a/client/js/runtime-18-scene-webgpu-board-water.test.js
+++ b/client/js/runtime-18-scene-webgpu-board-water.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // WebGPU board bundles and the Selena water passes, including the compiled
 // fixture parity checks and the per-frame device-call shape budgets.
 //
@@ -1070,7 +1072,7 @@ test("Scene3D fake WebGPU timing partial allocation failure destroys candidates 
 });
 
 test("Scene3D WebGL water binds the full Selena object contract", () => {
-  const source = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const source = readSceneRendererBackendSrc("webgl");
   assert.match(source, /mvp: mvp, modelMatrix: identity4, normalMatrix: identity3/,
     "direct analytic objects must receive an identity model matrix when their vertices are already world-baked");
   assert.match(source, /name: "causticTexture", target: gl\.TEXTURE_2D, tex: causticTex/,

--- a/client/js/runtime-20-scene-shaders-custom-post.test.js
+++ b/client/js/runtime-20-scene-shaders-custom-post.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Authored shader payloads: compute particles, authored point pipelines, the
 // shaderLib reference inflation and the custom post-effect passes.
 //
@@ -16,7 +18,7 @@ const {
   bootstrapRuntimeSource,
   bootstrapFeatureEnginesSource,
   bootstrapFeatureScene3DSource,
-  bootstrapScene3DWebGPUSourceFile,
+  scene3DWebGPUBackendSource,
   bootstrapScene3DInputSourceFile,
   bootstrapScene3DMountSourceFile,
   FakeWebGLContext,
@@ -46,7 +48,7 @@ const {
 } = require("./runtime-test-harness.js");
 
 test("Scene3D WebGL normalizes custom GLSL precision before Firefox link", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   assert.match(webgl, /function sceneWebGLNormalizeCustomShaderSource\(source\)/);
   assert.match(webgl, /precision\s+highp\s+float/);
@@ -897,11 +899,11 @@ test("normalizeSceneInstancedMeshEntry preserves cullKernelWGSL/cullKernelEntry/
 });
 
 test("WebGPU water sampled state only uses the defined ping-pong textures", () => {
-  assert.doesNotMatch(bootstrapScene3DWebGPUSourceFile, /stateTexture:\s*stateTexture[,\n]/);
-  assert.doesNotMatch(bootstrapScene3DWebGPUSourceFile, /system\.stateTexture(?![A-Z])/);
-  assert.match(bootstrapScene3DWebGPUSourceFile, /stateTextureA:\s*stateTextureA/);
-  assert.match(bootstrapScene3DWebGPUSourceFile, /stateTextureB:\s*stateTextureB/);
-  assert.match(bootstrapScene3DWebGPUSourceFile, /function syncWaterSampledState\(/);
+  assert.doesNotMatch(scene3DWebGPUBackendSource, /stateTexture:\s*stateTexture[,\n]/);
+  assert.doesNotMatch(scene3DWebGPUBackendSource, /system\.stateTexture(?![A-Z])/);
+  assert.match(scene3DWebGPUBackendSource, /stateTextureA:\s*stateTextureA/);
+  assert.match(scene3DWebGPUBackendSource, /stateTextureB:\s*stateTextureB/);
+  assert.match(scene3DWebGPUBackendSource, /function syncWaterSampledState\(/);
 });
 
 test("Scene3D raycast returns the exact nearest non-uniformly scaled instance", async () => {

--- a/client/js/runtime-21-scene-gpu-cull-bundles.test.js
+++ b/client/js/runtime-21-scene-gpu-cull-bundles.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // GPU and CPU instance culling, render bundles, indirect draws, GPU pass
 // timing and the Scene3D telemetry accessor.
 //
@@ -31,7 +33,7 @@ const {
 // Task 1: source-string — new layout constant + pipeline accessor exist in 16a
 // -------------------------------------------------------------------------
 test("gpu-cull T1: WGPU_PBR_INSTANCED_CULL_VERTEX_LAYOUT and cull pipeline accessor exist in 16a source", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // Layout constant: 80-byte stride, locations 4-8, uint32x4 at loc 8.
   assert.match(webgpu, /var WGPU_PBR_INSTANCED_CULL_VERTEX_LAYOUT/,
@@ -912,7 +914,7 @@ test("gpu-cull T3: extractFrustumPlanesJS source exists in 11-scene-math.ts (sha
   // so both the WebGPU renderer (16a) and the WebGL2 renderer (16) share one
   // implementation with no divergence.
   const math = fs.readFileSync(path.join(__dirname, "bootstrap-src", "11-scene-math.ts"), "utf8");
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // Function lives in the shared math module.
   assert.match(math, /function extractFrustumPlanesJS\(vp\)/,
@@ -1000,7 +1002,7 @@ test("gpu-cull T4a: no cullKernelWGSL → draw-all (direct pass.draw, not drawIn
   // renderer module (generateInstancedGeometry) which is not loaded in the WebGPU
   // test harness.  The behavioral contract is guaranteed by the source structure
   // and proven at runtime by T2e (compute dispatch) + T5-drawIndirect (fake records).
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // drawInstancedMeshes must contain a branch with pass.draw for draw-all.
   assert.match(webgpu, /pass\.draw\(geom\.vertexCount,\s*instanceCount\)/,
@@ -1023,7 +1025,7 @@ test("gpu-cull T4b: cullKernelWGSL present but system not-ready → draw-all fal
   // Source-level test: the not-ready fallback falls through to pass.draw.
   // D3: not-ready → draw-all (NOT skip).  The else-branch handles this because
   // cullSys.isReady() returns false when the async pipeline is pending.
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // The draw path gating — if cull system NOT ready, falls to else (draw-all).
   // Confirmed by: the if-guard is isReady(), so not-ready → else → pass.draw.
@@ -1049,7 +1051,7 @@ test("gpu-cull T4b: cullKernelWGSL present but system not-ready → draw-all fal
 // Task 5: capability gating
 // -------------------------------------------------------------------------
 test("gpu-cull T5: 16a source structure — dispatch hook calls updateInstancedCullSystems in frame loop", () => {
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // The dispatch hook must call updateInstancedCullSystems.
   assert.match(webgpu, /updateInstancedCullSystems\(bundle\.instancedMeshes,\s*encoder,\s*scratchSelenaViewProjection\)/,
@@ -1258,8 +1260,7 @@ test("cpu-cull S3-T3: absent or zero cullRadius defaults to 2.0 (matches GPU-cul
 // S3 T4: WebGL2 source — CPU cull path present in 16-scene-webgl.js
 // -------------------------------------------------------------------------
 test("cpu-cull S3-T4: 16-scene-webgl.js contains CPU cull path with correct structure", () => {
-  const webgl = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // The cull config check must be present.
   assert.match(webgl, /hasCullConfig/,
@@ -1292,8 +1293,7 @@ test("cpu-cull S3-T4: 16-scene-webgl.js contains CPU cull path with correct stru
 // S3 T5: WebGL2 capability gating — no-cull-config → draw-all (source check)
 // -------------------------------------------------------------------------
 test("cpu-cull S3-T5: no cullKernelWGSL on WebGL2 → draw-all (unchanged instanceCount)", () => {
-  const webgl = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // The hasCullConfig branch is conditional — draw-all when false.
   assert.match(webgl, /if\s*\(hasCullConfig\)\s*\{/,
@@ -1309,8 +1309,7 @@ test("cpu-cull S3-T5: no cullKernelWGSL on WebGL2 → draw-all (unchanged instan
 });
 
 test("cpu-cull S3-T5b: WebGL instanced draw validates attribute capacity before drawArraysInstanced", () => {
-  const webgl = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   assert.match(webgl, /function sceneInstancedAttributeCapacity\(data, components\)/,
     "instanced path must measure typed-array capacity");
@@ -1329,8 +1328,7 @@ test("cpu-cull S3-T5b: WebGL instanced draw validates attribute capacity before 
 });
 
 test("cpu-cull S3-T5c: WebGL instanced draw disables stale unowned vertex attributes", () => {
-  const webgl = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   assert.match(webgl, /function sceneDisableUnownedVertexAttribArrays\(allowed\)/,
     "instanced path must clear stale global vertex attributes");
@@ -1373,8 +1371,7 @@ test("cpu-cull S3-T5c: WebGL instanced draw disables stale unowned vertex attrib
 // S3 T6: WebGPU path untouched — extractFrustumPlanesJS not redefined in 16a
 // -------------------------------------------------------------------------
 test("cpu-cull S3-T6: WebGPU path (16a) does NOT redefine extractFrustumPlanesJS (uses shared 11)", () => {
-  const webgpu = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // Must not redefine the function (it was hoisted to 11).
   assert.doesNotMatch(webgpu, /function extractFrustumPlanesJS\(vp\)/,
@@ -1787,8 +1784,7 @@ test("telemetry T3: 16b-scene-compute.js exposes requestSurvivorReadback and pol
 // Telemetry T4: cull telemetry gate — 16a gates readback on cull_telemetry flag
 // -------------------------------------------------------------------------
 test("telemetry T4: 16a-scene-webgpu.js gates survivor readback on __gosx_scene3d_cull_telemetry", () => {
-  const webgpu = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   assert.match(webgpu, /__gosx_scene3d_cull_telemetry/,
     "16a must reference __gosx_scene3d_cull_telemetry gate");
@@ -1826,8 +1822,7 @@ test("telemetry T5: 20-scene-mount.js defines __gosx_scene3d_telemetry", () => {
 // the prior frame's submitted copy, not a not-yet-submitted copy.
 // -------------------------------------------------------------------------
 test("telemetry T6: 16a pollSurvivors is called BEFORE requestSurvivorReadback in telemetry block", () => {
-  const webgpu = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // Use the LAST occurrence of "return instancedCullSystems;" as the block boundary
   // (there is an earlier early-return for the empty-meshes case that must be excluded).
@@ -1866,8 +1861,7 @@ test("telemetry T7: 16b initialises lastSurvivors to null (not 0)", () => {
 // object comes from bundle.materials[] (which carries kind but never sets unlit).
 // -------------------------------------------------------------------------
 test("color T1: 16a materialUniformData sets unlit=1 for kind:flat and materialKind:flat", () => {
-  const webgpu = fs.readFileSync(
-    path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
 
   // The unlit uniform slot must be derived from mat.kind OR mat.materialKind,
   // not only from mat.unlit.  Regression guard: before the fix u[12] was set

--- a/client/js/runtime-22-scene-motion-fluid-signals.test.js
+++ b/client/js/runtime-22-scene-motion-fluid-signals.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // The WASM motion mixer, the managed fluid controls, and the shared-signal
 // bindings for camera, selection, gizmo, cursor and hub output.
 //
@@ -14,7 +16,7 @@ const vm = require("node:vm");
 
 const {
   bootstrapSource,
-  bootstrapScene3DWebGPUSourceFile,
+  scene3DWebGPUBackendSource,
   FakeElement,
   buildSkinnedGLBBytes,
   createContext,
@@ -375,22 +377,22 @@ test("P4-M3 motion mixer: grow-and-retick passes dt=0 to avoid double clock adva
 
 test("Scene3D WebGPU water retires replaced systems after submitted work drains", () => {
   assert.match(
-    bootstrapScene3DWebGPUSourceFile,
+    scene3DWebGPUBackendSource,
     /function retireWaterSystem\(system\) \{/,
     "water runtime should centralize delayed disposal for replaced systems"
   );
   assert.match(
-    bootstrapScene3DWebGPUSourceFile,
+    scene3DWebGPUBackendSource,
     /device\.queue\.onSubmittedWorkDone\(\)\.then\(function\(\) \{\s*system\.dispose\(\);/s,
     "replaced water resources should be retired after submitted WebGPU work drains"
   );
   assert.match(
-    bootstrapScene3DWebGPUSourceFile,
+    scene3DWebGPUBackendSource,
     /retireWaterSystem\(record\.system\);/,
     "syncWaterSystems should not immediately destroy resources for signature changes"
   );
   assert.match(
-    bootstrapScene3DWebGPUSourceFile,
+    scene3DWebGPUBackendSource,
     /if \(system\._gosxDisposed\) return;/,
     "water resource disposal must be idempotent across deferred and renderer teardown paths"
   );
@@ -2017,7 +2019,7 @@ test("P1 hub outbound binding: signal publishes to socket and in-binding still w
 });
 
 test("Selena context-class fields resolve to live per-frame scene state on WebGL", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
 
   // The per-frame updater exists and derives every reserved name from real
   // scene state: camera, the

--- a/client/js/runtime-24-scene-hdr-ibl.test.js
+++ b/client/js/runtime-24-scene-hdr-ibl.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
+
 const test = require("node:test");
 const assert = require("node:assert/strict");
 const fs = require("node:fs");
@@ -221,7 +223,7 @@ test("scene state and render bundles keep both specular texture slots distinct o
 });
 
 test("WebGL HDR IBL compiles the bounded variant and consumes split-sum products in linear space", () => {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   const vertexStart = source.indexOf("const SCENE_PBR_VERTEX_SOURCE");
   const fragmentStart = source.indexOf("const SCENE_PBR_FRAGMENT_SOURCE");
   const fragmentEnd = source.indexOf("const SCENE_PBR_INSTANCED_VERTEX_SOURCE");
@@ -252,7 +254,7 @@ test("WebGL HDR IBL compiles the bounded variant and consumes split-sum products
 });
 
 test("WebGPU consumes the same split-sum contract and keeps color/data texture formats distinct", () => {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   assert.match(source, new RegExp(BRDF_MODEL.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")));
   assert.match(source, /textureSampleLevel\(iblRadiance, iblSampler, Rr, roughness \* maxLod\)/);

--- a/client/js/runtime-31-scene-indexed-buffergeometry.test.js
+++ b/client/js/runtime-31-scene-indexed-buffergeometry.test.js
@@ -1,5 +1,7 @@
 "use strict";
 
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
+
 // Indexed BufferGeometry end-to-end slice: unique vertex streams plus an
 // authored triangle index stream survive Scene3D bundle construction, both the
 // direct and the retained object path, malformed streams fail closed, and the
@@ -458,7 +460,7 @@ test("exact CPU picking misses off the indexed quad", () => {
 // --- Source-level backend contract ------------------------------------------
 
 test("backends wire uint32 index buffers and indexed draws for indexed direct meshes", () => {
-  const webgl = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgl.ts"), "utf8");
+  const webgl = readSceneRendererBackendSrc("webgl");
   assert.match(webgl, /function bindScenePBRDirectIndexBuffer\(/);
   assert.match(webgl, /gl\.ELEMENT_ARRAY_BUFFER/);
   assert.match(webgl, /gl\.drawElements\(gl\.TRIANGLES, selenaIndexCount, gl\.UNSIGNED_INT, 0\)/);
@@ -466,7 +468,7 @@ test("backends wire uint32 index buffers and indexed draws for indexed direct me
   assert.match(webgl, /gl\.drawElements\(gl\.TRIANGLES, casterIndexCount, gl\.UNSIGNED_INT, 0\)/);
   assert.match(webgl, /uniform mat4 u_modelMatrix;/, "shadow depth shader transforms model-space casters");
 
-  const webgpu = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+  const webgpu = readSceneRendererBackendSrc("webgpu");
   assert.match(webgpu, /function webGPUBindRetainedMeshIndexBuffer\(/);
   assert.match(webgpu, /pass\.setIndexBuffer\(record\.buffer, "uint32"\)/);
   assert.match(webgpu, /pass\.drawIndexed\(pbrIndexCount\)/);

--- a/client/js/runtime-test-harness.js
+++ b/client/js/runtime-test-harness.js
@@ -23,6 +23,7 @@ const fs = require("node:fs");
 const path = require("node:path");
 const vm = require("node:vm");
 const nodeCrypto = require("node:crypto");
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 
 const bootstrapSource = fs.readFileSync(path.join(__dirname, "bootstrap.js"), "utf8");
 const bootstrapLiteSource = fs.readFileSync(path.join(__dirname, "bootstrap-lite.js"), "utf8");
@@ -37,7 +38,7 @@ const bootstrapFeatureScene3DComputeSource = fs.readFileSync(path.join(__dirname
 const bootstrapFeatureScene3DDecompressSource = fs.readFileSync(path.join(__dirname, "bootstrap-feature-scene3d-decompress.js"), "utf8");
 const bootstrapFeatureScene3DWebGLSource = fs.readFileSync(path.join(__dirname, "bootstrap-feature-scene3d-webgl.js"), "utf8");
 const bootstrapFeatureScene3DWebGPUSource = fs.readFileSync(path.join(__dirname, "bootstrap-feature-scene3d-webgpu.js"), "utf8");
-const bootstrapScene3DWebGPUSourceFile = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "webgpu.ts"), "utf8");
+const scene3DWebGPUBackendSource = readSceneRendererBackendSrc("webgpu");
 const bootstrapScene3DInputSourceFile = fs.readFileSync(path.join(__dirname, "bootstrap-src", "17-scene-input.ts"), "utf8");
 const bootstrapScene3DMountSourceFile = readSceneMountSrc();
 const bootstrapScene3DDOMRegionsSourceFile = fs.readFileSync(path.join(__dirname, "..", "runtime", "scene3d", "dom-regions.ts"), "utf8");
@@ -4284,13 +4285,6 @@ function readSceneMountSrc() {
   );
 }
 
-// readWebGPUBackendSrc joins the WebGPU backend source files. The Selena
-// uniform packer moved out of createSceneWebGPURenderer into 16a1, so a source
-// assertion about the backend must read both files.
-function readWebGPUBackendSrc() {
-  return readBootstrapSrc("../runtime/scene3d/webgpu.ts", "16a1-scene-webgpu-selena-uniforms.ts");
-}
-
 // readBootstrapTailSrc joins every 30x-tail-*.js file in build order. The old
 // single 30-tail.js is now that file set.
 function readBootstrapTailSrc() {
@@ -4316,13 +4310,20 @@ function freshFeatureBundleSource(name, options) {
   const clientJS = __dirname;
   const opts = options || {};
   function read(rel) {
-    const source = fs.readFileSync(path.join(clientJS, rel), "utf8");
-    if (rel.endsWith("webgl.ts") && opts.exportWaterRendererForTest) {
-      return source + "\nwindow.__gosx_test_create_water_webgl = createSceneWaterRendererWebGL;\n";
-    }
-    return source;
+    return fs.readFileSync(path.join(clientJS, rel), "utf8");
   }
-  return bootstrapChunkSources("bootstrap-feature-" + name + ".js").map(read).join("\n");
+  const sourceParts = bootstrapChunkSources("bootstrap-feature-" + name + ".js").map(read);
+  let source = sourceParts.join("\n");
+  if (name === "scene3d-webgl" && opts.exportWaterRendererForTest) {
+    // Inject at the joined chunk's final-source boundary. The final source is
+    // the feature suffix that closes the registry factory, so the export stays
+    // in lexical scope without depending on which renderer file owns it.
+    const finalSourceStart = source.length - sourceParts[sourceParts.length - 1].length;
+    source = source.slice(0, finalSourceStart)
+      + "window.__gosx_test_create_water_webgl = createSceneWaterRendererWebGL;\n"
+      + source.slice(finalSourceStart);
+  }
+  return source;
 }
 
 // createBoardWebGPUHarness boots the runtime + scene3d + scene3d-webgpu chunks
@@ -5642,7 +5643,7 @@ module.exports = {
   bootstrapFeatureScene3DDecompressSource,
   bootstrapFeatureScene3DWebGLSource,
   bootstrapFeatureScene3DWebGPUSource,
-  bootstrapScene3DWebGPUSourceFile,
+  scene3DWebGPUBackendSource,
   bootstrapScene3DInputSourceFile,
   bootstrapScene3DMountSourceFile,
   bootstrapScene3DDOMRegionsSourceFile,
@@ -5736,7 +5737,6 @@ module.exports = {
   bootstrapChunkSources,
   readBootstrapSrc,
   readSceneMountSrc,
-  readWebGPUBackendSrc,
   readBootstrapTailSrc,
   freshFeatureBundleSource,
   createBoardWebGPUHarness,

--- a/client/js/scene3d-material-ior.test.js
+++ b/client/js/scene3d-material-ior.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Scene3D material IOR slice: numeric contract, normalization carry-through,
 // profile cache key differentiation, named-material/model/instanced plumbing,
 // planner signature invalidation, and the PBR shader uniform wiring for the
@@ -426,7 +428,7 @@ test("planner CSS input signature invalidates when authored ior changes", () => 
 // --- WebGL PBR ----------------------------------------------------------------
 
 test("WebGL PBR shaders upload and consume the effective specular factors", () => {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
 
   // The dead u_dielectricF0 uniform is fully removed: declaration, cache
   // slot and upload. Shading reads only the effective uniforms.
@@ -564,7 +566,7 @@ test("WebGL PBR shaders upload and consume the effective specular factors", () =
 // --- WebGPU PBR ---------------------------------------------------------------
 
 test("WebGPU material uniform packing carries the effective specular factors without moving existing slots", () => {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
 
   // The WebGPU struct keeps its legacy trailing dielectricF0 scalar at f40
   // for layout compatibility, then packs the live effective specular F0 as

--- a/client/js/scene3d-material-specular-render.test.js
+++ b/client/js/scene3d-material-specular-render.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Scene3D authored specular render slice: the KHR specularIntensity /
 // specularColor factors must actually shade, not just normalize. This file
 // drives the production WebGL uploadMaterial and the production WebGPU
@@ -81,7 +83,7 @@ function expectedDielectricF0(ior) {
 // --- WebGL -------------------------------------------------------------------
 
 function setupWebGLRenderer() {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   const context = createSceneCoreContext();
   runFragment(context, [
     "function sceneFiniteNumber(value, fallback) { const n = Number(value); return Number.isFinite(n) ? n : fallback; }",
@@ -435,7 +437,7 @@ test("WebGL frame layout threads real GL unit limits", () => {
 
 test("WebGL HDR IBL guard needs 20 sampler units", () => {
   const { context } = setupWebGLRenderer();
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   assert.match(source, /fragment-texture-units<20/);
   assert.doesNotMatch(source, /fragment-texture-units<19/);
   assert.equal(callIn(context, "scenePBRHDRIBLAvailable(glWithUnits(16))"), false);
@@ -445,7 +447,7 @@ test("WebGL HDR IBL guard needs 20 sampler units", () => {
 });
 
 test("WebGL PBR shader consumes the uploaded factors in direct and IBL paths", () => {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   // The dedicated uniforms are declared, cached and uploaded.
   assert.match(source, /uniform vec3 u_specularF0;/);
   assert.match(source, /uniform float u_specularF90;/);
@@ -685,7 +687,7 @@ test("WebGL specular-color late load takes effect and the loaded cache short-cir
 });
 
 test("WebGL PBR shader samples the specular-color map RGB-only before the metallic mix", () => {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   assert.match(source, /uniform sampler2D u_specularColorMap;/);
   assert.match(source, /uniform bool u_hasSpecularColorMap;/);
   assert.match(source, /uniform vec3 u_specularColorLog;/);
@@ -720,7 +722,7 @@ test("WebGL PBR shader samples the specular-color map RGB-only before the metall
 // --- WebGPU ------------------------------------------------------------------
 
 function setupWebGPURenderer() {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
   const bufferDecls = (source.match(/var\s+_materialUniform\w+\s*=\s*[^;\n]+;/g) || []).join("\n");
   const context = createSceneCoreContext();
   runFragment(context, [
@@ -827,7 +829,7 @@ test("WebGPU materialUniformData packs finite effective specular factors", () =>
 });
 
 test("WebGPU WGSL consumes the uploaded factors in direct and IBL paths", () => {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
   assert.match(source, /"    specularF0: vec3f,",/);
   assert.match(source, /"    specularF90: f32,",/);
   // Production uses a mutable var because the color-texture slice updates
@@ -896,7 +898,7 @@ test("WebGPU WGSL consumes the uploaded factors in direct and IBL paths", () => 
 // --- WebGPU recording-boundary material binding ------------------------------
 
 function setupWebGPUMaterialBinding() {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
   const context = createSceneCoreContext();
   const bufferDecls = (source.match(/var\s+_materialUniform\w+\s*=\s*[^;\n]+;/g) || []).join("\n");
   runFragment(context, [
@@ -1055,7 +1057,7 @@ test("WebGPU specular-intensity late load and new view invalidate the cached bin
 });
 
 test("WebGPU material bind group layout declares specular-intensity texture and sampler at 13/14", () => {
-  const source = readRuntimeSource("webgpu.ts");
+  const source = readSceneRendererBackendSrc("webgpu");
   const context = createSceneCoreContext();
   context.GPUShaderStage = { VERTEX: 1, FRAGMENT: 2 };
   runFragment(context,

--- a/client/js/scene3d-render-truth.test.mjs
+++ b/client/js/scene3d-render-truth.test.mjs
@@ -16,6 +16,9 @@ import fs from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
@@ -25,8 +28,8 @@ function readSrc(name) {
 }
 
 const sharedSource = readSrc("15a-scene-postfx-shared.ts");
-const webglSource = readSrc("../runtime/scene3d/webgl.ts");
-const webgpuSource = readSrc("../runtime/scene3d/webgpu.ts");
+const webglSource = readSceneRendererBackendSrc("webgl");
+const webgpuSource = readSceneRendererBackendSrc("webgpu");
 // sceneRenderBackendTruth and its DOM surface live in
 // 20b-scene-mount-webgl-chunk.js, not 20-scene-mount.js: applySceneRendererState
 // (its only caller) moved there when the former single 20-scene-mount.js split

--- a/client/js/scene3d-renderer-architecture.test.js
+++ b/client/js/scene3d-renderer-architecture.test.js
@@ -1,0 +1,560 @@
+"use strict";
+
+const test = require("node:test");
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  architecture,
+  directRendererReadFindings,
+  directRendererReferenceRegistryFindings,
+  generatedBootstrapArtifactPaths,
+  rendererBackendSources,
+  rendererReferenceCounts,
+  scanDirectRendererReads,
+} = require("./scene3d-renderer-source-set.js");
+const {
+  createBoardWebGPUHarness,
+  createWebGLRendererForPost,
+} = require("./runtime-test-harness.js");
+
+function manifest(chunk, sources) {
+  return { chunks: [{ name: chunk, sources }] };
+}
+
+function sourceContract(backend, sources) {
+  return {
+    sourceSets: {
+      [backend]: {
+        chunk: `bootstrap-feature-scene3d-${backend}.js`,
+        chunkSourceRoles: Object.fromEntries(sources.map((source) => [source, "governed-renderer"])),
+        sources,
+      },
+    },
+  };
+}
+
+function gitInit(root) {
+  try {
+    require("node:child_process").execFileSync("git", ["-C", root, "init", "-q"], { stdio: "ignore" });
+    require("node:child_process").execFileSync("git", ["-C", root, "add", "."], { stdio: "ignore" });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+test("renderer source sets are manifest-ordered and reject missing, reordered, duplicate, or unregistered sources", () => {
+  for (const backend of ["webgl", "webgpu"]) {
+    assert.deepEqual(rendererBackendSources(backend), architecture.sourceSets[backend].sources);
+  }
+
+  const backend = "webgpu";
+  const sources = ["../runtime/scene3d/webgpu.ts", "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts"];
+  const contract = sourceContract(backend, sources);
+  const chunk = contract.sourceSets[backend].chunk;
+  const resolve = (listed, available = sources) => rendererBackendSources(backend, {
+    contract,
+    manifest: manifest(chunk, listed),
+    availableSources: available,
+    validateFiles: false,
+  });
+  assert.throws(() => resolve(sources.slice(0, 1)), /chunkSourceRoles must exactly match chunkSources/);
+  assert.throws(() => resolve(sources.slice().reverse()), /source order mismatch/);
+  assert.throws(() => resolve([sources[0], sources[0], sources[1]]), /duplicate source/);
+  assert.throws(
+    () => resolve(sources, sources.concat("../runtime/scene3d/webgpu-resources.ts")),
+    /not registered/,
+  );
+  assert.throws(
+    () => rendererBackendSources(backend, {
+      contract,
+      manifest: manifest(chunk, sources.concat("../runtime/scene3d/gpu-resources.ts")),
+      availableSources: sources,
+      validateFiles: false,
+    }),
+    /chunkSourceRoles must exactly match chunkSources/,
+  );
+  assert.throws(
+    () => resolve(sources.concat("bootstrap-src/16a9-scene-webgpu-secret-renderer.ts")),
+    /chunkSourceRoles must exactly match chunkSources/,
+  );
+  assert.throws(
+    () => rendererBackendSources("webgpu", {
+      contract: { sourceSets: { webgpu: { chunk, chunkSources: sources, sources } } },
+      manifest: manifest(chunk, sources.concat("bootstrap-src/16a9-renderer-webgpu-secret.ts")),
+      availableSources: sources,
+      validateFiles: false,
+    }),
+    /source roster mismatch/,
+  );
+  assert.throws(
+    () => rendererBackendSources("webgpu", {
+      contract: {
+        sourceSets: { webgpu: { chunk, sources: ["../runtime/scene3d/webgpu-core.ts", sources[1]] } },
+        directRendererReferenceSources: ["webgpu.ts", path.basename(sources[1])],
+      },
+      manifest: manifest(chunk, ["../runtime/scene3d/webgpu-core.ts", sources[1]]),
+      availableSources: ["../runtime/scene3d/webgpu-core.ts", sources[1]],
+      validateFiles: false,
+    }),
+    /directRendererReferenceSources must equal sourceSets plus extraProtectedSources/,
+  );
+});
+
+test("backend chunk roles are closed, exact, and path-authorized", () => {
+  assert.deepEqual(rendererBackendSources("webgl"), architecture.sourceSets.webgl.sources);
+  assert.deepEqual(rendererBackendSources("webgpu"), architecture.sourceSets.webgpu.sources);
+
+  const invented = clone(architecture);
+  invented.sourceSets.webgpu.chunkSourceRoles["bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts"] = "invented-role";
+  assert.throws(() => rendererBackendSources("webgpu", { contract: invented }), /unknown governed role/);
+
+  const swapped = clone(architecture);
+  swapped.sourceSets.webgpu.chunkSourceRoles["bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts"] = "backend-support";
+  assert.throws(() => rendererBackendSources("webgpu", { contract: swapped }), /not authorized for this path/);
+
+  const stale = clone(architecture);
+  stale.sourceSets.webgpu.chunkSourceRoles["bootstrap-src/not-in-roster.ts"] = "governed-renderer";
+  assert.throws(() => rendererBackendSources("webgpu", { contract: stale }), /chunkSourceRoles must exactly match chunkSources/);
+});
+
+test("validateFiles false still enforces semantic chunk role governance", () => {
+  const backend = "webgpu";
+  const source = "bootstrap-src/26e2-feature-scene3d-webgpu-core.ts";
+  const chunk = "bootstrap-feature-scene3d-webgpu.js";
+  const sources = [
+    "../runtime/scene3d/webgpu.ts",
+    "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts",
+  ];
+  const chunkSources = sources.concat(source);
+  assert.throws(
+    () => rendererBackendSources(backend, {
+      contract: {
+        sourceSets: {
+          webgpu: {
+            chunk,
+            chunkSources,
+            sources,
+          },
+        },
+        directRendererReferenceSources: [
+          "16a1-scene-webgpu-selena-uniforms.ts",
+          "webgpu.ts",
+        ],
+      },
+      manifest: manifest(chunk, chunkSources),
+      availableSources: sources,
+      validateFiles: false,
+    }),
+    /chunkSourceRoles must exactly match chunkSources/,
+  );
+});
+
+test("renderer source consumers cannot bypass the canonical source-set helper", () => {
+  assert.deepEqual(scanDirectRendererReads(), []);
+  const fileFixture = ["fs.read", "FileSync(path.join(root, ", "\"webgpu.ts\"", "), ", "\"utf8\"", ")"].join("");
+  assert.equal(directRendererReadFindings(fileFixture, "negative-file-fixture.js").length, 1);
+  const helperFixture = ["readBootstrap", "Src(", "\"../runtime/scene3d/webgpu.ts\"", ")"].join("");
+  assert.equal(directRendererReadFindings(helperFixture, "negative-helper-fixture.js").length, 1);
+});
+
+test("repo-wide renderer source references match the explicit registry", () => {
+  assert.deepEqual(directRendererReferenceRegistryFindings(), []);
+});
+
+test("repo-wide renderer reference registry rejects Go, path alias, and cross-package bypasses", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-ref-"));
+  try {
+    fs.mkdirSync(path.join(root, "render", "bundle"), { recursive: true });
+    fs.writeFileSync(path.join(root, "render", "bundle", "bypass_test.go"), [
+      "package bundle",
+      "import \"path/filepath\"",
+      "var p = filepath.Join(\"..\", \"..\", \"client\", \"runtime\", \"scene3d\", \"webgpu.ts\")",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(path.join(root, "scene", "capability"), { recursive: true });
+    fs.writeFileSync(path.join(root, "scene", "capability", "alias_test.go"), [
+      "package capability",
+      "const alias = \"../../client/runtime/scene3d/\" + \"webgl.ts\"",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(path.join(root, "client", "js"), { recursive: true });
+    fs.writeFileSync(path.join(root, "client", "js", "consumer.cjs"), [
+      "const source = readRenderer('../runtime/scene3d/mount-webgl.ts')",
+      "",
+    ].join("\n"));
+    fs.mkdirSync(path.join(root, "scripts"), { recursive: true });
+    fs.writeFileSync(path.join(root, "scripts", "renderer-check.sh"), "grep webgpu.ts \"$1\"\n");
+    fs.mkdirSync(path.join(root, "client", "jsx"), { recursive: true });
+    fs.writeFileSync(path.join(root, "client", "jsx", "probe.mts"), "export const p = 'webgpu.ts';\n");
+
+    const findings = directRendererReferenceRegistryFindings(root, {
+      contract: {
+        sourceSets: architecture.sourceSets,
+        extraProtectedSources: architecture.extraProtectedSources,
+        directRendererReferenceSources: architecture.directRendererReferenceSources,
+        intentionalDirectRendererReferences: [],
+      },
+    });
+    assert.deepEqual(
+      findings.map((finding) => `${finding.file}:${finding.source}:${finding.reason}`),
+      [
+        "client/js/consumer.cjs:mount-webgl.ts:unregistered direct renderer-source reference",
+        "client/jsx/probe.mts:webgpu.ts:unregistered direct renderer-source reference",
+        "render/bundle/bypass_test.go:webgpu.ts:unregistered direct renderer-source reference",
+        "scene/capability/alias_test.go:webgl.ts:unregistered direct renderer-source reference",
+        "scripts/renderer-check.sh:webgpu.ts:unregistered direct renderer-source reference",
+      ],
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("repo-wide renderer references scan Git-tracked text without suffix escape hatches", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-text-inventory-"));
+  try {
+    const fixtures = {
+      Makefile: "probe:\n\t@echo webgpu.ts\n",
+      "probe.gsx": "<script>const renderer = 'webgpu.ts'</script>\n",
+      "probe.html": "<!-- webgpu.ts -->\n",
+      "probe.py": "source = 'webgpu.ts'\n",
+      "probe.yaml": "source: webgpu.ts\n",
+      "probe.yml": "source: webgpu.ts\n",
+      "probe.bash": "echo webgpu.ts\n",
+      "client/js/runtime-probe.test.js": "const source = 'webgpu.ts';\n",
+      "client/js/bootstrap-runtime-region-errors.test.js": "const source = 'webgpu.ts';\n",
+      "client/js/bootstrap-feature-scene3d-webgpu.js": "const generated = 'webgpu.ts';\n",
+      "client/js/bootstrap-feature-scene3d-webgpu.js.map": "{\"sources\":[\"webgpu.ts\"]}\n",
+      "client/js/bootstrap-feature-scene3d-webgpu.js.gz": "webgpu.ts\n",
+      "client/js/bootstrap-feature-scene3d-webgpu.js.br": "webgpu.ts\n",
+      "binary.dat": Buffer.from([0x77, 0x65, 0x62, 0x67, 0x70, 0x75, 0x2e, 0x74, 0x73, 0x00]),
+    };
+    for (const [name, contents] of Object.entries(fixtures)) {
+      fs.mkdirSync(path.dirname(path.join(root, name)), { recursive: true });
+      fs.writeFileSync(path.join(root, name), contents);
+    }
+    gitInit(root);
+    const counts = rendererReferenceCounts(root, {
+      contract: {
+        sourceSets: { webgpu: { sources: ["../runtime/scene3d/webgpu.ts"] } },
+        directRendererReferenceSources: ["webgpu.ts"],
+      },
+    }).map((entry) => entry.file).sort();
+    assert.deepEqual(counts, [
+      "Makefile",
+      "client/js/bootstrap-runtime-region-errors.test.js",
+      "client/js/runtime-probe.test.js",
+      "probe.bash",
+      "probe.gsx",
+      "probe.html",
+      "probe.py",
+      "probe.yaml",
+      "probe.yml",
+    ]);
+    const generated = [...generatedBootstrapArtifactPaths()];
+    assert.equal(generated.length, 64);
+    assert.ok(generated.includes("client/js/bootstrap-feature-scene3d-webgpu.js"));
+    assert.ok(generated.includes("client/js/bootstrap-feature-scene3d-webgpu.js.map"));
+    assert.ok(generated.includes("client/js/bootstrap-feature-scene3d-webgpu.js.gz"));
+    assert.ok(generated.includes("client/js/bootstrap-feature-scene3d-webgpu.js.br"));
+    assert.ok(!generated.includes("client/js/bootstrap-runtime-region-errors.test.js"));
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("governed renderer sources reject symlink and duplicate physical aliases", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-alias-"));
+  try {
+    const clientRoot = path.join(root, "client", "js");
+    fs.mkdirSync(path.join(root, "client", "runtime", "scene3d"), { recursive: true });
+    fs.mkdirSync(path.join(clientRoot, "bootstrap-src"), { recursive: true });
+    fs.writeFileSync(path.join(root, "client", "runtime", "scene3d", "webgpu.ts"), "function renderer() {}\n");
+    fs.symlinkSync("webgpu.ts", path.join(root, "client", "runtime", "scene3d", "webgpu-alias.ts"));
+    const chunk = "bootstrap-feature-scene3d-webgpu.js";
+    const sources = ["../runtime/scene3d/webgpu.ts", "../runtime/scene3d/webgpu-alias.ts"];
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: { sourceSets: { webgpu: { chunk, chunkSources: sources, sources } }, directRendererReferenceSources: ["webgpu-alias.ts", "webgpu.ts"] },
+        manifest: manifest(chunk, sources),
+        availableSources: sources,
+      }),
+      /must not be a symlink|aliases the same physical file/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("extra protected renderer sources receive full physical validation", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-extra-"));
+  try {
+    const clientRoot = path.join(root, "client", "js");
+    const runtimeRoot = path.join(root, "client", "runtime", "scene3d");
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.mkdirSync(path.join(clientRoot, "bootstrap-src"), { recursive: true });
+    fs.writeFileSync(path.join(runtimeRoot, "webgpu.ts"), "function renderer() {}\n");
+    fs.writeFileSync(path.join(runtimeRoot, "mount-webgl.ts"), "function mount() {}\n");
+    fs.writeFileSync(path.join(root, "outside.ts"), "function outside() {}\n");
+    const chunk = "bootstrap-feature-scene3d-webgpu.js";
+    const sources = ["../runtime/scene3d/webgpu.ts"];
+    const baseContract = {
+      sourceSets: {
+        webgpu: {
+          chunk,
+          chunkSources: sources,
+          chunkSourceRoles: { "../runtime/scene3d/webgpu.ts": "governed-renderer" },
+          sources,
+        },
+      },
+    };
+    const run = (extraProtectedSources) => rendererBackendSources("webgpu", {
+      root: clientRoot,
+      contract: {
+        ...baseContract,
+        extraProtectedSources,
+        directRendererReferenceSources: ["webgpu.ts"].concat(extraProtectedSources.map((source) => path.posix.basename(source))).sort(),
+      },
+      manifest: manifest(chunk, sources),
+      availableSources: sources,
+    });
+    assert.deepEqual(run(["../runtime/scene3d/mount-webgl.ts"]), sources);
+    assert.throws(() => run(["../runtime/scene3d/./mount-webgl.ts"]), /malformed/);
+    assert.throws(() => run(["../runtime/scene3d/does-not-exist.ts"]), /no such file|ENOENT/);
+    assert.throws(() => run(["../../outside.ts"]), /resolves outside/);
+    fs.symlinkSync(path.join(root, "outside.ts"), path.join(runtimeRoot, "mount-webgl-symlink.ts"));
+    assert.throws(() => run(["../runtime/scene3d/mount-webgl-symlink.ts"]), /must not be a symlink/);
+    fs.symlinkSync(runtimeRoot, path.join(runtimeRoot, "alias-dir"));
+    assert.throws(() => run(["../runtime/scene3d/alias-dir/mount-webgl.ts"]), /symlink component/);
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("backend chunk rosters reject unclassified physical renderer-looking sources", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-roster-"));
+  try {
+    const clientRoot = path.join(root, "client", "js");
+    const bootstrapRoot = path.join(clientRoot, "bootstrap-src");
+    const runtimeRoot = path.join(root, "client", "runtime", "scene3d");
+    fs.mkdirSync(bootstrapRoot, { recursive: true });
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.writeFileSync(path.join(runtimeRoot, "webgpu.ts"), "function renderer() {}\n");
+    fs.writeFileSync(path.join(bootstrapRoot, "16a9-renderer-webgpu-secret.ts"), "function rendererSecret() {}\n");
+    fs.writeFileSync(path.join(bootstrapRoot, "26e2-feature-scene3d-webgpu-core.ts"), "function createSceneWebGPURendererSecret() {}\n");
+    const chunk = "bootstrap-feature-scene3d-webgpu.js";
+    const sources = ["../runtime/scene3d/webgpu.ts", "bootstrap-src/16a9-renderer-webgpu-secret.ts"];
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: {
+          sourceSets: {
+            webgpu: {
+              chunk,
+              chunkSources: sources,
+              chunkSourceRoles: { "../runtime/scene3d/webgpu.ts": "governed-renderer" },
+              sources: ["../runtime/scene3d/webgpu.ts"],
+            },
+          },
+          directRendererReferenceSources: ["webgpu.ts"],
+        },
+        manifest: manifest(chunk, sources),
+        availableSources: ["../runtime/scene3d/webgpu.ts"],
+      }),
+      /chunkSourceRoles must exactly match chunkSources|looks renderer-owned/,
+    );
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: {
+          sourceSets: {
+            webgpu: {
+              chunk,
+              chunkSources: sources,
+              chunkSourceRoles: {
+                "../runtime/scene3d/webgpu.ts": "governed-renderer",
+                "bootstrap-src/16a9-renderer-webgpu-secret.ts": "backend-support",
+              },
+              sources: ["../runtime/scene3d/webgpu.ts"],
+            },
+          },
+          directRendererReferenceSources: ["webgpu.ts"],
+        },
+        manifest: manifest(chunk, sources),
+        availableSources: ["../runtime/scene3d/webgpu.ts"],
+      }),
+      /not authorized for this path|looks renderer-owned/,
+    );
+    const camouflagedSources = ["../runtime/scene3d/webgpu.ts", "bootstrap-src/26e2-feature-scene3d-webgpu-core.ts"];
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: {
+          sourceSets: {
+            webgpu: {
+              chunk,
+              chunkSources: camouflagedSources,
+              chunkSourceRoles: {
+                "../runtime/scene3d/webgpu.ts": "governed-renderer",
+                "bootstrap-src/26e2-feature-scene3d-webgpu-core.ts": "backend-support",
+              },
+              sources: ["../runtime/scene3d/webgpu.ts"],
+            },
+          },
+          directRendererReferenceSources: ["webgpu.ts"],
+        },
+        manifest: manifest(chunk, camouflagedSources),
+        availableSources: ["../runtime/scene3d/webgpu.ts"],
+      }),
+      /not authorized for this path/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("governed renderer sources reject hardlink path aliases", () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-hardlink-"));
+  try {
+    const clientRoot = path.join(root, "client", "js");
+    fs.mkdirSync(path.join(root, "client", "runtime", "scene3d"), { recursive: true });
+    fs.mkdirSync(path.join(clientRoot, "bootstrap-src"), { recursive: true });
+    const original = path.join(root, "client", "runtime", "scene3d", "webgpu.ts");
+    const alias = path.join(root, "client", "runtime", "scene3d", "webgpu-hardlink.ts");
+    fs.writeFileSync(original, "function renderer() {}\n");
+    fs.linkSync(original, alias);
+    const chunk = "bootstrap-feature-scene3d-webgpu.js";
+    const sources = ["../runtime/scene3d/webgpu.ts", "../runtime/scene3d/webgpu-hardlink.ts"];
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: { sourceSets: { webgpu: { chunk, chunkSources: sources, sources } }, directRendererReferenceSources: ["webgpu-hardlink.ts", "webgpu.ts"] },
+        manifest: manifest(chunk, sources),
+        availableSources: sources,
+      }),
+      /aliases the same physical file|hardlinks/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("governed renderer sources reject single listed hardlinks with out-of-roster aliases", (t) => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "gosx-renderer-single-hardlink-"));
+  try {
+    const clientRoot = path.join(root, "client", "js");
+    const runtimeRoot = path.join(root, "client", "runtime", "scene3d");
+    fs.mkdirSync(runtimeRoot, { recursive: true });
+    fs.mkdirSync(path.join(clientRoot, "bootstrap-src"), { recursive: true });
+    const outside = path.join(root, "outside-webgpu.ts");
+    const governed = path.join(runtimeRoot, "webgpu.ts");
+    fs.writeFileSync(outside, "function renderer() {}\n");
+    try {
+      fs.linkSync(outside, governed);
+    } catch (err) {
+      t.skip(`hardlinks unavailable on this filesystem: ${err.message}`);
+    }
+    const chunk = "bootstrap-feature-scene3d-webgpu.js";
+    const sources = ["../runtime/scene3d/webgpu.ts"];
+    assert.throws(
+      () => rendererBackendSources("webgpu", {
+        root: clientRoot,
+        contract: { sourceSets: { webgpu: { chunk, chunkSources: sources, sources } }, directRendererReferenceSources: ["webgpu.ts"] },
+        manifest: manifest(chunk, sources),
+        availableSources: sources,
+      }),
+      /hardlinks/,
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function physicalLines(source) {
+  if (source.length === 0) return 0;
+  return source.split("\n").length - (source.endsWith("\n") ? 1 : 0);
+}
+
+test("renderer source-set and file lines can only decrease from the Canopy-derived baseline", () => {
+  for (const [source, maxLines] of Object.entries(architecture.files)) {
+    const contents = fs.readFileSync(path.join(__dirname, source), "utf8");
+    assert.ok(physicalLines(contents) <= maxLines, `${source} exceeds ${maxLines} physical lines`);
+  }
+  for (const [backend, baseline] of Object.entries(architecture.sourceSets)) {
+    const counts = baseline.sources.map((source) => physicalLines(fs.readFileSync(path.join(__dirname, source), "utf8")));
+    assert.ok(counts.reduce((sum, count) => sum + count, 0) <= baseline.maxLines, `${backend} source set grew`);
+    assert.ok(Math.max(...counts) <= baseline.maxFileLines, `${backend} maximum renderer file grew`);
+  }
+});
+
+test("governance line budget records the live authored governance surface", () => {
+  const files = [
+    "scene3d-renderer-source-set.js",
+    "scene3d-renderer-architecture.test.js",
+    "testdata/scene3d-renderer-architecture.json",
+    "../../cmd/buildbootstrap/scene3d_renderer_architecture_test.go",
+    "../../internal/scene3drenderersource/source.go",
+  ];
+  const actual = files.reduce((sum, file) => sum + physicalLines(fs.readFileSync(path.join(__dirname, file), "utf8")), 0);
+  assert.equal(actual, architecture.governanceBudgetRevision.actualGovernanceLinesAtReview);
+  assert.ok(actual <= architecture.governanceBudgetRevision.revisedGovernanceLineBudget);
+});
+
+function rendererSetSizes(chunks) {
+  const sum = (suffix) => chunks.reduce((total, chunk) => total + fs.statSync(path.join(__dirname, chunk + suffix)).size, 0);
+  return { raw: sum(""), gzip: sum(".gz"), brotli: sum(".br") };
+}
+
+function assertAtOrBelow(actual, baseline, label) {
+  for (const metric of ["raw", "gzip", "brotli"]) {
+    assert.ok(actual[metric] <= baseline[metric], `${label} ${metric} ${actual[metric]} exceeds ${baseline[metric]}`);
+  }
+}
+
+test("renderer-set bytes cannot hide growth between base and lazy chunks", () => {
+  for (const [label, baseline] of Object.entries(architecture.rendererSets)) {
+    assertAtOrBelow(rendererSetSizes(baseline.chunks), baseline, label);
+  }
+  assert.throws(
+    () => assertAtOrBelow({ raw: 11, gzip: 8, brotli: 6 }, { raw: 10, gzip: 8, brotli: 6 }, "negative fixture"),
+    /negative fixture raw 11 exceeds 10/,
+  );
+});
+
+function assertRendererABI(renderer, backend) {
+  const contract = architecture.rendererABI;
+  assert.deepEqual(Object.keys(renderer).sort(), contract.implementations[backend]);
+  assert.equal(renderer.kind, backend);
+  assert.equal(typeof renderer.render, "function");
+  assert.equal(typeof renderer.dispose, "function");
+  for (const key of contract.optional) {
+    if (!(key in renderer)) continue;
+    if (key === "supportsRetainedGeometry") assert.equal(typeof renderer[key], "boolean");
+    else if (key === "textureVariantContext") assert.equal(typeof renderer[key], "object");
+    else assert.equal(typeof renderer[key], "function");
+  }
+}
+
+test("WebGL and WebGPU pin the mount-facing renderer ABI while queuePick stays experimental", async () => {
+  const webgl = createWebGLRendererForPost().renderer;
+  const webgpu = (await createBoardWebGPUHarness()).renderer;
+  try {
+    assertRendererABI(webgl, "webgl");
+    assertRendererABI(webgpu, "webgpu");
+    assert.equal(typeof webgpu.queuePick, "function");
+    assert.ok(architecture.rendererABI.experimental.includes("queuePick"));
+    assert.ok(!architecture.rendererABI.required.includes("queuePick"));
+  } finally {
+    webgl.dispose();
+    webgpu.dispose();
+  }
+});

--- a/client/js/scene3d-renderer-source-set.js
+++ b/client/js/scene3d-renderer-source-set.js
@@ -1,0 +1,435 @@
+"use strict";
+
+const fs = require("node:fs");
+const path = require("node:path");
+const childProcess = require("node:child_process");
+
+const clientJS = __dirname;
+const repoRoot = path.resolve(clientJS, "..", "..");
+const manifest = JSON.parse(fs.readFileSync(path.join(clientJS, "bootstrap-src", "chunks.json"), "utf8"));
+const architecture = JSON.parse(fs.readFileSync(path.join(clientJS, "testdata", "scene3d-renderer-architecture.json"), "utf8"));
+
+function backendContract(backend, contract = architecture) {
+  if (backend !== "webgl" && backend !== "webgpu") {
+    throw new Error(`unknown Scene3D renderer backend ${JSON.stringify(backend)}`);
+  }
+  const entry = contract && contract.sourceSets && contract.sourceSets[backend];
+  if (!entry || typeof entry.chunk !== "string" || !Array.isArray(entry.sources)) {
+    throw new Error(`Scene3D renderer contract has no valid ${backend} source set`);
+  }
+  return entry;
+}
+
+function sameList(actual, expected) {
+  return actual.length === expected.length && actual.every((value, index) => value === expected[index]);
+}
+
+function isRendererSource(backend, source) {
+  const runtime = new RegExp(`^\\.\\./runtime/scene3d/${backend}(?:-[a-z0-9-]+)?\\.ts$`);
+  if (runtime.test(source)) return true;
+  return backend === "webgpu" && /^bootstrap-src\/16a\d+-scene-webgpu-[a-z0-9-]+\.ts$/.test(source);
+}
+
+function isPotentialRendererExtractionSource(backend, source) {
+  if (!/\.ts$/.test(source)) return false;
+  const name = path.posix.basename(source);
+  if (isRendererSource(backend, source)) return true;
+  if (name.startsWith("mount-")) return false;
+  if (source.startsWith("../runtime/scene3d/")) {
+    return name.includes(backend) || name.includes("renderer") || (backend === "webgpu" && /\bgpu\b|^gpu-|gpu-/.test(name));
+  }
+  if (source.startsWith("bootstrap-src/")) return backend === "webgpu" && /^16a\d+-scene-webgpu-/.test(name);
+  return false;
+}
+
+function discoverRendererSources(backend, root = clientJS) {
+  backendContract(backend);
+  const runtimeDir = path.resolve(root, "..", "runtime", "scene3d");
+  const runtime = fs.readdirSync(runtimeDir).map((name) => `../runtime/scene3d/${name}`);
+  const supplemental = fs.readdirSync(path.join(root, "bootstrap-src"))
+    .map((name) => `bootstrap-src/${name}`);
+  for (const source of runtime.concat(supplemental)) {
+    if (isPotentialRendererExtractionSource(backend, source) && !isRendererSource(backend, source)) {
+      throw new Error(`${source} looks like an extracted ${backend} renderer source but violates the naming contract`);
+    }
+  }
+  return runtime.concat(supplemental).filter((source) => isRendererSource(backend, source)).sort();
+}
+
+function rendererSourcesInChunk(backend, sources) {
+  const selected = [];
+  for (const source of sources) {
+    if (isRendererSource(backend, source)) {
+      selected.push(source);
+      continue;
+    }
+    if (source.startsWith("../runtime/scene3d/")) {
+      throw new Error(`${source} is a runtime Scene3D source in the ${backend} renderer chunk but is not named/listed as a governed renderer source`);
+    }
+  }
+  return selected;
+}
+
+function rendererBackendSources(backend, options = {}) {
+  const contract = options.contract || architecture;
+  const entry = backendContract(backend, contract);
+  protectedRendererReferenceSources(contract);
+  validateProtectedSourceFiles(contract, options.root || clientJS, options);
+  const sourceManifest = options.manifest || manifest;
+  const chunks = sourceManifest && Array.isArray(sourceManifest.chunks)
+    ? sourceManifest.chunks.filter((chunk) => chunk && chunk.name === entry.chunk)
+    : [];
+  if (chunks.length !== 1 || !Array.isArray(chunks[0].sources)) {
+    throw new Error(`${entry.chunk} must appear exactly once with an ordered source list`);
+  }
+  const chunkSources = chunks[0].sources;
+  if (Array.isArray(entry.chunkSources) && !sameList(chunkSources, entry.chunkSources)) {
+    throw new Error(`${entry.chunk} source roster mismatch: want ${entry.chunkSources.join(" -> ")}; got ${chunkSources.join(" -> ")}`);
+  }
+  const duplicate = chunkSources.find((source, index) => chunkSources.indexOf(source) !== index);
+  if (duplicate) throw new Error(`${entry.chunk} registers duplicate source ${duplicate}`);
+  validateChunkSourceRoles(backend, chunkSources, entry, options.root || clientJS, options);
+
+  const actual = rendererSourcesInChunk(backend, chunkSources);
+  const expected = entry.sources;
+  if (actual.length !== expected.length || actual.some((source, index) => source !== expected[index])) {
+    throw new Error(`${backend} renderer source order mismatch: want ${expected.join(" -> ")}; got ${actual.join(" -> ")}`);
+  }
+
+  const available = options.availableSources || discoverRendererSources(backend, options.root || clientJS);
+  const unregistered = available.filter((source) => isRendererSource(backend, source) && !chunkSources.includes(source));
+  if (unregistered.length) {
+    throw new Error(`${backend} renderer sources are not registered in ${entry.chunk}: ${unregistered.sort().join(", ")}`);
+  }
+  return actual.slice();
+}
+
+function allProtectedSourcePaths(contract = architecture) {
+  const sources = [];
+  for (const sourceSet of Object.values(contract.sourceSets || {})) {
+    for (const source of sourceSet.sources || []) sources.push(source);
+  }
+  for (const source of contract.extraProtectedSources || []) sources.push(source);
+  return sources;
+}
+
+function validateProtectedSourceFiles(contract = architecture, root = clientJS, options = {}) {
+  validateGovernedSourceFiles(allProtectedSourcePaths(contract), root, options);
+}
+
+function validateGovernedSourceFiles(sources, root = clientJS, options = {}) {
+  if (options.validateFiles === false) return;
+  const roots = [
+    path.resolve(root, "..", "runtime", "scene3d"),
+    path.resolve(root, "bootstrap-src"),
+  ];
+  const realPaths = new Map();
+  const fileIDs = new Map();
+  for (const source of sources) {
+    if (typeof source !== "string" || source.length === 0 || source.includes("\\") || path.posix.isAbsolute(source) || path.posix.normalize(source) !== source) {
+      throw new Error(`Scene3D renderer source path ${JSON.stringify(source)} is malformed`);
+    }
+    const filename = path.resolve(root, source);
+    const stat = fs.lstatSync(filename);
+    if (stat.isSymbolicLink()) throw new Error(`${source} must not be a symlink`);
+    validateNoSymlinkPathComponents(source, filename, root, roots);
+    if (!stat.isFile()) throw new Error(`${source} is not a regular file`);
+    const real = fs.realpathSync(filename);
+    if (!roots.some((allowed) => real === allowed || real.startsWith(allowed + path.sep))) {
+      throw new Error(`${source} resolves outside the approved Scene3D renderer source roots`);
+    }
+    const duplicate = realPaths.get(real);
+    if (duplicate) throw new Error(`${source} aliases the same physical file as ${duplicate}`);
+    realPaths.set(real, source);
+    const fileID = `${stat.dev}:${stat.ino}`;
+    const inodeDuplicate = fileIDs.get(fileID);
+    if (inodeDuplicate) throw new Error(`${source} aliases the same physical file as ${inodeDuplicate}`);
+    fileIDs.set(fileID, source);
+    if (stat.nlink > 1) {
+      throw new Error(`${source} has ${stat.nlink} hardlinks; governed renderer sources must have a single owned path`);
+    }
+  }
+}
+
+function validateNoSymlinkPathComponents(source, filename, root, roots) {
+  const base = roots.find((allowed) => filename === allowed || filename.startsWith(allowed + path.sep));
+  if (!base) return;
+  const rel = path.relative(base, filename);
+  const parts = rel ? rel.split(path.sep) : [];
+  let current = base;
+  const baseStat = fs.lstatSync(base);
+  if (baseStat.isSymbolicLink()) throw new Error(`${source} traverses symlink component ${path.relative(root, base)}`);
+  for (const part of parts) {
+    current = path.join(current, part);
+    const stat = fs.lstatSync(current);
+    if (stat.isSymbolicLink()) throw new Error(`${source} traverses symlink component ${path.relative(root, current)}`);
+  }
+}
+
+function validateChunkSourceRoles(backend, chunkSources, entry, root = clientJS, options = {}) {
+  const roles = entry.chunkSourceRoles || {};
+  const roleKeys = Object.keys(roles).sort();
+  const rosterKeys = chunkSources.slice().sort();
+  if (!sameList(roleKeys, rosterKeys)) {
+    throw new Error(`${entry.chunk} chunkSourceRoles must exactly match chunkSources: want ${rosterKeys.join(", ")}; got ${roleKeys.join(", ")}`);
+  }
+  const authorities = chunkRoleAuthorities(backend, entry);
+  const governed = new Set(entry.sources || []);
+  for (const source of chunkSources) {
+    const role = roles[source];
+    if (!authorities.has(role)) {
+      throw new Error(`${entry.chunk} source ${source} has unknown governed role ${JSON.stringify(role)}`);
+    }
+    if (!authorities.get(role).has(source)) {
+      throw new Error(`${entry.chunk} source ${source} has role ${role}, but that role is not authorized for this path`);
+    }
+    if (governed.has(source)) {
+      if (role !== "governed-renderer") throw new Error(`${entry.chunk} governed renderer source ${source} has role ${role}`);
+      continue;
+    }
+    if (role === "governed-renderer") {
+      throw new Error(`${entry.chunk} source ${source} is marked governed-renderer but is missing from sourceSets.${backend}.sources`);
+    }
+    if (isRendererOwnedChunkSource(backend, source)) {
+      throw new Error(`${entry.chunk} source ${source} looks renderer-owned but is not governed by sourceSets.${backend}.sources`);
+    }
+  }
+  validateGovernedSourceFiles(chunkSources, root, options);
+}
+
+function chunkRoleAuthorities(backend, entry) {
+  const exact = {
+    webgl: {
+      "chunk-wrapper": [
+        "bootstrap-src/26j-feature-scene3d-webgl-prefix.ts",
+        "bootstrap-src/26j-feature-scene3d-webgl-suffix.ts",
+      ],
+      "shared-scene-support": [
+        "bootstrap-src/15a1-scene-texture-budget.ts",
+        "bootstrap-src/16b-scene-hdr.ts",
+      ],
+      "backend-support": [
+        "bootstrap-src/16e-scene-webgl-legacy.ts",
+      ],
+    },
+    webgpu: {
+      "chunk-wrapper": [
+        "bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts",
+        "bootstrap-src/26e-feature-scene3d-webgpu-suffix.ts",
+      ],
+      "backend-support": [
+        "bootstrap-src/26e1-feature-scene3d-webgpu-compute-bridge.ts",
+      ],
+    },
+  };
+  const roles = new Map([["governed-renderer", new Set(entry.sources || [])]]);
+  for (const [role, sources] of Object.entries(exact[backend] || {})) {
+    roles.set(role, new Set(sources));
+  }
+  return roles;
+}
+
+function isRendererOwnedChunkSource(backend, source) {
+  if (isRendererSource(backend, source)) return true;
+  const name = path.posix.basename(source);
+  if (source.startsWith("../runtime/scene3d/")) {
+    return name.includes(backend) || name.includes("renderer") || (backend === "webgpu" && /\bgpu\b|^gpu-|gpu-/.test(name));
+  }
+  if (source.startsWith("bootstrap-src/")) {
+    return name.includes("renderer") || (backend === "webgpu" && /^16a\d+-scene-webgpu-/.test(name));
+  }
+  return false;
+}
+
+function readSceneRendererBackendSrc(backend, options = {}) {
+  const root = options.root || clientJS;
+  const readSource = options.readSource || ((source) => fs.readFileSync(path.join(root, source), "utf8"));
+  return rendererBackendSources(backend, options).map(readSource).join("\n");
+}
+
+function directRendererReadFindings(source, filename) {
+  const findings = [];
+  const patterns = [
+    /\b(?:read|load)[A-Za-z0-9_$]*\s*\(\s*["'](?:[^"']*\/)?web(?:gl|gpu)\.ts["']/g,
+    /\b(?:[A-Za-z0-9_$]+\.)*readFile(?:Sync)?\s*\([\s\S]{0,240}?["'](?:[^"']*\/)?web(?:gl|gpu)\.ts["'][\s\S]{0,120}?\)/g,
+  ];
+  for (const pattern of patterns) {
+    for (const match of source.matchAll(pattern)) {
+      findings.push({ filename, line: source.slice(0, match.index).split("\n").length, text: match[0] });
+    }
+  }
+  return findings;
+}
+
+function walkedFiles(root) {
+  const files = [];
+  for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+    if (entry.name === ".git" || entry.name === "node_modules" || entry.name === "vendor") continue;
+    const filename = path.join(root, entry.name);
+    if (entry.isDirectory()) files.push(...walkedFiles(filename));
+    else files.push(filename);
+  }
+  return files.sort();
+}
+
+function scanDirectRendererReads(root = clientJS) {
+  const findings = [];
+  const canonical = path.resolve(root, path.basename(__filename));
+  for (const filename of walkedFiles(root)) {
+    if (!isTextInventoryFile(root, filename)) continue;
+    if (path.resolve(filename) === canonical) continue;
+    findings.push(...directRendererReadFindings(fs.readFileSync(filename, "utf8"), filename));
+  }
+  return findings;
+}
+
+function protectedRendererReferenceSources(contract = architecture) {
+  const names = new Set();
+  for (const sourceSet of Object.values(contract.sourceSets || {})) {
+    for (const source of sourceSet.sources || []) names.add(path.posix.basename(source));
+  }
+  for (const source of contract.extraProtectedSources || []) names.add(path.posix.basename(source));
+  const listed = contract.directRendererReferenceSources;
+  if (listed !== undefined) {
+    const actual = [...names].sort();
+    const expected = listed.slice().sort();
+    if (!sameList(actual, expected)) {
+      throw new Error(`directRendererReferenceSources must equal sourceSets plus extraProtectedSources: want ${actual.join(", ")}; got ${expected.join(", ")}`);
+    }
+  }
+  return [...names].sort();
+}
+
+function gitInventoryFiles(root) {
+  try {
+    const output = childProcess.execFileSync("git", ["-C", root, "ls-files", "--cached", "--others", "--exclude-standard", "-z"], {
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    });
+    return output.split("\0")
+      .filter(Boolean)
+      .map((file) => path.join(root, file))
+      .sort();
+  } catch {
+    return walkedFiles(root);
+  }
+}
+
+function generatedBootstrapArtifactPaths(sourceManifest = manifest) {
+  const names = new Set(["bootstrap.js"]);
+  for (const chunk of sourceManifest.chunks || []) {
+    if (chunk && typeof chunk.name === "string" && chunk.name.startsWith("bootstrap")) names.add(chunk.name);
+  }
+  const generated = new Set();
+  for (const name of names) {
+    for (const suffix of ["", ".map", ".gz", ".br"]) generated.add(`client/js/${name}${suffix}`);
+  }
+  return generated;
+}
+
+function isGeneratedInventoryPath(rel) {
+  if (rel.startsWith("build/") || rel.startsWith("dist/") || rel.startsWith("tmp/")) return true;
+  if (generatedBootstrapArtifactPaths().has(rel)) return true;
+  return false;
+}
+
+function isTextInventoryFile(root, filename) {
+  const rel = path.relative(root, filename).split(path.sep).join("/");
+  if (isGeneratedInventoryPath(rel)) return false;
+  let stat;
+  try {
+    stat = fs.lstatSync(filename);
+  } catch {
+    return false;
+  }
+  if (!stat.isFile() || stat.isSymbolicLink()) return false;
+  const chunk = fs.readFileSync(filename);
+  if (chunk.includes(0)) return false;
+  return true;
+}
+
+function validateDirectRendererReferenceRegistry(contract = architecture) {
+  const protectedNames = new Set(protectedRendererReferenceSources(contract));
+  const seen = new Set();
+  for (const entry of contract.intentionalDirectRendererReferences || []) {
+    const key = `${entry.file}\0${entry.source}`;
+    if (seen.has(key)) throw new Error(`duplicate direct renderer-source reference registry key ${entry.file}:${entry.source}`);
+    seen.add(key);
+    if (!protectedNames.has(entry.source)) throw new Error(`direct renderer-source registry protects unknown source ${entry.source}`);
+    if (!entry.file || entry.file.includes("\\") || path.posix.isAbsolute(entry.file) || entry.file.split("/").includes("..")) {
+      throw new Error(`direct renderer-source registry has malformed file key ${entry.file}`);
+    }
+    if (!Number.isInteger(entry.count) || entry.count < 1) {
+      throw new Error(`direct renderer-source registry has invalid count for ${entry.file}:${entry.source}`);
+    }
+  }
+}
+
+function rendererReferenceCounts(root = repoRoot, options = {}) {
+  const contract = options.contract || architecture;
+  const sourceNames = options.sourceNames || protectedRendererReferenceSources(contract);
+  const ignoreFiles = new Set([
+    "client/runtime/scene3d/webgl.ts",
+    "client/runtime/scene3d/webgpu.ts",
+    "client/runtime/scene3d/mount-webgl.ts",
+    "client/js/scene3d-renderer-source-set.js",
+    "client/js/scene3d-renderer-architecture.test.js",
+    "client/js/testdata/scene3d-renderer-architecture.json",
+    "internal/scene3drenderersource/source.go",
+    ...(options.ignoreFiles || []),
+  ]);
+  const counts = new Map();
+  for (const filename of gitInventoryFiles(root)) {
+    const rel = path.relative(root, filename).split(path.sep).join("/");
+    if (ignoreFiles.has(rel)) continue;
+    if (!isTextInventoryFile(root, filename)) continue;
+    const source = fs.readFileSync(filename, "utf8");
+    for (const sourceName of sourceNames) {
+      const count = [...source.matchAll(new RegExp(`(?<![-A-Za-z0-9_$])${sourceName.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}(?![A-Za-z0-9_$])`, "g"))].length;
+      if (count > 0) counts.set(`${rel}\0${sourceName}`, { file: rel, source: sourceName, count });
+    }
+  }
+  return [...counts.values()].sort((a, b) => (
+    a.file.localeCompare(b.file) || a.source.localeCompare(b.source)
+  ));
+}
+
+function directRendererReferenceRegistryFindings(root = repoRoot, options = {}) {
+  const contract = options.contract || architecture;
+  validateDirectRendererReferenceRegistry(contract);
+  const allowed = new Map((contract.intentionalDirectRendererReferences || []).map((entry) => [
+    `${entry.file}\0${entry.source}`,
+    entry.count,
+  ]));
+  const actual = rendererReferenceCounts(root, options);
+  const seen = new Set();
+  const findings = [];
+  for (const entry of actual) {
+    const key = `${entry.file}\0${entry.source}`;
+    seen.add(key);
+    const want = allowed.get(key);
+    if (want === undefined) {
+      findings.push({ ...entry, reason: "unregistered direct renderer-source reference" });
+    } else if (want !== entry.count) {
+      findings.push({ ...entry, expected: want, reason: "direct renderer-source reference count changed" });
+    }
+  }
+  for (const [key, count] of allowed) {
+    if (seen.has(key)) continue;
+    const [file, source] = key.split("\0");
+    findings.push({ file, source, expected: count, count: 0, reason: "registered direct renderer-source reference disappeared" });
+  }
+  return findings;
+}
+
+module.exports = {
+  architecture,
+  directRendererReadFindings,
+  directRendererReferenceRegistryFindings,
+  rendererReferenceCounts,
+  readSceneRendererBackendSrc,
+  rendererBackendSources,
+  rendererSourcesInChunk,
+  generatedBootstrapArtifactPaths,
+  scanDirectRendererReads,
+};

--- a/client/js/scene3d-shadow-budget.test.js
+++ b/client/js/scene3d-shadow-budget.test.js
@@ -1,4 +1,6 @@
 "use strict";
+
+const { readSceneRendererBackendSrc } = require("./scene3d-renderer-source-set.js");
 // Scene3D cascaded-shadow texture-unit budget regressions.
 //
 // These tests drive the PRODUCTION webgl.ts upload/render path and assert on
@@ -59,7 +61,7 @@ function callIn(context, expression) {
 // --- direct upload path (production functions inside a vm sandbox) ---------
 
 function setupUploadContext() {
-  const source = readRuntimeSource("webgl.ts");
+  const source = readSceneRendererBackendSrc("webgl");
   const context = vm.createContext({ console, window: {} });
   runFragment(context,
     "function sceneFiniteNumber(value, fallback) { const n = Number(value); return Number.isFinite(n) ? n : fallback; }" +

--- a/client/js/scene3d-webgpu-error-scope.test.mjs
+++ b/client/js/scene3d-webgpu-error-scope.test.mjs
@@ -36,6 +36,9 @@ import fs from "node:fs";
 import path from "node:path";
 import vm from "node:vm";
 import { fileURLToPath } from "node:url";
+import rendererSourceSet from "./scene3d-renderer-source-set.js";
+
+const { readSceneRendererBackendSrc } = rendererSourceSet;
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const srcDir = path.join(__dirname, "bootstrap-src");
@@ -45,7 +48,7 @@ function readSrc(name) {
 }
 
 const computeSource = readSrc("../runtime/scene3d/compute.ts");
-const webgpuSource = readSrc("../runtime/scene3d/webgpu.ts");
+const webgpuSource = readSceneRendererBackendSrc("webgpu");
 const sharedSource = readSrc("15a-scene-postfx-shared.ts");
 
 const GOOD_KERNEL = "@compute @workgroup_size(64) fn simulate() {}";

--- a/client/js/testdata/scene3d-renderer-architecture.json
+++ b/client/js/testdata/scene3d-renderer-architecture.json
@@ -1,0 +1,867 @@
+{
+  "schemaVersion": 1,
+  "measuredAtCommit": "05778d2f5f2b496ab88e978b7d2e87615e487395",
+  "canopyVersion": "v0.18.0-19-g01a5f95-dirty",
+  "audit": {
+    "architectureReportConsumerFiles": 25,
+    "physicalConsumerFilesAtMeasuredCommit": 24,
+    "directLiteralReadSitesMigrated": 98,
+    "filenameCoupledInjectionSitesMigrated": 1,
+    "joinedHelperCallSitesMigrated": 4,
+    "totalSourceCoupledSitesMigrated": 103,
+    "goSourceInspectionReadersMigrated": 7,
+    "intentionalDirectRendererReferenceEntries": 22,
+    "intentionalBypassExceptions": 22
+  },
+  "governanceBudgetRevision": {
+    "originalAuthoredLineTarget": 600,
+    "revisedGovernanceLineBudget": 2700,
+    "actualGovernanceLinesAtReview": 2607,
+    "reason": "Definitive final review required validateFiles:false to skip only physical filesystem checks, not semantic role governance. Fresh final review also required manifest-exact generated-artifact exclusion, canonical lexical and physical path validation, complete backend chunk role classification with closed path-authorized role vocabularies in JS and Go, Git-tracked text inventory scanning without a suffix allowlist, physical validation for extra protected sources, hardlink alias rejection, a manifest-derived Go source authority, canonical file identity checks, adversarial fixtures, and 47 explicit source-qualified legacy function exception baselines. The added machine-readable baselines are intentionally verbose so future reductions ratchet down safely instead of hiding legacy hotspots."
+  },
+  "rendererSourceNamingContract": [
+    "Extracted backend runtime sources must live under client/runtime/scene3d and be named webgl*.ts or webgpu*.ts.",
+    "WebGPU bootstrap supplemental renderer sources must be named bootstrap-src/16aN-scene-webgpu-*.ts.",
+    "The lazy backend chunks may not add runtime Scene3D sources outside sourceSets without updating this contract and its ratchets."
+  ],
+  "extraProtectedSources": [
+    "../runtime/scene3d/mount-webgl.ts"
+  ],
+  "directRendererReferenceSources": [
+    "16a1-scene-webgpu-selena-uniforms.ts",
+    "mount-webgl.ts",
+    "webgl.ts",
+    "webgpu.ts"
+  ],
+  "intentionalDirectRendererReferences": [
+    {
+      "file": "client/js/16a-scene-webgpu-pick.test.mjs",
+      "source": "webgpu.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/19a-scene-animation.test.mjs",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/bootstrap-src/chunks.json",
+      "source": "16a1-scene-webgpu-selena-uniforms.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/bootstrap-src/chunks.json",
+      "source": "mount-webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/bootstrap-src/chunks.json",
+      "source": "webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/bootstrap-src/chunks.json",
+      "source": "webgpu.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/runtime-06-scene-webgpu-water.test.js",
+      "source": "16a1-scene-webgpu-selena-uniforms.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/runtime-18-scene-webgpu-board-water.test.js",
+      "source": "webgpu.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/runtime-24-scene-hdr-ibl.test.js",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/runtime-31-scene-indexed-buffergeometry.test.js",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/runtime-test-harness.js",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/scene3d-material-ior.test.js",
+      "source": "mount-webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/scene3d-material-specular.test.js",
+      "source": "mount-webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "client/js/scene3d-render-truth.test.mjs",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "client/js/scene3d-shadow-budget.test.js",
+      "source": "webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "cmd/buildbootstrap/main.go",
+      "source": "16a1-scene-webgpu-selena-uniforms.ts",
+      "count": 2
+    },
+    {
+      "file": "cmd/buildbootstrap/main.go",
+      "source": "mount-webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "cmd/buildbootstrap/main.go",
+      "source": "webgl.ts",
+      "count": 2
+    },
+    {
+      "file": "cmd/buildbootstrap/main.go",
+      "source": "webgpu.ts",
+      "count": 2
+    },
+    {
+      "file": "cmd/buildbootstrap/scene3d_runtime_sources_test.go",
+      "source": "mount-webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "cmd/buildbootstrap/scene3d_runtime_sources_test.go",
+      "source": "webgl.ts",
+      "count": 1
+    },
+    {
+      "file": "cmd/buildbootstrap/scene3d_runtime_sources_test.go",
+      "source": "webgpu.ts",
+      "count": 1
+    }
+  ],
+  "sourceSets": {
+    "webgl": {
+      "chunk": "bootstrap-feature-scene3d-webgl.js",
+      "chunkSources": [
+        "bootstrap-src/26j-feature-scene3d-webgl-prefix.ts",
+        "bootstrap-src/15a1-scene-texture-budget.ts",
+        "bootstrap-src/16b-scene-hdr.ts",
+        "bootstrap-src/16e-scene-webgl-legacy.ts",
+        "../runtime/scene3d/webgl.ts",
+        "bootstrap-src/26j-feature-scene3d-webgl-suffix.ts"
+      ],
+      "chunkSourceRoles": {
+        "bootstrap-src/26j-feature-scene3d-webgl-prefix.ts": "chunk-wrapper",
+        "bootstrap-src/15a1-scene-texture-budget.ts": "shared-scene-support",
+        "bootstrap-src/16b-scene-hdr.ts": "shared-scene-support",
+        "bootstrap-src/16e-scene-webgl-legacy.ts": "backend-support",
+        "../runtime/scene3d/webgl.ts": "governed-renderer",
+        "bootstrap-src/26j-feature-scene3d-webgl-suffix.ts": "chunk-wrapper"
+      },
+      "sources": [
+        "../runtime/scene3d/webgl.ts"
+      ],
+      "maxLines": 9643,
+      "maxFileLines": 9643
+    },
+    "webgpu": {
+      "chunk": "bootstrap-feature-scene3d-webgpu.js",
+      "chunkSources": [
+        "bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts",
+        "bootstrap-src/26e1-feature-scene3d-webgpu-compute-bridge.ts",
+        "../runtime/scene3d/webgpu.ts",
+        "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts",
+        "bootstrap-src/26e-feature-scene3d-webgpu-suffix.ts"
+      ],
+      "chunkSourceRoles": {
+        "bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts": "chunk-wrapper",
+        "bootstrap-src/26e1-feature-scene3d-webgpu-compute-bridge.ts": "backend-support",
+        "../runtime/scene3d/webgpu.ts": "governed-renderer",
+        "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts": "governed-renderer",
+        "bootstrap-src/26e-feature-scene3d-webgpu-suffix.ts": "chunk-wrapper"
+      },
+      "sources": [
+        "../runtime/scene3d/webgpu.ts",
+        "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts"
+      ],
+      "maxLines": 19062,
+      "maxFileLines": 18864
+    }
+  },
+  "files": {
+    "../runtime/scene3d/webgl.ts": 9643,
+    "../runtime/scene3d/webgpu.ts": 18864,
+    "bootstrap-src/16a1-scene-webgpu-selena-uniforms.ts": 198,
+    "../runtime/scene3d/mount-webgl.ts": 4879,
+    "../runtime/scene3d/mount.ts": 3561
+  },
+  "functionDefaults": {
+    "lines": 200,
+    "cyclomatic": 40,
+    "cognitive": 60,
+    "maxNesting": 4,
+    "parameters": 8
+  },
+  "functionExceptions": [
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createSceneWaterSimWebGL@2124:3",
+      "lines": 255,
+      "cyclomatic": 78,
+      "cognitive": 84,
+      "maxNesting": 2,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createSceneWaterRendererWebGL@2898:3",
+      "lines": 1287,
+      "cyclomatic": 354,
+      "cognitive": 437,
+      "maxNesting": 4,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "waterShadowSignature@3084:5",
+      "lines": 11,
+      "cyclomatic": 4,
+      "cognitive": 4,
+      "maxNesting": 2,
+      "parameters": 10
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "applyWaterQualityProfile@3525:5",
+      "lines": 100,
+      "cyclomatic": 58,
+      "cognitive": 68,
+      "maxNesting": 3,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "renderMeshTextureTarget@3683:5",
+      "lines": 28,
+      "cyclomatic": 6,
+      "cognitive": 5,
+      "maxNesting": 1,
+      "parameters": 15
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawFrame@3712:5",
+      "lines": 398,
+      "cyclomatic": 103,
+      "cognitive": 126,
+      "maxNesting": 4,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createScenePostProcessor@4251:3",
+      "lines": 550,
+      "cyclomatic": 140,
+      "cognitive": 200,
+      "maxNesting": 5,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "anonymous@4653:14",
+      "lines": 136,
+      "cyclomatic": 34,
+      "cognitive": 74,
+      "maxNesting": 5,
+      "parameters": 6
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "scenePBRUploadLights@6022:3",
+      "lines": 116,
+      "cyclomatic": 33,
+      "cognitive": 64,
+      "maxNesting": 7,
+      "parameters": 5
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "scenePBRUploadEnvironmentMap@6495:3",
+      "lines": 110,
+      "cyclomatic": 49,
+      "cognitive": 95,
+      "maxNesting": 9,
+      "parameters": 6
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createScenePBRRenderer@6611:3",
+      "lines": 2736,
+      "cyclomatic": 770,
+      "cognitive": 1179,
+      "maxNesting": 7,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "uploadCustomUniforms@7244:5",
+      "lines": 24,
+      "cyclomatic": 21,
+      "cognitive": 31,
+      "maxNesting": 5,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "render@7420:5",
+      "lines": 283,
+      "cyclomatic": 73,
+      "cognitive": 105,
+      "maxNesting": 3,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawPBRObjectList@8221:5",
+      "lines": 261,
+      "cyclomatic": 74,
+      "cognitive": 173,
+      "maxNesting": 6,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "applyPointsAuthoredCustomUniforms@8628:5",
+      "lines": 33,
+      "cyclomatic": 16,
+      "cognitive": 44,
+      "maxNesting": 7,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawPointsEntries@8804:5",
+      "lines": 219,
+      "cyclomatic": 63,
+      "cognitive": 125,
+      "maxNesting": 6,
+      "parameters": 7
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawInstancedMeshes@9129:5",
+      "lines": 206,
+      "cyclomatic": 55,
+      "cognitive": 117,
+      "maxNesting": 5,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "wgpuLoadTexture@3225:3",
+      "lines": 116,
+      "cyclomatic": 33,
+      "cognitive": 63,
+      "maxNesting": 5,
+      "parameters": 6
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "wgpuCreateSceneColorPipeline@3838:3",
+      "lines": 26,
+      "cyclomatic": 2,
+      "cognitive": 1,
+      "maxNesting": 0,
+      "parameters": 9
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "wgpuCreatePostProcessor@4090:3",
+      "lines": 667,
+      "cyclomatic": 126,
+      "cognitive": 194,
+      "maxNesting": 8,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "anonymous@4458:14",
+      "lines": 303,
+      "cyclomatic": 29,
+      "cognitive": 81,
+      "maxNesting": 8,
+      "parameters": 8
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSceneWebGPUPicker@5125:3",
+      "lines": 415,
+      "cyclomatic": 118,
+      "cognitive": 173,
+      "maxNesting": 5,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "queuePick@5287:5",
+      "lines": 31,
+      "cyclomatic": 9,
+      "cognitive": 18,
+      "maxNesting": 5,
+      "parameters": 5
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSceneWebGPURenderer@6176:3",
+      "lines": 12004,
+      "cyclomatic": 4022,
+      "cognitive": 5194,
+      "maxNesting": 7,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "initGPUResources@7416:6",
+      "lines": 394,
+      "cyclomatic": 26,
+      "cognitive": 34,
+      "maxNesting": 4,
+      "parameters": 0
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSelenaBindGroup@8460:5",
+      "lines": 124,
+      "cyclomatic": 48,
+      "cognitive": 70,
+      "maxNesting": 3,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "sceneWaterObjectState@9546:5",
+      "lines": 95,
+      "cyclomatic": 39,
+      "cognitive": 57,
+      "maxNesting": 5,
+      "parameters": 5
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "sceneWaterManifestShaderSources@9826:5",
+      "lines": 85,
+      "cyclomatic": 74,
+      "cognitive": 121,
+      "maxNesting": 5,
+      "parameters": 0
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "ingestManifestValue@9852:7",
+      "lines": 20,
+      "cyclomatic": 19,
+      "cognitive": 38,
+      "maxNesting": 5,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "ingestManifestText@9872:7",
+      "lines": 22,
+      "cyclomatic": 22,
+      "cognitive": 41,
+      "maxNesting": 5,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSceneWaterSystem@10360:5",
+      "lines": 202,
+      "cyclomatic": 33,
+      "cognitive": 32,
+      "maxNesting": 1,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "renderWaterObjectMeshTargetPass@11160:5",
+      "lines": 27,
+      "cyclomatic": 14,
+      "cognitive": 13,
+      "maxNesting": 1,
+      "parameters": 11
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "renderWaterObjectSceneTexturePasses@11528:5",
+      "lines": 147,
+      "cyclomatic": 39,
+      "cognitive": 60,
+      "maxNesting": 3,
+      "parameters": 9
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "updateWaterSystems@11679:5",
+      "lines": 507,
+      "cyclomatic": 168,
+      "cognitive": 280,
+      "maxNesting": 6,
+      "parameters": 10
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawWaterPoolEntries@13207:5",
+      "lines": 104,
+      "cyclomatic": 34,
+      "cognitive": 79,
+      "maxNesting": 6,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawWaterSurfaceSide@13355:5",
+      "lines": 104,
+      "cyclomatic": 34,
+      "cognitive": 84,
+      "maxNesting": 6,
+      "parameters": 6
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "updateInstancedCullSystems@13516:5",
+      "lines": 164,
+      "cyclomatic": 68,
+      "cognitive": 113,
+      "maxNesting": 5,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "syncEnvironmentIBL@13956:5",
+      "lines": 60,
+      "cyclomatic": 31,
+      "cognitive": 63,
+      "maxNesting": 7,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "renderShadowPass@15426:5",
+      "lines": 104,
+      "cyclomatic": 35,
+      "cognitive": 67,
+      "maxNesting": 4,
+      "parameters": 5
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawPBRObjects@15547:5",
+      "lines": 179,
+      "cyclomatic": 87,
+      "cognitive": 170,
+      "maxNesting": 6,
+      "parameters": 9
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "instancedMeshColorData@15769:5",
+      "lines": 48,
+      "cyclomatic": 20,
+      "cognitive": 35,
+      "maxNesting": 5,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawPointsEntries@16428:5",
+      "lines": 178,
+      "cyclomatic": 51,
+      "cognitive": 86,
+      "maxNesting": 6,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawComputeParticleEntries@16624:5",
+      "lines": 155,
+      "cyclomatic": 44,
+      "cognitive": 60,
+      "maxNesting": 2,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "publishWebGPUFrameStats@16847:5",
+      "lines": 313,
+      "cyclomatic": 257,
+      "cognitive": 257,
+      "maxNesting": 2,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawBoardLabels@17520:5",
+      "lines": 117,
+      "cyclomatic": 39,
+      "cognitive": 76,
+      "maxNesting": 4,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "render@17755:5",
+      "lines": 653,
+      "cyclomatic": 175,
+      "cognitive": 226,
+      "maxNesting": 4,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "diagnostics@18705:5",
+      "lines": 90,
+      "cyclomatic": 49,
+      "cognitive": 49,
+      "maxNesting": 2,
+      "parameters": 0
+    }
+  ],
+  "symbols": [
+    {
+      "source": "../runtime/scene3d/mount-telemetry.ts",
+      "name": "mountSnapshot",
+      "lines": 118,
+      "cyclomatic": 66,
+      "cognitive": 81,
+      "maxNesting": 4,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/mount.ts",
+      "name": "renderFrame",
+      "lines": 202,
+      "cyclomatic": 60,
+      "cognitive": 70,
+      "maxNesting": 3,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createSceneWaterSimWebGL",
+      "lines": 255,
+      "cyclomatic": 78,
+      "cognitive": 84,
+      "maxNesting": 2,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createSceneWaterRendererWebGL",
+      "lines": 1287,
+      "cyclomatic": 354,
+      "cognitive": 437,
+      "maxNesting": 4,
+      "parameters": 3
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawFrame",
+      "lines": 398,
+      "cyclomatic": 103,
+      "cognitive": 126,
+      "maxNesting": 4,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createScenePostProcessor",
+      "lines": 550,
+      "cyclomatic": 140,
+      "cognitive": 200,
+      "maxNesting": 5,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "createScenePBRRenderer",
+      "lines": 2736,
+      "cyclomatic": 770,
+      "cognitive": 1179,
+      "maxNesting": 7,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgl.ts",
+      "name": "drawPBRObjectList",
+      "lines": 261,
+      "cyclomatic": 74,
+      "cognitive": 173,
+      "maxNesting": 6,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "wgpuCreatePostProcessor",
+      "lines": 667,
+      "cyclomatic": 126,
+      "cognitive": 194,
+      "maxNesting": 8,
+      "parameters": 4
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSceneWebGPUPicker",
+      "lines": 415,
+      "cyclomatic": 118,
+      "cognitive": 173,
+      "maxNesting": 5,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "createSceneWebGPURenderer",
+      "lines": 12004,
+      "cyclomatic": 4022,
+      "cognitive": 5194,
+      "maxNesting": 7,
+      "parameters": 2
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "updateWaterSystems",
+      "lines": 507,
+      "cyclomatic": 168,
+      "cognitive": 280,
+      "maxNesting": 6,
+      "parameters": 10
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "drawPBRObjects",
+      "lines": 179,
+      "cyclomatic": 87,
+      "cognitive": 170,
+      "maxNesting": 6,
+      "parameters": 9
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "publishWebGPUFrameStats",
+      "lines": 313,
+      "cyclomatic": 257,
+      "cognitive": 257,
+      "maxNesting": 2,
+      "parameters": 1
+    },
+    {
+      "source": "../runtime/scene3d/webgpu.ts",
+      "name": "render",
+      "lines": 653,
+      "cyclomatic": 175,
+      "cognitive": 226,
+      "maxNesting": 4,
+      "parameters": 3
+    }
+  ],
+  "rendererSets": {
+    "base+webgl": {
+      "chunks": [
+        "bootstrap-feature-scene3d.js",
+        "bootstrap-feature-scene3d-webgl.js"
+      ],
+      "raw": 767915,
+      "gzip": 212127,
+      "brotli": 176975
+    },
+    "base+webgpu": {
+      "chunks": [
+        "bootstrap-feature-scene3d.js",
+        "bootstrap-feature-scene3d-webgpu.js"
+      ],
+      "raw": 940631,
+      "gzip": 246602,
+      "brotli": 205089
+    },
+    "base+webgl+gltf+animation": {
+      "chunks": [
+        "bootstrap-feature-scene3d.js",
+        "bootstrap-feature-scene3d-webgl.js",
+        "bootstrap-feature-scene3d-gltf.js",
+        "bootstrap-feature-scene3d-animation.js"
+      ],
+      "raw": 821021,
+      "gzip": 231683,
+      "brotli": 194407
+    },
+    "base+webgpu+gltf+animation": {
+      "chunks": [
+        "bootstrap-feature-scene3d.js",
+        "bootstrap-feature-scene3d-webgpu.js",
+        "bootstrap-feature-scene3d-gltf.js",
+        "bootstrap-feature-scene3d-animation.js"
+      ],
+      "raw": 993737,
+      "gzip": 266158,
+      "brotli": 222521
+    }
+  },
+  "rendererABI": {
+    "required": [
+      "kind",
+      "render",
+      "dispose"
+    ],
+    "optional": [
+      "supportsRetainedGeometry",
+      "supportsBundle",
+      "setLifecycle",
+      "diagnostics",
+      "textureVariantContext",
+      "getStats",
+      "pollPerformanceSample",
+      "getPerformanceTimingStatus",
+      "disablePostProcessing",
+      "enablePostProcessing"
+    ],
+    "experimental": [
+      "queuePick"
+    ],
+    "implementationDetail": [
+      "type"
+    ],
+    "implementations": {
+      "webgl": [
+        "diagnostics",
+        "dispose",
+        "kind",
+        "render",
+        "supportsRetainedGeometry",
+        "textureVariantContext",
+        "type"
+      ],
+      "webgpu": [
+        "diagnostics",
+        "disablePostProcessing",
+        "dispose",
+        "enablePostProcessing",
+        "getPerformanceTimingStatus",
+        "kind",
+        "pollPerformanceSample",
+        "queuePick",
+        "render",
+        "setLifecycle",
+        "supportsBundle",
+        "supportsRetainedGeometry",
+        "textureVariantContext",
+        "type"
+      ]
+    }
+  }
+}

--- a/cmd/buildbootstrap/scene3d_renderer_architecture_test.go
+++ b/cmd/buildbootstrap/scene3d_renderer_architecture_test.go
@@ -1,0 +1,633 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gotreesitter "github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+type rendererArchitectureBaseline struct {
+	SourceSets         map[string]rendererSourceSetBaseline `json:"sourceSets"`
+	FunctionDefaults   rendererSymbolMetric                 `json:"functionDefaults"`
+	FunctionExceptions []rendererSymbolMetric               `json:"functionExceptions"`
+	Symbols            []rendererSymbolMetric               `json:"symbols"`
+}
+
+type rendererSourceSetBaseline struct {
+	Chunk            string            `json:"chunk"`
+	ChunkSources     []string          `json:"chunkSources"`
+	ChunkSourceRoles map[string]string `json:"chunkSourceRoles"`
+	Sources          []string          `json:"sources"`
+}
+
+type rendererSymbolMetric struct {
+	Source     string `json:"source"`
+	Name       string `json:"name"`
+	Lines      int    `json:"lines"`
+	Cyclomatic int    `json:"cyclomatic"`
+	Cognitive  int    `json:"cognitive"`
+	MaxNesting int    `json:"maxNesting"`
+	Parameters int    `json:"parameters"`
+}
+
+func loadRendererArchitectureBaseline(t *testing.T) (string, rendererArchitectureBaseline) {
+	t.Helper()
+	clientJS := shippedClientJS(t)
+	raw, err := os.ReadFile(filepath.Join(clientJS, "testdata", "scene3d-renderer-architecture.json"))
+	if err != nil {
+		t.Fatalf("read renderer architecture baseline: %v", err)
+	}
+	var baseline rendererArchitectureBaseline
+	if err := json.Unmarshal(raw, &baseline); err != nil {
+		t.Fatalf("parse renderer architecture baseline: %v", err)
+	}
+	return clientJS, baseline
+}
+
+func TestRendererSourceOrderMatchesMonolithAndLazyChunks(t *testing.T) {
+	_, baseline := loadRendererArchitectureBaseline(t)
+	for backend, sourceSet := range baseline.SourceSets {
+		var lazyRoster, lazy, monolith []string
+		for _, entry := range outputs {
+			var selected []string
+			for _, source := range entry.sources {
+				for _, expected := range sourceSet.Sources {
+					if source.rel == expected {
+						selected = append(selected, source.rel)
+					}
+				}
+			}
+			switch entry.name {
+			case sourceSet.Chunk:
+				lazy = selected
+				for _, source := range entry.sources {
+					lazyRoster = append(lazyRoster, source.rel)
+				}
+			case "bootstrap.js":
+				monolith = selected
+			}
+		}
+		if got, want := strings.Join(lazyRoster, "\x00"), strings.Join(sourceSet.ChunkSources, "\x00"); got != want {
+			t.Errorf("%s lazy renderer chunk roster = %q, want %q", backend, lazyRoster, sourceSet.ChunkSources)
+		}
+		if got, want := strings.Join(lazy, "\x00"), strings.Join(sourceSet.Sources, "\x00"); got != want {
+			t.Errorf("%s lazy renderer order = %q, want %q", backend, lazy, sourceSet.Sources)
+		}
+		if got, want := strings.Join(monolith, "\x00"), strings.Join(sourceSet.Sources, "\x00"); got != want {
+			t.Errorf("%s monolith renderer order = %q, want %q", backend, monolith, sourceSet.Sources)
+		}
+		if err := validateRendererChunkRoles(backend, sourceSet); err != nil {
+			t.Errorf("%s renderer chunk role contract failed: %v", backend, err)
+		}
+	}
+}
+
+func TestRendererChunkRoleContractRejectsSpoofedRoster(t *testing.T) {
+	_, baseline := loadRendererArchitectureBaseline(t)
+	sourceSet := baseline.SourceSets["webgpu"]
+
+	invented := cloneRendererSourceSet(sourceSet)
+	invented.ChunkSourceRoles["bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts"] = "invented-role"
+	if err := validateRendererChunkRoles("webgpu", invented); err == nil || !strings.Contains(err.Error(), "unknown governed role") {
+		t.Fatalf("invented role was not rejected correctly: %v", err)
+	}
+
+	swapped := cloneRendererSourceSet(sourceSet)
+	swapped.ChunkSourceRoles["bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts"] = "backend-support"
+	if err := validateRendererChunkRoles("webgpu", swapped); err == nil || !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("swapped role was not rejected correctly: %v", err)
+	}
+
+	stale := cloneRendererSourceSet(sourceSet)
+	stale.ChunkSourceRoles["bootstrap-src/not-in-roster.ts"] = "governed-renderer"
+	if err := validateRendererChunkRoles("webgpu", stale); err == nil || !strings.Contains(err.Error(), "must exactly match") {
+		t.Fatalf("stale role key was not rejected correctly: %v", err)
+	}
+
+	camouflaged := cloneRendererSourceSet(sourceSet)
+	extra := "bootstrap-src/26e2-feature-scene3d-webgpu-core.ts"
+	camouflaged.ChunkSources = append(camouflaged.ChunkSources, extra)
+	camouflaged.ChunkSourceRoles[extra] = "backend-support"
+	if err := validateRendererChunkRoles("webgpu", camouflaged); err == nil || !strings.Contains(err.Error(), "not authorized") {
+		t.Fatalf("coordinated output/manifest/contract camouflage was not rejected correctly: %v", err)
+	}
+}
+
+func cloneRendererSourceSet(sourceSet rendererSourceSetBaseline) rendererSourceSetBaseline {
+	clone := rendererSourceSetBaseline{
+		Chunk:            sourceSet.Chunk,
+		ChunkSources:     append([]string(nil), sourceSet.ChunkSources...),
+		ChunkSourceRoles: map[string]string{},
+		Sources:          append([]string(nil), sourceSet.Sources...),
+	}
+	for source, role := range sourceSet.ChunkSourceRoles {
+		clone.ChunkSourceRoles[source] = role
+	}
+	return clone
+}
+
+func validateRendererChunkRoles(backend string, sourceSet rendererSourceSetBaseline) error {
+	authorities := rendererChunkRoleAuthorities(backend, sourceSet.Sources)
+	roster := map[string]bool{}
+	for _, source := range sourceSet.ChunkSources {
+		if roster[source] {
+			return fmt.Errorf("%s registers duplicate source %s", sourceSet.Chunk, source)
+		}
+		roster[source] = true
+	}
+	if len(sourceSet.ChunkSourceRoles) != len(roster) {
+		return fmt.Errorf("%s chunkSourceRoles must exactly match chunkSources", sourceSet.Chunk)
+	}
+	for source := range sourceSet.ChunkSourceRoles {
+		if !roster[source] {
+			return fmt.Errorf("%s chunkSourceRoles must exactly match chunkSources; stale key %s", sourceSet.Chunk, source)
+		}
+	}
+	governed := map[string]bool{}
+	for _, source := range sourceSet.Sources {
+		governed[source] = true
+	}
+	for _, source := range sourceSet.ChunkSources {
+		role := sourceSet.ChunkSourceRoles[source]
+		allowed, ok := authorities[role]
+		if !ok {
+			return fmt.Errorf("%s source %s has unknown governed role %q", sourceSet.Chunk, source, role)
+		}
+		if !allowed[source] {
+			return fmt.Errorf("%s source %s has role %s, but that role is not authorized for this path", sourceSet.Chunk, source, role)
+		}
+		if governed[source] && role != "governed-renderer" {
+			return fmt.Errorf("%s governed renderer source %s has role %s", sourceSet.Chunk, source, role)
+		}
+		if role == "governed-renderer" && !governed[source] {
+			return fmt.Errorf("%s source %s is marked governed-renderer but is missing from sourceSets.%s.sources", sourceSet.Chunk, source, backend)
+		}
+	}
+	return nil
+}
+
+func rendererChunkRoleAuthorities(backend string, governedSources []string) map[string]map[string]bool {
+	authorities := map[string]map[string]bool{"governed-renderer": {}}
+	for _, source := range governedSources {
+		authorities["governed-renderer"][source] = true
+	}
+	exact := map[string]map[string][]string{
+		"webgl": {
+			"chunk-wrapper": {
+				"bootstrap-src/26j-feature-scene3d-webgl-prefix.ts",
+				"bootstrap-src/26j-feature-scene3d-webgl-suffix.ts",
+			},
+			"shared-scene-support": {
+				"bootstrap-src/15a1-scene-texture-budget.ts",
+				"bootstrap-src/16b-scene-hdr.ts",
+			},
+			"backend-support": {
+				"bootstrap-src/16e-scene-webgl-legacy.ts",
+			},
+		},
+		"webgpu": {
+			"chunk-wrapper": {
+				"bootstrap-src/26e-feature-scene3d-webgpu-prefix.ts",
+				"bootstrap-src/26e-feature-scene3d-webgpu-suffix.ts",
+			},
+			"backend-support": {
+				"bootstrap-src/26e1-feature-scene3d-webgpu-compute-bridge.ts",
+			},
+		},
+	}
+	for role, sources := range exact[backend] {
+		if authorities[role] == nil {
+			authorities[role] = map[string]bool{}
+		}
+		for _, source := range sources {
+			authorities[role][source] = true
+		}
+	}
+	return authorities
+}
+
+func TestRendererCompleteFunctionInventoryRatchetsOffline(t *testing.T) {
+	clientJS, baseline := loadRendererArchitectureBaseline(t)
+	defaults := baseline.FunctionDefaults
+	exceptions := map[string]rendererSymbolMetric{}
+	for _, exception := range baseline.FunctionExceptions {
+		key := exception.Source + "\x00" + exception.Name
+		if _, ok := exceptions[key]; ok {
+			t.Fatalf("duplicate renderer function exception %s:%s", exception.Source, exception.Name)
+		}
+		exceptions[key] = exception
+	}
+	seen := map[string]bool{}
+	neededExceptions := map[string]bool{}
+	for _, sourceSet := range baseline.SourceSets {
+		for _, source := range sourceSet.Sources {
+			raw, err := os.ReadFile(filepath.Join(clientJS, filepath.FromSlash(source)))
+			if err != nil {
+				t.Fatalf("read %s: %v", source, err)
+			}
+			metrics, err := rendererAllFunctionMetrics(raw, source)
+			if err != nil {
+				t.Fatalf("measure function inventory for %s: %v", source, err)
+			}
+			for _, metric := range metrics {
+				key := metric.Source + "\x00" + metric.Name
+				seen[key] = true
+				if regressions := rendererMetricRegressions(metric, defaults); len(regressions) == 0 {
+					continue
+				}
+				exception, ok := exceptions[key]
+				if !ok {
+					t.Errorf("%s:%s exceeds default renderer function budget without an explicit exception: %s", metric.Source, metric.Name, strings.Join(rendererMetricRegressions(metric, defaults), ", "))
+					continue
+				}
+				neededExceptions[key] = true
+				if regressions := rendererMetricRegressions(metric, exception); len(regressions) != 0 {
+					t.Errorf("%s:%s complexity regressed beyond exception: %s", metric.Source, metric.Name, strings.Join(regressions, ", "))
+				}
+			}
+		}
+	}
+	for key, exception := range exceptions {
+		if !seen[key] {
+			t.Errorf("renderer function exception no longer matches a governed function: %s:%s", exception.Source, exception.Name)
+			continue
+		}
+		if !neededExceptions[key] {
+			t.Errorf("renderer function exception no longer exceeds default budgets and must be pruned: %s:%s", exception.Source, exception.Name)
+		}
+	}
+}
+
+func TestRendererCanopyComplexityRatchetsOffline(t *testing.T) {
+	clientJS, baseline := loadRendererArchitectureBaseline(t)
+	bySource := map[string][]rendererSymbolMetric{}
+	for _, symbol := range baseline.Symbols {
+		bySource[symbol.Source] = append(bySource[symbol.Source], symbol)
+	}
+	for source, symbols := range bySource {
+		raw, err := os.ReadFile(filepath.Join(clientJS, filepath.FromSlash(source)))
+		if err != nil {
+			t.Fatalf("read %s: %v", source, err)
+		}
+		actual, err := rendererMetrics(raw, symbols)
+		if err != nil {
+			t.Fatalf("measure %s: %v", source, err)
+		}
+		for _, want := range symbols {
+			got := actual[want.Name]
+			if regressions := rendererMetricRegressions(got, want); len(regressions) != 0 {
+				t.Errorf("%s:%s complexity regressed: %s", source, want.Name, strings.Join(regressions, ", "))
+			}
+		}
+	}
+}
+
+func TestRendererComplexityRatchetRejectsExceedance(t *testing.T) {
+	baseline := rendererSymbolMetric{Lines: 10, Cyclomatic: 3, Cognitive: 4, MaxNesting: 2, Parameters: 1}
+	if got := rendererMetricRegressions(rendererSymbolMetric{Lines: 9, Cyclomatic: 3, Cognitive: 3, MaxNesting: 1, Parameters: 1}, baseline); len(got) != 0 {
+		t.Fatalf("ratchet rejected a reduction: %v", got)
+	}
+	actual := baseline
+	actual.Cognitive++
+	got := rendererMetricRegressions(actual, baseline)
+	if len(got) != 1 || got[0] != "cognitive 5 > 4" {
+		t.Fatalf("ratchet did not reject the negative fixture: %v", got)
+	}
+}
+
+func TestRendererCompleteInventoryRejectsUnlistedHotspots(t *testing.T) {
+	source := []byte(`
+function okSmall() { return 1; }
+const tooHot = () => {
+  if (a) {}
+  if (b) {}
+  if (c) {}
+  if (d) {}
+  if (e) {}
+}
+class RendererProbe {
+  draw() {
+    if (a) {}
+    if (b) {}
+    if (c) {}
+    if (d) {}
+    if (e) {}
+  }
+}
+`)
+	metrics, err := rendererAllFunctionMetrics(source, "../runtime/scene3d/webgpu-probe.ts")
+	if err != nil {
+		t.Fatalf("measure fixture: %v", err)
+	}
+	names := map[string]bool{}
+	defaults := rendererSymbolMetric{Lines: 200, Cyclomatic: 4, Cognitive: 4, MaxNesting: 4, Parameters: 8}
+	for _, metric := range metrics {
+		if regressions := rendererMetricRegressions(metric, defaults); len(regressions) != 0 {
+			names[metric.Name] = true
+		}
+	}
+	if !rendererHasMetricPrefix(names, "tooHot@") || !rendererHasMetricPrefix(names, "RendererProbe.draw@") {
+		t.Fatalf("complete inventory did not catch arrow and method hotspots: %v", names)
+	}
+}
+
+func TestRendererFunctionExceptionMustRemainAboveDefaults(t *testing.T) {
+	defaults := rendererSymbolMetric{Lines: 200, Cyclomatic: 40, Cognitive: 60, MaxNesting: 4, Parameters: 8}
+	current := rendererSymbolMetric{
+		Source:     "../runtime/scene3d/probe.ts",
+		Name:       "small@1:1",
+		Lines:      12,
+		Cyclomatic: 2,
+		Cognitive:  2,
+		MaxNesting: 1,
+		Parameters: 1,
+	}
+	if regressions := rendererMetricRegressions(current, defaults); len(regressions) != 0 {
+		t.Fatalf("stale-exception fixture should be below defaults: %v", regressions)
+	}
+	if regressions := rendererMetricRegressions(rendererSymbolMetric{
+		Lines:      201,
+		Cyclomatic: 2,
+		Cognitive:  2,
+		MaxNesting: 1,
+		Parameters: 1,
+	}, defaults); len(regressions) != 1 || regressions[0] != "lines 201 > 200" {
+		t.Fatalf("default budget fixture stopped catching actual growth: %v", regressions)
+	}
+}
+
+func rendererMetricRegressions(actual, baseline rendererSymbolMetric) []string {
+	checks := []struct {
+		name        string
+		actual, max int
+	}{
+		{"lines", actual.Lines, baseline.Lines},
+		{"cyclomatic", actual.Cyclomatic, baseline.Cyclomatic},
+		{"cognitive", actual.Cognitive, baseline.Cognitive},
+		{"max nesting", actual.MaxNesting, baseline.MaxNesting},
+		{"parameters", actual.Parameters, baseline.Parameters},
+	}
+	var regressions []string
+	for _, check := range checks {
+		if check.actual > check.max {
+			regressions = append(regressions, fmt.Sprintf("%s %d > %d", check.name, check.actual, check.max))
+		}
+	}
+	return regressions
+}
+
+func rendererMetrics(source []byte, wanted []rendererSymbolMetric) (map[string]rendererSymbolMetric, error) {
+	language := grammars.TypescriptLanguage()
+	if language == nil {
+		return nil, fmt.Errorf("TypeScript grammar is unavailable")
+	}
+	tree, err := gotreesitter.NewParser(language).Parse(source)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Release()
+	wantedNames := map[string]bool{}
+	for _, metric := range wanted {
+		wantedNames[metric.Name] = true
+	}
+	found := map[string]rendererSymbolMetric{}
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		if node.Type(language) == "function_declaration" {
+			nameNode := node.ChildByFieldName("name", language)
+			name := ""
+			if nameNode != nil {
+				name = nameNode.Text(source)
+			}
+			if wantedNames[name] {
+				if _, duplicate := found[name]; duplicate {
+					found[name] = rendererSymbolMetric{Name: "duplicate:" + name}
+				} else {
+					found[name] = measureRendererFunction(node, language, source, name)
+				}
+			}
+		}
+		for _, child := range node.Children() {
+			walk(child)
+		}
+	}
+	walk(tree.RootNode())
+	for name := range wantedNames {
+		metric, ok := found[name]
+		if !ok {
+			return nil, fmt.Errorf("function %s is missing", name)
+		}
+		if strings.HasPrefix(metric.Name, "duplicate:") {
+			return nil, fmt.Errorf("function %s is ambiguous", name)
+		}
+	}
+	return found, nil
+}
+
+func rendererAllFunctionMetrics(source []byte, sourceName string) ([]rendererSymbolMetric, error) {
+	language := grammars.TypescriptLanguage()
+	if language == nil {
+		return nil, fmt.Errorf("TypeScript grammar is unavailable")
+	}
+	tree, err := gotreesitter.NewParser(language).Parse(source)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Release()
+	found := map[string]rendererSymbolMetric{}
+	var metrics []rendererSymbolMetric
+	var walk func(*gotreesitter.Node)
+	walk = func(node *gotreesitter.Node) {
+		if node == nil {
+			return
+		}
+		nodeType := node.Type(language)
+		if rendererSupportedFunctionNode(nodeType) {
+			name, ok := rendererFunctionName(node, language, source)
+			if !ok {
+				name = fmt.Sprintf("anonymous@%d:%d", node.StartPoint().Row+1, node.StartPoint().Column+1)
+			} else {
+				name = fmt.Sprintf("%s@%d:%d", name, node.StartPoint().Row+1, node.StartPoint().Column+1)
+			}
+			metric := measureRendererFunction(node, language, source, name)
+			metric.Source = sourceName
+			if _, duplicate := found[name]; duplicate {
+				found[name] = rendererSymbolMetric{Name: "duplicate:" + name}
+			} else {
+				found[name] = metric
+				metrics = append(metrics, metric)
+			}
+		} else if strings.Contains(nodeType, "function") && !rendererFunctionTypeKnown(nodeType) {
+			found["unsupported"] = rendererSymbolMetric{Name: "unsupported:" + nodeType}
+		}
+		for _, child := range node.Children() {
+			walk(child)
+		}
+	}
+	walk(tree.RootNode())
+	for name, metric := range found {
+		if strings.HasPrefix(metric.Name, "duplicate:") {
+			return nil, fmt.Errorf("function identity %s is ambiguous", name)
+		}
+		if strings.HasPrefix(metric.Name, "unsupported:") {
+			return nil, fmt.Errorf("unsupported TypeScript function form %s", strings.TrimPrefix(metric.Name, "unsupported:"))
+		}
+	}
+	return metrics, nil
+}
+
+func rendererSupportedFunctionNode(nodeType string) bool {
+	switch nodeType {
+	case "function_declaration", "generator_function_declaration", "method_definition", "function_expression", "arrow_function":
+		return true
+	default:
+		return false
+	}
+}
+
+func rendererFunctionTypeKnown(nodeType string) bool {
+	return rendererSupportedFunctionNode(nodeType) || nodeType == "function" || nodeType == "function_signature" || nodeType == "function_type"
+}
+
+func rendererHasMetricPrefix(names map[string]bool, prefix string) bool {
+	for name := range names {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func rendererFunctionName(node *gotreesitter.Node, language *gotreesitter.Language, source []byte) (string, bool) {
+	if node.Type(language) == "method_definition" {
+		if name := node.ChildByFieldName("name", language); name != nil {
+			className := ""
+			for ancestor := node.Parent(); ancestor != nil; ancestor = ancestor.Parent() {
+				if ancestor.Type(language) != "class_declaration" {
+					continue
+				}
+				if class := ancestor.ChildByFieldName("name", language); class != nil {
+					className = class.Text(source)
+				}
+				break
+			}
+			if className != "" {
+				return className + "." + name.Text(source), true
+			}
+			return name.Text(source), true
+		}
+	}
+	if name := node.ChildByFieldName("name", language); name != nil {
+		if text := name.Text(source); text != "" {
+			return text, true
+		}
+	}
+	for parent := node.Parent(); parent != nil; parent = parent.Parent() {
+		switch parent.Type(language) {
+		case "variable_declarator":
+			if name := parent.ChildByFieldName("name", language); name != nil {
+				return name.Text(source), true
+			}
+		case "method_definition":
+			if name := parent.ChildByFieldName("name", language); name != nil {
+				className := ""
+				for ancestor := parent.Parent(); ancestor != nil; ancestor = ancestor.Parent() {
+					if ancestor.Type(language) != "class_declaration" {
+						continue
+					}
+					if class := ancestor.ChildByFieldName("name", language); class != nil {
+						className = class.Text(source)
+					}
+					break
+				}
+				if className != "" {
+					return className + "." + name.Text(source), true
+				}
+				return name.Text(source), true
+			}
+		case "assignment_expression":
+			if left := parent.ChildByFieldName("left", language); left != nil {
+				return left.Text(source), true
+			}
+		case "program", "statement_block":
+			return "", false
+		}
+	}
+	return "", false
+}
+
+// measureRendererFunction mirrors the small AST walk used by Canopy v0.18's
+// complexity report. Keeping it here makes the ratchet hermetic in ordinary CI;
+// maintainers use Canopy to refresh the checked baseline, not to run the gate.
+func measureRendererFunction(root *gotreesitter.Node, language *gotreesitter.Language, source []byte, name string) rendererSymbolMetric {
+	metric := rendererSymbolMetric{Name: name, Cyclomatic: 1, Lines: rendererNonBlankLines(root.Text(source))}
+	if parameters := root.ChildByFieldName("parameters", language); parameters != nil {
+		metric.Parameters = parameters.NamedChildCount()
+	}
+	var walk func(*gotreesitter.Node, int)
+	walk = func(node *gotreesitter.Node, depth int) {
+		if node == nil {
+			return
+		}
+		nodeType := node.Type(language)
+		if rendererBranchingNode(nodeType) {
+			metric.Cyclomatic++
+			metric.Cognitive += 1 + depth
+			depth++
+			if depth > metric.MaxNesting {
+				metric.MaxNesting = depth
+			}
+		}
+		if rendererLogicalNode(nodeType) {
+			text := node.Text(source)
+			if strings.Contains(text, "&&") || strings.Contains(text, "||") || strings.Contains(text, " and ") || strings.Contains(text, " or ") {
+				metric.Cyclomatic++
+				metric.Cognitive++
+			}
+		}
+		for _, child := range node.Children() {
+			walk(child, depth)
+		}
+	}
+	walk(root, 0)
+	return metric
+}
+
+func rendererNonBlankLines(source string) int {
+	count := 0
+	for _, line := range strings.Split(source, "\n") {
+		if strings.TrimSpace(line) != "" {
+			count++
+		}
+	}
+	return count
+}
+
+func rendererBranchingNode(nodeType string) bool {
+	switch nodeType {
+	case "if_statement", "if_expression", "if_let_expression",
+		"for_statement", "for_expression", "for_in_statement",
+		"while_statement", "while_expression",
+		"switch_statement", "switch_expression",
+		"match_expression", "match_statement",
+		"case_clause", "case_statement", "match_arm",
+		"try_statement", "catch_clause", "except_clause", "rescue",
+		"conditional_expression", "ternary_expression", "elif_clause", "else_if_clause":
+		return true
+	default:
+		return false
+	}
+}
+
+func rendererLogicalNode(nodeType string) bool {
+	return nodeType == "binary_expression" || nodeType == "boolean_operator" || nodeType == "logical_expression"
+}

--- a/examples/gosx-docs/app/demos/water/program_test.go
+++ b/examples/gosx-docs/app/demos/water/program_test.go
@@ -3,6 +3,7 @@ package docs
 import (
 	"encoding/json"
 	"m31labs.dev/gosx"
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 	"m31labs.dev/gosx/route"
 	"m31labs.dev/gosx/scene"
 	"m31labs.dev/selena/bindings"
@@ -257,10 +258,6 @@ func TestWaterDemoControlsContract(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read managed water controls runtime: %v", err)
 	}
-	webgpuBytes, err := os.ReadFile(filepath.Join(dir, "../../../../../client/runtime/scene3d/webgpu.ts"))
-	if err != nil {
-		t.Fatalf("read Scene3D WebGPU runtime: %v", err)
-	}
 	programBytes, err := os.ReadFile(filepath.Join(dir, "program.go"))
 	if err != nil {
 		t.Fatalf("read program.go: %v", err)
@@ -268,7 +265,7 @@ func TestWaterDemoControlsContract(t *testing.T) {
 	page := string(pageBytes)
 	css := string(cssBytes)
 	runtimeSource := string(runtimeBytes)
-	webgpuSource := string(webgpuBytes)
+	webgpuSource := scene3drenderersource.ReadBackend(t, "webgpu")
 	program := string(programBytes)
 	if got := strings.Count(page, `y={10}`); got != 2 {
 		t.Fatalf("water page hidden object y count = %d, want 2 eagerly authored inactive meshes", got)
@@ -838,11 +835,8 @@ func readWaterWebGPURuntimeSource(t *testing.T) string {
 		t.Fatal("runtime.Caller failed")
 	}
 	dir := filepath.Dir(file)
-	webgpuBytes, err := os.ReadFile(filepath.Join(dir, "../../../../../client/runtime/scene3d/webgpu.ts"))
-	if err != nil {
-		t.Fatalf("read Scene3D WebGPU runtime: %v", err)
-	}
-	return string(webgpuBytes)
+	_ = dir
+	return scene3drenderersource.ReadBackend(t, "webgpu")
 }
 
 // TestWaterAtRestGatingEmitsStatsAttr is the M5 (water-parity-campaign)

--- a/internal/scene3drenderersource/source.go
+++ b/internal/scene3drenderersource/source.go
@@ -1,0 +1,112 @@
+package scene3drenderersource
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+type architectureContract struct {
+	SourceSets map[string]struct {
+		Sources []string `json:"sources"`
+	} `json:"sourceSets"`
+	ExtraProtectedSources []string `json:"extraProtectedSources"`
+}
+
+const labelPrefix = "scene3d-renderer-source-set:"
+const sourcePrefix = "scene3d-protected-source:"
+
+func BackendLabel(backend string) string { return labelPrefix + backend }
+
+func ProtectedSourceLabel(source string) string {
+	return sourcePrefix + strings.TrimSuffix(source, ".ts")
+}
+
+func ReadBackend(t testing.TB, backend string) string {
+	t.Helper()
+	root := repoRoot(t)
+	contract := loadContract(t, root)
+	entry, ok := contract.SourceSets[backend]
+	if !ok || len(entry.Sources) == 0 {
+		t.Fatalf("Scene3D renderer source set %q is not registered", backend)
+	}
+	parts := make([]string, 0, len(entry.Sources))
+	for _, source := range entry.Sources {
+		parts = append(parts, readContractSource(t, root, source))
+	}
+	return strings.Join(parts, "\n")
+}
+
+func ReadSource(t testing.TB, label string) string {
+	t.Helper()
+	if strings.HasPrefix(label, labelPrefix) {
+		return ReadBackend(t, strings.TrimPrefix(label, labelPrefix))
+	}
+	source := strings.TrimPrefix(label, sourcePrefix)
+	if !strings.HasSuffix(source, ".ts") {
+		source += ".ts"
+	}
+	root := repoRoot(t)
+	contract := loadContract(t, root)
+	for _, protected := range contract.ExtraProtectedSources {
+		if protected == source {
+			return readContractSource(t, root, source)
+		}
+	}
+	t.Fatalf("Scene3D protected source %q is not registered", source)
+	return ""
+}
+
+func repoRoot(t testing.TB) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	return filepath.Clean(filepath.Join(filepath.Dir(file), "..", ".."))
+}
+
+func loadContract(t testing.TB, root string) architectureContract {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(root, "client", "js", "testdata", "scene3d-renderer-architecture.json"))
+	if err != nil {
+		t.Fatalf("read Scene3D renderer architecture contract: %v", err)
+	}
+	var contract architectureContract
+	if err := json.Unmarshal(raw, &contract); err != nil {
+		t.Fatalf("parse Scene3D renderer architecture contract: %v", err)
+	}
+	return contract
+}
+
+func readContractSource(t testing.TB, root, source string) string {
+	t.Helper()
+	clean := filepath.Clean(filepath.FromSlash(source))
+	if filepath.IsAbs(clean) || strings.HasPrefix(clean, ".."+string(filepath.Separator)+".."+string(filepath.Separator)) {
+		t.Fatalf("Scene3D renderer source %q escapes the contract root", source)
+	}
+	path := filepath.Join(root, "client", "js", clean)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read Scene3D renderer source %s: %v", source, err)
+	}
+	if len(data) == 0 {
+		t.Fatalf("Scene3D renderer source %s is empty", source)
+	}
+	return string(data)
+}
+
+func Describe(label string) string {
+	switch {
+	case strings.HasPrefix(label, labelPrefix):
+		return fmt.Sprintf("Scene3D %s renderer source set", strings.TrimPrefix(label, labelPrefix))
+	case strings.HasPrefix(label, sourcePrefix):
+		return fmt.Sprintf("Scene3D protected source %s", strings.TrimPrefix(label, sourcePrefix))
+	default:
+		return label
+	}
+}

--- a/render/boardgpu/board_text_drift_test.go
+++ b/render/boardgpu/board_text_drift_test.go
@@ -1,11 +1,11 @@
 package boardgpu
 
 import (
-	"os"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 // TestBoardTextJSWGSLMatchesGo guards the single source of truth for the glyph
@@ -17,22 +17,13 @@ import (
 // JS stale (wrong bindings/offsets → broken glyphs or a silent pipeline-create
 // fallback). This test fails when the two diverge.
 func TestBoardTextJSWGSLMatchesGo(t *testing.T) {
-	jsPath := filepath.Join("..", "..", "client", "runtime", "scene3d", "webgpu.ts")
-	data, err := os.ReadFile(jsPath)
-	if err != nil {
-		// Fail, never skip. This is the only Go-to-JavaScript shader drift guard
-		// in the repository, so a stale relative path or a moved source file
-		// deletes the guard and still reports a green run. A missing input is a
-		// broken test, not an absent one.
-		t.Fatalf("cannot read %s (%v); the JS↔Go BoardText drift guard needs this file — fix the path or restore the file",
-			jsPath, err)
-	}
+	data := scene3drenderersource.ReadBackend(t, "webgpu")
 	re := regexp.MustCompile(`var BOARD_TEXT_WGSL = ("(?:[^"\\]|\\.)*");`)
-	m := re.FindSubmatch(data)
+	m := re.FindStringSubmatch(data)
 	if m == nil {
 		t.Fatal("BOARD_TEXT_WGSL literal not found in 16a-scene-webgpu.js — was it renamed?")
 	}
-	jsWGSL, err := strconv.Unquote(string(m[1]))
+	jsWGSL, err := strconv.Unquote(m[1])
 	if err != nil {
 		t.Fatalf("could not unquote BOARD_TEXT_WGSL: %v", err)
 	}

--- a/render/bundle/browser_geometry_transform_test.go
+++ b/render/bundle/browser_geometry_transform_test.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 func readBrowserSceneSource(t *testing.T, name string) string {
@@ -12,9 +14,9 @@ func readBrowserSceneSource(t *testing.T, name string) string {
 	path := filepath.Join("..", "..", "client", "js", "bootstrap-src", name)
 	switch name {
 	case "16-scene-webgl.js":
-		path = filepath.Join("..", "..", "client", "runtime", "scene3d", "webgl.ts")
+		return scene3drenderersource.ReadBackend(t, "webgl")
 	case "16a-scene-webgpu.js":
-		path = filepath.Join("..", "..", "client", "runtime", "scene3d", "webgpu.ts")
+		return scene3drenderersource.ReadBackend(t, "webgpu")
 	}
 	data, err := os.ReadFile(path)
 	if err != nil {

--- a/render/bundle/js_shader_source_drift_test.go
+++ b/render/bundle/js_shader_source_drift_test.go
@@ -1,11 +1,11 @@
 package bundle
 
 import (
-	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 // This file holds the reader that the *_drift_test.go guards in this package
@@ -21,19 +21,12 @@ import (
 // jsWebGPURendererFile is the browser WebGPU renderer, relative to this package
 // directory. Go runs a test with its package directory as the working
 // directory, so this path is stable.
-var jsWebGPURendererFile = filepath.Join("..", "..", "client", "runtime", "scene3d", "webgpu.ts")
+var jsWebGPURendererFile = scene3drenderersource.BackendLabel("webgpu")
 
 // readJSWebGPURenderer returns the whole browser WebGPU renderer source.
 func readJSWebGPURenderer(t *testing.T) string {
 	t.Helper()
-	data, err := os.ReadFile(jsWebGPURendererFile)
-	if err != nil {
-		t.Fatalf("read %s: %v\nThe Go-to-JS shader drift guards in render/bundle need this file. Fix the path; do not skip the guard.", jsWebGPURendererFile, err)
-	}
-	if len(data) == 0 {
-		t.Fatalf("%s is empty; the drift guards cannot compare against nothing", jsWebGPURendererFile)
-	}
-	return string(data)
+	return scene3drenderersource.ReadBackend(t, "webgpu")
 }
 
 // jsWebGLRendererFile is the browser WebGL2 renderer, relative to this package
@@ -41,19 +34,12 @@ func readJSWebGPURenderer(t *testing.T) string {
 // shadow pass decides which face fills the map with a gl.cullFace call rather
 // than with shader text, and the tone-map table guard, because WebGL2 carries
 // two name-to-number tables where WebGPU carries one.
-var jsWebGLRendererFile = filepath.Join("..", "..", "client", "runtime", "scene3d", "webgl.ts")
+var jsWebGLRendererFile = scene3drenderersource.BackendLabel("webgl")
 
 // readJSWebGLRenderer returns the whole browser WebGL2 renderer source.
 func readJSWebGLRenderer(t *testing.T) string {
 	t.Helper()
-	data, err := os.ReadFile(jsWebGLRendererFile)
-	if err != nil {
-		t.Fatalf("read %s: %v\nThe Go-to-JS drift guards in render/bundle need this file. Fix the path; do not skip the guard.", jsWebGLRendererFile, err)
-	}
-	if len(data) == 0 {
-		t.Fatalf("%s is empty; the drift guards cannot compare against nothing", jsWebGLRendererFile)
-	}
-	return string(data)
+	return scene3drenderersource.ReadBackend(t, "webgl")
 }
 
 // jsShaderSource resolves one shader constant in the browser WebGPU renderer to

--- a/scene/capability/gpupicking_test.go
+++ b/scene/capability/gpupicking_test.go
@@ -3,6 +3,8 @@ package capability
 import (
 	"os"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 // TestGPUPickingVerdictTracksMatrix pins the required-feature behavior without
@@ -52,12 +54,8 @@ func TestGPUPickingVerdictTracksMatrix(t *testing.T) {
 // re-introducing the original defect — a false cell over a working picker —
 // would have deleted this check instead of failing it.
 func TestGPUPickingRendererEvidence(t *testing.T) {
-	const rendererPath = "../../client/runtime/scene3d/webgpu.ts"
-	data, err := os.ReadFile(rendererPath)
-	if err != nil {
-		t.Fatalf("read WebGPU renderer at %s: %v", rendererPath, err)
-	}
-	source := string(data)
+	rendererPath := scene3drenderersource.BackendLabel("webgpu")
+	source := scene3drenderersource.ReadBackend(t, "webgpu")
 
 	evidenceFor(t, FeatureGPUPicking, BackendWebGPU).
 		needs(rendererPath, source,

--- a/scene/capability/lights_test.go
+++ b/scene/capability/lights_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 // These tests corroborate every light-related Matrix cell against renderer
@@ -15,17 +17,20 @@ import (
 // added here must name the symbols that make it true, and a cell left false
 // must show that the implementation is genuinely absent.
 
-const (
-	webgpuRendererPath = "../../client/runtime/scene3d/webgpu.ts"
-	webglRendererPath  = "../../client/runtime/scene3d/webgl.ts"
+var (
+	webgpuRendererPath = scene3drenderersource.BackendLabel("webgpu")
+	webglRendererPath  = scene3drenderersource.BackendLabel("webgl")
 	sceneGraphPath     = "../scene.go"
 )
 
-func readRenderer(t *testing.T, path string) string {
+func readRenderer(t *testing.T, label string) string {
 	t.Helper()
-	data, err := os.ReadFile(path)
+	if strings.HasPrefix(label, "scene3d-") {
+		return scene3drenderersource.ReadSource(t, label)
+	}
+	data, err := os.ReadFile(label)
 	if err != nil {
-		t.Fatalf("read %s: %v", path, err)
+		t.Fatalf("read %s: %v", label, err)
 	}
 	return string(data)
 }

--- a/scene/capability/water_shadow_test.go
+++ b/scene/capability/water_shadow_test.go
@@ -8,7 +8,7 @@ import (
 // webglWaterShadowPath and webgpuWaterShadowPath name the two renderers that
 // own the water shadow passes. webglRendererPath and webgpuRendererPath come
 // from lights_test.go, and readRenderer reads either one.
-const (
+var (
 	webglWaterShadowPath  = webglRendererPath
 	webgpuWaterShadowPath = webgpuRendererPath
 )

--- a/scene/capability/watersim_test.go
+++ b/scene/capability/watersim_test.go
@@ -3,6 +3,8 @@ package capability
 import (
 	"strings"
 	"testing"
+
+	"m31labs.dev/gosx/internal/scene3drenderersource"
 )
 
 // This file corroborates the water-simulation row in full.
@@ -152,4 +154,4 @@ func TestWaterSimStaysRequired(t *testing.T) {
 // webglMountChunkPath resolves the WebGL2 water renderer at mount time. A
 // definition nobody reaches is a promise, not an implementation, so the true
 // WebGL2 cell rests on this file as much as on the renderer.
-const webglMountChunkPath = "../../client/runtime/scene3d/mount-webgl.ts"
+var webglMountChunkPath = scene3drenderersource.ProtectedSourceLabel("../runtime/scene3d/mount-webgl")


### PR DESCRIPTION
## Summary

This PR adds behavior-neutral Scene3D renderer architecture governance. It does not claim or introduce a renderer feature change; it pins ownership, source-role boundaries, and drift detection around the existing generated/runtime renderer surface.

Key controls:

- closed renderer source/role ownership governance, including complete chunk roster role classification
- manifest-derived source authority across JS and Go checks
- repo-wide direct renderer-source bypass detection
- canonical regular-file/path containment checks, with symlink/path-alias/hardlink adversarial coverage
- function inventory ratchets across supported TS/JS function forms
- generated bootstrap artifact identity preserved byte-for-byte

Measured contract facts:

- governance line budget: 2607 / 2700
- governed function inventory: 921 functions
- legacy function exceptions: 47
- generated bootstrap artifacts: 64
- generated artifact digest: b67fdd0a4d6f69aafe02d58db8a465cb82957e267b47dc0e8c17934a39225453

## Verification

Local verification on rebased head 39713247c32bd67f2298a90d4d04aed980229bd9:

- stable patch-id preserved: 9cc847781e49c238b2cb1e693023246c3663548b
- full binary diff SHA preserved: d8917496dd95c4ef798eb7c6d6138e5feb62249580a62f9b5be51636f13d70ca
- Scene3D renderer architecture JS suite: 16 / 16 passed
- focused Go source/role/function/exception ratchets passed
- `make release-gate` passed
- `make test-js` passed: 1485 / 1485
- `actionlint .github/workflows/ci.yml .github/workflows/release-governed.yml` passed
- `make fmt-check` passed
- `git diff --check origin/main HEAD` passed

## Notes

- No generated renderer artifact drift: 64 manifest-derived generated artifacts remain at digest b67fdd0a4d6f69aafe02d58db8a465cb82957e267b47dc0e8c17934a39225453.
- `measuredAtCommit` provenance remains unchanged at the approved base commit.
- This PR creates no tag or release and performs no deployment.

## Rollback

Revert this merge commit to remove the governance tests/helpers and restore the previous test-only source inspection shape. Since this is intended to be behavior-neutral and generated artifacts are byte-identical, rollback should not require runtime migration.
