### PR TITLE
fix(islands): enforce discovery identity and watches

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,17 +35,21 @@ component WelcomePage() {
     return <main><Greeting name="GoSX" /></main>
 }
 
-// Islands hydrate client-side, so they still use the Go-function form.
-// See "Legacy component syntax" below.
+type CounterProps struct {
+    Initial int
+}
+
+// Strict islands keep the same typed component boundary, then hydrate the
+// supported signal/handler subset in the shared browser VM.
 //gosx:island
-func Counter(initial int) Node {
-    count := signal.New(initial)
-    increment := func() { count.Update(func(n int) int { return n + 1 }) }
-    decrement := func() { count.Update(func(n int) int { return n - 1 }) }
+component Counter(props: CounterProps) {
+    count := signal.New(props.Initial)
+    increment := func() { count.Set(count.Get() + 1) }
+    decrement := func() { count.Set(count.Get() - 1) }
 
     return <div class="counter">
         <button onClick={decrement}>-</button>
-        <span>{count}</span>
+        <span>{count.Get()}</span>
         <button onClick={increment}>+</button>
     </div>
 }
@@ -98,14 +102,17 @@ A strict `component Name` compiles to a package-level Go `func Name`, and a
 sibling `.go` file in the same package already declares, naming both
 declarations and their positions.
 
-### Islands and engines still use the function form
+### Islands are strict-capable; engines use the programmatic v1 surface
 
-In v0.49, islands and engines have no strict spelling; both continue to use
-`func Name(...) Node`. The `//gosx:island` directive marks a component for
-client-side hydration. The compiler extracts signals, computed values, and
-handlers from the Go source, compiles expressions to VM instructions, and
-serializes an island program. Server components emit static HTML with no
-client-side cost.
+The `//gosx:island` directive may mark a strict `component Name(...)` or a
+legacy function component for client-side hydration. The compiler extracts
+supported signals, computed values, and handlers, compiles expressions to VM
+instructions, and serializes an island program. Server components emit static
+HTML with no client-side cost.
+
+Strict `//gosx:engine` declarations and automatic `.gsx` engine-surface
+discovery remain preview/post-v1. The v1 engine contract is the programmatic
+`engine.Config` / `ctx.Engine` surface described below.
 
 ### Legacy component syntax (deprecated)
 
@@ -152,9 +159,10 @@ component either. An untyped legacy render frame binds `props` to a
 composition fails on every render. Converting the callee to a typed legacy
 or strict component removes the restriction.
 
-An island or an engine component cannot convert to strict syntax today (see
-"Islands and engines still use the function form" above). Leave its
-declaration as `func Name(...) Node`, whether or not its props are typed.
+An island can convert to strict syntax when its props and browser behavior fit
+the strict island subset. A `.gsx` engine component cannot convert to strict
+syntax today; keep `.gsx //gosx:engine` discovery out of the v1 contract and
+use programmatic `engine.Config` / `ctx.Engine` for v1 engine work.
 
 ## Philosophy
 

--- a/buildmanifest/manifest.go
+++ b/buildmanifest/manifest.go
@@ -198,6 +198,9 @@ func Load(path string) (*Manifest, error) {
 	if err := json.Unmarshal(data, &manifest); err != nil {
 		return nil, fmt.Errorf("decode build manifest %s: %w", path, err)
 	}
+	if err := manifest.ValidateIslandAssets(); err != nil {
+		return nil, fmt.Errorf("validate build manifest %s: %w", path, err)
+	}
 	return &manifest, nil
 }
 
@@ -236,14 +239,45 @@ func (m *Manifest) RuntimeURLs(assetBaseURL string) RuntimePaths {
 	}
 }
 
-// IslandAssetByName returns the hashed island asset for a component, if any.
+// ValidateIslandAssets rejects ambiguous unqualified runtime names. Island
+// mounts, compatibility asset requests, and renderer program maps all resolve
+// by this name, so accepting two rows would let different consumers select
+// different programs for the same component.
+func (m *Manifest) ValidateIslandAssets() error {
+	if m == nil {
+		return fmt.Errorf("build manifest is nil")
+	}
+	seen := make(map[string]IslandAsset, len(m.Islands))
+	for _, asset := range m.Islands {
+		if previous, ok := seen[asset.Name]; ok {
+			return fmt.Errorf(
+				"duplicate island asset name %q: files %q and %q would resolve the same runtime component",
+				asset.Name,
+				previous.File,
+				asset.File,
+			)
+		}
+		seen[asset.Name] = asset
+	}
+	return nil
+}
+
+// IslandAssetByName returns the unique hashed island asset for a component.
+// An ambiguous in-memory manifest fails closed even if it did not come through
+// Load's validation path.
 func (m *Manifest) IslandAssetByName(componentName string) (IslandAsset, bool) {
+	var match IslandAsset
+	found := false
 	for _, asset := range m.Islands {
 		if asset.Name == componentName {
-			return asset, true
+			if found {
+				return IslandAsset{}, false
+			}
+			match = asset
+			found = true
 		}
 	}
-	return IslandAsset{}, false
+	return match, found
 }
 
 // ContentHash returns the first 16 hex characters (8 bytes) of the sha256

--- a/buildmanifest/manifest_test.go
+++ b/buildmanifest/manifest_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -87,6 +88,43 @@ func TestLoadAndURLs(t *testing.T) {
 	}
 	if cssAsset.File != "app_counter.66666666.css" {
 		t.Fatalf("unexpected css asset file: %s", cssAsset.File)
+	}
+}
+
+func TestManifestRejectsAmbiguousIslandAssetNames(t *testing.T) {
+	manifest := &Manifest{Islands: []IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+		},
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: HashedAsset{File: "Counter.bbbbbbbb.gxi", Hash: "bbbbbbbb", Size: 1},
+		},
+	}}
+
+	err := manifest.ValidateIslandAssets()
+	for _, want := range []string{"duplicate island asset name \"Counter\"", "Counter.aaaaaaaa.gxi", "Counter.bbbbbbbb.gxi"} {
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("ValidateIslandAssets error = %v, want substring %q", err, want)
+		}
+	}
+	if asset, ok := manifest.IslandAssetByName("Counter"); ok {
+		t.Fatalf("IslandAssetByName accepted ambiguous rows: %+v", asset)
+	}
+
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "build.json")
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(path); err == nil || !strings.Contains(err.Error(), "duplicate island asset name \"Counter\"") {
+		t.Fatalf("Load error = %v, want ambiguous island rejection", err)
 	}
 }
 

--- a/cmd/gosx/build.go
+++ b/cmd/gosx/build.go
@@ -185,6 +185,9 @@ func removeFileIfExists(path string) error {
 // RunBuildWithOptions also performs — see
 // TestWarnStaleIslandsEndToEndAfterRealBuildPipeline.
 func writeIslandManifestAssets(dir, islandDir string, dev bool, islandProgs []*IslandProgramSource) ([]IslandAsset, error) {
+	if err := validateUniqueIslandProgramNames(islandProgs); err != nil {
+		return nil, err
+	}
 	fmt.Println("\n  Islands:")
 	islandExt := ".gxi" // GoSX Island — binary prod format
 	if dev {
@@ -255,11 +258,16 @@ func RunBuild(dir string, dev bool) error {
 }
 
 func RunBuildWithOptions(dir string, opts BuildOptions) error {
-	absDir, err := filepath.Abs(dir)
+	absDir, err := canonicalExistingDir(dir)
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
 	}
 	dir = absDir
+	// The initial discovery is a side-effect barrier: invalid source must fail
+	// before module sync, dependency resolution, or a user hook can run.
+	if _, err := collectProjectIslandDiscovery(dir); err != nil {
+		return err
+	}
 
 	if err := checkVersionSkew(dir); err != nil {
 		return err
@@ -274,9 +282,11 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	if err != nil {
 		return err
 	}
-	if err := runBuildHookCommands(dir, "pre-build", cfg.Build.Hooks.Pre); err != nil {
+	discovery, err := runPreBuildHooksAndRefreshIslandDiscovery(dir, cfg.Build.Hooks.Pre)
+	if err != nil {
 		return err
 	}
+	islandProgs, gsxFiles := discovery.Programs, discovery.GSXFiles
 	printBundlePolicyWarnings(cfg.Build.Bundle)
 	if diagnostics := bundlepolicy.ValidateProject(dir, cfg.Build.Bundle); !diagnostics.Empty() {
 		return errors.New(diagnostics.Error())
@@ -284,7 +294,6 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	if err := checkStrictProject(context.Background(), dir); err != nil {
 		return fmt.Errorf("check strict components: %w", err)
 	}
-
 	distDir := filepath.Join(dir, "dist")
 	if err := os.RemoveAll(distDir); err != nil {
 		return fmt.Errorf("clean output directory: %w", err)
@@ -340,11 +349,6 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	fmt.Printf("  Grammar: gosx-grammar.blob (%d bytes)\n", len(grammarBlob))
 
 	// ── Tier 1: Compile .gsx files ──────────────────────────────────────
-
-	islandProgs, gsxFiles, err := collectProjectIslandPrograms(dir)
-	if err != nil {
-		return err
-	}
 
 	fmt.Printf("  Sources: %d .gsx files\n", len(gsxFiles))
 
@@ -646,13 +650,9 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 		)
 	}
 
-	// ── Engine surface bytecode lowering ────────────────────────────────
-	//
-	// Engine surfaces no longer produce a per-component WASM artifact at
-	// build time. They lower to shared-VM bytecode at server start via
-	// engine/surface.Discover, which writes JSON programs into
-	// .gosx/cache/surfaces/. See ADR 0003 (supersedure) and ADR 0005
-	// (buildsurface deletion) in the m31labs-gosx hyphae space.
+	// Automatic .gsx engine-surface discovery is preview/post-v1 and is not
+	// part of the production build contract. Programmatic engine.Config is
+	// the v1 engine surface and uses the runtime assets staged above.
 
 	// Build the application binary when the target directory is a runnable app.
 	serverBinaryPath := filepath.Join(distDir, "server", "app"+targetExecutableExt())
@@ -777,6 +777,21 @@ func RunBuildWithOptions(dir string, opts BuildOptions) error {
 	}
 
 	return nil
+}
+
+// runPreBuildHooksAndRefreshIslandDiscovery makes the post-hook filesystem the
+// sole source of truth for build artifacts. Hooks are allowed to mutate,
+// generate, or delete .gsx files, so the pre-hook validation snapshot must
+// never be reused for manifest rows, island programs, or sidecar CSS.
+func runPreBuildHooksAndRefreshIslandDiscovery(dir string, commands []string) (*islandDiscoveryResult, error) {
+	if err := runBuildHookCommands(dir, "pre-build", commands); err != nil {
+		return nil, err
+	}
+	discovery, err := collectProjectIslandDiscovery(dir)
+	if err != nil {
+		return discovery, fmt.Errorf("validate island sources after pre-build hook: %w", err)
+	}
+	return discovery, nil
 }
 
 func checkStrictProject(ctx context.Context, dir string) error {

--- a/cmd/gosx/build_test.go
+++ b/cmd/gosx/build_test.go
@@ -448,6 +448,93 @@ func TestProjectBuildHooksLoadAndRun(t *testing.T) {
 	}
 }
 
+func TestPreBuildHookRefreshesIslandDiscoveryForMutationGenerationAndDeletion(t *testing.T) {
+	t.Run("mutation", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWriteFile(t, filepath.Join(dir, "go.mod"), "module corp/app\n\ngo 1.22\n")
+		mustWriteFile(t, filepath.Join(dir, "counter.gsx"), testIslandSource("main", "Counter"))
+		before, err := collectProjectIslandDiscovery(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		mutated := strings.Replace(testIslandSource("main", "Counter"), "signal.New(0)", "signal.New(7)", 1)
+		mustWriteFile(t, filepath.Join(dir, "counter.after"), mutated)
+
+		after, err := runPreBuildHooksAndRefreshIslandDiscovery(dir, []string{"cp counter.after counter.gsx"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(before.Programs) != 1 || len(after.Programs) != 1 || before.Programs[0].SourceHash == after.Programs[0].SourceHash {
+			t.Fatalf("post-hook mutation reused stale program: before=%v after=%v", before.Programs, after.Programs)
+		}
+	})
+
+	t.Run("generation", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWriteFile(t, filepath.Join(dir, "go.mod"), "module corp/app\n\ngo 1.22\n")
+		mustWriteFile(t, filepath.Join(dir, "counter.gsx"), testIslandSource("main", "Counter"))
+		mustWriteFile(t, filepath.Join(dir, "badge.source"), testIslandSource("main", "Badge"))
+		if _, err := collectProjectIslandDiscovery(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		after, err := runPreBuildHooksAndRefreshIslandDiscovery(dir, []string{"cp badge.source badge.gsx"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := islandProgramIdentities(after.Programs), []string{"corp/app#Badge", "corp/app#Counter"}; !slices.Equal(got, want) {
+			t.Fatalf("post-hook generated programs = %#v, want %#v", got, want)
+		}
+		if len(after.GSXFiles) != 2 {
+			t.Fatalf("post-hook GSX files = %#v, want generated and original sources", after.GSXFiles)
+		}
+	})
+
+	t.Run("deletion", func(t *testing.T) {
+		dir := t.TempDir()
+		mustWriteFile(t, filepath.Join(dir, "go.mod"), "module corp/app\n\ngo 1.22\n")
+		mustWriteFile(t, filepath.Join(dir, "counter.gsx"), testIslandSource("main", "Counter"))
+		if _, err := collectProjectIslandDiscovery(dir); err != nil {
+			t.Fatal(err)
+		}
+
+		after, err := runPreBuildHooksAndRefreshIslandDiscovery(dir, []string{"rm counter.gsx"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(after.Programs) != 0 || len(after.GSXFiles) != 0 {
+			t.Fatalf("post-hook deletion retained stale discovery: programs=%v files=%v", after.Programs, after.GSXFiles)
+		}
+	})
+}
+
+func TestRunBuildRejectsHookCreatedIslandAmbiguityBeforeReplacingDist(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "go.mod"), "module corp/app\n\ngo 1.22\n")
+	mustWriteFile(t, filepath.Join(dir, "counter.gsx"), testIslandSource("main", "Counter"))
+	mustWriteFile(t, filepath.Join(dir, "duplicate.source"), testIslandSource("main", "Counter"))
+	mustWriteFile(t, filepath.Join(dir, "gosx.config.json"), `{
+  "build": {
+    "hooks": {
+      "pre": ["cp duplicate.source duplicate.gsx"]
+    }
+  }
+}`)
+	sentinel := filepath.Join(dir, "dist", "sentinel.txt")
+	mustWriteFile(t, sentinel, "keep")
+
+	err := RunBuildWithOptions(dir, BuildOptions{Dev: true})
+	if err == nil || !strings.Contains(err.Error(), `ambiguous island program "Counter"`) {
+		t.Fatalf("RunBuildWithOptions error = %v, want hook-created ambiguity", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(dir, "duplicate.gsx")); statErr != nil {
+		t.Fatalf("pre-build hook did not run: %v", statErr)
+	}
+	if got := readFile(t, sentinel); got != "keep" {
+		t.Fatalf("post-hook validation replaced existing dist before failing: %q", got)
+	}
+}
+
 func TestStageManifestCompatibilityRuntimeCopiesOnlyReferencedAssets(t *testing.T) {
 	distDir := t.TempDir()
 	outputDir := t.TempDir()
@@ -824,6 +911,27 @@ func TestRunBuildStrictGateRunsBeforeDistWrites(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "dist")); !os.IsNotExist(statErr) {
 		t.Fatalf("strict gate wrote dist before failing: %v", statErr)
+	}
+}
+
+func TestRunBuildRejectsAmbiguousImportedIslandNamesBeforeDistWrites(t *testing.T) {
+	dir, _, _ := newAmbiguousIslandProject(t, true)
+	writeTempFile(t, dir, "gosx.config.json", `{
+  "build": {
+    "hooks": {
+      "pre": ["printf ran > pre-build-hook-ran.txt"]
+    }
+  }
+}`)
+
+	err := RunBuild(dir, false)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("RunBuild error = %v, want ambiguous island rejection", err)
+	}
+	for _, output := range []string{"dist", "modules/modules.go", "pre-build-hook-ran.txt"} {
+		if _, statErr := os.Stat(filepath.Join(dir, filepath.FromSlash(output))); !os.IsNotExist(statErr) {
+			t.Fatalf("ambiguous island preflight created %s before failing: %v", output, statErr)
+		}
 	}
 }
 

--- a/cmd/gosx/desktop.go
+++ b/cmd/gosx/desktop.go
@@ -107,9 +107,13 @@ func RunDesktop(dir string, options DesktopRunOptions) error {
 		return runDesktopHost(options)
 	}
 
-	absDir, err := filepath.Abs(dir)
+	absDir, err := canonicalExistingDir(dir)
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
+	}
+	discovery, err := collectProjectIslandDiscovery(absDir)
+	if err != nil {
+		return err
 	}
 	isMain, err := isMainPackage(absDir)
 	if err != nil {
@@ -118,7 +122,7 @@ func RunDesktop(dir string, options DesktopRunOptions) error {
 	if !isMain {
 		return fmt.Errorf("gosx desktop requires a runnable app directory (package main): %s", absDir)
 	}
-	if err := prepareDesktopDevProject(context.Background(), absDir); err != nil {
+	if err := prepareDesktopDevProjectAfterDiscovery(context.Background(), absDir, discovery); err != nil {
 		return err
 	}
 
@@ -159,9 +163,12 @@ func RunDesktop(dir string, options DesktopRunOptions) error {
 	publicURL := displayListenURL(publicAddr)
 	buildDir := filepath.Join(absDir, "build")
 	devServer := &dev.Server{
-		Dir:         absDir,
-		BuildDir:    buildDir,
-		ProxyTarget: internalBaseURL,
+		Dir:          absDir,
+		BuildDir:     buildDir,
+		WatchDirs:    discovery.WatchDirs,
+		WatchFiles:   discovery.WatchFiles,
+		WatchGoFiles: discovery.WatchGoFiles,
+		ProxyTarget:  internalBaseURL,
 		Logf: func(format string, args ...any) {
 			fmt.Fprintf(os.Stderr, "gosx desktop: "+format+"\n", args...)
 		},
@@ -177,6 +184,9 @@ func RunDesktop(dir string, options DesktopRunOptions) error {
 				fmt.Fprintf(os.Stderr, "gosx desktop: host reload notification failed: %v\n", err)
 			}
 			return nil
+		},
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			return collectProjectIslandWatchTargets(absDir)
 		},
 	}
 
@@ -261,6 +271,27 @@ func RunDesktop(dir string, options DesktopRunOptions) error {
 }
 
 func prepareDesktopDevProject(ctx context.Context, dir string) error {
+	_, err := prepareDesktopDevProjectWithDiscovery(ctx, dir)
+	return err
+}
+
+func prepareDesktopDevProjectWithDiscovery(ctx context.Context, dir string) (*islandDiscoveryResult, error) {
+	canonicalDir, err := canonicalExistingDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project dir: %w", err)
+	}
+	dir = canonicalDir
+	discovery, err := collectProjectIslandDiscovery(dir)
+	if err != nil {
+		return nil, err
+	}
+	if err := prepareDesktopDevProjectAfterDiscovery(ctx, dir, discovery); err != nil {
+		return nil, err
+	}
+	return discovery, nil
+}
+
+func prepareDesktopDevProjectAfterDiscovery(ctx context.Context, dir string, discovery *islandDiscoveryResult) error {
 	if err := syncModulesPackage(dir); err != nil {
 		return err
 	}
@@ -273,7 +304,7 @@ func prepareDesktopDevProject(ctx context.Context, dir string) error {
 	if err := checkStrictProject(ctx, dir); err != nil {
 		return fmt.Errorf("check strict components: %w", err)
 	}
-	if err := prepareDevAssets(dir); err != nil {
+	if err := prepareDevAssetsWithPrograms(dir, discovery.Programs); err != nil {
 		return err
 	}
 	return nil

--- a/cmd/gosx/desktop_test.go
+++ b/cmd/gosx/desktop_test.go
@@ -232,6 +232,19 @@ func TestDesktopAppInitialStrictGateRunsBeforeAssetWrites(t *testing.T) {
 	}
 }
 
+func TestDesktopAppInitialIslandClosureGateRunsBeforeGeneratedWrites(t *testing.T) {
+	dir, _, _ := newAmbiguousIslandProject(t, true)
+	err := prepareDesktopDevProject(context.Background(), dir)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("prepareDesktopDevProject error = %v, want ambiguous island rejection", err)
+	}
+	for _, output := range []string{"build", "modules/modules.go"} {
+		if _, statErr := os.Stat(filepath.Join(dir, filepath.FromSlash(output))); !os.IsNotExist(statErr) {
+			t.Fatalf("ambiguous island desktop preflight created %s before failing: %v", output, statErr)
+		}
+	}
+}
+
 func TestDesktopAppChangeStrictGateStopsUnsafeUpstream(t *testing.T) {
 	dir := newInvalidStrictStarter(t, "desktop-change-strict-gate")
 	runner := &recordingDevStopper{}

--- a/cmd/gosx/dev.go
+++ b/cmd/gosx/dev.go
@@ -35,9 +35,13 @@ func RunDev(dir string) error {
 // RunDevWithOptions stages local runtime assets, runs the target app on an
 // internal port, and fronts it with the GoSX dev proxy for live reload.
 func RunDevWithOptions(dir string, options DevOptions) error {
-	absDir, err := filepath.Abs(dir)
+	absDir, err := canonicalExistingDir(dir)
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
+	}
+	discovery, err := collectProjectIslandDiscovery(absDir)
+	if err != nil {
+		return err
 	}
 	if err := checkVersionSkew(absDir); err != nil {
 		return err
@@ -63,7 +67,7 @@ func RunDevWithOptions(dir string, options DevOptions) error {
 	if err := checkStrictProject(context.Background(), absDir); err != nil {
 		return fmt.Errorf("check strict components: %w", err)
 	}
-	if err := prepareDevAssets(absDir); err != nil {
+	if err := prepareDevAssetsWithPrograms(absDir, discovery.Programs); err != nil {
 		return err
 	}
 
@@ -90,6 +94,9 @@ func RunDevWithOptions(dir string, options DevOptions) error {
 	devServer := &dev.Server{
 		Dir:            absDir,
 		BuildDir:       buildDir,
+		WatchDirs:      discovery.WatchDirs,
+		WatchFiles:     discovery.WatchFiles,
+		WatchGoFiles:   discovery.WatchGoFiles,
 		ProxyTarget:    internalBaseURL,
 		SceneInspector: options.SceneInspector,
 		Logf: func(format string, args ...any) {
@@ -101,6 +108,9 @@ func RunDevWithOptions(dir string, options DevOptions) error {
 		OnChange: func() error {
 			fmt.Fprintln(os.Stderr, "gosx dev: change detected, rebuilding assets and restarting app")
 			return rebuildChangedDevApp(context.Background(), absDir, runner, internalPort, internalBaseURL)
+		},
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			return collectProjectIslandWatchTargets(absDir)
 		},
 	}
 
@@ -141,6 +151,14 @@ type devProcessStopper interface {
 // hot swaps. When source is invalid it stops the old app process so the proxy
 // cannot keep serving newly mutated files through a previously valid binary.
 func preflightChangedDevApp(ctx context.Context, dir string, runner devProcessStopper) error {
+	if _, _, err := collectProjectIslandPrograms(dir); err != nil {
+		if runner != nil {
+			if stopErr := runner.stop(); stopErr != nil {
+				return fmt.Errorf("check island programs: %w (also stop invalid app: %v)", err, stopErr)
+			}
+		}
+		return fmt.Errorf("check island programs: %w", err)
+	}
 	if err := checkStrictProject(ctx, dir); err != nil {
 		if runner != nil {
 			if stopErr := runner.stop(); stopErr != nil {
@@ -169,6 +187,17 @@ func rebuildChangedDevApp(ctx context.Context, dir string, runner *devRunner, in
 }
 
 func prepareDevAssets(dir string) error {
+	islands, _, err := collectProjectIslandPrograms(dir)
+	if err != nil {
+		return err
+	}
+	return prepareDevAssetsWithPrograms(dir, islands)
+}
+
+func prepareDevAssetsWithPrograms(dir string, islands []*IslandProgramSource) error {
+	if err := validateUniqueIslandProgramNames(islands); err != nil {
+		return err
+	}
 	buildDir := filepath.Join(dir, "build")
 	islandDir := filepath.Join(buildDir, "islands")
 	cssDir := filepath.Join(buildDir, "css")
@@ -264,19 +293,30 @@ func prepareDevAssets(dir string) error {
 		return fmt.Errorf("stage relay.js: %w", err)
 	}
 
-	if err := compileDevIslands(dir, islandDir); err != nil {
+	if err := writeDevIslandPrograms(islandDir, islands); err != nil {
 		return err
 	}
 	if err := stageSidecarCSS(dir, cssDir); err != nil {
 		return err
 	}
-	// Engine surfaces are no longer pre-compiled in dev. The server-side
-	// engine/surface.Discover lowers them to shared-VM bytecode at start.
-	// See ADR 0003 (supersedure) and ADR 0005 (buildsurface deletion).
+	// Automatic .gsx engine-surface discovery is preview/post-v1 and is not
+	// part of dev asset staging. The v1 engine surface is programmatic
+	// engine.Config, whose runtime assets are staged above.
 	return nil
 }
 
 func compileDevIslands(dir, islandDir string) error {
+	islands, _, err := collectProjectIslandPrograms(dir)
+	if err != nil {
+		return err
+	}
+	return writeDevIslandPrograms(islandDir, islands)
+}
+
+func writeDevIslandPrograms(islandDir string, islands []*IslandProgramSource) error {
+	if err := validateUniqueIslandProgramNames(islands); err != nil {
+		return err
+	}
 	if err := os.MkdirAll(islandDir, 0755); err != nil {
 		return fmt.Errorf("create island dir: %w", err)
 	}
@@ -288,11 +328,6 @@ func compileDevIslands(dir, islandDir string) error {
 				_ = os.Remove(filepath.Join(islandDir, entry.Name()))
 			}
 		}
-	}
-
-	islands, _, err := collectProjectIslandPrograms(dir)
-	if err != nil {
-		return err
 	}
 
 	for _, isl := range islands {

--- a/cmd/gosx/dev_test.go
+++ b/cmd/gosx/dev_test.go
@@ -48,6 +48,19 @@ func TestRunDevStrictGateRunsBeforeAssetWritesOrRunnerStart(t *testing.T) {
 	}
 }
 
+func TestRunDevRejectsAmbiguousIslandClosureBeforeGeneratedWritesOrRunnerStart(t *testing.T) {
+	dir, _, _ := newAmbiguousIslandProject(t, true)
+	err := RunDev(dir)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("RunDev error = %v, want ambiguous island rejection", err)
+	}
+	for _, output := range []string{"build", "modules/modules.go"} {
+		if _, statErr := os.Stat(filepath.Join(dir, filepath.FromSlash(output))); !os.IsNotExist(statErr) {
+			t.Fatalf("ambiguous island dev preflight created %s before failing: %v", output, statErr)
+		}
+	}
+}
+
 func TestDevChangeStrictGateRunsBeforeAssetWritesOrRestart(t *testing.T) {
 	dir := newInvalidStrictStarter(t, "dev-change-strict-gate")
 	err := rebuildChangedDevApp(context.Background(), dir, nil, "0", "http://127.0.0.1:0")
@@ -80,6 +93,19 @@ func TestDevHotSwapPreflightStopsUnsafeUpstream(t *testing.T) {
 	}
 	if _, statErr := os.Stat(filepath.Join(dir, "build")); !os.IsNotExist(statErr) {
 		t.Fatalf("hot-swap preflight wrote assets before failing: %v", statErr)
+	}
+}
+
+func TestDevHotSwapPreflightStopsAmbiguousIslandUpstream(t *testing.T) {
+	dir, _, _ := newAmbiguousIslandProject(t, false)
+	runner := &recordingDevStopper{}
+
+	err := preflightChangedDevApp(context.Background(), dir, runner)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("preflightChangedDevApp error = %v, want ambiguous island rejection", err)
+	}
+	if !runner.stopped {
+		t.Fatal("ambiguous island hot swap left the old upstream process running")
 	}
 }
 
@@ -232,6 +258,24 @@ var _ = studio.ServerOnlyValue
 	}
 	if !strings.Contains(string(data), `"name": "HomeLayerSelectionIsland"`) {
 		t.Fatalf("unexpected imported island JSON: %s", data)
+	}
+}
+
+func TestCompileDevIslandsRejectsAmbiguousNamesBeforeReplacingAssets(t *testing.T) {
+	appDir, _, _ := newAmbiguousIslandProject(t, false)
+	out := filepath.Join(appDir, "build", "islands")
+	writeTempFile(t, out, "Counter.json", "previous-valid-program")
+
+	err := compileDevIslands(appDir, out)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("compileDevIslands error = %v, want ambiguous island rejection", err)
+	}
+	data, readErr := os.ReadFile(filepath.Join(out, "Counter.json"))
+	if readErr != nil {
+		t.Fatalf("read previous island asset: %v", readErr)
+	}
+	if got := string(data); got != "previous-valid-program" {
+		t.Fatalf("ambiguous discovery replaced previous island asset with %q", got)
 	}
 }
 

--- a/cmd/gosx/export.go
+++ b/cmd/gosx/export.go
@@ -15,9 +15,13 @@ import (
 
 // RunExport prerenders static file-routed pages into dist/static.
 func RunExport(dir string) error {
-	absDir, err := filepath.Abs(dir)
+	absDir, err := canonicalExistingDir(dir)
 	if err != nil {
 		return fmt.Errorf("resolve %s: %w", dir, err)
+	}
+	discovery, err := collectProjectIslandDiscovery(absDir)
+	if err != nil {
+		return err
 	}
 	if err := checkVersionSkew(absDir); err != nil {
 		return err
@@ -55,7 +59,7 @@ func RunExport(dir string) error {
 	if err := os.RemoveAll(distDir); err != nil {
 		return fmt.Errorf("clean output directory: %w", err)
 	}
-	if err := prepareDevAssets(absDir); err != nil {
+	if err := prepareDevAssetsWithPrograms(absDir, discovery.Programs); err != nil {
 		return err
 	}
 

--- a/cmd/gosx/export_test.go
+++ b/cmd/gosx/export_test.go
@@ -97,6 +97,20 @@ func TestRunExportStrictGateRunsBeforeAssetOrDistWrites(t *testing.T) {
 	}
 }
 
+func TestRunExportRejectsAmbiguousImportedIslandNamesBeforeAssetOrDistWrites(t *testing.T) {
+	dir, _, _ := newAmbiguousIslandProject(t, true)
+
+	err := RunExport(dir)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("RunExport error = %v, want ambiguous island rejection", err)
+	}
+	for _, output := range []string{"build", "dist", "modules/modules.go"} {
+		if _, statErr := os.Stat(filepath.Join(dir, filepath.FromSlash(output))); !os.IsNotExist(statErr) {
+			t.Fatalf("ambiguous island gate wrote %s before failing: %v", output, statErr)
+		}
+	}
+}
+
 func TestCopyExportRuntimeCopiesOnlyReferencedAssets(t *testing.T) {
 	buildDir := t.TempDir()
 	outputDir := t.TempDir()

--- a/cmd/gosx/island_discovery.go
+++ b/cmd/gosx/island_discovery.go
@@ -24,65 +24,272 @@ import (
 // RunBuildWithOptions stores SourceHash in the build manifest so a server
 // started later can detect that source changed since `gosx build` without
 // re-running the compiler pipeline — see buildmanifest.Manifest.StaleIslands.
+// PackageDir and PackagePath retain the declaration's package identity while
+// the project dependency closure is traversed and validated; they are build
+// metadata and do not change the serialized island-program ABI.
 type IslandProgramSource struct {
 	*islandprogram.Program
-	SourceFile string
-	SourceHash string
+	SourceFile     string
+	SourceHash     string
+	PackageDir     string
+	PackagePath    string
+	ProjectPackage bool
+}
+
+type islandPackageSource struct {
+	Dir         string
+	ImportPath  string
+	PackageName string
+	Files       []string
+	GoFiles     []string
+	GoImports   []string
+	Project     bool
+}
+
+type islandDiscoveryResult struct {
+	Programs  []*IslandProgramSource
+	GSXFiles  []string
+	WatchDirs []string
+	// WatchFiles is the exact canonical physical source allowlist paired with
+	// WatchDirs. It contains discovered GSX sources plus the active Go build
+	// inputs selected by the Go tool. Most entries are already observed through
+	// a project tree or a dependency package root; the explicit list matters
+	// when a top-level dependency source is a symlink to a nested file inside
+	// that same package.
+	WatchFiles []string
+	// WatchGoFiles is the exact active-Go subset of WatchFiles. Keeping the
+	// subset explicit prevents dev from recreating Go build-selection rules or
+	// broadening a package root to inactive GOOS/GOARCH/cgo/build-tag files.
+	WatchGoFiles []string
 }
 
 func collectProjectIslandPrograms(projectDir string) ([]*IslandProgramSource, []string, error) {
-	absProjectDir, err := filepath.Abs(projectDir)
+	discovery, err := collectProjectIslandDiscovery(projectDir)
 	if err != nil {
-		return nil, nil, fmt.Errorf("resolve project dir: %w", err)
+		return nil, nil, err
 	}
-	projectDir = absProjectDir
+	return discovery.Programs, discovery.GSXFiles, nil
+}
+
+// collectProjectIslandWatchDirs returns the canonical package directories
+// reached before any source-level validation error. Dev uses this narrower
+// result only to keep an invalid newly imported package observable so editing
+// that package can recover the quarantined app; build consumers still reject
+// the same discovery error and perform no writes.
+func collectProjectIslandWatchDirs(projectDir string) ([]string, error) {
+	dirs, _, _, err := collectProjectIslandWatchTargets(projectDir)
+	return dirs, err
+}
+
+// collectProjectIslandWatchTargets returns the canonical package-directory
+// closure together with the exact canonical .gsx sources discovered inside
+// it. Dev needs both halves: package roots remain direct-file allowlists for
+// import changes, while exact files let the watcher observe an accepted
+// top-level symlink whose physical target lives in a nested in-package
+// directory without recursively trusting that nested tree.
+func collectProjectIslandWatchTargets(projectDir string) ([]string, []string, []string, error) {
+	discovery, err := collectProjectIslandDiscovery(projectDir)
+	if discovery != nil {
+		return discovery.WatchDirs, discovery.WatchFiles, discovery.WatchGoFiles, err
+	}
+	return nil, nil, nil, err
+}
+
+func collectProjectIslandDiscovery(projectDir string) (*islandDiscoveryResult, error) {
+	canonicalProjectDir, err := canonicalExistingDir(projectDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project dir: %w", err)
+	}
+	projectDir = canonicalProjectDir
 
 	projectFiles, err := discoverProjectGSXFiles(projectDir)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	programs, importedPaths, qualifiedAliases, err := collectIslandProgramsFromFiles(projectFiles)
+	projectPackages, err := projectIslandPackages(projectDir, projectFiles)
 	if err != nil {
-		return nil, nil, err
-	}
-	qualifiedImportPaths, err := resolveQualifiedComponentImportPaths(projectDir, qualifiedAliases)
-	if err != nil {
-		return nil, nil, err
-	}
-	importedPaths = mergeStringSets(importedPaths, qualifiedImportPaths)
-
-	importedDirs, err := resolveImportedGSXPackageDirs(projectDir, importedPaths)
-	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	var importedFiles []string
-	for _, dir := range importedDirs {
-		files, err := packageGSXFiles(dir)
-		if err != nil {
-			return nil, nil, err
+	pending := append([]islandPackageSource(nil), projectPackages...)
+	knownPackages := make(map[string]struct{}, len(pending))
+	for _, pkg := range pending {
+		knownPackages[islandPackageKey(pkg)] = struct{}{}
+	}
+	visitedPackages := make(map[string]struct{}, len(pending))
+	gsxFileSet := make(map[string]struct{}, len(projectFiles))
+	goFileSet := make(map[string]struct{})
+	watchDirSet := make(map[string]struct{}, len(projectPackages))
+	var programs []*IslandProgramSource
+	resolver := newIslandPackageResolver(projectDir)
+
+	for len(pending) > 0 {
+		sortIslandPackages(pending)
+		pkg := pending[0]
+		pending = pending[1:]
+		key := islandPackageKey(pkg)
+		if _, ok := visitedPackages[key]; ok {
+			continue
 		}
-		importedFiles = append(importedFiles, files...)
-	}
-	if len(importedFiles) == 0 {
-		return programs, projectFiles, nil
+		visitedPackages[key] = struct{}{}
+		watchDirSet[pkg.Dir] = struct{}{}
+		// Retain every already-resolved canonical source in partial discovery
+		// results as well. If validation below quarantines dev, the exact source
+		// that must be edited to recover remains observable.
+		for _, file := range pkg.Files {
+			gsxFileSet[filepath.Clean(file)] = struct{}{}
+		}
+		for _, file := range pkg.GoFiles {
+			goFileSet[filepath.Clean(file)] = struct{}{}
+		}
+
+		packagePrograms, importedPaths, qualifiedAliases, err := collectIslandProgramsFromPackage(pkg)
+		if err != nil {
+			return finishIslandDiscovery(programs, gsxFileSet, goFileSet, watchDirSet), err
+		}
+		programs = append(programs, packagePrograms...)
+
+		if len(pkg.Files) == 0 {
+			// A Go-only package can bridge a GSX package to another package that
+			// owns the actual island source. Traverse its active Go dependency
+			// edges; standard-library packages are filtered by go list below.
+			importedPaths = mergeStringSets(importedPaths, pkg.GoImports)
+		} else {
+			qualifiedImportPaths, err := resolveQualifiedComponentImportPaths(resolver, pkg.GoFiles, qualifiedAliases)
+			if err != nil {
+				return finishIslandDiscovery(programs, gsxFileSet, goFileSet, watchDirSet), err
+			}
+			importedPaths = mergeStringSets(importedPaths, qualifiedImportPaths)
+		}
+		importedPackages, resolveErr := resolver.resolve(importedPaths)
+		for _, imported := range importedPackages {
+			// Resolver failures may occur only after the Go tool has already
+			// established a package's canonical physical root (for example,
+			// while validating one escaping top-level .gsx symlink). Retain that
+			// safe root and every source resolved before the failure so dev can
+			// observe the edit that repairs the quarantined closure.
+			watchDirSet[imported.Dir] = struct{}{}
+			for _, file := range imported.Files {
+				gsxFileSet[filepath.Clean(file)] = struct{}{}
+			}
+			for _, file := range imported.GoFiles {
+				goFileSet[filepath.Clean(file)] = struct{}{}
+			}
+			importedKey := islandPackageKey(imported)
+			if _, ok := knownPackages[importedKey]; ok {
+				continue
+			}
+			knownPackages[importedKey] = struct{}{}
+			pending = append(pending, imported)
+		}
+		if resolveErr != nil {
+			return finishIslandDiscovery(programs, gsxFileSet, goFileSet, watchDirSet), resolveErr
+		}
 	}
 
-	importedPrograms, _, _, err := collectIslandProgramsFromFiles(importedFiles)
-	if err != nil {
-		return nil, nil, err
+	discovery := finishIslandDiscovery(programs, gsxFileSet, goFileSet, watchDirSet)
+	programs = discovery.Programs
+	if err := validateUniqueIslandProgramNames(programs); err != nil {
+		return discovery, err
 	}
-	programs = append(programs, importedPrograms...)
+	return discovery, nil
+}
 
-	allFiles := append([]string(nil), projectFiles...)
-	allFiles = append(allFiles, importedFiles...)
-	sort.Strings(allFiles)
-	return programs, allFiles, nil
+func finishIslandDiscovery(programs []*IslandProgramSource, gsxFileSet, goFileSet, watchDirSet map[string]struct{}) *islandDiscoveryResult {
+	programs = append([]*IslandProgramSource(nil), programs...)
+	sortIslandProgramSources(programs)
+	gsxFiles := make([]string, 0, len(gsxFileSet))
+	for file := range gsxFileSet {
+		gsxFiles = append(gsxFiles, file)
+	}
+	sort.Strings(gsxFiles)
+	goFiles := make([]string, 0, len(goFileSet))
+	for file := range goFileSet {
+		goFiles = append(goFiles, file)
+	}
+	sort.Strings(goFiles)
+	watchDirs := make([]string, 0, len(watchDirSet))
+	for dir := range watchDirSet {
+		watchDirs = append(watchDirs, dir)
+	}
+	sort.Strings(watchDirs)
+	return &islandDiscoveryResult{
+		Programs:     programs,
+		GSXFiles:     gsxFiles,
+		WatchDirs:    watchDirs,
+		WatchFiles:   mergeStringSets(gsxFiles, goFiles),
+		WatchGoFiles: goFiles,
+	}
+}
+
+func projectIslandPackages(projectDir string, files []string) ([]islandPackageSource, error) {
+	filesByDir := make(map[string][]string)
+	for _, file := range files {
+		dir := filepath.Clean(filepath.Dir(file))
+		filesByDir[dir] = append(filesByDir[dir], filepath.Clean(file))
+	}
+
+	moduleRoot, modulePath, _ := moduleInfo(projectDir)
+	packages := make([]islandPackageSource, 0, len(filesByDir))
+	for dir, packageFiles := range filesByDir {
+		sort.Strings(packageFiles)
+		pkg := islandPackageSource{
+			Dir:        dir,
+			ImportPath: projectPackageImportPath(moduleRoot, modulePath, dir),
+			Files:      packageFiles,
+			Project:    true,
+		}
+		goFiles, packageName, goImports, err := localGoPackageMetadata(dir)
+		if err != nil {
+			return nil, err
+		}
+		pkg.GoFiles = goFiles
+		pkg.PackageName = packageName
+		pkg.GoImports = goImports
+		packages = append(packages, pkg)
+	}
+	sortIslandPackages(packages)
+	return packages, nil
+}
+
+func projectPackageImportPath(moduleRoot, modulePath, packageDir string) string {
+	moduleRoot = filepath.Clean(strings.TrimSpace(moduleRoot))
+	modulePath = strings.TrimSpace(modulePath)
+	packageDir = filepath.Clean(packageDir)
+	if moduleRoot == "." || modulePath == "" || !isPathWithin(packageDir, moduleRoot) {
+		return ""
+	}
+	rel, err := filepath.Rel(moduleRoot, packageDir)
+	if err != nil || rel == "." || rel == "" {
+		return modulePath
+	}
+	return pathpkg.Join(modulePath, filepath.ToSlash(rel))
+}
+
+func islandPackageKey(pkg islandPackageSource) string {
+	// Dir is a canonical physical directory. Runtime names remain deliberately
+	// unqualified, so the same package reached through two logical module paths
+	// must be visited once rather than compiled twice and falsely diagnosed as
+	// two declarations.
+	return filepath.Clean(pkg.Dir)
+}
+
+func sortIslandPackages(packages []islandPackageSource) {
+	sort.SliceStable(packages, func(i, j int) bool {
+		if packages[i].Project != packages[j].Project {
+			return packages[i].Project
+		}
+		if packages[i].ImportPath != packages[j].ImportPath {
+			return packages[i].ImportPath < packages[j].ImportPath
+		}
+		return filepath.ToSlash(packages[i].Dir) < filepath.ToSlash(packages[j].Dir)
+	})
 }
 
 func discoverProjectGSXFiles(projectDir string) ([]string, error) {
 	var files []string
+	var identities []os.FileInfo
 	if err := filepath.Walk(projectDir, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
@@ -91,7 +298,15 @@ func discoverProjectGSXFiles(projectDir string) ([]string, error) {
 			return filepath.SkipDir
 		}
 		if strings.HasSuffix(path, ".gsx") {
-			files = append(files, path)
+			canonical, canonicalInfo, err := canonicalSourceFileWithin(path, projectDir)
+			if err != nil {
+				return err
+			}
+			if samePhysicalFile(canonicalInfo, identities) {
+				return nil
+			}
+			identities = append(identities, canonicalInfo)
+			files = append(files, canonical)
 		}
 		return nil
 	}); err != nil {
@@ -101,12 +316,73 @@ func discoverProjectGSXFiles(projectDir string) ([]string, error) {
 	return files, nil
 }
 
-func collectIslandProgramsFromFiles(files []string) ([]*IslandProgramSource, []string, []string, error) {
+func canonicalExistingDir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	canonical, err = filepath.Abs(canonical)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func canonicalSourceFileWithin(path, root string) (string, os.FileInfo, error) {
+	canonicalRoot, err := canonicalExistingDir(root)
+	if err != nil {
+		return "", nil, err
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", nil, err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", nil, fmt.Errorf("resolve source path %s: %w", path, err)
+	}
+	canonical = filepath.Clean(canonical)
+	if !isPathWithin(canonical, canonicalRoot) {
+		return "", nil, fmt.Errorf("source path %s resolves outside package root %s", path, canonicalRoot)
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, fmt.Errorf("source path %s is not a regular file", path)
+	}
+	return canonical, info, nil
+}
+
+func samePhysicalFile(candidate os.FileInfo, seen []os.FileInfo) bool {
+	for _, previous := range seen {
+		if os.SameFile(candidate, previous) {
+			return true
+		}
+	}
+	return false
+}
+
+func collectIslandProgramsFromPackage(pkg islandPackageSource) ([]*IslandProgramSource, []string, []string, error) {
 	var programs []*IslandProgramSource
 	importSet := map[string]struct{}{}
 	qualifiedAliasSet := map[string]struct{}{}
+	expectedPackage := strings.TrimSpace(pkg.PackageName)
+	expectedSource := ""
 
-	for _, file := range files {
+	for _, file := range pkg.Files {
 		source, err := os.ReadFile(file)
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("read %s: %w", file, err)
@@ -116,6 +392,32 @@ func collectIslandProgramsFromFiles(files []string) ([]*IslandProgramSource, []s
 		if err != nil {
 			return nil, nil, nil, fmt.Errorf("compile %s: %w", file, err)
 		}
+		declaredPackage := strings.TrimSpace(irProg.Package)
+		if expectedPackage == "" {
+			expectedPackage = declaredPackage
+			expectedSource = file
+		} else if declaredPackage != expectedPackage {
+			if expectedSource != "" {
+				return nil, nil, nil, fmt.Errorf(
+					"mixed island package declarations in %q: %q declares package %q but %q declares package %q",
+					filepath.ToSlash(pkg.Dir),
+					filepath.ToSlash(expectedSource),
+					expectedPackage,
+					filepath.ToSlash(file),
+					declaredPackage,
+				)
+			}
+			return nil, nil, nil, fmt.Errorf(
+				"island package identity mismatch for import %q at %q: %q declares package %q but the resolved Go package is %q",
+				pkg.ImportPath,
+				filepath.ToSlash(pkg.Dir),
+				filepath.ToSlash(file),
+				declaredPackage,
+				expectedPackage,
+			)
+		}
+		irProg.Dir = pkg.Dir
+		irProg.PackagePath = pkg.ImportPath
 		for _, imp := range irProg.Imports {
 			path := strings.TrimSpace(imp.Path)
 			if path != "" {
@@ -135,9 +437,12 @@ func collectIslandProgramsFromFiles(files []string) ([]*IslandProgramSource, []s
 				return nil, nil, nil, fmt.Errorf("lower island %s in %s: %w", comp.Name, file, err)
 			}
 			programs = append(programs, &IslandProgramSource{
-				Program:    island,
-				SourceFile: file,
-				SourceHash: buildmanifest.ContentHash(source),
+				Program:        island,
+				SourceFile:     file,
+				SourceHash:     buildmanifest.ContentHash(source),
+				PackageDir:     pkg.Dir,
+				PackagePath:    pkg.ImportPath,
+				ProjectPackage: pkg.Project,
 			})
 		}
 	}
@@ -153,6 +458,54 @@ func collectIslandProgramsFromFiles(files []string) ([]*IslandProgramSource, []s
 	}
 	sort.Strings(aliases)
 	return programs, imports, aliases, nil
+}
+
+func sortIslandProgramSources(programs []*IslandProgramSource) {
+	sort.SliceStable(programs, func(i, j int) bool {
+		left, right := programs[i], programs[j]
+		if left.ProjectPackage != right.ProjectPackage {
+			return left.ProjectPackage
+		}
+		if left.PackagePath != right.PackagePath {
+			return left.PackagePath < right.PackagePath
+		}
+		if left.SourceFile != right.SourceFile {
+			return filepath.ToSlash(left.SourceFile) < filepath.ToSlash(right.SourceFile)
+		}
+		return left.Name < right.Name
+	})
+}
+
+func validateUniqueIslandProgramNames(programs []*IslandProgramSource) error {
+	seen := make(map[string]*IslandProgramSource, len(programs))
+	for i, prog := range programs {
+		if prog == nil || prog.Program == nil {
+			return fmt.Errorf("invalid island program at index %d: program is nil", i)
+		}
+		if previous, ok := seen[prog.Name]; ok {
+			origins := []string{islandProgramOrigin(previous), islandProgramOrigin(prog)}
+			sort.Strings(origins)
+			return fmt.Errorf(
+				"ambiguous island program %q: %s and %s declare the same unqualified runtime name; rename one island because names must be unique across the project dependency closure",
+				prog.Name,
+				origins[0],
+				origins[1],
+			)
+		}
+		seen[prog.Name] = prog
+	}
+	return nil
+}
+
+func islandProgramOrigin(prog *IslandProgramSource) string {
+	if prog == nil {
+		return "unknown source"
+	}
+	packagePath := strings.TrimSpace(prog.PackagePath)
+	if packagePath == "" {
+		packagePath = filepath.ToSlash(filepath.Clean(prog.PackageDir))
+	}
+	return fmt.Sprintf("package %q at %q", packagePath, filepath.ToSlash(filepath.Clean(prog.SourceFile)))
 }
 
 func qualifiedComponentAliases(prog *ir.Program) []string {
@@ -178,7 +531,7 @@ func qualifiedComponentAliases(prog *ir.Program) []string {
 	return aliases
 }
 
-func resolveQualifiedComponentImportPaths(projectDir string, aliases []string) ([]string, error) {
+func resolveQualifiedComponentImportPaths(resolver *islandPackageResolver, goFiles []string, aliases []string) ([]string, error) {
 	if len(aliases) == 0 {
 		return nil, nil
 	}
@@ -193,13 +546,9 @@ func resolveQualifiedComponentImportPaths(projectDir string, aliases []string) (
 		return nil, nil
 	}
 
-	goFiles, err := discoverProjectGoFiles(projectDir)
-	if err != nil {
-		return nil, err
-	}
 	importSet := map[string]struct{}{}
 	for _, file := range goFiles {
-		fileImports, err := matchingGoImportPaths(projectDir, file, aliasSet)
+		fileImports, err := matchingGoImportPaths(resolver, file, aliasSet)
 		if err != nil {
 			return nil, err
 		}
@@ -215,27 +564,43 @@ func resolveQualifiedComponentImportPaths(projectDir string, aliases []string) (
 	return imports, nil
 }
 
-func discoverProjectGoFiles(projectDir string) ([]string, error) {
-	var files []string
-	if err := filepath.Walk(projectDir, func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if shouldSkipProjectWalkDir(projectDir, path, info) {
-			return filepath.SkipDir
-		}
-		if !info.IsDir() && strings.HasSuffix(path, ".go") && !strings.HasSuffix(path, "_test.go") {
-			files = append(files, path)
-		}
-		return nil
-	}); err != nil {
-		return nil, fmt.Errorf("walk go files: %w", err)
+func localGoPackageMetadata(packageDir string) ([]string, string, []string, error) {
+	hasGoFiles, err := packageHasNonTestGoFiles(packageDir)
+	if err != nil {
+		return nil, "", nil, err
 	}
-	sort.Strings(files)
-	return files, nil
+	if !hasGoFiles {
+		// Standalone compiler callers and tests may operate on a GSX-only
+		// directory with no module. There is no Go package metadata to select
+		// in that case, so avoid requiring go.mod solely to discover .gsx.
+		return nil, "", nil, nil
+	}
+	info, err := goListPackageAtDirReadOnly(packageDir)
+	if err != nil {
+		return nil, "", nil, fmt.Errorf("resolve active Go package metadata in %s: %w", packageDir, err)
+	}
+	files, err := canonicalGoListFiles(packageDir, mergeStringSets(info.GoFiles, info.CgoFiles))
+	if err != nil {
+		return nil, "", nil, err
+	}
+	return files, strings.TrimSpace(info.Name), mergeStringSets(info.Imports), nil
 }
 
-func matchingGoImportPaths(projectDir, file string, aliases map[string]struct{}) ([]string, error) {
+func packageHasNonTestGoFiles(packageDir string) (bool, error) {
+	entries, err := os.ReadDir(packageDir)
+	if err != nil {
+		return false, fmt.Errorf("read package dir %s: %w", packageDir, err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		if !entry.IsDir() && strings.HasSuffix(name, ".go") && !strings.HasSuffix(name, "_test.go") {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func matchingGoImportPaths(resolver *islandPackageResolver, file string, aliases map[string]struct{}) ([]string, error) {
 	parsed, err := parser.ParseFile(token.NewFileSet(), file, nil, parser.ImportsOnly)
 	if err != nil {
 		return nil, fmt.Errorf("parse imports %s: %w", file, err)
@@ -260,12 +625,12 @@ func matchingGoImportPaths(projectDir, file string, aliases map[string]struct{})
 			matches = append(matches, importPath)
 			continue
 		}
-		if !shouldResolveImportedPackage(importPath) {
+		if !shouldResolveGoPackage(importPath) {
 			continue
 		}
-		info, err := goListPackage(projectDir, importPath)
+		info, err := resolver.goList(importPath)
 		if err != nil {
-			continue
+			return nil, fmt.Errorf("resolve default Go import name %s referenced by %s: %w", importPath, file, err)
 		}
 		if _, ok := aliases[info.Name]; ok {
 			matches = append(matches, importPath)
@@ -292,71 +657,147 @@ func mergeStringSets(values ...[]string) []string {
 	return merged
 }
 
-func resolveImportedGSXPackageDirs(projectDir string, importPaths []string) ([]string, error) {
-	projectDir = filepath.Clean(projectDir)
-	seen := map[string]struct{}{}
-	var dirs []string
-
-	for _, importPath := range importPaths {
-		if !shouldResolveImportedPackage(importPath) {
-			continue
-		}
-		info, err := goListPackage(projectDir, importPath)
-		if err != nil {
-			return nil, err
-		}
-		if info.Standard || info.Dir == "" {
-			continue
-		}
-
-		dir := filepath.Clean(info.Dir)
-		if isPathWithin(dir, projectDir) {
-			continue
-		}
-		if _, ok := seen[dir]; ok {
-			continue
-		}
-		files, err := packageGSXFiles(dir)
-		if err != nil {
-			return nil, err
-		}
-		if len(files) == 0 {
-			continue
-		}
-		seen[dir] = struct{}{}
-		dirs = append(dirs, dir)
-	}
-
-	sort.Strings(dirs)
-	return dirs, nil
-}
-
-func shouldResolveImportedPackage(importPath string) bool {
+func shouldResolveGoPackage(importPath string) bool {
 	importPath = strings.TrimSpace(importPath)
-	if importPath == "" || strings.HasPrefix(importPath, ".") {
+	if importPath == "" || importPath == "C" || strings.HasPrefix(importPath, ".") {
 		return false
 	}
-	first := importPath
-	if slash := strings.IndexByte(importPath, '/'); slash >= 0 {
-		first = importPath[:slash]
-	}
-	return strings.Contains(first, ".")
+	return true
 }
 
 type goListPackageInfo struct {
-	Dir        string
-	ImportPath string
-	Name       string
-	Standard   bool
+	Dir            string
+	ImportPath     string
+	Name           string
+	Standard       bool
+	GoFiles        []string
+	CgoFiles       []string
+	IgnoredGoFiles []string
+	InvalidGoFiles []string
+	Imports        []string
+	Error          *goListPackageError
 }
 
-func goListPackage(projectDir, importPath string) (goListPackageInfo, error) {
-	cmd := exec.Command("go", "list", "-json", importPath)
-	cmd.Dir = projectDir
-	cmd.Env = append(execEnvWithoutGoFlags(), "GOFLAGS="+goModuleCommandFlags, "GOWORK=off")
-	out, err := cmd.Output()
+type goListPackageError struct {
+	Err string
+}
+
+type goListCacheEntry struct {
+	info goListPackageInfo
+	err  error
+}
+
+type islandPackageResolver struct {
+	projectDir string
+	cache      map[string]goListCacheEntry
+}
+
+func newIslandPackageResolver(projectDir string) *islandPackageResolver {
+	return &islandPackageResolver{projectDir: filepath.Clean(projectDir), cache: map[string]goListCacheEntry{}}
+}
+
+func (r *islandPackageResolver) goList(importPath string) (goListPackageInfo, error) {
+	importPath = strings.TrimSpace(importPath)
+	if cached, ok := r.cache[importPath]; ok {
+		return cached.info, cached.err
+	}
+	info, err := goListPackageReadOnly(r.projectDir, importPath)
+	r.cache[importPath] = goListCacheEntry{info: info, err: err}
+	return info, err
+}
+
+func (r *islandPackageResolver) resolve(importPaths []string) ([]islandPackageSource, error) {
+	paths := mergeStringSets(importPaths)
+	seen := map[string]struct{}{}
+	packages := make([]islandPackageSource, 0, len(paths))
+	for _, requestedPath := range paths {
+		if !shouldResolveGoPackage(requestedPath) {
+			continue
+		}
+		info, err := r.goList(requestedPath)
+		if err != nil {
+			return nil, err
+		}
+		if info.Standard || strings.TrimSpace(info.Dir) == "" {
+			continue
+		}
+		dir, err := canonicalExistingDir(info.Dir)
+		if err != nil {
+			return nil, fmt.Errorf("resolve imported package directory %s: %w", requestedPath, err)
+		}
+		logicalImportPath := strings.TrimSpace(info.ImportPath)
+		if logicalImportPath == "" {
+			logicalImportPath = requestedPath
+		}
+		pkg := islandPackageSource{
+			Dir:         dir,
+			ImportPath:  logicalImportPath,
+			PackageName: strings.TrimSpace(info.Name),
+			GoImports:   mergeStringSets(info.Imports),
+			Project:     isPathWithin(dir, r.projectDir),
+		}
+		goFiles, err := canonicalGoListFiles(dir, mergeStringSets(info.GoFiles, info.CgoFiles))
+		pkg.GoFiles = goFiles
+		if err != nil {
+			packages = append(packages, pkg)
+			sortIslandPackages(packages)
+			return packages, err
+		}
+		files, err := packageGSXFiles(dir)
+		pkg.Files = files
+		if err != nil {
+			packages = append(packages, pkg)
+			sortIslandPackages(packages)
+			return packages, err
+		}
+		key := islandPackageKey(pkg)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		packages = append(packages, pkg)
+	}
+	sortIslandPackages(packages)
+	return packages, nil
+}
+
+func goListPackageReadOnly(projectDir, importPath string) (goListPackageInfo, error) {
+	return runGoListPackageReadOnly(projectDir, importPath, false)
+}
+
+// goListPackageAtDirReadOnly asks the Go tool for the active package files in
+// one physical directory. A directory with no active Go files is valid for
+// GoSX because it may contain only .gsx sources (or only files excluded by the
+// current GOOS/GOARCH/cgo/build constraints). All other Go package errors stay
+// fail-closed.
+func goListPackageAtDirReadOnly(packageDir string) (goListPackageInfo, error) {
+	info, err := runGoListPackageReadOnly(packageDir, ".", false)
+	if err == nil {
+		return info, nil
+	}
+	fallback, fallbackErr := runGoListPackageReadOnly(packageDir, ".", true)
+	if fallbackErr == nil && len(fallback.GoFiles) == 0 && len(fallback.CgoFiles) == 0 && len(fallback.InvalidGoFiles) == 0 {
+		return fallback, nil
+	}
+	return goListPackageInfo{}, err
+}
+
+func runGoListPackageReadOnly(commandDir, importPath string, tolerateErrors bool) (goListPackageInfo, error) {
+	args := []string{"list"}
+	if tolerateErrors {
+		args = append(args, "-e")
+	}
+	args = append(args, "-json", importPath)
+	cmd := exec.Command("go", args...)
+	cmd.Dir = commandDir
+	cmd.Env = append(execEnvWithoutGoFlags(), "GOFLAGS=-mod=readonly -buildvcs=false", "GOWORK=off")
+	out, err := cmd.CombinedOutput()
 	if err != nil {
-		return goListPackageInfo{}, fmt.Errorf("resolve imported package %s: %w", importPath, err)
+		detail := strings.TrimSpace(string(out))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return goListPackageInfo{}, fmt.Errorf("resolve Go package %s from %s without modifying go.mod/go.sum: %s", importPath, commandDir, detail)
 	}
 	var info goListPackageInfo
 	if err := json.Unmarshal(out, &info); err != nil {
@@ -365,20 +806,62 @@ func goListPackage(projectDir, importPath string) (goListPackageInfo, error) {
 	return info, nil
 }
 
+func canonicalGoListFiles(dir string, names []string) ([]string, error) {
+	files := make([]string, 0, len(names))
+	identities := make([]os.FileInfo, 0, len(names))
+	for _, name := range names {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		path := name
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(dir, path)
+		}
+		canonical, info, err := canonicalSourceFileWithin(path, dir)
+		if err != nil {
+			return nil, err
+		}
+		if samePhysicalFile(info, identities) {
+			continue
+		}
+		identities = append(identities, info)
+		files = append(files, canonical)
+	}
+	sort.Strings(files)
+	return files, nil
+}
+
 func packageGSXFiles(dir string) ([]string, error) {
 	entries, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, fmt.Errorf("read package dir %s: %w", dir, err)
 	}
 	files := make([]string, 0, len(entries))
+	identities := make([]os.FileInfo, 0, len(entries))
+	var firstErr error
 	for _, entry := range entries {
 		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".gsx") {
 			continue
 		}
-		files = append(files, filepath.Join(dir, entry.Name()))
+		path, info, err := canonicalSourceFileWithin(filepath.Join(dir, entry.Name()), dir)
+		if err != nil {
+			// Preserve all independently safe direct sources in a partial
+			// discovery result, even when an earlier entry is invalid. The first
+			// deterministic error still fails the package closed.
+			if firstErr == nil {
+				firstErr = err
+			}
+			continue
+		}
+		if samePhysicalFile(info, identities) {
+			continue
+		}
+		identities = append(identities, info)
+		files = append(files, path)
 	}
 	sort.Strings(files)
-	return files, nil
+	return files, firstErr
 }
 
 func isPathWithin(path, root string) bool {

--- a/cmd/gosx/island_discovery.go
+++ b/cmd/gosx/island_discovery.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"go/parser"
@@ -791,16 +792,23 @@ func runGoListPackageReadOnly(commandDir, importPath string, tolerateErrors bool
 	cmd := exec.Command("go", args...)
 	cmd.Dir = commandDir
 	cmd.Env = append(execEnvWithoutGoFlags(), "GOFLAGS=-mod=readonly -buildvcs=false", "GOWORK=off")
-	out, err := cmd.CombinedOutput()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
 	if err != nil {
-		detail := strings.TrimSpace(string(out))
+		detail := strings.TrimSpace(stderr.String())
+		if detail == "" {
+			detail = strings.TrimSpace(stdout.String())
+		}
 		if detail == "" {
 			detail = err.Error()
 		}
 		return goListPackageInfo{}, fmt.Errorf("resolve Go package %s from %s without modifying go.mod/go.sum: %s", importPath, commandDir, detail)
 	}
 	var info goListPackageInfo
-	if err := json.Unmarshal(out, &info); err != nil {
+	if err := json.Unmarshal(stdout.Bytes(), &info); err != nil {
 		return goListPackageInfo{}, fmt.Errorf("decode go list for %s: %w", importPath, err)
 	}
 	return info, nil

--- a/cmd/gosx/island_discovery_test.go
+++ b/cmd/gosx/island_discovery_test.go
@@ -181,6 +181,66 @@ func TestIslandPackageResolverDistinguishesStandardLibraryWithGoMetadata(t *test
 	}
 }
 
+func TestRunGoListPackageReadOnlyParsesSuccessfulJSONWithStderrChatter(t *testing.T) {
+	installFakeGoListCommand(t)
+	t.Setenv("FAKE_GO_STDOUT", `{"Dir":"/tmp/fake-package","ImportPath":"corp/fake","Name":"fake","GoFiles":["active.go"]}`)
+	t.Setenv("FAKE_GO_STDERR", "go: downloading corp/dependency v1.2.3\n")
+	t.Setenv("FAKE_GO_EXIT", "0")
+
+	info, err := runGoListPackageReadOnly(t.TempDir(), ".", false)
+	if err != nil {
+		t.Fatalf("successful go list with stderr chatter: %v", err)
+	}
+	if info.Dir != "/tmp/fake-package" || info.ImportPath != "corp/fake" || info.Name != "fake" || !reflect.DeepEqual(info.GoFiles, []string{"active.go"}) {
+		t.Fatalf("go list metadata = %#v, want parsed stdout JSON", info)
+	}
+}
+
+func TestRunGoListPackageReadOnlyFailureRetainsStderrDiagnostics(t *testing.T) {
+	installFakeGoListCommand(t)
+	t.Setenv("FAKE_GO_STDOUT", `{"Dir":"/tmp/incomplete"}`)
+	t.Setenv("FAKE_GO_STDERR", "go: corp/missing@v1.2.3: module lookup failed\n")
+	t.Setenv("FAKE_GO_EXIT", "1")
+
+	_, err := runGoListPackageReadOnly(t.TempDir(), "corp/missing", false)
+	if err == nil {
+		t.Fatal("failed go list returned no error")
+	}
+	if !strings.Contains(err.Error(), "module lookup failed") || !strings.Contains(err.Error(), "without modifying go.mod/go.sum") {
+		t.Fatalf("failed go list error = %q, want stderr diagnostics and read-only context", err)
+	}
+}
+
+func installFakeGoListCommand(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake go command fixture requires a POSIX shell")
+	}
+	fakeBin := t.TempDir()
+	fakeGo := filepath.Join(fakeBin, "go")
+	script := `#!/bin/sh
+if [ "$GOFLAGS" != "-mod=readonly -buildvcs=false" ]; then
+	echo "unexpected GOFLAGS: $GOFLAGS" >&2
+	exit 91
+fi
+if [ "$GOWORK" != "off" ]; then
+	echo "unexpected GOWORK: $GOWORK" >&2
+	exit 92
+fi
+if [ "$1" != "list" ] || [ "$2" != "-json" ]; then
+	echo "unexpected go arguments: $*" >&2
+	exit 93
+fi
+printf '%s' "$FAKE_GO_STDOUT"
+printf '%s' "$FAKE_GO_STDERR" >&2
+exit "$FAKE_GO_EXIT"
+`
+	if err := os.WriteFile(fakeGo, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake go command: %v", err)
+	}
+	t.Setenv("PATH", fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestCollectProjectIslandProgramsHonorsActivePlatformGoFiles(t *testing.T) {
 	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
 		t.Skip("platform fixture exercises the Linux/amd64 active-file set")

--- a/cmd/gosx/island_discovery_test.go
+++ b/cmd/gosx/island_discovery_test.go
@@ -1,7 +1,11 @@
 package main
 
 import (
+	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
+	"strings"
 	"testing"
 
 	"m31labs.dev/gosx/buildmanifest"
@@ -82,5 +86,1083 @@ func Counter() Node {
 	stale := manifest.StaleIslands(dir)
 	if len(stale) != 1 || stale[0].Name != "Counter" {
 		t.Fatalf("changed island stale report = %+v, want [Counter]", stale)
+	}
+}
+
+func TestCollectProjectIslandProgramsFollowsTransitiveImportsDeterministically(t *testing.T) {
+	appDir := newTransitiveIslandProject(t)
+
+	programs, files, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatalf("collectProjectIslandPrograms: %v", err)
+	}
+	wantPrograms := []string{
+		"example.com/leaf#LeafIsland",
+		"example.com/middle#MiddleIsland",
+	}
+	if got := islandProgramIdentities(programs); !reflect.DeepEqual(got, wantPrograms) {
+		t.Fatalf("program identities = %#v, want %#v", got, wantPrograms)
+	}
+	if len(files) != 3 {
+		t.Fatalf("discovered files = %#v, want app, middle, and transitive leaf files", files)
+	}
+	for _, suffix := range []string{"app/app/page.gsx", "middle/island.gsx", "leaf/island.gsx"} {
+		if !hasPathSuffix(files, suffix) {
+			t.Fatalf("discovered files = %#v, missing %q", files, suffix)
+		}
+	}
+
+	againPrograms, againFiles, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatalf("second collectProjectIslandPrograms: %v", err)
+	}
+	if got, want := islandProgramIdentities(againPrograms), islandProgramIdentities(programs); !reflect.DeepEqual(got, want) {
+		t.Fatalf("second program order = %#v, want %#v", got, want)
+	}
+	if !reflect.DeepEqual(againFiles, files) {
+		t.Fatalf("second file order = %#v, want %#v", againFiles, files)
+	}
+}
+
+func newDiamondCycleIslandRoot(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	leafDir := writeIslandModule(t, root, "leaf", "example.com/leaf", "leaf", `package leaf
+
+//gosx:island
+component LeafIsland() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`)
+	return root, leafDir
+}
+
+func newNonDottedIslandProject(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	leafDir := writeIslandModule(t, root, "leaf", "corp/leaf", "leaf", testIslandSource("leaf", "LeafIsland"))
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/leaf v0.0.0
+replace corp/leaf => ../leaf
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import leaf "corp/leaf"
+
+func Page() Node {
+	return <leaf.LeafIsland></leaf.LeafIsland>
+}
+`)
+	return appDir, leafDir
+}
+
+func TestIslandPackageResolverDistinguishesStandardLibraryWithGoMetadata(t *testing.T) {
+	appDir := t.TempDir()
+	writeTempFile(t, appDir, "go.mod", "module corp/app\n\ngo 1.22\n")
+	resolver := newIslandPackageResolver(appDir)
+	info, err := resolver.goList("fmt")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !info.Standard || info.ImportPath != "fmt" || info.Name != "fmt" {
+		t.Fatalf("fmt metadata = %#v, want Standard Go package", info)
+	}
+	packages, err := resolver.resolve([]string{"fmt"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(packages) != 0 {
+		t.Fatalf("standard library resolved as island package: %#v", packages)
+	}
+}
+
+func TestCollectProjectIslandProgramsHonorsActivePlatformGoFiles(t *testing.T) {
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("platform fixture exercises the Linux/amd64 active-file set")
+	}
+	root := t.TempDir()
+	widgetDir := writeIslandModule(t, root, "widget", "corp/widget", "widget", testIslandSource("widget", "Widget"))
+	writeTempFile(t, widgetDir, "stub.go", "package widget\n\nconst Marker = true\n")
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/widget v0.0.0
+replace corp/widget => ../widget
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+func Page() Node {
+	return <widget.Widget></widget.Widget>
+}
+`)
+	writeTempFile(t, appDir, "app/bridge_active.go", `//go:build linux && amd64
+
+package app
+
+import widget "corp/widget"
+
+var _ = widget.Marker
+`)
+	writeTempFile(t, appDir, "app/bridge_inactive.go", `//go:build windows || arm64
+
+package inactiveplatform
+
+import widget "corp/windows-widget"
+
+var _ = widget.Marker
+`)
+
+	files, packageName, imports, err := localGoPackageMetadata(filepath.Join(appDir, "app"))
+	if err != nil {
+		t.Fatalf("resolve active platform files: %v", err)
+	}
+	if packageName != "app" || !reflect.DeepEqual(imports, []string{"corp/widget"}) {
+		t.Fatalf("active metadata: package=%q imports=%v, want app and corp/widget", packageName, imports)
+	}
+	if len(files) != 1 || !strings.HasSuffix(files[0], "bridge_active.go") {
+		t.Fatalf("active Go files = %v, want only bridge_active.go", files)
+	}
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("inactive platform package/import influenced discovery: %v", err)
+	}
+	if got, want := islandProgramIdentities(discovery.Programs), []string{"corp/widget#Widget"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("program identities = %#v, want %#v", got, want)
+	}
+	activePath := filepath.Join(appDir, "app", "bridge_active.go")
+	inactivePath := filepath.Join(appDir, "app", "bridge_inactive.go")
+	if !containsPath(discovery.WatchGoFiles, activePath) || !containsPath(discovery.WatchFiles, activePath) {
+		t.Fatalf("active platform Go source missing from watch identities: go=%#v all=%#v", discovery.WatchGoFiles, discovery.WatchFiles)
+	}
+	if containsPath(discovery.WatchGoFiles, inactivePath) || containsPath(discovery.WatchFiles, inactivePath) {
+		t.Fatalf("inactive platform Go source entered watch identities: go=%#v all=%#v", discovery.WatchGoFiles, discovery.WatchFiles)
+	}
+}
+
+func TestCollectProjectIslandProgramsHonorsCgoBuildConstraint(t *testing.T) {
+	t.Setenv("CGO_ENABLED", "0")
+	root := t.TempDir()
+	widgetDir := writeIslandModule(t, root, "widget", "corp/widget", "widget", testIslandSource("widget", "Widget"))
+	writeTempFile(t, widgetDir, "stub.go", "package widget\n\nconst Marker = true\n")
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/widget v0.0.0
+replace corp/widget => ../widget
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+func Page() Node {
+	return <widget.Widget></widget.Widget>
+}
+`)
+	writeTempFile(t, appDir, "app/bridge_nocgo.go", `//go:build !cgo
+
+package app
+
+import widget "corp/widget"
+
+var _ = widget.Marker
+`)
+	writeTempFile(t, appDir, "app/bridge_cgo.go", `//go:build cgo
+
+package inactivecgo
+
+import widget "corp/cgo-only-widget"
+
+var _ = widget.Marker
+`)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("cgo-excluded package/import influenced discovery: %v", err)
+	}
+	if got, want := islandProgramIdentities(discovery.Programs), []string{"corp/widget#Widget"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("program identities = %#v, want %#v", got, want)
+	}
+	activePath := filepath.Join(appDir, "app", "bridge_nocgo.go")
+	inactivePath := filepath.Join(appDir, "app", "bridge_cgo.go")
+	if !containsPath(discovery.WatchGoFiles, activePath) || containsPath(discovery.WatchGoFiles, inactivePath) {
+		t.Fatalf("cgo active selection not preserved in watch identities: go=%#v", discovery.WatchGoFiles)
+	}
+}
+
+func TestCollectProjectIslandDiscoveryCarriesApplicableCgoFile(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("active cgo watcher fixture is exercised on Linux")
+	}
+	t.Setenv("CGO_ENABLED", "1")
+	root := t.TempDir()
+	widgetDir := writeIslandModule(t, root, "widget", "corp/widget", "widget", testIslandSource("widget", "Widget"))
+	writeTempFile(t, widgetDir, "stub.go", "package widget\n\nconst Marker = true\n")
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/widget v0.0.0
+replace corp/widget => ../widget
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+func Page() Node {
+	return <widget.Widget></widget.Widget>
+}
+`)
+	writeTempFile(t, appDir, "app/bridge_cgo.go", `package app
+
+/*
+*/
+import "C"
+import widget "corp/widget"
+
+var _ = widget.Marker
+`)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("discover active cgo package: %v", err)
+	}
+	cgoPath := filepath.Join(appDir, "app", "bridge_cgo.go")
+	if !containsPath(discovery.WatchGoFiles, cgoPath) || !containsPath(discovery.WatchFiles, cgoPath) {
+		t.Fatalf("applicable CgoFiles input missing from watch identities: go=%#v all=%#v", discovery.WatchGoFiles, discovery.WatchFiles)
+	}
+}
+
+func TestCollectProjectIslandProgramsUsesResolvedGoPackageNameForDefaultImport(t *testing.T) {
+	root := t.TempDir()
+	widgetsDir := writeIslandModule(t, root, "components", "corp/components", "widgets", testIslandSource("widgets", "SharedIsland"))
+	writeTempFile(t, widgetsDir, "stub.go", "package widgets\n\nconst Marker = true\n")
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/components v0.0.0
+replace corp/components => ../components
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+func Page() Node {
+	return <widgets.SharedIsland></widgets.SharedIsland>
+}
+`)
+	writeTempFile(t, appDir, "app/page.server.go", `package app
+
+import "corp/components"
+
+var _ = widgets.Marker
+`)
+
+	programs, _, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := islandProgramIdentities(programs), []string{"corp/components#SharedIsland"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("program identities = %#v, want package-name-aware import resolution %#v", got, want)
+	}
+}
+
+func TestCollectProjectIslandProgramsFollowsNonDottedModulePath(t *testing.T) {
+	appDir, leafDir := newNonDottedIslandProject(t)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("collect non-dotted module closure: %v", err)
+	}
+	if got, want := islandProgramIdentities(discovery.Programs), []string{"corp/leaf#LeafIsland"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("program identities = %#v, want %#v", got, want)
+	}
+	canonicalLeaf, err := canonicalExistingDir(leafDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsPath(discovery.WatchDirs, canonicalLeaf) {
+		t.Fatalf("watch dirs = %#v, missing non-dotted dependency %q", discovery.WatchDirs, canonicalLeaf)
+	}
+}
+
+func TestCollectProjectIslandProgramsFailsClosedWhenDefaultGoImportNameCannotResolve(t *testing.T) {
+	appDir := t.TempDir()
+	writeTempFile(t, appDir, "go.mod", "module corp/app\n\ngo 1.22\n")
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+func Page() Node {
+	return <mystery.SharedIsland></mystery.SharedIsland>
+}
+`)
+	writeTempFile(t, appDir, "app/page.server.go", `package app
+
+import "corp/app/missing"
+`)
+
+	_, _, err := collectProjectIslandPrograms(appDir)
+	if err == nil || !strings.Contains(err.Error(), "resolve default Go import name corp/app/missing") {
+		t.Fatalf("unresolved default import error = %v", err)
+	}
+}
+
+func TestCollectProjectIslandProgramsDedupesSymlinkedSourceIdentity(t *testing.T) {
+	appDir := t.TempDir()
+	writeTempFile(t, appDir, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeTempFile(t, appDir, "pkg/island.gsx", testIslandSource("pkg", "Counter"))
+	target := filepath.Join(appDir, "pkg", "island.gsx")
+	if err := os.Symlink(target, filepath.Join(appDir, "pkg", "island_alias.gsx")); err != nil {
+		t.Fatal(err)
+	}
+
+	programs, files, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatalf("collect same physical source through symlink: %v", err)
+	}
+	if len(programs) != 1 || programs[0].Name != "Counter" || len(files) != 1 {
+		t.Fatalf("programs=%#v files=%#v, want one physical source", islandProgramIdentities(programs), files)
+	}
+}
+
+func TestCollectProjectIslandDiscoveryCarriesCanonicalNestedSymlinkWatchTarget(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	writeTempFile(t, depDir, "go.mod", "module corp/dep\n\ngo 1.22\n")
+	writeTempFile(t, depDir, "stub.go", "package dep\n")
+	physical := filepath.Join(depDir, "physical", "counter.gsx")
+	writeTempFile(t, depDir, "physical/counter.gsx", testIslandSource("dep", "Counter"))
+	if err := os.Symlink(physical, filepath.Join(depDir, "counter.gsx")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module corp/app
+
+go 1.22
+
+require corp/dep v0.0.0
+replace corp/dep => ../dep
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import dep "corp/dep"
+
+func Page() Node {
+	return <dep.Counter></dep.Counter>
+}
+`)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("discovery rejected in-package symlink target: %v", err)
+	}
+	if len(discovery.Programs) != 1 || discovery.Programs[0].SourceFile != physical {
+		t.Fatalf("program source = %#v, want canonical nested target %q", discovery.Programs, physical)
+	}
+	canonicalDep, err := canonicalExistingDir(depDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !containsPath(discovery.WatchDirs, canonicalDep) {
+		t.Fatalf("watch dirs %#v do not include dependency root %q", discovery.WatchDirs, canonicalDep)
+	}
+	if !containsPath(discovery.WatchFiles, physical) {
+		t.Fatalf("watch files %#v do not include canonical nested target %q", discovery.WatchFiles, physical)
+	}
+
+	dirs, files, goFiles, err := collectProjectIslandWatchTargets(appDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(dirs, discovery.WatchDirs) || !reflect.DeepEqual(files, discovery.WatchFiles) || !reflect.DeepEqual(goFiles, discovery.WatchGoFiles) {
+		t.Fatalf("refreshed watch targets dirs=%#v files=%#v go=%#v, want discovery dirs=%#v files=%#v go=%#v", dirs, files, goFiles, discovery.WatchDirs, discovery.WatchFiles, discovery.WatchGoFiles)
+	}
+}
+
+func TestCollectProjectIslandProgramsCanonicalizesSymlinkedProjectRoot(t *testing.T) {
+	root := t.TempDir()
+	realDir := filepath.Join(root, "real")
+	writeTempFile(t, realDir, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeTempFile(t, realDir, "island.gsx", testIslandSource("app", "Counter"))
+	linkedDir := filepath.Join(root, "linked")
+	if err := os.Symlink(realDir, linkedDir); err != nil {
+		t.Fatal(err)
+	}
+
+	programs, files, err := collectProjectIslandPrograms(linkedDir)
+	if err != nil {
+		t.Fatalf("collect through symlinked project root: %v", err)
+	}
+	if len(programs) != 1 || programs[0].Name != "Counter" || len(files) != 1 {
+		t.Fatalf("programs=%#v files=%#v, want Counter through symlinked root", islandProgramIdentities(programs), files)
+	}
+	if strings.HasPrefix(files[0], linkedDir+string(filepath.Separator)) {
+		t.Fatalf("source identity remained logical symlink path instead of canonical physical path: %q", files[0])
+	}
+}
+
+func TestCollectProjectIslandProgramsDedupesSameModuleThroughSymlinkAliases(t *testing.T) {
+	root := t.TempDir()
+	sharedDir := writeIslandModule(t, root, "shared", "example.com/shared", "shared", testIslandSource("shared", "SharedIsland"))
+	leftDir := filepath.Join(root, "left")
+	rightDir := filepath.Join(root, "right")
+	if err := os.Symlink(sharedDir, leftDir); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(sharedDir, rightDir); err != nil {
+		t.Fatal(err)
+	}
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/left v0.0.0
+	example.com/right v0.0.0
+)
+replace example.com/left => ../left
+replace example.com/right => ../right
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import (
+	left "example.com/left"
+	right "example.com/right"
+)
+
+func Page() Node {
+	return <main><left.SharedIsland></left.SharedIsland><right.SharedIsland></right.SharedIsland></main>
+}
+`)
+
+	programs, files, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatalf("collect same physical module through symlink aliases: %v", err)
+	}
+	if len(programs) != 1 || programs[0].Name != "SharedIsland" || len(files) != 2 {
+		t.Fatalf("programs=%#v files=%#v, want one physical imported island plus project source", islandProgramIdentities(programs), files)
+	}
+}
+
+func TestCollectProjectIslandProgramsTraversesGoOnlyBridgePackage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture keeps bridge_windows.go inactive")
+	}
+	root := t.TempDir()
+	leafDir := writeIslandModule(t, root, "leaf", "example.com/leaf", "leaf", testIslandSource("leaf", "LeafIsland"))
+	writeTempFile(t, leafDir, "stub.go", "package leaf\n\nconst Marker = true\n")
+	bridgeDir := filepath.Join(root, "bridge")
+	writeTempFile(t, bridgeDir, "go.mod", `module example.com/bridge
+
+go 1.22
+
+require example.com/leaf v0.0.0
+replace example.com/leaf => ../leaf
+`)
+	writeTempFile(t, bridgeDir, "bridge.go", `package bridge
+
+import leaf "example.com/leaf"
+
+var _ = leaf.Marker
+`)
+	writeTempFile(t, bridgeDir, "bridge_windows.go", `//go:build windows
+
+package inactivebridge
+
+import leaf "example.com/inactive-leaf"
+
+var _ = leaf.Marker
+`)
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/bridge v0.0.0
+	example.com/leaf v0.0.0
+)
+replace example.com/bridge => ../bridge
+replace example.com/leaf => ../leaf
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import bridge "example.com/bridge"
+
+func Page() Node {
+	return <bridge.Wrapper></bridge.Wrapper>
+}
+`)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatalf("collect through Go-only bridge: %v", err)
+	}
+	if got, want := islandProgramIdentities(discovery.Programs), []string{"example.com/leaf#LeafIsland"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("program identities = %#v, want %#v", got, want)
+	}
+	for _, dir := range []string{bridgeDir, leafDir} {
+		canonical, err := canonicalExistingDir(dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !containsPath(discovery.WatchDirs, canonical) {
+			t.Fatalf("watch dirs = %#v, missing closure directory %q", discovery.WatchDirs, canonical)
+		}
+	}
+	activeBridge := filepath.Join(bridgeDir, "bridge.go")
+	inactiveBridge := filepath.Join(bridgeDir, "bridge_windows.go")
+	if !containsPath(discovery.WatchGoFiles, activeBridge) || !containsPath(discovery.WatchFiles, activeBridge) {
+		t.Fatalf("active Go-only bridge source missing from watch identities: go=%#v all=%#v", discovery.WatchGoFiles, discovery.WatchFiles)
+	}
+	if containsPath(discovery.WatchGoFiles, inactiveBridge) || containsPath(discovery.WatchFiles, inactiveBridge) {
+		t.Fatalf("inactive platform bridge source entered watch identities: go=%#v all=%#v", discovery.WatchGoFiles, discovery.WatchFiles)
+	}
+}
+
+func TestCollectProjectIslandProgramsRejectsMixedGSXPackageDeclarationsDeterministically(t *testing.T) {
+	appDir := t.TempDir()
+	writeTempFile(t, appDir, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeTempFile(t, appDir, "pkg/alpha.gsx", testIslandSource("alpha", "AlphaIsland"))
+	writeTempFile(t, appDir, "pkg/beta.gsx", testIslandSource("beta", "BetaIsland"))
+
+	_, _, err := collectProjectIslandPrograms(appDir)
+	if err == nil || !strings.Contains(err.Error(), "mixed island package declarations") {
+		t.Fatalf("mixed package declarations error = %v", err)
+	}
+	_, _, againErr := collectProjectIslandPrograms(appDir)
+	if againErr == nil || againErr.Error() != err.Error() {
+		t.Fatalf("mixed-package diagnostic changed across runs:\nfirst: %v\nsecond: %v", err, againErr)
+	}
+}
+
+func TestCollectProjectIslandProgramsRejectsResolvedGoPackageMismatch(t *testing.T) {
+	root := t.TempDir()
+	leafDir := writeIslandModule(t, root, "leaf", "example.com/leaf", "leaf", testIslandSource("wrong", "LeafIsland"))
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require example.com/leaf v0.0.0
+replace example.com/leaf => ../leaf
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import leaf "example.com/leaf"
+
+func Page() Node {
+	return <leaf.LeafIsland></leaf.LeafIsland>
+}
+`)
+
+	_, _, err := collectProjectIslandPrograms(appDir)
+	if err == nil {
+		t.Fatal("resolved Go package accepted mismatched .gsx package declaration")
+	}
+	for _, want := range []string{"island package identity mismatch", "example.com/leaf", `declares package "wrong"`, `resolved Go package is "leaf"`} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("package mismatch error = %q, missing %q", err, want)
+		}
+	}
+	if !strings.Contains(err.Error(), filepath.ToSlash(filepath.Join(leafDir, "island.gsx"))) {
+		t.Fatalf("package mismatch error lacks source origin: %v", err)
+	}
+}
+
+func TestCollectProjectIslandProgramsRejectsGSXSymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", "module example.com/app\n\ngo 1.22\n")
+	writeTempFile(t, root, "outside.gsx", testIslandSource("pkg", "Outside"))
+	external := filepath.Join(root, "outside.gsx")
+	if err := os.MkdirAll(filepath.Join(appDir, "pkg"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	logical := filepath.Join(appDir, "pkg", "outside.gsx")
+	if err := os.Symlink(external, logical); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := collectProjectIslandPrograms(appDir)
+	if err == nil || !strings.Contains(err.Error(), "resolves outside package root") {
+		t.Fatalf("GSX symlink escape error = %v", err)
+	}
+}
+
+func TestCollectProjectIslandProgramsHandlesDiamondCycleOnce(t *testing.T) {
+	root, leafDir := newDiamondCycleIslandRoot(t)
+	leftDir := writeIslandModule(t, root, "left", "example.com/left", "left", `package left
+
+import (
+	leaf "example.com/leaf"
+	right "example.com/right"
+)
+
+func LeftWrapper() Node {
+	return <main><leaf.LeafIsland></leaf.LeafIsland><right.RightWrapper></right.RightWrapper></main>
+}
+
+//gosx:island
+component LeftIsland() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`)
+	rightDir := writeIslandModule(t, root, "right", "example.com/right", "right", `package right
+
+import (
+	leaf "example.com/leaf"
+	left "example.com/left"
+)
+
+func RightWrapper() Node {
+	return <main><leaf.LeafIsland></leaf.LeafIsland><left.LeftWrapper></left.LeftWrapper></main>
+}
+
+//gosx:island
+component RightIsland() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`)
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/leaf v0.0.0
+	example.com/left v0.0.0
+	example.com/right v0.0.0
+)
+
+replace example.com/leaf => ../leaf
+replace example.com/left => ../left
+replace example.com/right => ../right
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import left "example.com/left"
+
+func Page() Node {
+	return <left.LeftWrapper></left.LeftWrapper>
+}
+`)
+
+	programs, files, err := collectProjectIslandPrograms(appDir)
+	if err != nil {
+		t.Fatalf("collectProjectIslandPrograms: %v", err)
+	}
+	wantPrograms := []string{
+		"example.com/leaf#LeafIsland",
+		"example.com/left#LeftIsland",
+		"example.com/right#RightIsland",
+	}
+	if got := islandProgramIdentities(programs); !reflect.DeepEqual(got, wantPrograms) {
+		t.Fatalf("cycle program identities = %#v, want %#v", got, wantPrograms)
+	}
+	if len(files) != 4 {
+		t.Fatalf("cycle discovered files = %#v, want each package exactly once", files)
+	}
+	for _, dir := range []string{leafDir, leftDir, rightDir} {
+		count := 0
+		for _, file := range files {
+			if filepath.Clean(filepath.Dir(file)) == filepath.Clean(dir) {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Fatalf("package %s appeared %d times in %#v, want once", dir, count, files)
+		}
+	}
+}
+
+func TestCollectProjectIslandProgramsRejectsAmbiguousNamesWithBothOrigins(t *testing.T) {
+	appDir, firstSource, secondSource := newAmbiguousIslandProject(t, false)
+
+	_, _, err := collectProjectIslandPrograms(appDir)
+	if err == nil {
+		t.Fatal("collectProjectIslandPrograms accepted duplicate Counter islands")
+	}
+	for _, want := range []string{
+		"ambiguous island program \"Counter\"",
+		"example.com/alpha",
+		"example.com/beta",
+		filepath.ToSlash(firstSource),
+		filepath.ToSlash(secondSource),
+		"names must be unique across the project dependency closure",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("collectProjectIslandPrograms error = %q, want substring %q", err, want)
+		}
+	}
+
+	_, _, againErr := collectProjectIslandPrograms(appDir)
+	if againErr == nil || againErr.Error() != err.Error() {
+		t.Fatalf("duplicate diagnostic changed across runs:\nfirst:  %v\nsecond: %v", err, againErr)
+	}
+
+	partial, partialErr := collectProjectIslandDiscovery(appDir)
+	if partialErr == nil || partial == nil {
+		t.Fatalf("ambiguous discovery partial=%#v error=%v, want safe watcher closure plus validation error", partial, partialErr)
+	}
+	for _, source := range []string{firstSource, secondSource} {
+		if !containsPath(partial.WatchDirs, filepath.Dir(source)) {
+			t.Fatalf("partial watcher closure = %#v, missing invalid dependency directory %q", partial.WatchDirs, filepath.Dir(source))
+		}
+	}
+	watchDirs, watchErr := collectProjectIslandWatchDirs(appDir)
+	if watchErr == nil || watchErr.Error() != partialErr.Error() {
+		t.Fatalf("recovery watch dirs error = %v, want original validation error %v", watchErr, partialErr)
+	}
+	if !reflect.DeepEqual(watchDirs, partial.WatchDirs) {
+		t.Fatalf("recovery watch dirs = %#v, want %#v", watchDirs, partial.WatchDirs)
+	}
+}
+
+func TestIslandManifestStageWritesTransitiveProgramsDeterministically(t *testing.T) {
+	appDir := newTransitiveIslandProject(t)
+
+	manifest, manifestPath, err := islandManifestStage(appDir, false)
+	if err != nil {
+		t.Fatalf("islandManifestStage: %v", err)
+	}
+	if got, want := islandAssetNames(manifest.Islands), []string{"LeafIsland", "MiddleIsland"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("manifest islands = %#v, want %#v", got, want)
+	}
+	firstManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstAssets, err := os.ReadDir(filepath.Join(appDir, "dist", "assets", "islands"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	firstNames := directoryEntryNames(firstAssets)
+
+	if _, _, err := islandManifestStage(appDir, false); err != nil {
+		t.Fatalf("second islandManifestStage: %v", err)
+	}
+	secondManifest, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondAssets, err := os.ReadDir(filepath.Join(appDir, "dist", "assets", "islands"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(secondManifest, firstManifest) {
+		t.Fatalf("manifest bytes changed across identical runs:\nfirst:\n%s\nsecond:\n%s", firstManifest, secondManifest)
+	}
+	if got := directoryEntryNames(secondAssets); !reflect.DeepEqual(got, firstNames) {
+		t.Fatalf("island artifact names changed across runs: first=%#v second=%#v", firstNames, got)
+	}
+}
+
+func TestIslandManifestStageRejectsAmbiguousNamesBeforeDistWrites(t *testing.T) {
+	appDir, _, _ := newAmbiguousIslandProject(t, false)
+
+	_, _, err := islandManifestStage(appDir, false)
+	if err == nil || !strings.Contains(err.Error(), "ambiguous island program \"Counter\"") {
+		t.Fatalf("islandManifestStage error = %v, want ambiguous island rejection", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(appDir, "dist")); !os.IsNotExist(statErr) {
+		t.Fatalf("ambiguous island stage wrote dist before failing: %v", statErr)
+	}
+}
+
+func newTransitiveIslandProject(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	leafDir := writeIslandModule(t, root, "leaf", "example.com/leaf", "leaf", `package leaf
+
+//gosx:island
+component LeafIsland() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`)
+	writeTempFile(t, leafDir, "stub.go", "package leaf\n\nconst Marker = true\n")
+	middleDir := writeIslandModule(t, root, "middle", "example.com/middle", "middle", `package middle
+
+func Wrapper() Node {
+	return <leaf.LeafIsland></leaf.LeafIsland>
+}
+
+//gosx:island
+component MiddleIsland() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`)
+	writeTempFile(t, middleDir, "go.mod", `module example.com/middle
+
+go 1.22
+
+require example.com/leaf v0.0.0
+`)
+	writeTempFile(t, middleDir, "bridge.go", `package middle
+
+import leaf "example.com/leaf"
+
+var _ = leaf.Marker
+`)
+	appDir := filepath.Join(root, "app")
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/leaf v0.0.0
+	example.com/middle v0.0.0
+)
+
+replace example.com/leaf => ../leaf
+replace example.com/middle => ../middle
+`)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import middle "example.com/middle"
+
+func Page() Node {
+	return <middle.Wrapper></middle.Wrapper>
+}
+`)
+	return appDir
+}
+
+func newAmbiguousIslandProject(t *testing.T, includeGoSX bool) (string, string, string) {
+	t.Helper()
+	root := t.TempDir()
+	alphaDir := writeIslandModule(t, root, "alpha", "example.com/alpha", "alpha", `package alpha
+
+//gosx:island
+component Counter() {
+	value := signal.New(1)
+	return <span>{value.Get()}</span>
+}
+`)
+	betaDir := writeIslandModule(t, root, "beta", "example.com/beta", "beta", `package beta
+
+//gosx:island
+component Counter() {
+	value := signal.New(2)
+	return <span>{value.Get()}</span>
+}
+`)
+	appDir := filepath.Join(root, "app")
+	gosxRequire := ""
+	gosxReplace := ""
+	if includeGoSX {
+		gosxRequire = "\tm31labs.dev/gosx v0.53.9\n"
+		gosxReplace = "replace m31labs.dev/gosx => " + filepath.ToSlash(testRepoRoot(t)) + "\n"
+		writeTempFile(t, appDir, "main.go", "package main\n\nfunc main() {}\n")
+	}
+	writeTempFile(t, appDir, "go.mod", `module example.com/app
+
+go 1.22
+
+require (
+	example.com/alpha v0.0.0
+	example.com/beta v0.0.0
+`+gosxRequire+`)
+
+replace example.com/alpha => ../alpha
+replace example.com/beta => ../beta
+`+gosxReplace)
+	writeTempFile(t, appDir, "app/page.gsx", `package app
+
+import (
+	alpha "example.com/alpha"
+	beta "example.com/beta"
+)
+
+func Page() Node {
+	return <main><alpha.Counter></alpha.Counter><beta.Counter></beta.Counter></main>
+}
+`)
+	return appDir, filepath.Join(alphaDir, "island.gsx"), filepath.Join(betaDir, "island.gsx")
+}
+
+func writeIslandModule(t *testing.T, root, dirName, modulePath, packageName, source string) string {
+	t.Helper()
+	dir := filepath.Join(root, dirName)
+	writeTempFile(t, dir, "go.mod", "module "+modulePath+"\n\ngo 1.22\n")
+	writeTempFile(t, dir, "stub.go", "package "+packageName+"\n")
+	writeTempFile(t, dir, "island.gsx", source)
+	return dir
+}
+
+func islandProgramIdentities(programs []*IslandProgramSource) []string {
+	identities := make([]string, 0, len(programs))
+	for _, program := range programs {
+		identities = append(identities, program.PackagePath+"#"+program.Name)
+	}
+	return identities
+}
+
+func islandAssetNames(assets []IslandAsset) []string {
+	names := make([]string, 0, len(assets))
+	for _, asset := range assets {
+		names = append(names, asset.Name)
+	}
+	return names
+}
+
+func directoryEntryNames(entries []os.DirEntry) []string {
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func hasPathSuffix(files []string, suffix string) bool {
+	suffix = filepath.ToSlash(suffix)
+	for _, file := range files {
+		if strings.HasSuffix(filepath.ToSlash(file), suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsPath(paths []string, want string) bool {
+	want = filepath.Clean(want)
+	for _, path := range paths {
+		if filepath.Clean(path) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func testIslandSource(packageName, componentName string) string {
+	return `package ` + packageName + `
+
+//gosx:island
+component ` + componentName + `() {
+	value := signal.New(0)
+	return <span>{value.Get()}</span>
+}
+`
+}
+
+func frozenWriteCmd(t *testing.T, filename, contents string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, []byte(contents), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func frozenIsland(pkg, name string) string {
+	return "package " + pkg + "\n\n//gosx:island\ncomponent " + name + "() {\n\tvalue := signal.New(0)\n\treturn <span>{value.Get()}</span>\n}\n"
+}
+
+func frozenImportedApp(t *testing.T, root, depDir string) string {
+	t.Helper()
+	appDir := filepath.Join(root, "app")
+	frozenWriteCmd(t, filepath.Join(appDir, "go.mod"), `module corp/app
+
+go 1.22
+
+require corp/dep v0.0.0
+replace corp/dep => ../dep
+`)
+	frozenWriteCmd(t, filepath.Join(appDir, "app", "page.gsx"), `package app
+
+import dep "corp/dep"
+
+func Page() Node {
+	return <dep.Counter></dep.Counter>
+}
+`)
+	return appDir
+}
+
+func TestFrozenReviewerPartialInvalidSourceIdentityRetainsNewPackageRoot(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	frozenWriteCmd(t, filepath.Join(depDir, "go.mod"), "module corp/dep\n\ngo 1.22\n")
+	frozenWriteCmd(t, filepath.Join(depDir, "stub.go"), "package dep\n")
+	outside := filepath.Join(root, "outside.gsx")
+	frozenWriteCmd(t, outside, frozenIsland("dep", "Counter"))
+	logical := filepath.Join(depDir, "counter.gsx")
+	if err := os.Symlink(outside, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	safePhysical := filepath.Join(depDir, "physical", "recovery.gsx")
+	frozenWriteCmd(t, safePhysical, frozenIsland("dep", "Recovery"))
+	if err := os.Symlink(safePhysical, filepath.Join(depDir, "z_recovery.gsx")); err != nil {
+		t.Fatal(err)
+	}
+	appDir := frozenImportedApp(t, root, depDir)
+
+	partial, err := collectProjectIslandDiscovery(appDir)
+	if err == nil || !strings.Contains(err.Error(), "resolves outside package root") {
+		t.Fatalf("escaping imported source error = %v", err)
+	}
+	if partial == nil {
+		t.Fatal("invalid imported source returned no partial watcher closure")
+	}
+	canonicalDep, canonicalErr := canonicalExistingDir(depDir)
+	if canonicalErr != nil {
+		t.Fatal(canonicalErr)
+	}
+	if !containsPath(partial.WatchDirs, canonicalDep) {
+		t.Fatalf("partial invalid source closure lost newly resolved package root %q: dirs=%#v; retargeting the top-level link cannot recover dev without another project edit", canonicalDep, partial.WatchDirs)
+	}
+	if !containsPath(partial.WatchFiles, safePhysical) {
+		t.Fatalf("partial invalid source closure lost independently safe exact source %q: files=%#v", safePhysical, partial.WatchFiles)
+	}
+}
+
+func TestFrozenReviewerDiscoveryAcceptsUntrackedNestedHardlinkAlias(t *testing.T) {
+	root := t.TempDir()
+	depDir := filepath.Join(root, "dep")
+	frozenWriteCmd(t, filepath.Join(depDir, "go.mod"), "module corp/dep\n\ngo 1.22\n")
+	frozenWriteCmd(t, filepath.Join(depDir, "stub.go"), "package dep\n")
+	logical := filepath.Join(depDir, "counter.gsx")
+	frozenWriteCmd(t, logical, frozenIsland("dep", "Counter"))
+	alias := filepath.Join(depDir, "physical", "counter-alias.gsx")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(logical, alias); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	appDir := frozenImportedApp(t, root, depDir)
+
+	discovery, err := collectProjectIslandDiscovery(appDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(discovery.Programs) != 1 || discovery.Programs[0].SourceFile != logical {
+		t.Fatalf("discovery programs=%#v, want canonical top-level hardlink %q", discovery.Programs, logical)
+	}
+	if containsPath(discovery.WatchFiles, alias) {
+		t.Fatalf("nested hardlink alias unexpectedly appeared in direct source discovery: %#v", discovery.WatchFiles)
+	}
+	info, err := os.Stat(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	aliasInfo, err := os.Stat(alias)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !os.SameFile(info, aliasInfo) {
+		t.Fatal("fixture paths are not the same physical file")
 	}
 }

--- a/cmd/gosx/island_manifest_stage.go
+++ b/cmd/gosx/island_manifest_stage.go
@@ -18,16 +18,22 @@ import (
 // runtime compile RunBuildWithOptions also performs. See
 // TestWarnStaleIslandsEndToEndAfterRealBuildPipeline.
 func islandManifestStage(dir string, dev bool) (*BuildManifest, string, error) {
+	canonicalDir, err := canonicalExistingDir(dir)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve project dir: %w", err)
+	}
+	dir = canonicalDir
+	islandProgs, _, err := collectProjectIslandPrograms(dir)
+	if err != nil {
+		return nil, "", err
+	}
+
 	distDir := filepath.Join(dir, "dist")
 	islandDir := filepath.Join(distDir, "assets", "islands")
 	if err := os.MkdirAll(islandDir, 0755); err != nil {
 		return nil, "", fmt.Errorf("create island output directory %s: %w", islandDir, err)
 	}
 
-	islandProgs, _, err := collectProjectIslandPrograms(dir)
-	if err != nil {
-		return nil, "", err
-	}
 	islandAssets, err := writeIslandManifestAssets(dir, islandDir, dev, islandProgs)
 	if err != nil {
 		return nil, "", err
@@ -44,6 +50,9 @@ func islandManifestStage(dir string, dev bool) (*BuildManifest, string, error) {
 // writeBuildManifest marshals manifest and writes it to distDir/build.json —
 // the same write RunBuildWithOptions performs for the full manifest.
 func writeBuildManifest(distDir string, manifest *BuildManifest) (string, error) {
+	if err := manifest.ValidateIslandAssets(); err != nil {
+		return "", fmt.Errorf("validate manifest: %w", err)
+	}
 	manifestJSON, err := json.MarshalIndent(manifest, "", "  ")
 	if err != nil {
 		return "", fmt.Errorf("marshal manifest: %w", err)

--- a/dev/hotswap.go
+++ b/dev/hotswap.go
@@ -27,9 +27,10 @@ type islandProgram struct {
 // broadcasts the matching SSE events.
 //
 // Classification (scoped to the Phase-0 hot-swap seam):
-//   - If every changed path is an island .gsx that recompiles to one or more
-//     island programs, broadcast one "program" event per island component and
-//     do NOT reload, and do NOT run OnChange (no app rebuild/restart). The
+//   - If every changed path is an island-only .gsx that recompiles to one or
+//     more island programs and declares no server components, broadcast one
+//     "program" event per island component and do NOT reload, and do NOT run
+//     OnChange (no app rebuild/restart). The
 //     client routes each "program" event to __gosx_reload_program, which
 //     hot-swaps the live island in place (signal state intact) — no
 //     window.location.reload(). Skipping the restart is what keeps the swap
@@ -213,9 +214,15 @@ func (s *Server) classifyChange(paths []string) (programs []islandProgram, fullR
 			// declared is gone. Reload so the page reflects its removal.
 			return nil, true, nil
 		}
-		compiled, compileErr := compileIslandPrograms(path)
+		compiled, serverBearing, compileErr := compileChangedGSX(path)
 		if compileErr != nil {
 			return nil, false, compileErr
+		}
+		if serverBearing {
+			// Replacing only the island bytecode would leave co-located server
+			// component code stale in the running Go process. Conservatively
+			// rebuild/restart the whole app for mixed or server-bearing files.
+			return nil, true, nil
 		}
 		if len(compiled) == 0 {
 			// A .gsx with no island components (e.g. a server page template)
@@ -232,29 +239,39 @@ func (s *Server) classifyChange(paths []string) (programs []islandProgram, fullR
 // lowering compileDevIslands performs at full-build time, so a hot-swapped
 // program is byte-identical to what a fresh page load would fetch.
 func compileIslandPrograms(path string) ([]islandProgram, error) {
+	programs, _, err := compileChangedGSX(path)
+	return programs, err
+}
+
+// compileChangedGSX returns the island programs plus whether the same source
+// declares any server component. Only a source whose component set is purely
+// islands is safe for the no-restart hot-swap path.
+func compileChangedGSX(path string) ([]islandProgram, bool, error) {
 	source, err := os.ReadFile(path)
 	if err != nil {
-		return nil, fmt.Errorf("read %s: %w", path, err)
+		return nil, false, fmt.Errorf("read %s: %w", path, err)
 	}
 	irProg, err := gosx.Compile(source)
 	if err != nil {
-		return nil, fmt.Errorf("compile %s: %w", path, err)
+		return nil, false, fmt.Errorf("compile %s: %w", path, err)
 	}
 
 	var out []islandProgram
+	serverBearing := false
 	for i, comp := range irProg.Components {
 		if !comp.IsIsland {
+			serverBearing = true
 			continue
 		}
 		isl, err := ir.LowerIsland(irProg, i)
 		if err != nil {
-			return nil, fmt.Errorf("lower island %s in %s: %w", comp.Name, path, err)
+			return nil, false, fmt.Errorf("lower island %s in %s: %w", comp.Name, path, err)
 		}
 		data, err := program.EncodeJSON(isl)
 		if err != nil {
-			return nil, fmt.Errorf("encode island %s: %w", comp.Name, err)
+			return nil, false, fmt.Errorf("encode island %s: %w", comp.Name, err)
 		}
 		out = append(out, islandProgram{Component: comp.Name, ProgramJSON: data})
 	}
-	return out, nil
+	return out, serverBearing, nil
 }

--- a/dev/hotswap_test.go
+++ b/dev/hotswap_test.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/fsnotify/fsnotify"
 )
 
 // islandGSX is a self-contained island component that compiles cleanly via
@@ -111,6 +113,129 @@ func TestHotSwapIslandChangeEmitsProgramNotReload(t *testing.T) {
 	}
 	if err := json.Unmarshal([]byte(payload.Program), &island); err != nil || island.Name != "Counter" {
 		t.Fatalf("expected island program for Counter, got name=%q err=%v", island.Name, err)
+	}
+}
+
+func TestHotSwapMixedServerAndIslandFileForcesRestart(t *testing.T) {
+	dir := t.TempDir()
+	gsxPath := filepath.Join(dir, "mixed.gsx")
+	writeTestFile(t, gsxPath, []byte(`package app
+
+func Wrapper() Node {
+	return <main>server output</main>
+}
+
+//gosx:island
+component Counter() {
+	count := signal.New(0)
+	return <button data-on-click="count.Set(count.Get() + 1)">{count.Get()}</button>
+}
+`))
+
+	restarts := 0
+	s := &Server{Dir: dir, OnChange: func() error { restarts++; return nil }}
+	events := captureEvents(t, s)
+	s.emitChange([]string{gsxPath})
+	got := drainEvents(events)
+	if restarts != 1 {
+		t.Fatalf("mixed server/island source restarts = %d, want 1", restarts)
+	}
+	if _, ok := got["reload"]; !ok {
+		t.Fatalf("mixed server/island source did not reload: %v", keys(got))
+	}
+	if _, ok := got["program"]; ok {
+		t.Fatalf("mixed server/island source used unsafe island-only hot swap: %v", keys(got))
+	}
+}
+
+func TestAllowlistedExternalMixedGSXServerEditForcesRestart(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	gsxPath := filepath.Join(external, "mixed.gsx")
+	beforeSource := `package shared
+
+func Wrapper() Node {
+	return <main>server output one</main>
+}
+
+//gosx:island
+component Counter() {
+	count := signal.New(0)
+	return <button data-on-click="count.Set(count.Get() + 1)">{count.Get()}</button>
+}
+`
+	writeTestFile(t, gsxPath, []byte(beforeSource))
+	dirs, err := normalizeDependencyWatchDirs(root, []string{external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := watchedSourceSnapshot(root, dirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, gsxPath, []byte(strings.Replace(beforeSource, "server output one", "server output two with a different size", 1)))
+	after, err := watchedSourceSnapshot(root, dirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changed := changedWatchedPaths(before, after)
+	if len(changed) != 1 || changed[0] != canonicalWatchEventPath(gsxPath) {
+		t.Fatalf("external mixed-file changes = %v, want %q", changed, canonicalWatchEventPath(gsxPath))
+	}
+
+	restarts := 0
+	s := &Server{Dir: root, WatchDirs: dirs, OnChange: func() error { restarts++; return nil }}
+	events := captureEvents(t, s)
+	s.emitChange(changed)
+	got := drainEvents(events)
+	if restarts != 1 {
+		t.Fatalf("external mixed server edit restarts = %d, want 1", restarts)
+	}
+	if _, ok := got["reload"]; !ok {
+		t.Fatalf("external mixed server edit did not reload: %v", keys(got))
+	}
+	if _, ok := got["program"]; ok {
+		t.Fatalf("external mixed server edit emitted island-only program event: %v", keys(got))
+	}
+}
+
+func TestAllowlistedExternalIslandChangeReachesHotSwapPipeline(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	gsxPath := filepath.Join(external, "counter.gsx")
+	writeTestFile(t, gsxPath, []byte(islandGSX))
+	dirs, err := normalizeDependencyWatchDirs(root, []string{external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := watchedSourceSnapshot(root, dirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedSource := strings.Replace(islandGSX, "+ 1", "+ 2", 1) + "\n"
+	writeTestFile(t, gsxPath, []byte(changedSource))
+	after, err := watchedSourceSnapshot(root, dirs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	changedPaths := changedWatchedPaths(before, after)
+	if len(changedPaths) != 1 || changedPaths[0] != canonicalWatchEventPath(gsxPath) {
+		t.Fatalf("external polling snapshot changes = %#v, want %q", changedPaths, canonicalWatchEventPath(gsxPath))
+	}
+	event := fsnotify.Event{Name: gsxPath, Op: fsnotify.Write}
+	if !isWatchedSourceEvent(root, dirs, event) {
+		t.Fatal("allowlisted external island change did not enter the watcher pipeline")
+	}
+
+	s := &Server{Dir: root, WatchDirs: dirs}
+	events := captureEvents(t, s)
+	s.emitChange(changedPaths)
+	got := drainEvents(events)
+	if _, ok := got["program"]; !ok {
+		t.Fatalf("external island change did not emit a program event: %v", keys(got))
+	}
+	if _, ok := got["reload"]; ok {
+		t.Fatalf("external island hot swap unexpectedly emitted reload: %v", keys(got))
 	}
 }
 

--- a/dev/server.go
+++ b/dev/server.go
@@ -3,6 +3,7 @@ package dev
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -12,6 +13,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -28,8 +30,24 @@ const (
 )
 
 type snapshotEntry struct {
-	ModTime time.Time
-	Size    int64
+	ModTime        time.Time
+	Size           int64
+	Info           os.FileInfo
+	ContentHash    [sha256.Size]byte
+	HasContentHash bool
+}
+
+// dependencyWatchTargets keeps the distinct permissions needed outside the
+// recursive project root. dirs allow bounded direct .gsx discovery in an
+// imported package root; files allow only an exact canonical discovered
+// source whose physical parent may be nested below that root; goFiles is the
+// exact active-Go subset selected upstream by the Go tool. Kernel watch
+// directories are derived from files, but event and polling filters retain
+// the narrower active-input distinction.
+type dependencyWatchTargets struct {
+	dirs    []string
+	files   []string
+	goFiles []string
 }
 
 type sseEvent struct {
@@ -45,14 +63,37 @@ type sseEvent struct {
 //   - watches Dir for source changes, runs PreflightChange for every batch, and
 //     triggers OnChange for batches that require a full restart
 type Server struct {
-	Dir             string
-	BuildDir        string
-	ProxyTarget     string
-	PreflightChange func([]string) error
-	OnChange        func() error
-	PollInterval    time.Duration
-	SceneInspector  bool
-	Logf            func(format string, args ...any)
+	Dir      string
+	BuildDir string
+	// WatchDirs is an explicit allowlist of package directories outside Dir.
+	// Their direct .gsx sources participate in island discovery; Go sources are
+	// admitted only through WatchGoFiles. It never broadens the recursive
+	// project-root watcher to arbitrary external paths.
+	WatchDirs []string
+	// WatchFiles is an exact allowlist of canonical discovered sources. It is
+	// used only when a source's physical parent differs from its package root;
+	// watching that parent does not allow changes to any sibling file.
+	WatchFiles []string
+	// WatchGoFiles is the exact active-Go subset of WatchFiles, already selected
+	// from GoFiles/CgoFiles by the Go tool. Dev hashes and observes only these Go
+	// inputs and never reimplements GOOS/GOARCH/cgo/build-tag selection.
+	WatchGoFiles []string
+	// RefreshWatchDirs recomputes the dependency closure after a handled
+	// change, so newly imported packages become watched without restarting the
+	// dev proxy. A partial invalid closure is unioned with the last valid
+	// allowlist so edits in the new package can recover the quarantined app.
+	// It remains as a compatibility seam for directory-only callers.
+	RefreshWatchDirs func() ([]string, error)
+	// RefreshWatchTargets atomically recomputes package roots, exact canonical
+	// source files, and the active-Go subset. New GoSX callers use this seam so
+	// build selection and accepted nested physical sources cannot diverge.
+	RefreshWatchTargets func() ([]string, []string, []string, error)
+	ProxyTarget         string
+	PreflightChange     func([]string) error
+	OnChange            func() error
+	PollInterval        time.Duration
+	SceneInspector      bool
+	Logf                func(format string, args ...any)
 
 	mu          sync.RWMutex
 	clients     map[chan sseEvent]struct{}
@@ -406,7 +447,12 @@ func (s *Server) watchLoop(stop <-chan struct{}) {
 }
 
 func (s *Server) watchWithPolling(stop <-chan struct{}) {
-	snapshot, err := projectSnapshot(s.Dir)
+	targets, err := normalizeDependencyWatchTargets(s.Dir, s.WatchDirs, s.WatchFiles, s.WatchGoFiles)
+	if err != nil {
+		s.logf("normalize dependency watch targets: %v", err)
+		return
+	}
+	snapshot, err := watchedSourceSnapshotForTargets(s.Dir, targets)
 	if err != nil {
 		s.logf("initial snapshot failed: %v", err)
 		return
@@ -419,23 +465,35 @@ func (s *Server) watchWithPolling(stop <-chan struct{}) {
 
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
+	refreshFailed := false
 
 	for {
 		select {
 		case <-stop:
 			return
 		case <-ticker.C:
-			next, err := projectSnapshot(s.Dir)
+			nextTargets, refreshErr := s.refreshDependencyWatchTargetsWithError(targets)
+			refreshTransition := (refreshErr != nil) != refreshFailed
+			refreshFailed = refreshErr != nil
+			targets = nextTargets
+			next, err := watchedSourceSnapshotForTargets(s.Dir, targets)
 			if err != nil {
 				s.logf("snapshot failed: %v", err)
 				continue
 			}
-			changed := changedPaths(s.Dir, snapshot, next)
+			changed := changedWatchedPaths(snapshot, next)
+			if refreshTransition {
+				changed = sortedStringUnion(changed, []string{dependencyRefreshMarker(s.Dir, targets)})
+			}
 			if len(changed) == 0 {
 				continue
 			}
+			// Acknowledge exactly the filesystem state that produced this
+			// callback before invoking a potentially blocking rebuild. A second
+			// mutation during OnChange then remains different from this baseline
+			// and is delivered on the next poll instead of being absorbed into a
+			// post-handler snapshot.
 			snapshot = next
-
 			s.handleProjectChange(changed)
 		}
 	}
@@ -451,11 +509,25 @@ func (s *Server) watchWithFSNotify(stop <-chan struct{}) error {
 	if err := addProjectWatchDirs(s.Dir, watcher.Add); err != nil {
 		return err
 	}
+	targets, err := normalizeDependencyWatchTargets(s.Dir, s.WatchDirs, s.WatchFiles, s.WatchGoFiles)
+	if err != nil {
+		return fmt.Errorf("normalize dependency watch targets: %w", err)
+	}
+	for _, dir := range dependencyKernelWatchDirs(targets) {
+		if err := watcher.Add(dir); err != nil {
+			return fmt.Errorf("watch dependency directory %s: %w", dir, err)
+		}
+	}
+	dependencySnapshot, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		return fmt.Errorf("initial dependency snapshot: %w", err)
+	}
 
 	var (
-		timer   *time.Timer
-		timerC  <-chan time.Time
-		pending = make(map[string]struct{})
+		timer         *time.Timer
+		timerC        <-chan time.Time
+		pending       = make(map[string]struct{})
+		refreshFailed bool
 	)
 	stopTimer := func() {
 		if timer == nil {
@@ -475,12 +547,55 @@ func (s *Server) watchWithFSNotify(stop <-chan struct{}) error {
 		timer = time.NewTimer(defaultWatchDebounce)
 		timerC = timer.C
 	}
+	addPending := func(paths []string) bool {
+		added := false
+		for _, path := range paths {
+			path = strings.TrimSpace(path)
+			if path == "" {
+				continue
+			}
+			path = filepath.Clean(path)
+			if _, exists := pending[path]; !exists {
+				added = true
+			}
+			pending[path] = struct{}{}
+		}
+		return added
+	}
+	queuePending := func(paths []string) {
+		if addPending(paths) {
+			resetTimer()
+		}
+	}
 	defer stopTimer()
+	repairInterval := s.PollInterval
+	if repairInterval <= 0 {
+		repairInterval = defaultPollInterval
+	}
+	repairTicker := time.NewTicker(repairInterval)
+	defer repairTicker.Stop()
 
 	for {
 		select {
 		case <-stop:
 			return nil
+		case <-repairTicker.C:
+			previousRefreshFailed := refreshFailed
+			nextTargets, refreshErr := s.reconcileDependencyWatchTargetsWithError(watcher, targets)
+			targets = nextTargets
+			refreshFailed = refreshErr != nil
+			s.repairDependencyTargetWatches(watcher, targets)
+			nextSnapshot, snapshotErr := dependencySourceSnapshotForTargets(targets)
+			if snapshotErr != nil {
+				s.logf("dependency catch-up snapshot failed: %v", snapshotErr)
+				continue
+			}
+			changed := changedWatchedPaths(dependencySnapshot, nextSnapshot)
+			if refreshFailed != previousRefreshFailed {
+				changed = sortedStringUnion(changed, []string{dependencyRefreshMarker(s.Dir, targets)})
+			}
+			dependencySnapshot = nextSnapshot
+			queuePending(changed)
 		case err, ok := <-watcher.Errors:
 			if !ok {
 				return nil
@@ -493,23 +608,231 @@ func (s *Server) watchWithFSNotify(stop <-chan struct{}) error {
 			if event.Op&fsnotify.Create != 0 {
 				s.watchCreatedDirs(event.Name, watcher.Add)
 			}
-			if !isProjectWatchEvent(s.Dir, event) {
+			if isDirectDependencyGoEvent(targets, event) {
+				previousRefreshFailed := refreshFailed
+				nextTargets, refreshErr := s.reconcileDependencyWatchTargetsWithError(watcher, targets)
+				targets = nextTargets
+				refreshFailed = refreshErr != nil
+				nextSnapshot, snapshotErr := dependencySourceSnapshotForTargets(targets)
+				if snapshotErr != nil {
+					s.logf("dependency Go-event snapshot failed: %v", snapshotErr)
+					queuePending([]string{filepath.Clean(event.Name)})
+					continue
+				}
+				changed := changedWatchedPaths(dependencySnapshot, nextSnapshot)
+				if refreshErr != nil {
+					// The Go tool could not select the new package state. Deliver the
+					// safe direct logical path so strict preflight quarantines it.
+					changed = sortedStringUnion(changed, []string{filepath.Clean(event.Name)})
+				} else if refreshFailed != previousRefreshFailed {
+					changed = sortedStringUnion(changed, []string{dependencyRefreshMarker(s.Dir, targets)})
+				}
+				dependencySnapshot = nextSnapshot
+				queuePending(changed)
 				continue
 			}
-			pending[event.Name] = struct{}{}
-			resetTimer()
+			if !isWatchedSourceEventForTargets(s.Dir, targets, event) {
+				continue
+			}
+			queuePending([]string{canonicalWatchEventPath(event.Name)})
 		case <-timerC:
 			timer = nil
 			timerC = nil
 			if len(pending) == 0 {
 				continue
 			}
+			// Refresh and install newly authorized package/physical-parent
+			// watches before invoking a potentially blocking rebuild. Compare the
+			// bounded dependency snapshot after installation so mutations which
+			// landed between the triggering event and the new kernel watch are
+			// folded into this batch.
+			previousRefreshFailed := refreshFailed
+			nextTargets, refreshErr := s.reconcileDependencyWatchTargetsWithError(watcher, targets)
+			targets = nextTargets
+			refreshFailed = refreshErr != nil
+			if refreshFailed != previousRefreshFailed {
+				addPending([]string{dependencyRefreshMarker(s.Dir, targets)})
+			}
+			nextSnapshot, snapshotErr := dependencySourceSnapshotForTargets(targets)
+			if snapshotErr != nil {
+				s.logf("dependency pre-change catch-up snapshot failed: %v", snapshotErr)
+			} else {
+				addPending(changedWatchedPaths(dependencySnapshot, nextSnapshot))
+				dependencySnapshot = nextSnapshot
+			}
 			paths := make([]string, 0, len(pending))
 			for path := range pending {
 				paths = append(paths, path)
 			}
+			sort.Strings(paths)
 			pending = make(map[string]struct{})
 			s.handleProjectChange(paths)
+
+			// Hooks or a second filesystem mutation may change the authoritative
+			// closure while OnChange is blocked. Reconcile again, then queue a
+			// deterministic catch-up batch before returning to the event loop.
+			previousRefreshFailed = refreshFailed
+			nextTargets, refreshErr = s.reconcileDependencyWatchTargetsWithError(watcher, targets)
+			targets = nextTargets
+			refreshFailed = refreshErr != nil
+			nextSnapshot, snapshotErr = dependencySourceSnapshotForTargets(targets)
+			if snapshotErr != nil {
+				s.logf("dependency post-change catch-up snapshot failed: %v", snapshotErr)
+				continue
+			}
+			changed := changedWatchedPaths(dependencySnapshot, nextSnapshot)
+			if refreshFailed != previousRefreshFailed {
+				changed = sortedStringUnion(changed, []string{dependencyRefreshMarker(s.Dir, targets)})
+			}
+			dependencySnapshot = nextSnapshot
+			queuePending(changed)
+		}
+	}
+}
+
+// refreshDependencyWatchTargets asks the caller for the latest validated
+// island dependency closure. An unresolved closure preserves the last
+// known-good allowlist; a safely resolved but source-invalid partial closure
+// is unioned with it so the invalid package and its exact physical sources
+// remain observable for recovery.
+func (s *Server) refreshDependencyWatchTargets(current dependencyWatchTargets) dependencyWatchTargets {
+	next, _ := s.refreshDependencyWatchTargetsWithError(current)
+	return next
+}
+
+func (s *Server) refreshDependencyWatchTargetsWithError(current dependencyWatchTargets) (dependencyWatchTargets, error) {
+	var (
+		dirs       []string
+		files      []string
+		goFiles    []string
+		refreshErr error
+	)
+	switch {
+	case s.RefreshWatchTargets != nil:
+		dirs, files, goFiles, refreshErr = s.RefreshWatchTargets()
+	case s.RefreshWatchDirs != nil:
+		dirs, refreshErr = s.RefreshWatchDirs()
+		// A directory-only refresh cannot safely recalculate exact source
+		// membership, so preserve any explicit initial files.
+		files = current.files
+		goFiles = current.goFiles
+	default:
+		return current, nil
+	}
+	if refreshErr != nil && len(dirs) == 0 && len(files) == 0 && len(goFiles) == 0 {
+		s.logf("refresh dependency watch targets failed: %v", refreshErr)
+		return current, refreshErr
+	}
+	// A source-invalid partial closure deliberately omits the unsafe source
+	// identity that caused discovery to fail. Normalize its already-canonical
+	// roots and exact safe files without re-deriving the same invalid direct
+	// symlink; the package root must remain watched so retargeting that logical
+	// entry can recover the app. Fully valid refreshes retain strict derivation.
+	normalized, normalizeErr := normalizeDependencyWatchTargetsInternal(s.Dir, dirs, files, goFiles, refreshErr == nil)
+	if normalizeErr != nil {
+		s.logf("normalize refreshed dependency watch targets failed: %v", normalizeErr)
+		return current, normalizeErr
+	}
+	if refreshErr != nil {
+		s.logf("refresh dependency watch targets found an invalid closure: %v", refreshErr)
+		normalized.dirs = sortedStringUnion(current.dirs, normalized.dirs)
+		normalized.files = sortedStringUnion(current.files, normalized.files)
+		normalized.goFiles = sortedStringUnion(current.goFiles, normalized.goFiles)
+	}
+	return normalized, refreshErr
+}
+
+// refreshDependencyWatchDirs preserves the directory-only test/API seam.
+func (s *Server) refreshDependencyWatchDirs(current []string) []string {
+	return s.refreshDependencyWatchTargets(dependencyWatchTargets{dirs: current}).dirs
+}
+
+func sortedStringUnion(values ...[]string) []string {
+	set := map[string]struct{}{}
+	for _, list := range values {
+		for _, value := range list {
+			set[value] = struct{}{}
+		}
+	}
+	out := make([]string, 0, len(set))
+	for value := range set {
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func dependencyRefreshMarker(root string, targets dependencyWatchTargets) string {
+	if len(targets.dirs) > 0 {
+		return filepath.Clean(targets.dirs[0])
+	}
+	return filepath.Clean(root)
+}
+
+func dependencyKernelWatchDirs(targets dependencyWatchTargets) []string {
+	parents := make([]string, 0, len(targets.files))
+	for _, file := range targets.files {
+		parents = append(parents, filepath.Clean(filepath.Dir(file)))
+	}
+	return sortedStringUnion(targets.dirs, parents)
+}
+
+func (s *Server) reconcileDependencyWatchTargetsWithError(watcher *fsnotify.Watcher, current dependencyWatchTargets) (dependencyWatchTargets, error) {
+	next, refreshErr := s.refreshDependencyWatchTargetsWithError(current)
+	s.syncDependencyWatches(watcher, dependencyKernelWatchDirs(current), dependencyKernelWatchDirs(next))
+	return next, refreshErr
+}
+
+func (s *Server) reconcileDependencyWatchDirs(watcher *fsnotify.Watcher, current []string) []string {
+	currentTargets := dependencyWatchTargets{dirs: current}
+	return s.reconcileDependencyWatchTargets(watcher, currentTargets).dirs
+}
+
+func (s *Server) reconcileDependencyWatchTargets(watcher *fsnotify.Watcher, current dependencyWatchTargets) dependencyWatchTargets {
+	next, _ := s.reconcileDependencyWatchTargetsWithError(watcher, current)
+	return next
+}
+
+// repairDependencyWatches restores kernel watches for logically desired
+// dependency directories. Linux drops a directory watch when that directory
+// is removed; retaining the logical path and checking WatchList lets a later
+// recreation be re-added even though the dependency closure did not change.
+func (s *Server) repairDependencyWatches(watcher *fsnotify.Watcher, desired []string) {
+	s.syncDependencyWatches(watcher, desired, desired)
+}
+
+func (s *Server) repairDependencyTargetWatches(watcher *fsnotify.Watcher, desired dependencyWatchTargets) {
+	dirs := dependencyKernelWatchDirs(desired)
+	s.syncDependencyWatches(watcher, dirs, dirs)
+}
+
+func (s *Server) syncDependencyWatches(watcher *fsnotify.Watcher, current, next []string) {
+	liveSet := make(map[string]struct{})
+	for _, dir := range watcher.WatchList() {
+		liveSet[filepath.Clean(dir)] = struct{}{}
+	}
+	nextSet := stringSet(next)
+	for _, dir := range next {
+		dir = filepath.Clean(dir)
+		if _, ok := liveSet[dir]; ok {
+			continue
+		}
+		if err := watcher.Add(dir); err != nil {
+			s.logf("watch dependency directory %s failed: %v", dir, err)
+			continue
+		}
+		liveSet[dir] = struct{}{}
+	}
+	for _, dir := range current {
+		dir = filepath.Clean(dir)
+		if _, ok := nextSet[dir]; ok {
+			continue
+		}
+		if _, ok := liveSet[dir]; !ok {
+			continue
+		}
+		if err := watcher.Remove(dir); err != nil {
+			s.logf("unwatch dependency directory %s failed: %v", dir, err)
 		}
 	}
 }
@@ -604,6 +927,331 @@ func isProjectWatchEvent(root string, event fsnotify.Event) bool {
 	return shouldWatchProjectFile(filepath.ToSlash(rel))
 }
 
+func isWatchedSourceEvent(root string, dependencyDirs []string, event fsnotify.Event) bool {
+	return isWatchedSourceEventForTargets(root, dependencyWatchTargets{dirs: dependencyDirs}, event)
+}
+
+func isWatchedSourceEventForTargets(root string, targets dependencyWatchTargets, event fsnotify.Event) bool {
+	if isProjectWatchEvent(root, event) {
+		return true
+	}
+	if event.Name == "" || !isRelevantWatchOp(event.Op) {
+		return false
+	}
+	path := canonicalWatchEventPath(event.Name)
+	if path == "" {
+		return false
+	}
+	for _, dir := range targets.dirs {
+		if path == filepath.Clean(dir) && event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+			return true
+		}
+	}
+	for _, dir := range dependencyKernelWatchDirs(targets) {
+		if path == filepath.Clean(dir) && event.Op&(fsnotify.Remove|fsnotify.Rename) != 0 {
+			return true
+		}
+	}
+	if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
+		return false
+	}
+	// Exact physical identities cover active Go files and accepted nested GSX
+	// targets. Same-file comparison keeps an authoritative inode observable
+	// through a hardlink without granting permission to unrelated siblings.
+	if eventMatchesExactWatchFile(path, event.Name, targets.files) {
+		return true
+	}
+	if !shouldWatchDependencyGSXFile(event.Name) {
+		return false
+	}
+
+	// Test the logical parent separately from the fully resolved source path.
+	// This keeps every direct package-root GSX source observable even when a new
+	// symlink is invalid; strict rediscovery can then quarantine it. Go inputs do
+	// not inherit this root-wide permission: they must be in the active exact set.
+	// Physical edits below a package root still require an exact match above.
+	logicalParent := canonicalWatchEventPath(filepath.Dir(event.Name))
+	for _, dir := range targets.dirs {
+		if logicalParent == filepath.Clean(dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func isDirectDependencyGoEvent(targets dependencyWatchTargets, event fsnotify.Event) bool {
+	if event.Name == "" || !isRelevantWatchOp(event.Op) || strings.ToLower(filepath.Ext(event.Name)) != ".go" {
+		return false
+	}
+	logicalParent := canonicalWatchEventPath(filepath.Dir(event.Name))
+	for _, dir := range targets.dirs {
+		if logicalParent == filepath.Clean(dir) {
+			return true
+		}
+	}
+	return false
+}
+
+func eventMatchesExactWatchFile(path, logical string, files []string) bool {
+	for _, file := range files {
+		if path == filepath.Clean(file) {
+			return true
+		}
+	}
+	info, err := os.Stat(logical)
+	if err != nil || !info.Mode().IsRegular() {
+		return false
+	}
+	for _, file := range files {
+		candidate, err := os.Stat(file)
+		if err == nil && candidate.Mode().IsRegular() && os.SameFile(info, candidate) {
+			return true
+		}
+	}
+	return false
+}
+
+// normalizeDependencyWatchDirs converts the discovery result into a minimal
+// physical allowlist. Project-owned directories are already covered by the
+// recursive root watcher, while external package directories are watched only
+// at their top level.
+func normalizeDependencyWatchDirs(root string, dirs []string) ([]string, error) {
+	canonicalRoot, err := canonicalExistingWatchDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve project watch root: %w", err)
+	}
+	var (
+		out        []string
+		identities []os.FileInfo
+	)
+	for _, candidate := range dirs {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		canonical, err := canonicalExistingWatchDir(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("resolve dependency watch directory %s: %w", candidate, err)
+		}
+		if pathWithinWatchRoot(canonical, canonicalRoot) {
+			continue
+		}
+		info, err := os.Stat(canonical)
+		if err != nil {
+			return nil, err
+		}
+		duplicate := false
+		for _, previous := range identities {
+			if os.SameFile(info, previous) {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		identities = append(identities, info)
+		out = append(out, canonical)
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+func normalizeDependencyWatchTargets(root string, dirs, files, goFiles []string) (dependencyWatchTargets, error) {
+	return normalizeDependencyWatchTargetsInternal(root, dirs, files, goFiles, true)
+}
+
+func normalizeDependencyWatchTargetsInternal(root string, dirs, files, goFiles []string, deriveDirectSymlinks bool) (dependencyWatchTargets, error) {
+	normalizedDirs, err := normalizeDependencyWatchDirs(root, dirs)
+	if err != nil {
+		return dependencyWatchTargets{}, err
+	}
+	if deriveDirectSymlinks {
+		// Preserve directory-only callers for GSX by deriving exact physical
+		// targets from safe direct .gsx symlinks. Active Go files must always be
+		// supplied explicitly from GoFiles/CgoFiles; this fallback never guesses
+		// build selection and never walks a nested tree.
+		derivedFiles, err := directDependencySymlinkTargets(normalizedDirs)
+		if err != nil {
+			return dependencyWatchTargets{}, err
+		}
+		files = append(append([]string(nil), files...), derivedFiles...)
+	}
+	// Every active Go input is also an exact source target. Keep the separately
+	// normalized subset for admission while deriving kernel parents from the
+	// complete exact-file set.
+	files = append(append([]string(nil), files...), goFiles...)
+	canonicalRoot, err := canonicalExistingWatchDir(root)
+	if err != nil {
+		return dependencyWatchTargets{}, fmt.Errorf("resolve project watch root: %w", err)
+	}
+	normalizedFiles, err := normalizeDependencyWatchFiles(canonicalRoot, normalizedDirs, files)
+	if err != nil {
+		return dependencyWatchTargets{}, err
+	}
+	normalizedGoFiles, err := normalizeDependencyWatchFiles(canonicalRoot, normalizedDirs, goFiles)
+	if err != nil {
+		return dependencyWatchTargets{}, err
+	}
+	return dependencyWatchTargets{dirs: normalizedDirs, files: normalizedFiles, goFiles: normalizedGoFiles}, nil
+}
+
+func normalizeDependencyWatchFiles(canonicalRoot string, normalizedDirs, files []string) ([]string, error) {
+	var (
+		normalizedFiles []string
+		identities      []os.FileInfo
+	)
+	for _, candidate := range files {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" {
+			continue
+		}
+		canonical, info, err := canonicalExistingWatchFile(candidate)
+		if err != nil {
+			return nil, fmt.Errorf("resolve dependency watch source %s: %w", candidate, err)
+		}
+		if pathWithinWatchRoot(canonical, canonicalRoot) {
+			continue
+		}
+		contained := false
+		for _, dir := range normalizedDirs {
+			if pathWithinWatchRoot(canonical, dir) {
+				contained = true
+				break
+			}
+		}
+		if !contained {
+			return nil, fmt.Errorf("dependency watch source %s resolves outside every allowlisted package directory", candidate)
+		}
+		duplicate := false
+		for _, previous := range identities {
+			if os.SameFile(info, previous) {
+				duplicate = true
+				break
+			}
+		}
+		if duplicate {
+			continue
+		}
+		identities = append(identities, info)
+		normalizedFiles = append(normalizedFiles, canonical)
+	}
+	sort.Strings(normalizedFiles)
+	return normalizedFiles, nil
+}
+
+func directDependencySymlinkTargets(dirs []string) ([]string, error) {
+	var targets []string
+	for _, dir := range dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("inspect dependency watch directory %s: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if !shouldWatchDependencyGSXFile(entry.Name()) {
+				continue
+			}
+			entryInfo, err := entry.Info()
+			if err != nil {
+				return nil, fmt.Errorf("inspect dependency source %s: %w", filepath.Join(dir, entry.Name()), err)
+			}
+			if entryInfo.Mode()&os.ModeSymlink == 0 {
+				continue
+			}
+			logical := filepath.Join(dir, entry.Name())
+			canonical, _, err := canonicalExistingWatchFile(logical)
+			if os.IsNotExist(err) {
+				// A broken target is represented by the prior refreshed allowlist,
+				// if any; there is no new physical identity to authorize here.
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("resolve dependency source %s: %w", logical, err)
+			}
+			if !pathWithinWatchRoot(canonical, dir) {
+				return nil, fmt.Errorf("dependency source %s resolves outside allowlisted package directory %s", logical, dir)
+			}
+			targets = append(targets, canonical)
+		}
+	}
+	sort.Strings(targets)
+	return targets, nil
+}
+
+func canonicalExistingWatchDir(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", err
+	}
+	if !info.IsDir() {
+		return "", fmt.Errorf("%s is not a directory", path)
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func canonicalExistingWatchFile(path string) (string, os.FileInfo, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", nil, err
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", nil, err
+	}
+	info, err := os.Stat(canonical)
+	if err != nil {
+		return "", nil, err
+	}
+	if !info.Mode().IsRegular() {
+		return "", nil, fmt.Errorf("%s is not a regular file", path)
+	}
+	return filepath.Clean(canonical), info, nil
+}
+
+func canonicalWatchEventPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return ""
+	}
+	if canonical, err := filepath.EvalSymlinks(abs); err == nil {
+		return filepath.Clean(canonical)
+	}
+	parent, err := filepath.EvalSymlinks(filepath.Dir(abs))
+	if err != nil {
+		return filepath.Clean(abs)
+	}
+	return filepath.Join(parent, filepath.Base(abs))
+}
+
+func pathWithinWatchRoot(path, root string) bool {
+	rel, err := filepath.Rel(root, path)
+	return err == nil && !relOutsideRoot(rel)
+}
+
+func shouldWatchDependencyGSXFile(path string) bool {
+	return strings.EqualFold(filepath.Ext(path), ".gsx")
+}
+
+func stringSet(values []string) map[string]struct{} {
+	set := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		set[value] = struct{}{}
+	}
+	return set
+}
+
 func isRelevantWatchOp(op fsnotify.Op) bool {
 	return op&(fsnotify.Create|fsnotify.Write|fsnotify.Remove|fsnotify.Rename) != 0
 }
@@ -637,10 +1285,158 @@ func projectSnapshot(dir string) (map[string]snapshotEntry, error) {
 		out[rel] = snapshotEntry{
 			ModTime: info.ModTime(),
 			Size:    info.Size(),
+			Info:    info,
 		}
 		return nil
 	})
 	return out, err
+}
+
+// watchedSourceSnapshot uses absolute physical paths so project and external
+// package changes share one deterministic diff without granting recursive
+// access outside the project root.
+func watchedSourceSnapshot(root string, dependencyDirs []string) (map[string]snapshotEntry, error) {
+	files, err := directDependencySymlinkTargets(dependencyDirs)
+	if err != nil {
+		return nil, err
+	}
+	return watchedSourceSnapshotForTargets(root, dependencyWatchTargets{dirs: dependencyDirs, files: files})
+}
+
+func watchedSourceSnapshotForTargets(root string, targets dependencyWatchTargets) (map[string]snapshotEntry, error) {
+	project, err := projectSnapshot(root)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string]snapshotEntry, len(project))
+	for rel, entry := range project {
+		out[filepath.Join(root, filepath.FromSlash(rel))] = entry
+	}
+	dependency, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		return nil, err
+	}
+	for path, entry := range dependency {
+		out[path] = entry
+	}
+	return out, nil
+}
+
+// dependencySourceSnapshotForTargets performs a bounded top-level GSX scan of
+// allowlisted package roots, then reads only the exact active Go identities
+// selected upstream by the Go tool. A direct GSX symlink may move between
+// nested targets inside its canonical package root without first appearing in
+// the stale exact-file set. Go sources receive no equivalent root-wide
+// permission: GOOS/GOARCH/cgo/build-tag-inactive files never enter this
+// snapshot. Periodic content hashing still observes accepted GSX and active Go
+// inodes through unenumerated hardlink aliases even when size and mtime are
+// restored. No nested sibling is enumerated or admitted.
+func dependencySourceSnapshotForTargets(targets dependencyWatchTargets) (map[string]snapshotEntry, error) {
+	out := make(map[string]snapshotEntry)
+	for _, dir := range targets.dirs {
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			return nil, fmt.Errorf("snapshot dependency directory %s: %w", dir, err)
+		}
+		for _, entry := range entries {
+			if entry.IsDir() || !shouldWatchDependencyGSXFile(entry.Name()) {
+				continue
+			}
+			logical := filepath.Join(dir, entry.Name())
+			canonical, snapshot, present, err := snapshotDependencySource(logical, dir)
+			if err != nil {
+				return nil, err
+			}
+			if present {
+				mergeDependencySnapshot(out, canonical, snapshot)
+			}
+		}
+	}
+	for _, file := range targets.goFiles {
+		dir := containingDependencyWatchDir(file, targets.dirs)
+		if dir == "" {
+			return nil, fmt.Errorf("active Go dependency source %s is outside every allowlisted package directory", file)
+		}
+		canonical, snapshot, present, err := snapshotDependencySource(file, dir)
+		if err != nil {
+			return nil, err
+		}
+		if present {
+			mergeDependencySnapshot(out, canonical, snapshot)
+		}
+	}
+	return out, nil
+}
+
+func containingDependencyWatchDir(path string, dirs []string) string {
+	path = filepath.Clean(path)
+	for _, dir := range dirs {
+		if pathWithinWatchRoot(path, filepath.Clean(dir)) {
+			return filepath.Clean(dir)
+		}
+	}
+	return ""
+}
+
+func snapshotDependencySource(logical, dir string) (string, snapshotEntry, bool, error) {
+	canonical := canonicalWatchEventPath(logical)
+	if canonical == "" {
+		return "", snapshotEntry{}, false, fmt.Errorf("resolve dependency source %s", logical)
+	}
+	if !pathWithinWatchRoot(canonical, filepath.Clean(dir)) {
+		return "", snapshotEntry{}, false, fmt.Errorf("dependency source %s resolves outside allowlisted package directory %s", logical, dir)
+	}
+	info, err := os.Stat(logical)
+	if os.IsNotExist(err) {
+		// A removed target is absent from the next snapshot. Polling reports the
+		// transition and refresh can later authorize its recreated identity.
+		return canonical, snapshotEntry{}, false, nil
+	}
+	if err != nil {
+		return "", snapshotEntry{}, false, fmt.Errorf("snapshot dependency source %s: %w", logical, err)
+	}
+	if !info.Mode().IsRegular() {
+		return canonical, snapshotEntry{}, false, nil
+	}
+	data, err := os.ReadFile(logical)
+	if err != nil {
+		return "", snapshotEntry{}, false, fmt.Errorf("read dependency source %s: %w", logical, err)
+	}
+	return canonical, snapshotEntry{
+		ModTime:        info.ModTime(),
+		Size:           info.Size(),
+		Info:           info,
+		ContentHash:    sha256.Sum256(data),
+		HasContentHash: true,
+	}, true, nil
+}
+
+func mergeDependencySnapshot(out map[string]snapshotEntry, path string, next snapshotEntry) {
+	if current, ok := out[path]; ok && current.HasContentHash && !next.HasContentHash {
+		return
+	}
+	out[path] = next
+}
+
+func changedWatchedPaths(prev map[string]snapshotEntry, next map[string]snapshotEntry) []string {
+	changed := make(map[string]struct{})
+	for path, prevEntry := range prev {
+		nextEntry, ok := next[path]
+		if !ok || !sameSnapshotEntry(prevEntry, nextEntry) {
+			changed[path] = struct{}{}
+		}
+	}
+	for path := range next {
+		if _, ok := prev[path]; !ok {
+			changed[path] = struct{}{}
+		}
+	}
+	paths := make([]string, 0, len(changed))
+	for path := range changed {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+	return paths
 }
 
 func snapshotChanged(prev map[string]snapshotEntry, next map[string]snapshotEntry) bool {
@@ -652,7 +1448,7 @@ func snapshotChanged(prev map[string]snapshotEntry, next map[string]snapshotEntr
 		if !ok {
 			return true
 		}
-		if !prevEntry.ModTime.Equal(nextEntry.ModTime) || prevEntry.Size != nextEntry.Size {
+		if !sameSnapshotEntry(prevEntry, nextEntry) {
 			return true
 		}
 	}
@@ -667,7 +1463,7 @@ func changedPaths(root string, prev map[string]snapshotEntry, next map[string]sn
 	changed := make(map[string]struct{})
 	for rel, prevEntry := range prev {
 		nextEntry, ok := next[rel]
-		if !ok || !prevEntry.ModTime.Equal(nextEntry.ModTime) || prevEntry.Size != nextEntry.Size {
+		if !ok || !sameSnapshotEntry(prevEntry, nextEntry) {
 			changed[rel] = struct{}{}
 		}
 	}
@@ -680,7 +1476,21 @@ func changedPaths(root string, prev map[string]snapshotEntry, next map[string]sn
 	for rel := range changed {
 		paths = append(paths, filepath.Join(root, filepath.FromSlash(rel)))
 	}
+	sort.Strings(paths)
 	return paths
+}
+
+func sameSnapshotEntry(left, right snapshotEntry) bool {
+	if !left.ModTime.Equal(right.ModTime) || left.Size != right.Size {
+		return false
+	}
+	if left.Info != nil && right.Info != nil && !os.SameFile(left.Info, right.Info) {
+		return false
+	}
+	if left.HasContentHash != right.HasContentHash || (left.HasContentHash && left.ContentHash != right.ContentHash) {
+		return false
+	}
+	return true
 }
 
 func shouldWatchProjectFile(path string) bool {

--- a/dev/server_test.go
+++ b/dev/server_test.go
@@ -1,13 +1,21 @@
 package dev
 
 import (
+	"crypto/sha256"
+	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"reflect"
+	"runtime"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/fsnotify/fsnotify"
 )
@@ -272,6 +280,808 @@ func TestIsProjectWatchEventFiltersSourceFiles(t *testing.T) {
 	}
 }
 
+func TestNormalizeDependencyWatchDirsUsesCanonicalExternalAllowlist(t *testing.T) {
+	root := t.TempDir()
+	inside := filepath.Join(root, "app")
+	external := t.TempDir()
+	if err := os.MkdirAll(inside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	alias := filepath.Join(t.TempDir(), "external-alias")
+	if err := os.Symlink(external, alias); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs, err := normalizeDependencyWatchDirs(root, []string{inside, alias, external, "", external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalExternal, err := canonicalExistingWatchDir(external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := dirs, []string{canonicalExternal}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("normalized watch dirs = %#v, want %#v", got, want)
+	}
+}
+
+func TestNormalizeDependencyWatchTargetsAllowsOnlyExactCanonicalSymlinkSources(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	nested := filepath.Join(external, "physical")
+	physical := filepath.Join(nested, "counter.gsx")
+	sibling := filepath.Join(nested, "unrelated.gsx")
+	writeTestFile(t, physical, []byte(islandGSX))
+	writeTestFile(t, sibling, []byte(islandGSX))
+	logical := filepath.Join(external, "counter.gsx")
+	if err := os.Symlink(physical, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{physical}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	canonicalExternal, err := canonicalExistingWatchDir(external)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := targets.dirs, []string{canonicalExternal}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("watch dirs = %#v, want %#v", got, want)
+	}
+	if got, want := targets.files, []string{physical}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("exact watch files = %#v, want %#v", got, want)
+	}
+	if got, want := dependencyKernelWatchDirs(targets), []string{external, nested}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("kernel watch dirs = %#v, want package root plus exact parent %#v", got, want)
+	}
+	for _, path := range []string{logical, physical} {
+		if !isWatchedSourceEventForTargets(root, targets, fsnotify.Event{Name: path, Op: fsnotify.Write}) {
+			t.Fatalf("accepted symlink source event %s was rejected", path)
+		}
+	}
+	if isWatchedSourceEventForTargets(root, targets, fsnotify.Event{Name: sibling, Op: fsnotify.Write}) {
+		t.Fatalf("unrelated nested sibling %s inherited exact source permission", sibling)
+	}
+	snapshot, err := watchedSourceSnapshotForTargets(root, targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := snapshot[physical]; !ok {
+		t.Fatalf("polling snapshot %#v omitted canonical nested source %q", snapshot, physical)
+	}
+	if _, ok := snapshot[sibling]; ok {
+		t.Fatalf("polling snapshot %#v included unrelated nested sibling %q", snapshot, sibling)
+	}
+
+	// Directory-only callers derive the same bounded exact target from the
+	// direct symlink, without walking or trusting the nested directory.
+	derived, err := normalizeDependencyWatchTargets(root, []string{external}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(derived, targets) {
+		t.Fatalf("directory-only exact targets = %#v, want %#v", derived, targets)
+	}
+
+	outside := filepath.Join(t.TempDir(), "outside.gsx")
+	writeTestFile(t, outside, []byte(islandGSX))
+	if _, err := normalizeDependencyWatchTargets(root, []string{external}, []string{outside}, nil); err == nil || !strings.Contains(err.Error(), "outside every allowlisted") {
+		t.Fatalf("explicit source escape error = %v", err)
+	}
+	escapeDir := t.TempDir()
+	escapeLogical := filepath.Join(escapeDir, "escape.gsx")
+	if err := os.Symlink(outside, escapeLogical); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := normalizeDependencyWatchTargets(root, []string{escapeDir}, nil, nil); err == nil || !strings.Contains(err.Error(), "resolves outside allowlisted") {
+		t.Fatalf("direct symlink escape error = %v", err)
+	}
+}
+
+func TestNormalizeDependencyWatchTargetsDedupesSameDirectorySymlink(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	physical := filepath.Join(external, "counter_source.gsx")
+	writeTestFile(t, physical, []byte(islandGSX))
+	if err := os.Symlink(physical, filepath.Join(external, "counter.gsx")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{physical}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := targets.files, []string{physical}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("same-directory symlink exact files = %#v, want one physical identity %#v", got, want)
+	}
+	if got, want := dependencyKernelWatchDirs(targets), []string{external}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("same-directory symlink kernel dirs = %#v, want no extra nested watch %#v", got, want)
+	}
+}
+
+func TestRefreshDependencyWatchDirsUnionsPartialInvalidClosureForRecovery(t *testing.T) {
+	root := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	current, err := normalizeDependencyWatchDirs(root, []string{first})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		Dir:  root,
+		Logf: func(string, ...any) {},
+		RefreshWatchDirs: func() ([]string, error) {
+			return []string{second}, errors.New("ambiguous new dependency")
+		},
+	}
+	canonicalSecond, err := canonicalExistingWatchDir(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantUnion := append(append([]string(nil), current...), canonicalSecond)
+	if current[0] > canonicalSecond {
+		wantUnion[0], wantUnion[1] = wantUnion[1], wantUnion[0]
+	}
+	if got := s.refreshDependencyWatchDirs(current); !reflect.DeepEqual(got, wantUnion) {
+		t.Fatalf("partial invalid closure refresh = %#v, want old+new recovery allowlist %#v", got, wantUnion)
+	}
+
+	s.RefreshWatchDirs = func() ([]string, error) { return nil, errors.New("unresolved import") }
+	if got := s.refreshDependencyWatchDirs(current); !reflect.DeepEqual(got, current) {
+		t.Fatalf("unresolved closure refresh = %#v, want preserved %#v", got, current)
+	}
+
+	s.RefreshWatchDirs = func() ([]string, error) { return []string{second}, nil }
+	if got, want := s.refreshDependencyWatchDirs(current), []string{canonicalSecond}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("valid closure refresh = %#v, want replacement %#v", got, want)
+	}
+}
+
+func TestRefreshDependencyWatchTargetsUpdatesExactFilesAtomically(t *testing.T) {
+	root := t.TempDir()
+	first := t.TempDir()
+	second := t.TempDir()
+	firstFile := filepath.Join(first, "physical", "first.gsx")
+	secondFile := filepath.Join(second, "physical", "second.gsx")
+	firstGo := filepath.Join(first, "bridge.go")
+	secondGo := filepath.Join(second, "bridge.go")
+	writeTestFile(t, firstFile, []byte(islandGSX))
+	writeTestFile(t, secondFile, []byte(islandGSX))
+	writeTestFile(t, firstGo, []byte("package first\n"))
+	writeTestFile(t, secondGo, []byte("package second\n"))
+	if err := os.Symlink(firstFile, filepath.Join(first, "first.gsx")); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(secondFile, filepath.Join(second, "second.gsx")); err != nil {
+		t.Fatal(err)
+	}
+	current, err := normalizeDependencyWatchTargets(root, []string{first}, []string{firstFile, firstGo}, []string{firstGo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	s := &Server{
+		Dir:  root,
+		Logf: func(string, ...any) {},
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			return []string{second}, []string{secondFile, secondGo}, []string{secondGo}, errors.New("invalid new source")
+		},
+	}
+	partial := s.refreshDependencyWatchTargets(current)
+	if got, want := partial.dirs, sortedStringUnion([]string{first}, []string{second}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial target dirs = %#v, want old+new %#v", got, want)
+	}
+	if got, want := partial.files, sortedStringUnion([]string{firstFile, firstGo}, []string{secondFile, secondGo}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial exact files = %#v, want old+new %#v", got, want)
+	}
+	if got, want := partial.goFiles, sortedStringUnion([]string{firstGo}, []string{secondGo}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial active Go files = %#v, want old+new %#v", got, want)
+	}
+
+	s.RefreshWatchTargets = func() ([]string, []string, []string, error) {
+		return []string{second}, []string{secondFile, secondGo}, []string{secondGo}, nil
+	}
+	valid := s.refreshDependencyWatchTargets(current)
+	if got, want := valid.dirs, []string{second}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("valid target dirs = %#v, want replacement %#v", got, want)
+	}
+	if got, want := valid.files, sortedStringUnion([]string{secondFile, secondGo}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("valid exact files = %#v, want replacement %#v", got, want)
+	}
+	if got, want := valid.goFiles, []string{secondGo}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("valid active Go files = %#v, want replacement %#v", got, want)
+	}
+
+	s.RefreshWatchTargets = func() ([]string, []string, []string, error) {
+		return nil, nil, nil, errors.New("unresolved closure")
+	}
+	if got := s.refreshDependencyWatchTargets(current); !reflect.DeepEqual(got, current) {
+		t.Fatalf("unresolved target refresh = %#v, want preserved %#v", got, current)
+	}
+}
+
+func TestRefreshDependencyWatchTargetsRetainsInvalidPackageRootWithoutFollowingEscape(t *testing.T) {
+	root := t.TempDir()
+	previous := t.TempDir()
+	invalid := t.TempDir()
+	outside := filepath.Join(t.TempDir(), "outside.gsx")
+	writeTestFile(t, outside, []byte(islandGSX))
+	logical := filepath.Join(invalid, "counter.gsx")
+	if err := os.Symlink(outside, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	current, err := normalizeDependencyWatchTargets(root, []string{previous}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{
+		Dir:  root,
+		Logf: func(string, ...any) {},
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			return []string{invalid}, nil, nil, errors.New("source resolves outside package root")
+		},
+	}
+	partial := s.refreshDependencyWatchTargets(current)
+	if got, want := partial.dirs, sortedStringUnion([]string{previous}, []string{invalid}); !reflect.DeepEqual(got, want) {
+		t.Fatalf("partial invalid roots = %#v, want safe old+new roots %#v", got, want)
+	}
+	if containsString(partial.files, outside) {
+		t.Fatalf("escaping source entered exact allowlist: %#v", partial.files)
+	}
+	if !isWatchedSourceEventForTargets(root, partial, fsnotify.Event{Name: logical, Op: fsnotify.Write}) {
+		t.Fatal("direct invalid logical source was not observable for safe retarget recovery")
+	}
+
+	inside := filepath.Join(invalid, "physical", "counter.gsx")
+	writeTestFile(t, inside, []byte(islandGSX))
+	frozenRetarget(t, logical, inside)
+	s.RefreshWatchTargets = func() ([]string, []string, []string, error) {
+		return []string{invalid}, []string{inside}, nil, nil
+	}
+	recovered := s.refreshDependencyWatchTargets(partial)
+	if got, want := recovered.dirs, []string{invalid}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovered roots = %#v, want authoritative replacement %#v", got, want)
+	}
+	if got, want := recovered.files, []string{inside}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("recovered exact files = %#v, want %#v", got, want)
+	}
+}
+
+func TestReconcileDependencyWatchDirsReaddsKernelDroppedWatch(t *testing.T) {
+	root := t.TempDir()
+	external := filepath.Join(t.TempDir(), "dependency")
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	current, err := normalizeDependencyWatchDirs(root, []string{external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	watcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer watcher.Close()
+	if err := watcher.Add(external); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.RemoveAll(external); err != nil {
+		t.Fatal(err)
+	}
+
+	deadline := time.After(2 * time.Second)
+	for len(watcher.WatchList()) != 0 {
+		select {
+		case <-watcher.Events:
+		case watchErr := <-watcher.Errors:
+			t.Fatalf("watcher error while removing dependency: %v", watchErr)
+		case <-deadline:
+			t.Fatalf("kernel did not drop removed watch; watch list=%v", watcher.WatchList())
+		}
+	}
+	if err := os.MkdirAll(external, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	s := &Server{
+		Dir:  root,
+		Logf: func(string, ...any) {},
+		RefreshWatchDirs: func() ([]string, error) {
+			return []string{external}, nil
+		},
+	}
+	got := s.reconcileDependencyWatchDirs(watcher, current)
+	if !reflect.DeepEqual(got, current) {
+		t.Fatalf("reconciled logical membership = %v, want %v", got, current)
+	}
+	if len(watcher.WatchList()) == 0 {
+		t.Fatal("reconciliation did not restore the kernel-dropped dependency watch")
+	}
+}
+
+func TestFSNotifyDependencyRemovalRecreationEditRecoversQuarantine(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("directory self-removal watch semantics are verified on Linux")
+	}
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := filepath.Join(t.TempDir(), "dependency")
+	writeTestFile(t, filepath.Join(external, "counter.gsx"), []byte(islandGSX))
+
+	removed := make(chan struct{}, 1)
+	recovered := make(chan struct{}, 1)
+	var restarts atomic.Int32
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		RefreshWatchDirs: func() ([]string, error) {
+			return []string{external}, nil
+		},
+		PreflightChange: func([]string) error {
+			if _, err := os.Stat(external); err != nil {
+				select {
+				case removed <- struct{}{}:
+				default:
+				}
+				return fmt.Errorf("dependency unavailable: %w", err)
+			}
+			return nil
+		},
+		OnChange: func() error {
+			if restarts.Add(1) == 1 {
+				recovered <- struct{}{}
+			}
+			return nil
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.watchWithFSNotify(stop)
+	}()
+	defer func() {
+		close(stop)
+		<-done
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	if err := os.RemoveAll(external); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-removed:
+	case <-time.After(2 * time.Second):
+		t.Fatal("dependency removal did not enter quarantine preflight")
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for !s.isQuarantined() && time.Now().Before(deadline) {
+		time.Sleep(5 * time.Millisecond)
+	}
+	if !s.isQuarantined() {
+		t.Fatal("dependency removal did not quarantine the server")
+	}
+
+	writeTestFile(t, filepath.Join(external, "counter.gsx"), []byte(islandGSX))
+	for attempt := 0; attempt < 20; attempt++ {
+		select {
+		case <-recovered:
+			if s.isQuarantined() {
+				t.Fatal("recovery restart left the server quarantined")
+			}
+			return
+		default:
+		}
+		changed := []byte(islandGSX + fmt.Sprintf("\n// recovery edit %d\n", attempt))
+		writeTestFile(t, filepath.Join(external, "counter.gsx"), changed)
+		// Leave a full debounce window between writes. Rapid writes are
+		// intentionally coalesced; this fixture is proving that at least one
+		// post-recreation edit is delivered after the kernel watch is repaired.
+		time.Sleep(150 * time.Millisecond)
+	}
+	t.Fatalf("recreated dependency edits were not observed; restarts=%d", restarts.Load())
+}
+
+func TestNestedDependencySymlinkFSNotifyLifecycle(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("fsnotify directory replacement and repair semantics are verified on Linux")
+	}
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	nested := filepath.Join(external, "physical")
+	physical := filepath.Join(nested, "counter.gsx")
+	sibling := filepath.Join(nested, "unrelated.gsx")
+	writeTestFile(t, physical, []byte(islandGSX))
+	writeTestFile(t, sibling, []byte(islandGSX))
+	logical := filepath.Join(external, "counter.gsx")
+	if err := os.Symlink(physical, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	changes := make(chan []string, 64)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{physical},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			changes <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+	}
+	stop := make(chan struct{})
+	done := make(chan error, 1)
+	go func() { done <- s.watchWithFSNotify(stop) }()
+	stopped := false
+	stopWatcher := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		close(stop)
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Errorf("watchWithFSNotify: %v", err)
+			}
+		case <-time.After(2 * time.Second):
+			t.Error("fsnotify watcher did not stop")
+		}
+	}
+	defer stopWatcher()
+
+	time.Sleep(100 * time.Millisecond)
+	writeTestFile(t, sibling, []byte(islandGSX+"\n// unrelated nested sibling\n"))
+	assertNoNestedWatchChange(t, changes, 150*time.Millisecond, "unrelated nested sibling")
+
+	writeTestFile(t, physical, []byte(islandGSX+"\n// canonical nested edit\n"))
+	awaitNestedWatchChange(t, changes, physical, "canonical nested edit")
+	drainNestedWatchChanges(changes)
+
+	beforeReplace, err := os.Stat(physical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := physical + ".replacement"
+	replacementData := []byte(islandGSX + "\n// canonical nested edit\n")
+	replacementData[len(replacementData)-2] = 'x'
+	writeTestFile(t, replacement, replacementData)
+	if err := os.Chtimes(replacement, beforeReplace.ModTime(), beforeReplace.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, physical); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "atomic replacement")
+	drainNestedWatchChanges(changes)
+
+	if err := os.Remove(physical); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "physical target removal")
+	drainNestedWatchChanges(changes)
+	writeTestFile(t, physical, []byte(islandGSX+"\n// target recreation\n"))
+	awaitNestedWatchChange(t, changes, physical, "physical target recreation")
+	drainNestedWatchChanges(changes)
+
+	if err := os.RemoveAll(nested); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "exact parent removal")
+	drainNestedWatchChanges(changes)
+	writeTestFile(t, physical, []byte(islandGSX+"\n// parent recreation\n"))
+	for attempt := 0; attempt < 20; attempt++ {
+		writeTestFile(t, physical, []byte(islandGSX+fmt.Sprintf("\n// repaired nested watch %d\n", attempt)))
+		if awaitOptionalNestedWatchChange(changes, physical, 125*time.Millisecond) {
+			break
+		}
+		if attempt == 19 {
+			t.Fatal("fsnotify did not repair the exact nested parent watch after recreation")
+		}
+	}
+
+	stopWatcher()
+	drainNestedWatchChanges(changes)
+	writeTestFile(t, physical, []byte(islandGSX+"\n// edit after shutdown\n"))
+	assertNoNestedWatchChange(t, changes, 150*time.Millisecond, "edit after watcher shutdown")
+}
+
+func TestNestedDependencySymlinkPollingLifecycle(t *testing.T) {
+	root := t.TempDir()
+	writeTestFile(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	nested := filepath.Join(external, "physical")
+	physical := filepath.Join(nested, "counter.gsx")
+	sibling := filepath.Join(nested, "unrelated.gsx")
+	writeTestFile(t, physical, []byte(islandGSX))
+	writeTestFile(t, sibling, []byte(islandGSX))
+	logical := filepath.Join(external, "counter.gsx")
+	if err := os.Symlink(physical, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	changes := make(chan []string, 64)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{physical},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			changes <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchWithPolling(stop)
+	}()
+	stopped := false
+	stopWatcher := func() {
+		if stopped {
+			return
+		}
+		stopped = true
+		close(stop)
+		select {
+		case <-done:
+		case <-time.After(2 * time.Second):
+			t.Error("polling watcher did not stop")
+		}
+	}
+	defer stopWatcher()
+
+	time.Sleep(50 * time.Millisecond)
+	writeTestFile(t, sibling, []byte(islandGSX+"\n// unrelated nested sibling\n"))
+	assertNoNestedWatchChange(t, changes, 75*time.Millisecond, "unrelated nested sibling")
+
+	writeTestFile(t, physical, []byte(islandGSX+"\n// canonical nested edit\n"))
+	awaitNestedWatchChange(t, changes, physical, "canonical nested edit")
+	drainNestedWatchChanges(changes)
+
+	beforeReplace, err := os.Stat(physical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := physical + ".replacement"
+	replacementData := []byte(islandGSX + "\n// canonical nested edit\n")
+	replacementData[len(replacementData)-2] = 'x'
+	writeTestFile(t, replacement, replacementData)
+	if err := os.Chtimes(replacement, beforeReplace.ModTime(), beforeReplace.ModTime()); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(replacement, physical); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "atomic replacement")
+	drainNestedWatchChanges(changes)
+
+	if err := os.Remove(logical); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "logical symlink removal")
+	drainNestedWatchChanges(changes)
+	if err := os.Symlink(physical, logical); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "logical symlink recreation")
+	drainNestedWatchChanges(changes)
+
+	if err := os.RemoveAll(nested); err != nil {
+		t.Fatal(err)
+	}
+	awaitNestedWatchChange(t, changes, physical, "physical parent removal")
+	drainNestedWatchChanges(changes)
+	writeTestFile(t, physical, []byte(islandGSX+"\n// physical parent recreation\n"))
+	awaitNestedWatchChange(t, changes, physical, "physical parent recreation")
+
+	stopWatcher()
+	drainNestedWatchChanges(changes)
+	writeTestFile(t, physical, []byte(islandGSX+"\n// edit after shutdown\n"))
+	assertNoNestedWatchChange(t, changes, 75*time.Millisecond, "edit after watcher shutdown")
+}
+
+func awaitNestedWatchChange(t *testing.T, changes <-chan []string, want, label string) {
+	t.Helper()
+	if !awaitOptionalNestedWatchChange(changes, want, 2*time.Second) {
+		t.Fatalf("watcher did not report %s at exact source %s", label, want)
+	}
+}
+
+func awaitOptionalNestedWatchChange(changes <-chan []string, want string, timeout time.Duration) bool {
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case paths := <-changes:
+			if containsString(paths, want) {
+				return true
+			}
+		case <-deadline.C:
+			return false
+		}
+	}
+}
+
+func assertNoNestedWatchChange(t *testing.T, changes <-chan []string, timeout time.Duration, label string) {
+	t.Helper()
+	select {
+	case paths := <-changes:
+		t.Fatalf("watcher reported %s: %#v", label, paths)
+	case <-time.After(timeout):
+	}
+}
+
+func drainNestedWatchChanges(changes <-chan []string) {
+	for {
+		select {
+		case <-changes:
+		default:
+			return
+		}
+	}
+}
+
+func TestPollingQueuesMutationArrivingDuringOnChange(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "main.go")
+	writeTestFile(t, path, []byte("package main\n"))
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	var calls atomic.Int32
+	s := &Server{
+		Dir:          root,
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		OnChange: func() error {
+			if calls.Add(1) == 1 {
+				started <- struct{}{}
+				<-release
+			}
+			return nil
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		s.watchWithPolling(stop)
+	}()
+	defer func() {
+		close(stop)
+		unblock()
+		<-done
+	}()
+
+	time.Sleep(40 * time.Millisecond)
+	writeTestFile(t, path, []byte("package main\n// first\n"))
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("polling watcher did not observe first change")
+	}
+	writeTestFile(t, path, []byte("package main\n// second mutation while rebuilding\n"))
+	unblock()
+	deadline := time.Now().Add(2 * time.Second)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("polling watcher absorbed a mutation during OnChange; calls=%d, want at least 2", got)
+	}
+}
+
+func TestIsWatchedSourceEventAllowsDirectGSXAndOnlySelectedGo(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	unrelated := t.TempDir()
+	gsx := filepath.Join(external, "island.gsx")
+	goSource := filepath.Join(external, "bridge.go")
+	inactiveGo := filepath.Join(external, "inactive.go")
+	readme := filepath.Join(external, "README.md")
+	nested := filepath.Join(external, "nested", "island.gsx")
+	other := filepath.Join(unrelated, "island.gsx")
+	for path, data := range map[string][]byte{
+		gsx:        []byte("package external"),
+		goSource:   []byte("package external"),
+		inactiveGo: []byte("package external"),
+		readme:     []byte("ignored"),
+		nested:     []byte("package nested"),
+		other:      []byte("package unrelated"),
+	} {
+		writeTestFile(t, path, data)
+	}
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{goSource}, []string{goSource})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, path := range []string{gsx, goSource} {
+		if !isWatchedSourceEventForTargets(root, targets, fsnotify.Event{Name: path, Op: fsnotify.Write}) {
+			t.Fatalf("allowlisted dependency source %s was rejected", path)
+		}
+	}
+	if !isWatchedSourceEventForTargets(root, targets, fsnotify.Event{Name: external, Op: fsnotify.Remove}) {
+		t.Fatal("removing an allowlisted dependency package directory was rejected")
+	}
+	for _, event := range []fsnotify.Event{
+		{Name: inactiveGo, Op: fsnotify.Write},
+		{Name: readme, Op: fsnotify.Write},
+		{Name: nested, Op: fsnotify.Write},
+		{Name: other, Op: fsnotify.Write},
+		{Name: gsx, Op: fsnotify.Chmod},
+	} {
+		if isWatchedSourceEventForTargets(root, targets, event) {
+			t.Fatalf("unexpected external event accepted: %#v", event)
+		}
+	}
+}
+
+func TestWatchedSourceSnapshotReportsExternalChangesDeterministically(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	rootSource := filepath.Join(root, "z.go")
+	externalGo := filepath.Join(external, "a.go")
+	externalGSX := filepath.Join(external, "z.gsx")
+	writeTestFile(t, rootSource, []byte("package main\n"))
+	writeTestFile(t, externalGo, []byte("package external\n"))
+	writeTestFile(t, externalGSX, []byte("package external\n"))
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{externalGo}, []string{externalGo})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := watchedSourceSnapshotForTargets(root, targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	writeTestFile(t, externalGSX, []byte("package external\n// changed\n"))
+	if err := os.Remove(externalGo); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(external, "README.md"), []byte("ignored"))
+	after, err := watchedSourceSnapshotForTargets(root, targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{externalGo, externalGSX}
+	if got := changedWatchedPaths(before, after); !reflect.DeepEqual(got, want) {
+		t.Fatalf("changed watched paths = %#v, want sorted %#v", got, want)
+	}
+	if again := changedWatchedPaths(before, after); !reflect.DeepEqual(again, want) {
+		t.Fatalf("changed watched path order changed across runs: %#v", again)
+	}
+}
+
+func TestWatchedSourceSnapshotRejectsDependencySymlinkEscape(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	outsideDir := t.TempDir()
+	outside := filepath.Join(outsideDir, "outside.gsx")
+	writeTestFile(t, outside, []byte("package outside"))
+	if err := os.Symlink(outside, filepath.Join(external, "escape.gsx")); err != nil {
+		t.Fatal(err)
+	}
+	dirs, err := normalizeDependencyWatchDirs(root, []string{external})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := watchedSourceSnapshot(root, dirs); err == nil || !strings.Contains(err.Error(), "resolves outside allowlisted") {
+		t.Fatalf("dependency symlink escape snapshot error = %v", err)
+	}
+}
+
 func TestShouldWatchProjectFile(t *testing.T) {
 	for _, path := range []string{"page.gsx", "main.go", "style.CSS", "app.JS"} {
 		if !shouldWatchProjectFile(path) {
@@ -301,5 +1111,635 @@ func writeTestFile(t *testing.T, path string, data []byte) {
 	}
 	if err := os.WriteFile(path, data, 0644); err != nil {
 		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func frozenWriteDev(t *testing.T, filename string, data []byte) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(filename), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filename, data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func frozenRetarget(t *testing.T, logical, target string) {
+	t.Helper()
+	temporary := logical + ".next"
+	if err := os.Symlink(target, temporary); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Rename(temporary, logical); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func frozenStopWatcher(t *testing.T, stop chan struct{}, done <-chan struct{}) {
+	t.Helper()
+	close(stop)
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not stop")
+	}
+}
+
+func TestFrozenReviewerPureIslandNestedSourceRunsPreflightWithoutRestart(t *testing.T) {
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	physical := filepath.Join(external, "physical", "counter.gsx")
+	frozenWriteDev(t, physical, []byte(islandGSX))
+	logical := filepath.Join(external, "counter.gsx")
+	if err := os.Symlink(physical, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	preflight := make(chan []string, 8)
+	var restarts atomic.Int32
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{physical},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { restarts.Add(1); return nil },
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := s.watchWithFSNotify(stop); err != nil {
+			t.Errorf("watchWithFSNotify: %v", err)
+		}
+	}()
+	defer frozenStopWatcher(t, stop, done)
+
+	time.Sleep(75 * time.Millisecond)
+	frozenWriteDev(t, physical, []byte(islandGSX+"\n// physical edit\n"))
+	select {
+	case paths := <-preflight:
+		found := false
+		for _, changed := range paths {
+			if filepath.Clean(changed) == filepath.Clean(physical) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("preflight paths=%#v, want exact physical source %q", paths, physical)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("pure-island nested edit never reached global preflight")
+	}
+	time.Sleep(150 * time.Millisecond)
+	if got := restarts.Load(); got != 0 {
+		t.Fatalf("pure island edit restarted server %d times; hot swap should deliver only preflight/program", got)
+	}
+}
+
+func TestFrozenReviewerPollingHandlesValidNestedSymlinkRetarget(t *testing.T) {
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	first := filepath.Join(external, "first", "counter.gsx")
+	second := filepath.Join(external, "second", "counter.gsx")
+	frozenWriteDev(t, first, []byte(islandGSX))
+	frozenWriteDev(t, second, []byte(islandGSX+"\n// second target\n"))
+	logical := filepath.Join(external, "counter.gsx")
+	if err := os.Symlink(first, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	preflight := make(chan []string, 8)
+	var logMu sync.Mutex
+	var logs []string
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{first},
+		PollInterval: 10 * time.Millisecond,
+		Logf: func(format string, args ...any) {
+			logMu.Lock()
+			if len(logs) < 5 {
+				logs = append(logs, fmt.Sprintf(format, args...))
+			}
+			logMu.Unlock()
+		},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			current, err := filepath.EvalSymlinks(logical)
+			if err != nil {
+				return []string{external}, nil, nil, err
+			}
+			return []string{external}, []string{current}, nil, nil
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() { defer close(done); s.watchWithPolling(stop) }()
+	defer frozenStopWatcher(t, stop, done)
+
+	time.Sleep(50 * time.Millisecond)
+	frozenRetarget(t, logical, second)
+	select {
+	case paths := <-preflight:
+		found := false
+		for _, changed := range paths {
+			if filepath.Clean(changed) == filepath.Clean(second) || filepath.Clean(changed) == filepath.Clean(first) {
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("retarget preflight paths=%#v, want old or new exact target", paths)
+		}
+	case <-time.After(750 * time.Millisecond):
+		logMu.Lock()
+		joined := strings.Join(logs, "\n")
+		logMu.Unlock()
+		t.Fatalf("valid in-package symlink retarget never reached preflight/refresh; polling remained pinned to the old exact allowlist; logs:\n%s", joined)
+	}
+}
+
+func TestFrozenReviewerFSNotifyQueuesEditToNewTargetDuringRetargetRebuild(t *testing.T) {
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	first := filepath.Join(external, "first", "page.gsx")
+	second := filepath.Join(external, "second", "page.gsx")
+	serverSource := []byte("package dep\n\nfunc Page() Node {\n\treturn <main>one</main>\n}\n")
+	frozenWriteDev(t, first, serverSource)
+	frozenWriteDev(t, second, []byte("package dep\n\nfunc Page() Node {\n\treturn <main>two</main>\n}\n"))
+	logical := filepath.Join(external, "page.gsx")
+	if err := os.Symlink(first, logical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+
+	started := make(chan struct{}, 1)
+	release := make(chan struct{})
+	var releaseOnce sync.Once
+	unblock := func() { releaseOnce.Do(func() { close(release) }) }
+	defer unblock()
+	var calls atomic.Int32
+	preflight := make(chan []string, 8)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{first},
+		PollInterval: 10 * time.Millisecond,
+		Logf: func(format string, args ...any) {
+			t.Logf(format, args...)
+		},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error {
+			if calls.Add(1) == 1 {
+				started <- struct{}{}
+				<-release
+			}
+			return nil
+		},
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			current, err := filepath.EvalSymlinks(logical)
+			if err != nil {
+				return []string{external}, nil, nil, err
+			}
+			return []string{external}, []string{current}, nil, nil
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := s.watchWithFSNotify(stop); err != nil {
+			t.Errorf("watchWithFSNotify: %v", err)
+		}
+	}()
+	defer func() { unblock(); frozenStopWatcher(t, stop, done) }()
+
+	time.Sleep(75 * time.Millisecond)
+	frozenRetarget(t, logical, second)
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		select {
+		case paths := <-preflight:
+			t.Fatalf("symlink retarget reached preflight at %#v but did not start full rebuild", paths)
+		default:
+			t.Fatal("symlink retarget did not reach preflight or start full rebuild")
+		}
+	}
+	frozenWriteDev(t, second, []byte("package dep\n\nfunc Page() Node {\n\treturn <main>edited during rebuild</main>\n}\n"))
+	unblock()
+	deadline := time.Now().Add(1 * time.Second)
+	for calls.Load() < 2 && time.Now().Before(deadline) {
+		time.Sleep(10 * time.Millisecond)
+	}
+	if got := calls.Load(); got < 2 {
+		t.Fatalf("edit to newly retargeted physical source during blocked rebuild was missed before its parent watch was installed; rebuild calls=%d", got)
+	}
+}
+
+func TestFrozenReviewerFSNotifyObservesNestedHardlinkAliasMutation(t *testing.T) {
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	logical := filepath.Join(external, "counter.gsx")
+	frozenWriteDev(t, logical, []byte(islandGSX))
+	alias := filepath.Join(external, "physical", "counter-alias.gsx")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(logical, alias); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+
+	preflight := make(chan []string, 8)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{logical},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := s.watchWithFSNotify(stop); err != nil {
+			t.Errorf("watchWithFSNotify: %v", err)
+		}
+	}()
+	defer frozenStopWatcher(t, stop, done)
+
+	time.Sleep(75 * time.Millisecond)
+	frozenWriteDev(t, alias, []byte(islandGSX+"\n// nested hardlink mutation\n"))
+	select {
+	case <-preflight:
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("nested hardlink alias changed the discovery-authoritative inode, but fsnotify watched only the top-level directory entry and missed the mutation")
+	}
+}
+
+func TestDependencySnapshotDetectsHardlinkAliasSameMetadataMutation(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	logical := filepath.Join(external, "counter.gsx")
+	original := []byte(islandGSX)
+	frozenWriteDev(t, logical, original)
+	alias := filepath.Join(external, "physical", "counter-alias.gsx")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(logical, alias); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{logical}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := []byte(strings.Replace(string(original), "Counter", "Changed", 1))
+	if len(replacement) != len(original) {
+		t.Fatalf("same-size hardlink fixture changed length: %d != %d", len(replacement), len(original))
+	}
+	frozenWriteDev(t, alias, replacement)
+	if err := os.Chtimes(alias, info.ModTime(), info.ModTime()); err != nil {
+		t.Skipf("cannot restore hardlink timestamps: %v", err)
+	}
+	after, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := changedWatchedPaths(before, after), []string{logical}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("same-size/same-mtime hardlink mutation changes = %#v, want authoritative source %#v", got, want)
+	}
+}
+
+func TestDependencySnapshotDetectsGoHardlinkAliasSameMetadataMutation(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	logical := filepath.Join(external, "bridge.go")
+	original := []byte("package dep\n\nvar Bridge = \"old\"\n")
+	frozenWriteDev(t, logical, original)
+	alias := filepath.Join(external, "physical", "bridge-alias.go")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(logical, alias); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{logical}, []string{logical})
+	if err != nil {
+		t.Fatal(err)
+	}
+	before, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	replacement := []byte("package dep\n\nvar Bridge = \"new\"\n")
+	if len(replacement) != len(original) {
+		t.Fatalf("same-size hardlink fixture changed length: %d != %d", len(replacement), len(original))
+	}
+	frozenWriteDev(t, alias, replacement)
+	if err := os.Chtimes(alias, info.ModTime(), info.ModTime()); err != nil {
+		t.Skipf("cannot restore hardlink timestamps: %v", err)
+	}
+	after, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := changedWatchedPaths(before, after), []string{logical}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("same-size/same-mtime Go hardlink mutation changes = %#v, want authoritative source %#v", got, want)
+	}
+}
+
+func TestDependencySnapshotCanonicalCollisionRetainsContentHash(t *testing.T) {
+	root := t.TempDir()
+	external := t.TempDir()
+	physical := filepath.Join(external, "physical", "source")
+	content := []byte("package dep\n")
+	frozenWriteDev(t, physical, content)
+	gsxLogical := filepath.Join(external, "component.gsx")
+	goLogical := filepath.Join(external, "bridge.go")
+	if err := os.Symlink(physical, gsxLogical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	if err := os.Symlink(physical, goLogical); err != nil {
+		t.Skipf("symlinks unavailable: %v", err)
+	}
+	targets, err := normalizeDependencyWatchTargets(root, []string{external}, []string{physical}, []string{physical})
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	entry, ok := snapshot[physical]
+	if !ok {
+		t.Fatalf("canonical collision snapshot = %#v, want physical source %q", snapshot, physical)
+	}
+	if !entry.HasContentHash || entry.ContentHash != sha256.Sum256(content) {
+		t.Fatalf("canonical collision downgraded content identity: %#v", entry)
+	}
+}
+
+func TestFSNotifyObservesGoHardlinkAliasSameMetadataMutation(t *testing.T) {
+	runGoHardlinkAliasSameMetadataWatcherTest(t, false)
+}
+
+func TestPollingObservesGoHardlinkAliasSameMetadataMutation(t *testing.T) {
+	runGoHardlinkAliasSameMetadataWatcherTest(t, true)
+}
+
+func runGoHardlinkAliasSameMetadataWatcherTest(t *testing.T, polling bool) {
+	t.Helper()
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	logical := filepath.Join(external, "bridge.go")
+	original := []byte("package dep\n\nvar Bridge = \"old\"\n")
+	frozenWriteDev(t, logical, original)
+	alias := filepath.Join(external, "physical", "bridge-alias.go")
+	if err := os.MkdirAll(filepath.Dir(alias), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Link(logical, alias); err != nil {
+		t.Skipf("hardlinks unavailable: %v", err)
+	}
+	info, err := os.Stat(logical)
+	if err != nil {
+		t.Fatal(err)
+	}
+	preflight := make(chan []string, 1)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{logical},
+		WatchGoFiles: []string{logical},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if polling {
+			s.watchWithPolling(stop)
+			return
+		}
+		if err := s.watchWithFSNotify(stop); err != nil {
+			t.Errorf("watchWithFSNotify: %v", err)
+		}
+	}()
+	defer frozenStopWatcher(t, stop, done)
+
+	time.Sleep(75 * time.Millisecond)
+	replacement := []byte("package dep\n\nvar Bridge = \"new\"\n")
+	if len(replacement) != len(original) {
+		t.Fatalf("same-size hardlink fixture changed length: %d != %d", len(replacement), len(original))
+	}
+	frozenWriteDev(t, alias, replacement)
+	if err := os.Chtimes(alias, info.ModTime(), info.ModTime()); err != nil {
+		t.Skipf("cannot restore hardlink timestamps: %v", err)
+	}
+	select {
+	case got := <-preflight:
+		if want := []string{logical}; !reflect.DeepEqual(got, want) {
+			t.Fatalf("same-size/same-mtime Go hardlink mutation paths = %#v, want authoritative source %#v", got, want)
+		}
+	case <-time.After(750 * time.Millisecond):
+		t.Fatal("same-size/same-mtime mutation through nested Go hardlink alias was not delivered")
+	}
+}
+
+func TestDependencySnapshotAdmitsOnlySelectedActiveGoAndDirectGSX(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("fixture pins Linux active/inactive source names")
+	}
+	root := t.TempDir()
+	external := t.TempDir()
+	activeGo := filepath.Join(external, "bridge_linux.go")
+	inactiveGo := filepath.Join(external, "bridge_windows.go")
+	directGSX := filepath.Join(external, "counter.gsx")
+	nestedGo := filepath.Join(external, "nested", "neighbor.go")
+	nestedGSX := filepath.Join(external, "nested", "neighbor.gsx")
+	unrelated := filepath.Join(external, "notes.txt")
+	activeBytes := []byte("//go:build linux\n\npackage dep\n")
+	gsxBytes := []byte(islandGSX)
+	frozenWriteDev(t, activeGo, activeBytes)
+	frozenWriteDev(t, inactiveGo, []byte("//go:build windows\n\npackage dep\n"))
+	frozenWriteDev(t, directGSX, gsxBytes)
+	frozenWriteDev(t, nestedGo, []byte("package dep\n"))
+	frozenWriteDev(t, nestedGSX, []byte("package dep\n"))
+	frozenWriteDev(t, unrelated, []byte("not source\n"))
+
+	targets, err := normalizeDependencyWatchTargets(
+		root,
+		[]string{external},
+		[]string{directGSX, activeGo},
+		[]string{activeGo},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	snapshot, err := dependencySourceSnapshotForTargets(targets)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(snapshot) != 2 {
+		t.Fatalf("dependency snapshot = %#v, want only active Go and direct GSX", snapshot)
+	}
+	for path, hash := range map[string][sha256.Size]byte{
+		activeGo:  sha256.Sum256(activeBytes),
+		directGSX: sha256.Sum256(gsxBytes),
+	} {
+		entry, ok := snapshot[path]
+		if !ok || !entry.HasContentHash || entry.ContentHash != hash {
+			t.Fatalf("admitted source %q snapshot = %#v, want content hash %x", path, entry, hash)
+		}
+	}
+	for _, path := range []string{inactiveGo, nestedGo, nestedGSX, unrelated} {
+		if _, ok := snapshot[path]; ok {
+			t.Fatalf("non-input source %q entered dependency snapshot: %#v", path, snapshot)
+		}
+	}
+}
+
+func TestFSNotifyActiveGoSelectionBoundary(t *testing.T) {
+	runActiveGoSelectionWatcherTest(t, false)
+}
+
+func TestPollingActiveGoSelectionBoundary(t *testing.T) {
+	runActiveGoSelectionWatcherTest(t, true)
+}
+
+func runActiveGoSelectionWatcherTest(t *testing.T, polling bool) {
+	t.Helper()
+	if runtime.GOOS != "linux" {
+		t.Skip("fixture pins Linux active/inactive source names")
+	}
+	root := t.TempDir()
+	frozenWriteDev(t, filepath.Join(root, "main.go"), []byte("package main\n"))
+	external := t.TempDir()
+	activeGo := filepath.Join(external, "bridge_linux.go")
+	inactiveGo := filepath.Join(external, "bridge_windows.go")
+	frozenWriteDev(t, activeGo, []byte("//go:build linux\n\npackage dep\n"))
+	frozenWriteDev(t, inactiveGo, []byte("//go:build windows\n\npackage dep\n"))
+
+	var selectionMu sync.RWMutex
+	selected := []string{activeGo}
+	currentSelection := func() []string {
+		selectionMu.RLock()
+		defer selectionMu.RUnlock()
+		return append([]string(nil), selected...)
+	}
+	preflight := make(chan []string, 16)
+	s := &Server{
+		Dir:          root,
+		WatchDirs:    []string{external},
+		WatchFiles:   []string{activeGo},
+		WatchGoFiles: []string{activeGo},
+		PollInterval: 10 * time.Millisecond,
+		Logf:         func(string, ...any) {},
+		PreflightChange: func(paths []string) error {
+			preflight <- append([]string(nil), paths...)
+			return nil
+		},
+		OnChange: func() error { return nil },
+		RefreshWatchTargets: func() ([]string, []string, []string, error) {
+			active := currentSelection()
+			return []string{external}, active, active, nil
+		},
+	}
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if polling {
+			s.watchWithPolling(stop)
+			return
+		}
+		if err := s.watchWithFSNotify(stop); err != nil {
+			t.Errorf("watchWithFSNotify: %v", err)
+		}
+	}()
+	defer frozenStopWatcher(t, stop, done)
+
+	time.Sleep(75 * time.Millisecond)
+	frozenWriteDev(t, inactiveGo, []byte("//go:build windows\n\npackage dep\n// inactive edit\n"))
+	select {
+	case got := <-preflight:
+		t.Fatalf("inactive direct Go edit reached preflight: %#v", got)
+	case <-time.After(250 * time.Millisecond):
+	}
+
+	frozenWriteDev(t, activeGo, []byte("//go:build linux\n\npackage dep\n// active edit\n"))
+	assertWatchPreflightContains(t, preflight, activeGo, "active Go edit")
+	drainWatchPreflight(preflight)
+
+	selectionMu.Lock()
+	selected = []string{activeGo, inactiveGo}
+	selectionMu.Unlock()
+	frozenWriteDev(t, inactiveGo, []byte("//go:build linux\n\npackage dep\n// activated\n"))
+	assertWatchPreflightContains(t, preflight, inactiveGo, "inactive-to-active Go transition")
+}
+
+func assertWatchPreflightContains(t *testing.T, changes <-chan []string, want, label string) {
+	t.Helper()
+	deadline := time.After(2 * time.Second)
+	for {
+		select {
+		case paths := <-changes:
+			for _, path := range paths {
+				if filepath.Clean(path) == filepath.Clean(want) {
+					return
+				}
+			}
+		case <-deadline:
+			t.Fatalf("%s never reached preflight for %q", label, want)
+		}
+	}
+}
+
+func drainWatchPreflight(changes <-chan []string) {
+	for {
+		select {
+		case <-changes:
+		default:
+			return
+		}
 	}
 }

--- a/examples/gosx-docs/app/docs/compiler/page.gsx
+++ b/examples/gosx-docs/app/docs/compiler/page.gsx
@@ -28,7 +28,7 @@ func Page() Node {
 		<div class="page-topper">
 			<span class="eyebrow">Language pipeline</span>
 			<p class="lede">
-				A single parser and IR serve both GSX component spellings. Strict declarations add a fail-closed typed boundary and are the only spelling GoSX teaches. The legacy Go-function form still parses for existing code, islands, engines, and loader-bound routes.
+				A single parser and IR serve both GSX component spellings. Strict declarations add a fail-closed typed boundary and are the only spelling GoSX teaches. The legacy Go-function form still parses for existing code, engines, and loader-bound routes. Strict islands use the supported client-VM subset and fail closed outside it.
 			</p>
 		</div>
 		<h2 id="source-model">GSX source model</h2>
@@ -111,7 +111,11 @@ func Page() Node {
 		<p>
 			An island is marked by
 			<span class="inline-code">//gosx:island</span>
-			. In v0.39, island and engine directives use the legacy Go-function component style. Their recognized signal, computed, and handler declarations are lowered with the returned markup into a compact program for the shared browser VM; applying a client directive to a strict declaration fails closed.
+			. Strict and legacy island declarations lower their recognized signal, computed, and handler declarations with the returned markup into a compact program for the shared browser VM. Strict engine declarations and automatic
+			<span class="inline-code">.gsx //gosx:engine</span>
+			discovery remain preview/post-v1; programmatic
+			<span class="inline-code">engine.Config</span>
+			is the v1 engine surface.
 		</p>
 		<CodeBlock lang="gosx" source={data.islandSample} />
 		<p>

--- a/examples/gosx-docs/app/docs/compiler/page.server.go
+++ b/examples/gosx-docs/app/docs/compiler/page.server.go
@@ -65,7 +65,7 @@ type Component struct {
 				"islandSample": `package counter
 
 //gosx:island
-func Counter() Node {
+component Counter() {
 	count := signal.New(0)
 	return <button data-on-click="count.Set(count.Get() + 1)">
 		{count.Get()}

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -18,7 +18,7 @@ func Page() Node {
 			<span class="inline-code">component Name(props: Type)</span>
 			. GoSX still runs the older Go-function spelling,
 			<span class="inline-code">func Name(...) Node</span>
-			, for islands, engines, and loader-bound routes. See "Legacy components (deprecated)" below for that spelling. This page does not teach it to a new author.
+			, for existing applications, engines, and loader-bound routes. Strict components can hydrate as islands when they stay within the supported island VM subset. See "Legacy components (deprecated)" below for the older spelling. This page does not teach it to a new author.
 		</p>
 		<section class="feature-grid">
 			<div class="card">
@@ -33,7 +33,7 @@ func Page() Node {
 				<strong>Legacy (deprecated)</strong>
 				<p>
 					<span class="inline-code">func Name(...) Node</span>
-					still runs, but it is deprecated for ordinary server components. Islands, engines, and loader-bound routes still need it. See below.
+					still runs, but it is deprecated for ordinary server components. Engines and loader-bound routes still need it; supported strict islands do not. See below.
 				</p>
 			</div>
 		</section>
@@ -216,7 +216,11 @@ func Page() Node {
 			<span class="inline-code">If</span>
 			, and
 			<span class="inline-code">Slot</span>
-			structural builtins. Islands and engines also use this form in v0.39; strict client directives fail closed until their browser and server paths can preserve the typed contract.
+			structural builtins. Islands may instead use the strict component form when they stay within the supported island VM subset. Strict engine declarations and automatic
+			<span class="inline-code">.gsx //gosx:engine</span>
+			discovery remain preview/post-v1; programmatic
+			<span class="inline-code">engine.Config</span>
+			is the v1 engine surface.
 		</p>
 		<h2 id="attributes">Elements and attributes</h2>
 		<p>
@@ -293,18 +297,18 @@ func Page() Node {
 		<p>
 			Declare every new server component with
 			<span class="inline-code">component Name(props: Type)</span>
-			. The legacy Go-function form remains necessary in three cases only, all structural limits of the current release, not a style choice.
+			. The legacy Go-function form remains necessary in two cases only, both structural limits of the current release, not a style choice.
 		</p>
 		<ul>
 			<li>
 				A route reads loader data, route params, structural control flow, or a helper-rich body that the strict expression subset does not cover yet.
 			</li>
 			<li>
-				A component hydrates client-side as an island. Strict islands are not supported yet.
-			</li>
-			<li>
 				A component runs as an engine (canvas, WebGL, WebGPU, or a background worker). Strict engines are not supported yet.
 			</li>
 		</ul>
+		<p>
+			A strict component may hydrate client-side as an island when its body stays within the supported island VM subset. Project-aware checks fail closed when an island uses an unsupported expression or client operation.
+		</p>
 	</article>
 }

--- a/examples/gosx-docs/app/docs/engines/page.gsx
+++ b/examples/gosx-docs/app/docs/engines/page.gsx
@@ -48,6 +48,13 @@ func Page() Node {
 			.
 		</p>
 		<p>
+			This programmatic
+			<span class="inline-code">engine.Config</span>
+			path is the v1 engine surface. Strict engine declarations and automatic
+			<span class="inline-code">.gsx //gosx:engine</span>
+			discovery remain preview/post-v1.
+		</p>
+		<p>
 			Engines own only their declared mount and communicate through props and events. They are separate from island DOM state and from the shared island VM.
 		</p>
 		<h2 id="mounting">Mounting an engine</h2>

--- a/examples/gosx-docs/app/docs/islands/page.server.go
+++ b/examples/gosx-docs/app/docs/islands/page.server.go
@@ -21,8 +21,8 @@ func init() {
 					{"href": "#program-assets", "label": "Program Assets"},
 					{"href": "#choosing", "label": "Choosing Islands"},
 				},
-				"counterSample": "package counter\n\n//gosx:island\nfunc Counter() Node {\n\tcount := signal.New(0)\n\tincrement := func() { count.Set(count.Get() + 1) }\n\tdecrement := func() { count.Set(count.Get() - 1) }\n\treturn <div class=\"counter\">\n\t\t<button onClick={decrement}>-</button>\n\t\t<span>{count.Get()}</span>\n\t\t<button onClick={increment}>+</button>\n\t</div>\n}",
-				"sharedSample":  "//gosx:island\nfunc ThemeSwitch() Node {\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\ttoggle := func() {\n\t\ttheme.Set(theme.Get() == \"dark\" ? \"light\" : \"dark\")\n\t}\n\treturn <button onClick={toggle}>{theme.Get()}</button>\n}",
+				"counterSample": "package counter\n\n//gosx:island\ncomponent Counter() {\n\tcount := signal.New(0)\n\tincrement := func() { count.Set(count.Get() + 1) }\n\tdecrement := func() { count.Set(count.Get() - 1) }\n\treturn <div class=\"counter\">\n\t\t<button onClick={decrement}>-</button>\n\t\t<span>{count.Get()}</span>\n\t\t<button onClick={increment}>+</button>\n\t</div>\n}",
+				"sharedSample":  "//gosx:island\ncomponent ThemeSwitch() {\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\ttoggle := func() {\n\t\ttheme.Set(theme.Get() == \"dark\" ? \"light\" : \"dark\")\n\t}\n\treturn <button onClick={toggle}>{theme.Get()}</button>\n}",
 				"assetSample":   "node := ctx.Runtime().IslandWithProgramAsset(\n\tcounterProgram,\n\tmap[string]int{\"initial\": 2},\n\t\"/islands/Counter.bin\",\n\t\"bin\",\n\tcounterHash,\n)",
 			}, nil
 		},

--- a/examples/gosx-docs/app/docs/signals/page.server.go
+++ b/examples/gosx-docs/app/docs/signals/page.server.go
@@ -26,7 +26,7 @@ func init() {
 				"deriveSample": "first := signal.New(\"Ada\")\nlast := signal.New(\"Lovelace\")\nfull := signal.Derive(func() string {\n\treturn first.Get() + \" \" + last.Get()\n})\ndefer full.Stop()\n\nfmt.Println(full.Get())",
 				"watchSample":  "effect := signal.Watch(func() {\n\tlog.Printf(\"total changed: %d\", total.Get())\n})\ndefer effect.Dispose()",
 				"batchSample":  "signal.Batch(func() {\n\tfirst.Set(\"Grace\")\n\tlast.Set(\"Hopper\")\n})",
-				"islandSample": "//gosx:island\nfunc Counter() Node {\n\tcount := signal.New(0)\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\tincrement := func() { count.Set(count.Get() + 1) }\n\treturn <button class={theme.Get()} onClick={increment}>\n\t\t{count.Get()}\n\t</button>\n}",
+				"islandSample": "//gosx:island\ncomponent Counter() {\n\tcount := signal.New(0)\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\tincrement := func() { count.Set(count.Get() + 1) }\n\treturn <button class={theme.Get()} onClick={increment}>\n\t\t{count.Get()}\n\t</button>\n}",
 			}, nil
 		},
 	})

--- a/examples/gosx-docs/app/docs/typed-live/page.gsx
+++ b/examples/gosx-docs/app/docs/typed-live/page.gsx
@@ -27,7 +27,11 @@ component Page() {
 			<ContractRow label="Runtime" value="server HTML" />
 		</ul>
 		<p className="typed-proof__boundary">
-			The strict form is deliberately server-only in v0.39. Routes that need loader data, control flow, islands, or engines continue to use the legacy Go-function style.
+			Strict components render on the server, and a strict component marked
+			<span className="inline-code">//gosx:island</span>
+			may hydrate the supported island VM subset. Strict engine declarations remain preview/post-v1; use programmatic
+			<span className="inline-code">engine.Config</span>
+			for the v1 engine surface.
 		</p>
 		<a
 			className="typed-proof__source"

--- a/examples/gosx-docs/docs_truth_test.go
+++ b/examples/gosx-docs/docs_truth_test.go
@@ -123,6 +123,7 @@ func TestRuntimeDeploymentSceneAndRelayDocsUseCurrentContracts(t *testing.T) {
 				// page has to name them, or it contradicts README.md.
 				"typed legacy",
 				"untyped legacy",
+				"A strict component may hydrate client-side as an island",
 				"gosx export .",
 			},
 			forbidden: []string{
@@ -133,6 +134,8 @@ func TestRuntimeDeploymentSceneAndRelayDocsUseCurrentContracts(t *testing.T) {
 				// stated. A typed legacy component now takes part in strict
 				// calls in both directions.
 				"v0.39 keeps component calls within the same style",
+				"Strict islands are not supported yet",
+				"Islands, engines, and loader-bound routes still need it",
 			},
 		},
 		{

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -117,11 +117,11 @@ func ValidateWarnings(prog *Program) []Diagnostic {
 // TYPED legacy component whose props struct is declared in this file
 // (Component.PropsTyped), is excluded — see the zero-props census in
 // gosx's untyped-legacy-warning change for why zero-props legacy functions
-// stay silent here. An engine or island component is excluded too, because
-// strict syntax rejects both outright today (see the "strict engine
-// declarations are not supported" and "strict island declarations are not
-// supported" diagnostics in lowerStrictComponentDecl) — the warning must
-// never recommend a form the compiler itself refuses.
+// stay silent here. Engine and island components are also excluded by the
+// current migration-warning policy. Strict islands are supported; extending
+// this legacy retirement warning to them is a separate v1 migration change.
+// Strict engines remain unsupported and automatic .gsx engine discovery is
+// preview/post-v1.
 func untypedLegacyPropsWarning(comp *Component) []Diagnostic {
 	if comp.Syntax != ComponentSyntaxLegacy || comp.PropsTyped || comp.IsEngine || comp.IsIsland {
 		return nil

--- a/island/island.go
+++ b/island/island.go
@@ -755,6 +755,9 @@ func (r *Renderer) ApplyBuildManifest(manifest *buildmanifest.Manifest, assetBas
 	if manifest == nil {
 		return fmt.Errorf("build manifest is nil")
 	}
+	if err := manifest.ValidateIslandAssets(); err != nil {
+		return fmt.Errorf("apply build manifest: %w", err)
+	}
 
 	runtime := manifest.RuntimeURLs(assetBaseURL)
 	r.runtimeAssets = manifest.Runtime

--- a/island/island_test.go
+++ b/island/island_test.go
@@ -764,6 +764,30 @@ func TestApplyBuildManifestUsesHashedRuntimeAndIslandAssets(t *testing.T) {
 	}
 }
 
+func TestApplyBuildManifestRejectsAmbiguousIslandAssetsBeforeMutation(t *testing.T) {
+	r := NewRenderer("main")
+	manifest := &buildmanifest.Manifest{Islands: []buildmanifest.IslandAsset{
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.aaaaaaaa.gxi", Hash: "aaaaaaaa", Size: 1},
+		},
+		{
+			Name:        "Counter",
+			Format:      "bin",
+			HashedAsset: buildmanifest.HashedAsset{File: "Counter.bbbbbbbb.gxi", Hash: "bbbbbbbb", Size: 1},
+		},
+	}}
+
+	err := r.ApplyBuildManifest(manifest, "/gosx/assets")
+	if err == nil || !strings.Contains(err.Error(), "duplicate island asset name \"Counter\"") {
+		t.Fatalf("ApplyBuildManifest error = %v, want ambiguous island rejection", err)
+	}
+	if asset, ok := r.programAssets["Counter"]; ok {
+		t.Fatalf("ApplyBuildManifest partially installed an ambiguous asset: %+v", asset)
+	}
+}
+
 func TestScene3DWebGPUFeatureLoaderCarriesGoSXScriptProvenance(t *testing.T) {
 	r := NewRenderer("main")
 	manifest := &buildmanifest.Manifest{Runtime: buildmanifest.RuntimeAssets{


### PR DESCRIPTION
## Summary

- Enforce strict island discovery identity and active-source watch boundaries consistently across dev and desktop.
- Preserve stronger content fingerprints on canonical collisions while excluding inactive Go inputs and unrelated neighbors.
- Final reviewed scope: **29 files, +4,643/−216**.

## B4–B10 verification

- [Exact corrected head](https://github.com/odvcencio/gosx/commit/8d978f3e345e99dea11cbf72abc60c647293a7ed)
- [Full diff against governed main](https://github.com/odvcencio/gosx/compare/2702b37fade7f5436574706acd9e929b0c34bf41...8d978f3e345e99dea11cbf72abc60c647293a7ed)
- Focused B4–B10 inactive/active/Cgo/discovery/fsnotify/polling/preflight/shutdown suites passed under -race -count=3.
- Full cmd/gosx and dev packages, adjacent buildmanifest/IR/island/docs tests, R0 renderer governance, the ten-step release gate, fmt, vet, actionlint, diff, and JS size/closure gates passed.

## Clean-cache CI correction

The [first exact-head CI run](https://github.com/odvcencio/gosx/actions/runs/33305913471) passed release, Go unit/race/CLI, JS, and WASM jobs but exposed a real clean-module-cache docs startup defect in browser-tests: successful go list -json output was combined with go: downloading stderr and then decoded as JSON.

- [Correction diff](https://github.com/odvcencio/gosx/compare/52d363b3f6effc0bf43f2efb134cc606df7c5b7f...8d978f3e345e99dea11cbf72abc60c647293a7ed): 2 files, +71/−3.
- The helper now decodes stdout only on success while preserving stderr-first diagnostics on command failure.
- Read-only GOFLAGS, GOWORK=off, normal and -e fallback argument order, and fail-closed fallback semantics remain unchanged.
- Fake-go regressions cover valid stdout JSON plus stderr chatter and nonzero exit with retained diagnostics.
- The formerly failing TestDocsSiteServes passed twice with brand-new module caches (77.94s implementation verification; 77.19s independent review).

## Independent review

**APPROVE** for corrected head 8d978f3e345e99dea11cbf72abc60c647293a7ed.

Independent checks included the committed stream tests at -race -count=50, a 20× race overlay covering stderr/stdout/process-error fallbacks and exact normal/-e readonly invocations, proportional B4–B10 race suites, a fresh clean-cache browser E2E pass, vet, formatting, and diff checks.

Final binary diff SHA-256: 1c59804c541b91e881e47713e572055727388d34612a43f6376f6475a8a2cf2a. Final stable patch ID: 47d9b6181a78eaa5923f168165bd47db77530f60.