### PR TITLE
feat(image): add consumer-backed art direction sources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 ### Added: consumer-backed image art direction
 
-- `server.ImageProps.Sources` accepts ordered `server.ImageSource` entries with `srcset`, `media`, `sizes`, and `type`. A non-empty source list opts the existing fallback `<img>` into native `<picture>` markup; source order is preserved because the browser's first matching source wins.
-- The file-routed `<Image>` builtin accepts the same contract through `sources={...}`. Authored art-direction sources precede any generic format source generated from the build manifest, so a media-specific crop cannot be shadowed by an unconditional WebP source.
+- `server.ImageProps.Sources` accepts ordered `server.ImageSource` entries with `srcset`, `media`, `sizes`, `type`, and optional positive `width`/`height`. A non-empty source list opts the existing fallback `<img>` into native `<picture>` markup; source order is preserved because the browser's first matching source wins, while per-source dimensions reserve the correct box for crops with a different aspect ratio.
+- `server.ImageProps.PictureAttrs` applies a distinct `gosx.AttrList` to the `<picture>` wrapper. Existing variadic attributes remain on the fallback `<img>`, and wrapper attributes alone do not create a wrapper. The file-routed `<Image>` builtin maps `pictureAttrs={...}` from an `AttrList` or a deterministically ordered string-keyed map and consumes the prop instead of leaking it onto the image.
+- The file-routed `<Image>` builtin accepts the source contract through `sources={...}`. Authored art-direction sources precede any generic format source generated from the build manifest, so a media-specific crop cannot be shadowed by an unconditional WebP source.
 - Source candidates remain author-owned: GoSX escapes them into HTML but does not fetch, cache, or rewrite remote media, and no client JavaScript is added. This slice follows the real Muddy Noni storefront layout that already had to hand-author mobile `<source media>` candidates.
 
 ## v0.55.2 (2026-09-04)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Added: consumer-backed image art direction
+
+- `server.ImageProps.Sources` accepts ordered `server.ImageSource` entries with `srcset`, `media`, `sizes`, and `type`. A non-empty source list opts the existing fallback `<img>` into native `<picture>` markup; source order is preserved because the browser's first matching source wins.
+- The file-routed `<Image>` builtin accepts the same contract through `sources={...}`. Authored art-direction sources precede any generic format source generated from the build manifest, so a media-specific crop cannot be shadowed by an unconditional WebP source.
+- Source candidates remain author-owned: GoSX escapes them into HTML but does not fetch, cache, or rewrite remote media, and no client JavaScript is added. This slice follows the real Muddy Noni storefront layout that already had to hand-author mobile `<source media>` candidates.
+
 ## v0.55.2 (2026-09-04)
 
 ### Fixed: comments inside GSX markup compile away

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ a same-origin root-relative path, with unsafe values resolving to `/`.
 
 **Streaming** — Deferred page regions via `ctx.Defer()` and component-level `ctx.Suspense()` boundaries render fallback content immediately, then stream resolved content into place as each boundary completes.
 
-**Image and Font Optimization** — Local image handler at `/_gosx/image` with resize, format conversion, immutable caching, auto responsive `server.Image` markup, and a `server.Font` helper for preload plus `@font-face`.
+**Image and Font Optimization** — Local image handler at `/_gosx/image` with resize, format conversion, immutable caching, auto responsive `server.Image` markup, ordered `server.ImageSource` art direction through native `<picture>` markup, and a `server.Font` helper for preload plus `@font-face`.
 
 **Routing and Edge** — Server middleware can be annotated with `app.UseEdge`, and `app.UseI18n` adds locale-prefix routing that composes with both `server.App` and file routing.
 

--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ a same-origin root-relative path, with unsafe values resolving to `/`.
 
 **Streaming** — Deferred page regions via `ctx.Defer()` and component-level `ctx.Suspense()` boundaries render fallback content immediately, then stream resolved content into place as each boundary completes.
 
-**Image and Font Optimization** — Local image handler at `/_gosx/image` with resize, format conversion, immutable caching, auto responsive `server.Image` markup, ordered `server.ImageSource` art direction through native `<picture>` markup, and a `server.Font` helper for preload plus `@font-face`.
+**Image and Font Optimization** — Local image handler at `/_gosx/image` with resize, format conversion, immutable caching, auto responsive `server.Image` markup, ordered `server.ImageSource` art direction through native `<picture>` markup with explicit wrapper attributes and per-crop dimensions, and a `server.Font` helper for preload plus `@font-face`.
 
 **Routing and Edge** — Server middleware can be annotated with `app.UseEdge`, and `app.UseI18n` adds locale-prefix routing that composes with both `server.App` and file routing.
 

--- a/cmd/gosx/templates/docs/app/docs/images/page.gsx
+++ b/cmd/gosx/templates/docs/app/docs/images/page.gsx
@@ -57,6 +57,12 @@ func Page() Node {
 					The optimizer is still just an HTTP endpoint. No client framework magic is required.
 				</p>
 			</div>
+			<div class="card">
+				<strong>Art direction</strong>
+				<p>
+					Ordered server.ImageSource entries add media-specific crops through native picture markup, with no browser JavaScript or remote fetching.
+				</p>
+			</div>
 		</section>
 		<pre class="code-block">
 			{`server.Image(server.ImageProps{
@@ -65,6 +71,18 @@ func Page() Node {
 		    Width:  960,
 		    Height: 624,
 		    Widths: []int{320, 640, 960},
+		})`}
+		</pre>
+		<pre class="code-block">
+			{`server.Image(server.ImageProps{
+		    Src:    "https://images.example.com/hero-wide.jpg",
+		    Alt:    "Potter shaping clay",
+		    Width:  1600,
+		    Height: 1200,
+		    Sources: []server.ImageSource{{
+		        Media:  "(max-width: 600px)",
+		        SrcSet: "https://images.example.com/hero-tight.jpg 800w",
+		    }},
 		})`}
 		</pre>
 		<div class="hero-actions">

--- a/cmd/gosx/templates/docs/app/docs/images/page.gsx
+++ b/cmd/gosx/templates/docs/app/docs/images/page.gsx
@@ -60,7 +60,7 @@ func Page() Node {
 			<div class="card">
 				<strong>Art direction</strong>
 				<p>
-					Ordered server.ImageSource entries add media-specific crops through native picture markup, with no browser JavaScript or remote fetching.
+					Ordered server.ImageSource entries add media-specific crops through native picture markup, with per-crop dimensions and explicit wrapper attributes.
 				</p>
 			</div>
 		</section>
@@ -78,12 +78,28 @@ func Page() Node {
 		    Src:    "https://images.example.com/hero-wide.jpg",
 		    Alt:    "Potter shaping clay",
 		    Width:  1600,
-		    Height: 1200,
+		    Height: 900,
 		    Sources: []server.ImageSource{{
 		        Media:  "(max-width: 600px)",
 		        SrcSet: "https://images.example.com/hero-tight.jpg 800w",
+		        Width:   800,
+		        Height:  1000,
 		    }},
+		    PictureAttrs: gosx.Attrs(
+		        gosx.Attr("class", "responsive-picture"),
+		    ),
 		})`}
+		</pre>
+		<pre class="code-block">
+			{`<Image
+		    src={data.hero}
+		    alt="Potter shaping clay"
+		    width={1600}
+		    height={900}
+		    sources={data.sources}
+		    pictureAttrs={data.pictureAttrs}
+		    class="hero-image"
+		/>`}
 		</pre>
 		<div class="hero-actions">
 			<Link class="cta-link" href="/docs/runtime">Back to runtime</Link>

--- a/examples/gosx-docs/app/docs/images/page.gsx
+++ b/examples/gosx-docs/app/docs/images/page.gsx
@@ -122,6 +122,7 @@ func Page() Node {
 		</p>
 		<h2 id="art-direction">Art direction</h2>
 		<CodeBlock lang="go" source={data.artDirectionSample} />
+		<CodeBlock lang="go" source={data.builtinArtDirectionSample} />
 		<p>
 			Use ordered
 			<span class="inline-code">server.ImageSource</span>
@@ -139,9 +140,34 @@ func Page() Node {
 			<span class="inline-code">media</span>
 			,
 			<span class="inline-code">sizes</span>
-			, and
+			,
 			<span class="inline-code">type</span>
+			,
+			<span class="inline-code">width</span>
+			, and
+			<span class="inline-code">height</span>
 			keys.
+		</p>
+		<p>
+			Set positive source
+			<span class="inline-code">Width</span>
+			and
+			<span class="inline-code">Height</span>
+			when a crop has a different aspect ratio from the fallback image. Apply layout attributes to the wrapper through
+			<span class="inline-code">PictureAttrs: gosx.Attrs(...)</span>
+			in Go, or
+			<span class="inline-code">pictureAttrs</span>
+			in a file route. Route data may provide either a
+			<span class="inline-code">gosx.AttrList</span>
+			or a string-keyed
+			<span class="inline-code">map[string]any</span>
+			with a
+			<span class="inline-code">class</span>
+			key for
+			<span class="inline-code">responsive-picture</span>
+			; map keys render in deterministic order. Ordinary component attributes such as
+			<span class="inline-code">class="hero-image"</span>
+			stay on the fallback image. Picture attributes do nothing when no wrapper is emitted. Map-provided names are validated, and names and values render through GoSX's normal escaping path.
 		</p>
 		<p>
 			Source candidate strings are escaped into markup but otherwise remain author-owned. GoSX does not download, cache, or rewrite remote candidates, and this feature adds no browser JavaScript.

--- a/examples/gosx-docs/app/docs/images/page.gsx
+++ b/examples/gosx-docs/app/docs/images/page.gsx
@@ -14,7 +14,9 @@ func Page() Node {
 			<span class="inline-code">server.Image</span>
 			returns an
 			<span class="inline-code">img</span>
-			node. It sets alt text, dimensions, and optimizer URLs, defaults to lazy loading and async decoding, and switches to eager/high priority when
+			node by default, or a native
+			<span class="inline-code">picture</span>
+			when art-direction sources are present. It sets alt text, dimensions, and optimizer URLs, defaults to lazy loading and async decoding, and switches to eager/high priority when
 			<span class="inline-code">Priority</span>
 			is true.
 		</p>
@@ -117,6 +119,32 @@ func Page() Node {
 			to
 			<span class="inline-code">100vw</span>
 			; set a real layout hint when the image is narrower than the viewport.
+		</p>
+		<h2 id="art-direction">Art direction</h2>
+		<CodeBlock lang="go" source={data.artDirectionSample} />
+		<p>
+			Use ordered
+			<span class="inline-code">server.ImageSource</span>
+			entries when a layout needs a different crop at a media breakpoint, not merely a smaller copy of the same composition. Supplying at least one non-empty
+			<span class="inline-code">SrcSet</span>
+			wraps the fallback image in
+			<span class="inline-code">&lt;picture&gt;</span>
+			and emits the authored sources first, in slice order. The
+			<span class="inline-code">&lt;Image&gt;</span>
+			builtin accepts the same contract through
+			<span class="inline-code">sources</span>
+			; legacy route data may use a slice of maps with
+			<span class="inline-code">srcset</span>
+			,
+			<span class="inline-code">media</span>
+			,
+			<span class="inline-code">sizes</span>
+			, and
+			<span class="inline-code">type</span>
+			keys.
+		</p>
+		<p>
+			Source candidate strings are escaped into markup but otherwise remain author-owned. GoSX does not download, cache, or rewrite remote candidates, and this feature adds no browser JavaScript.
 		</p>
 		<h2 id="formats">Formats and sizing</h2>
 		<ul>

--- a/examples/gosx-docs/app/docs/images/page.server.go
+++ b/examples/gosx-docs/app/docs/images/page.server.go
@@ -18,6 +18,7 @@ func init() {
 					{"href": "#helper", "label": "Image Helper"},
 					{"href": "#builtin", "label": "<Image> Builtin"},
 					{"href": "#responsive", "label": "Responsive Images"},
+					{"href": "#art-direction", "label": "Art Direction"},
 					{"href": "#formats", "label": "Formats & Sizing"},
 					{"href": "#serving", "label": "Serving"},
 					{"href": "#caching", "label": "Caching"},
@@ -29,6 +30,7 @@ func init() {
 				// all, which reserves no layout box before the image
 				// loads (layout-shift-prone; flagged in review).
 				"responsiveSample":      "node := server.Image(server.ImageProps{\n\tSrc:        \"/photos/harbor.jpg\",\n\tAlt:        \"Harbor at dusk\",\n\tResponsive: true,\n\tWidth:      1200,\n\tHeight:     750,\n\tWidths:     []int{320, 640, 960, 1200},\n\tSizes:      \"(max-width: 720px) 100vw, 720px\",\n})",
+				"artDirectionSample":    "node := server.Image(server.ImageProps{\n\tSrc:    \"https://images.example.com/hero-wide.jpg\",\n\tAlt:    \"Potter shaping clay at the wheel\",\n\tWidth:  1600,\n\tHeight: 1200,\n\tSources: []server.ImageSource{\n\t\t{\n\t\t\tMedia:  \"(max-width: 600px)\",\n\t\t\tSrcSet: \"https://images.example.com/hero-tight-480.jpg 480w, https://images.example.com/hero-tight-800.jpg 800w\",\n\t\t\tSizes:  \"100vw\",\n\t\t},\n\t},\n})",
 				"urlSample":             "url := server.ImageURL(\"/photos/harbor.jpg\", server.ImageTransform{\n\tWidth:   640,\n\tQuality: 78,\n\tFormat:  \"jpeg\",\n})",
 				"builtinLocalSample":    `<Image src="/photos/harbor.jpg" alt="Harbor at dusk" />`,
 				"builtinExternalSample": `<Image src="https://cdn.example.com/harbor.jpg" alt="Harbor at dusk" width={1200} height={800} />`,

--- a/examples/gosx-docs/app/docs/images/page.server.go
+++ b/examples/gosx-docs/app/docs/images/page.server.go
@@ -29,8 +29,17 @@ func init() {
 				// leaves the emitted <img> with no height attribute at
 				// all, which reserves no layout box before the image
 				// loads (layout-shift-prone; flagged in review).
-				"responsiveSample":      "node := server.Image(server.ImageProps{\n\tSrc:        \"/photos/harbor.jpg\",\n\tAlt:        \"Harbor at dusk\",\n\tResponsive: true,\n\tWidth:      1200,\n\tHeight:     750,\n\tWidths:     []int{320, 640, 960, 1200},\n\tSizes:      \"(max-width: 720px) 100vw, 720px\",\n})",
-				"artDirectionSample":    "node := server.Image(server.ImageProps{\n\tSrc:    \"https://images.example.com/hero-wide.jpg\",\n\tAlt:    \"Potter shaping clay at the wheel\",\n\tWidth:  1600,\n\tHeight: 1200,\n\tSources: []server.ImageSource{\n\t\t{\n\t\t\tMedia:  \"(max-width: 600px)\",\n\t\t\tSrcSet: \"https://images.example.com/hero-tight-480.jpg 480w, https://images.example.com/hero-tight-800.jpg 800w\",\n\t\t\tSizes:  \"100vw\",\n\t\t},\n\t},\n})",
+				"responsiveSample":   "node := server.Image(server.ImageProps{\n\tSrc:        \"/photos/harbor.jpg\",\n\tAlt:        \"Harbor at dusk\",\n\tResponsive: true,\n\tWidth:      1200,\n\tHeight:     750,\n\tWidths:     []int{320, 640, 960, 1200},\n\tSizes:      \"(max-width: 720px) 100vw, 720px\",\n})",
+				"artDirectionSample": "node := server.Image(server.ImageProps{\n\tSrc:    \"https://images.example.com/hero-wide.jpg\",\n\tAlt:    \"Potter shaping clay at the wheel\",\n\tWidth:  1600,\n\tHeight: 900,\n\tSources: []server.ImageSource{\n\t\t{\n\t\t\tMedia:  \"(max-width: 600px)\",\n\t\t\tSrcSet: \"https://images.example.com/hero-tight-480.jpg 480w, https://images.example.com/hero-tight-800.jpg 800w\",\n\t\t\tSizes:  \"100vw\",\n\t\t\tWidth:  800,\n\t\t\tHeight: 1000,\n\t\t},\n\t},\n\tPictureAttrs: gosx.Attrs(\n\t\tgosx.Attr(\"class\", \"responsive-picture\"),\n\t),\n})",
+				"builtinArtDirectionSample": `<Image
+	src={data.hero}
+	alt="Potter shaping clay at the wheel"
+	width={1600}
+	height={900}
+	sources={data.sources}
+	pictureAttrs={data.pictureAttrs}
+	class="hero-image"
+/>`,
 				"urlSample":             "url := server.ImageURL(\"/photos/harbor.jpg\", server.ImageTransform{\n\tWidth:   640,\n\tQuality: 78,\n\tFormat:  \"jpeg\",\n})",
 				"builtinLocalSample":    `<Image src="/photos/harbor.jpg" alt="Harbor at dusk" />`,
 				"builtinExternalSample": `<Image src="https://cdn.example.com/harbor.jpg" alt="Harbor at dusk" width={1200} height={800} />`,

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -699,6 +699,7 @@ func (r *fileProgramRenderer) renderImage(node *ir.Node, env fileRenderEnv) stri
 		Priority:      truthy(attrValue(node.Attrs, env, "priority")),
 		Quality:       int(numericValue(attrValue(node.Attrs, env, "quality"))),
 		Format:        stringValue(attrValue(node.Attrs, env, "format")),
+		Sources:       imageSourceListValue(attrValue(node.Attrs, env, "sources")),
 	}
 	if err := server.ValidateProducibleImageFormat(props.Format); err != nil {
 		panic(err)
@@ -3255,6 +3256,7 @@ func imageExtraAttrs(attrs []ir.Attr, env fileRenderEnv) []any {
 		"priority":      {},
 		"quality":       {},
 		"format":        {},
+		"sources":       {},
 	}
 	out := []any{}
 	for _, attr := range attrs {
@@ -3750,15 +3752,19 @@ func mapStringAnyValue(value any) map[string]any {
 }
 
 func videoSourceListValue(value any) []server.VideoSource {
-	return decodeVideoListValue[server.VideoSource](value)
+	return decodeListValue[server.VideoSource](value)
+}
+
+func imageSourceListValue(value any) []server.ImageSource {
+	return decodeListValue[server.ImageSource](value)
 }
 
 func videoAudioTrackListValue(value any) []server.VideoAudioTrack {
-	return decodeVideoListValue[server.VideoAudioTrack](value)
+	return decodeListValue[server.VideoAudioTrack](value)
 }
 
 func videoTrackListValue(value any) []server.VideoTrack {
-	return decodeVideoListValue[server.VideoTrack](value)
+	return decodeListValue[server.VideoTrack](value)
 }
 
 func videoSyncTuningValue(value any) *server.SyncTuning {
@@ -3836,7 +3842,7 @@ func decodeVideoStructPointerValue[T comparable](value any) *T {
 	return &out
 }
 
-func decodeVideoListValue[T any](value any) []T {
+func decodeListValue[T any](value any) []T {
 	if value == nil {
 		return nil
 	}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -700,6 +700,7 @@ func (r *fileProgramRenderer) renderImage(node *ir.Node, env fileRenderEnv) stri
 		Quality:       int(numericValue(attrValue(node.Attrs, env, "quality"))),
 		Format:        stringValue(attrValue(node.Attrs, env, "format")),
 		Sources:       imageSourceListValue(attrValue(node.Attrs, env, "sources")),
+		PictureAttrs:  imagePictureAttrsValue(attrValue(node.Attrs, env, "pictureAttrs", "pictureattrs")),
 	}
 	if err := server.ValidateProducibleImageFormat(props.Format); err != nil {
 		panic(err)
@@ -3257,6 +3258,8 @@ func imageExtraAttrs(attrs []ir.Attr, env fileRenderEnv) []any {
 		"quality":       {},
 		"format":        {},
 		"sources":       {},
+		"pictureAttrs":  {},
+		"pictureattrs":  {},
 	}
 	out := []any{}
 	for _, attr := range attrs {
@@ -3757,6 +3760,31 @@ func videoSourceListValue(value any) []server.VideoSource {
 
 func imageSourceListValue(value any) []server.ImageSource {
 	return decodeListValue[server.ImageSource](value)
+}
+
+// imagePictureAttrsValue maps file-route data onto the wrapper's distinct
+// attribute channel. An AttrList keeps authored order; string-keyed maps use
+// the same deterministic ordering, name normalization, invalid-name filter,
+// boolean semantics, and gosx.Attr rendering path as ordinary spread attrs.
+func imagePictureAttrsValue(value any) gosx.AttrList {
+	if attrs, ok := value.(gosx.AttrList); ok {
+		return attrs
+	}
+	values := mapStringAnyValue(value)
+	if len(values) == 0 {
+		return nil
+	}
+	attrs := make([]any, 0, len(values))
+	for _, entry := range sortedStringAnyMap(values) {
+		name := normalizeFileAttrName(entry.Key)
+		if name == "" || !validRenderAttrName(name) {
+			continue
+		}
+		if attr, ok := fileNodeAttr(name, entry.Value); ok {
+			attrs = append(attrs, attr)
+		}
+	}
+	return gosx.Attrs(attrs...)
 }
 
 func videoAudioTrackListValue(value any) []server.VideoAudioTrack {

--- a/route/image_attrs_test.go
+++ b/route/image_attrs_test.go
@@ -14,6 +14,10 @@ import (
 // attributes (gosx#199).
 
 func compileImageFixture(t *testing.T, attrs string) string {
+	return compileImageFixtureWithEnv(t, attrs, ProgramRenderEnv{})
+}
+
+func compileImageFixtureWithEnv(t *testing.T, attrs string, env ProgramRenderEnv) string {
 	t.Helper()
 	src := "package docs\n\n" +
 		"func Page() Node {\n" +
@@ -23,7 +27,7 @@ func compileImageFixture(t *testing.T, attrs string) string {
 	if err != nil {
 		t.Fatalf("compile: %v", err)
 	}
-	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{})
+	html, err := RenderProgramComponent(prog, "Page", env)
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
@@ -119,7 +123,7 @@ func TestFileRendererImageSourcesEnableConsumerBackedArtDirection(t *testing.T) 
 	src := `package docs
 
 func Page() Node {
-	return <Image src={data.hero} alt="Ceramic bowl" width={1600} height={1200} sources={data.sources} priority />
+	return <Image src={data.hero} alt="Ceramic bowl" width={1600} height={900} sources={data.sources} pictureAttrs={data.pictureAttrs} class="hero-image" priority />
 }
 `
 	prog, err := gosx.Compile([]byte(src))
@@ -130,7 +134,14 @@ func Page() Node {
 		"data": map[string]any{
 			"hero": "https://images.example.com/hero.jpg",
 			"sources": []map[string]any{
-				{"media": "(max-width: 600px)", "srcset": "https://images.example.com/hero-mobile.jpg 800w", "sizes": "100vw", "type": "image/jpeg"},
+				{"media": "(max-width: 600px)", "srcset": "https://images.example.com/hero-mobile.jpg 800w", "sizes": "100vw", "type": "image/jpeg", "width": 800, "height": 1000},
+			},
+			"pictureAttrs": map[string]any{
+				"data-layout": "wide & narrow",
+				"className":   "responsive-picture",
+				"aria-label":  `Product view "mobile"`,
+				"hidden":      false,
+				"x onload":    "alert(1)",
 			},
 		},
 	}})
@@ -138,15 +149,46 @@ func Page() Node {
 		t.Fatalf("render: %v", err)
 	}
 	for _, snippet := range []string{
-		`<picture>`,
-		`<source srcset="https://images.example.com/hero-mobile.jpg 800w" media="(max-width: 600px)" sizes="100vw" type="image/jpeg" />`,
-		`<img src="https://images.example.com/hero.jpg" alt="Ceramic bowl" width="1600" height="1200" loading="eager" decoding="async" fetchpriority="high" />`,
+		`<picture aria-label="Product view &#34;mobile&#34;" class="responsive-picture" data-layout="wide &amp; narrow">`,
+		`<source srcset="https://images.example.com/hero-mobile.jpg 800w" media="(max-width: 600px)" sizes="100vw" type="image/jpeg" width="800" height="1000" />`,
+		`<img src="https://images.example.com/hero.jpg" alt="Ceramic bowl" width="1600" height="900" loading="eager" decoding="async" fetchpriority="high" class="hero-image" />`,
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Fatalf("expected %q in %q", snippet, html)
 		}
 	}
-	if strings.Contains(html, " sources=") {
-		t.Fatalf("expected sources to be consumed, not leaked as an HTML attribute, got %q", html)
+	if strings.Contains(html, " sources=") || strings.Contains(html, "pictureAttrs") || strings.Contains(html, " pictureattrs=") {
+		t.Fatalf("expected image-only props to be consumed, not leaked as HTML attributes, got %q", html)
+	}
+	if strings.Contains(html, " hidden") {
+		t.Fatalf("expected a false boolean picture attr to be omitted, got %q", html)
+	}
+	if strings.Contains(html, "onload") || strings.Contains(html, "alert(1)") {
+		t.Fatalf("expected invalid picture attribute names to be dropped inertly, got %q", html)
+	}
+}
+
+func TestFileRendererPictureAttrsWithoutSourcesPreserveImgOnlyContract(t *testing.T) {
+	src := `package docs
+
+func Page() Node {
+	return <Image src="https://images.example.com/hero.jpg" alt="Hero" width={800} height={600} pictureAttrs={data.pictureAttrs} class="hero-image" />
+}
+`
+	prog, err := gosx.Compile([]byte(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{Values: map[string]any{
+		"data": map[string]any{"pictureAttrs": map[string]any{"class": "responsive-picture"}},
+	}})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	if strings.Contains(html, "<picture") || strings.Contains(html, "responsive-picture") || strings.Contains(html, "pictureAttrs") {
+		t.Fatalf("expected pictureAttrs alone not to create or leak a wrapper, got %q", html)
+	}
+	if !strings.Contains(html, `<img`) || !strings.Contains(html, `class="hero-image"`) {
+		t.Fatalf("expected ordinary attrs to remain on the img, got %q", html)
 	}
 }

--- a/route/image_attrs_test.go
+++ b/route/image_attrs_test.go
@@ -114,3 +114,39 @@ func TestFileRendererImageExplicitSizesWinsOverResponsiveDefault(t *testing.T) {
 		t.Fatalf("expected responsive default sizes not to override explicit sizes, got %q", html)
 	}
 }
+
+func TestFileRendererImageSourcesEnableConsumerBackedArtDirection(t *testing.T) {
+	src := `package docs
+
+func Page() Node {
+	return <Image src={data.hero} alt="Ceramic bowl" width={1600} height={1200} sources={data.sources} priority />
+}
+`
+	prog, err := gosx.Compile([]byte(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{Values: map[string]any{
+		"data": map[string]any{
+			"hero": "https://images.example.com/hero.jpg",
+			"sources": []map[string]any{
+				{"media": "(max-width: 600px)", "srcset": "https://images.example.com/hero-mobile.jpg 800w", "sizes": "100vw", "type": "image/jpeg"},
+			},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	for _, snippet := range []string{
+		`<picture>`,
+		`<source srcset="https://images.example.com/hero-mobile.jpg 800w" media="(max-width: 600px)" sizes="100vw" type="image/jpeg" />`,
+		`<img src="https://images.example.com/hero.jpg" alt="Ceramic bowl" width="1600" height="1200" loading="eager" decoding="async" fetchpriority="high" />`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+	if strings.Contains(html, " sources=") {
+		t.Fatalf("expected sources to be consumed, not leaked as an HTML attribute, got %q", html)
+	}
+}

--- a/route/image_picture.go
+++ b/route/image_picture.go
@@ -47,6 +47,7 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 
 	webp := imageVariantsByFormat(asset.Variants, "webp")
 	native, _ := nativeImageVariants(asset.Variants)
+	authored := manifestImageSourceNodes(props.Sources)
 
 	width, height := manifestImageDisplaySize(props, asset)
 	base := manifestImageBaseAttrs(props, width, height)
@@ -67,7 +68,7 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 			gosx.Attr("srcset", imageSrcsetValue(webp)),
 			gosx.Attr("sizes", sizes),
 		))
-		return gosx.El("picture", source, manifestImageOnly(base, sizes, native, extra)), true
+		return manifestImagePicture(authored, source, manifestImageOnly(base, sizes, native, extra)), true
 	case len(native) > 0:
 		// The default case with no WebP encoder registered: every raster
 		// source resizes to its own native format only (cmd/gosx's
@@ -75,7 +76,11 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 		// produces for a JPEG or PNG source. A plain <img>, not a
 		// <picture> — real hashed files, no per-request resize, and no
 		// empty <source> to render around.
-		return manifestImageOnly(base, sizes, native, extra), true
+		img := manifestImageOnly(base, sizes, native, extra)
+		if len(authored) > 0 {
+			return manifestImagePicture(authored, img), true
+		}
+		return img, true
 	case len(webp) > 0:
 		// A WebP-native source with no same-source native-format rung
 		// alongside it (cmd/gosx never generates a redundant same-format
@@ -85,10 +90,47 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 		// render already produces — rather than a <picture> wrapping one
 		// <source type="image/webp"> and an <img> naming the identical
 		// bytes twice.
-		return manifestImageOnly(base, sizes, webp, extra), true
+		img := manifestImageOnly(base, sizes, webp, extra)
+		if len(authored) > 0 {
+			return manifestImagePicture(authored, img), true
+		}
+		return img, true
 	default:
 		return gosx.Node{}, false
 	}
+}
+
+func manifestImageSourceNodes(sources []server.ImageSource) []gosx.Node {
+	nodes := make([]gosx.Node, 0, len(sources))
+	for _, source := range sources {
+		srcset := strings.TrimSpace(source.SrcSet)
+		if srcset == "" {
+			continue
+		}
+		attrs := []any{gosx.Attr("srcset", srcset)}
+		if media := strings.TrimSpace(source.Media); media != "" {
+			attrs = append(attrs, gosx.Attr("media", media))
+		}
+		if sizes := strings.TrimSpace(source.Sizes); sizes != "" {
+			attrs = append(attrs, gosx.Attr("sizes", sizes))
+		}
+		if typ := strings.TrimSpace(source.Type); typ != "" {
+			attrs = append(attrs, gosx.Attr("type", typ))
+		}
+		nodes = append(nodes, gosx.El("source", gosx.Attrs(attrs...)))
+	}
+	return nodes
+}
+
+func manifestImagePicture(authored []gosx.Node, tail ...gosx.Node) gosx.Node {
+	children := make([]any, 0, len(authored)+len(tail))
+	for _, source := range authored {
+		children = append(children, source)
+	}
+	for _, node := range tail {
+		children = append(children, node)
+	}
+	return gosx.El("picture", children...)
 }
 
 // manifestImageOnly renders one <img> whose src/srcset/sizes come from one

--- a/route/image_picture.go
+++ b/route/image_picture.go
@@ -14,10 +14,8 @@ import (
 // image variants gosx build's imagepipe stage recorded in
 // buildmanifest.Manifest.Images (issue #200), for the file-router's
 // <Image> BUILTIN TAG specifically (gosx#201). server.Image, the Go helper
-// function a page.server.go file calls directly, keeps its existing
-// single-<img> contract unchanged — only the JSX tag gains this markup, so
-// one Go function does not silently start returning a different element
-// shape out from under an existing direct caller.
+// function a page.server.go file calls directly, uses the same author-supplied
+// source and picture-attribute contracts but cannot use this manifest path.
 //
 // It returns ok=false — and renderImage falls straight through to the
 // unmodified #199-fixed server.Image call — in every one of these cases,
@@ -68,7 +66,7 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 			gosx.Attr("srcset", imageSrcsetValue(webp)),
 			gosx.Attr("sizes", sizes),
 		))
-		return manifestImagePicture(authored, source, manifestImageOnly(base, sizes, native, extra)), true
+		return manifestImagePicture(props.PictureAttrs, authored, source, manifestImageOnly(base, sizes, native, extra)), true
 	case len(native) > 0:
 		// The default case with no WebP encoder registered: every raster
 		// source resizes to its own native format only (cmd/gosx's
@@ -78,7 +76,7 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 		// empty <source> to render around.
 		img := manifestImageOnly(base, sizes, native, extra)
 		if len(authored) > 0 {
-			return manifestImagePicture(authored, img), true
+			return manifestImagePicture(props.PictureAttrs, authored, img), true
 		}
 		return img, true
 	case len(webp) > 0:
@@ -92,7 +90,7 @@ func buildManifestImagePicture(props server.ImageProps, extra []any) (gosx.Node,
 		// bytes twice.
 		img := manifestImageOnly(base, sizes, webp, extra)
 		if len(authored) > 0 {
-			return manifestImagePicture(authored, img), true
+			return manifestImagePicture(props.PictureAttrs, authored, img), true
 		}
 		return img, true
 	default:
@@ -117,13 +115,20 @@ func manifestImageSourceNodes(sources []server.ImageSource) []gosx.Node {
 		if typ := strings.TrimSpace(source.Type); typ != "" {
 			attrs = append(attrs, gosx.Attr("type", typ))
 		}
+		if source.Width > 0 {
+			attrs = append(attrs, gosx.Attr("width", source.Width))
+		}
+		if source.Height > 0 {
+			attrs = append(attrs, gosx.Attr("height", source.Height))
+		}
 		nodes = append(nodes, gosx.El("source", gosx.Attrs(attrs...)))
 	}
 	return nodes
 }
 
-func manifestImagePicture(authored []gosx.Node, tail ...gosx.Node) gosx.Node {
-	children := make([]any, 0, len(authored)+len(tail))
+func manifestImagePicture(pictureAttrs gosx.AttrList, authored []gosx.Node, tail ...gosx.Node) gosx.Node {
+	children := make([]any, 0, 1+len(authored)+len(tail))
+	children = append(children, pictureAttrs)
 	for _, source := range authored {
 		children = append(children, source)
 	}

--- a/route/image_picture_test.go
+++ b/route/image_picture_test.go
@@ -169,8 +169,18 @@ func TestFileRendererImagePicturePriorityFlipsLoadingAndFetchPriority(t *testing
 
 func TestFileRendererImagePictureExtraAttrsLandOnImgFallback(t *testing.T) {
 	buildManifestApp(t)
-	html := compileImageFixture(t, `src="/manifest-hero.jpg" alt="Hero" class="demo-image"`)
+	html := compileImageFixtureWithEnv(t, `src="/manifest-hero.jpg" alt="Hero" class="demo-image" pictureAttrs={data.pictureAttrs}`, ProgramRenderEnv{Values: map[string]any{
+		"data": map[string]any{
+			"pictureAttrs": gosx.Attrs(
+				gosx.Attr("class", "responsive-picture"),
+				gosx.Attr("data-layout", "manifest & responsive"),
+			),
+		},
+	}})
 
+	if !strings.HasPrefix(html, `<picture class="responsive-picture" data-layout="manifest &amp; responsive">`) {
+		t.Fatalf("expected explicit picture attributes on the manifest wrapper, got %q", html)
+	}
 	if !strings.Contains(html, `<img`) {
 		t.Fatalf("expected an <img> fallback, got %q", html)
 	}
@@ -186,6 +196,9 @@ func TestFileRendererImagePictureExtraAttrsLandOnImgFallback(t *testing.T) {
 	if strings.Contains(sourceTag, "demo-image") {
 		t.Fatalf("expected class not to leak onto <source>, got %q", sourceTag)
 	}
+	if strings.Contains(imgTag, "responsive-picture") || strings.Contains(imgTag, "pictureAttrs") {
+		t.Fatalf("expected picture attributes to stay off the <img> fallback, got %q", imgTag)
+	}
 }
 
 func TestFileRendererManifestPictureOrdersAuthoredSourcesBeforeFormatSources(t *testing.T) {
@@ -193,7 +206,7 @@ func TestFileRendererManifestPictureOrdersAuthoredSourcesBeforeFormatSources(t *
 	src := `package docs
 
 func Page() Node {
-	return <Image src="/manifest-hero.jpg" alt="Hero" sources={data.sources} />
+	return <Image src="/manifest-hero.jpg" alt="Hero" sources={data.sources} pictureAttrs={data.pictureAttrs} class="hero-image" />
 }
 `
 	prog, err := gosx.Compile([]byte(src))
@@ -202,17 +215,45 @@ func Page() Node {
 	}
 	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{Values: map[string]any{
 		"data": map[string]any{
-			"sources": []map[string]any{{"media": "(max-width: 600px)", "srcset": "/mobile-crop-800.jpg 800w"}},
+			"sources": []map[string]any{
+				{"media": "(max-width: 600px)", "srcset": "/mobile-crop-800.jpg 800w", "width": 800, "height": 1000},
+				{"media": "(max-width: 1000px)", "srcset": "/tablet-crop-1000.jpg 1000w", "width": -1, "height": 0},
+			},
+			"pictureAttrs": map[string]any{"class": "responsive-picture"},
 		},
 	}})
 	if err != nil {
 		t.Fatalf("render: %v", err)
 	}
 	authored := strings.Index(html, `/mobile-crop-800.jpg 800w`)
+	invalidDimensions := strings.Index(html, `/tablet-crop-1000.jpg 1000w`)
 	format := strings.Index(html, `type="image/webp"`)
 	img := strings.Index(html, "<img")
-	if authored < 0 || format < 0 || img < 0 || !(authored < format && format < img) {
+	if authored < 0 || invalidDimensions < 0 || format < 0 || img < 0 || !(authored < invalidDimensions && invalidDimensions < format && format < img) {
 		t.Fatalf("expected authored art direction before generic format selection and fallback, got %q", html)
+	}
+	if !strings.HasPrefix(html, `<picture class="responsive-picture">`) {
+		t.Fatalf("expected pictureAttrs on the manifest wrapper, got %q", html)
+	}
+	authoredEnd := strings.Index(html[authored:], ">")
+	authoredTag := html[strings.LastIndex(html[:authored], "<source") : authored+authoredEnd]
+	for _, snippet := range []string{`width="800"`, `height="1000"`} {
+		if !strings.Contains(authoredTag, snippet) {
+			t.Fatalf("expected %q on the authored source with its distinct mobile aspect ratio, got %q", snippet, authoredTag)
+		}
+	}
+	invalidStart := strings.LastIndex(html[:invalidDimensions], "<source")
+	invalidEnd := strings.Index(html[invalidDimensions:], ">")
+	invalidTag := html[invalidStart : invalidDimensions+invalidEnd]
+	if strings.Contains(invalidTag, " width=") || strings.Contains(invalidTag, " height=") {
+		t.Fatalf("expected non-positive source dimensions to be omitted in manifest mode, got %q", invalidTag)
+	}
+	imgEnd := strings.Index(html[img:], ">")
+	imgTag := html[img : img+imgEnd]
+	for _, snippet := range []string{`width="1200"`, `height="800"`, `class="hero-image"`} {
+		if !strings.Contains(imgTag, snippet) {
+			t.Fatalf("expected %q on the desktop fallback, got %q", snippet, imgTag)
+		}
 	}
 }
 
@@ -220,7 +261,7 @@ func TestFileRendererImageWebPSourceSkipsPictureWrapper(t *testing.T) {
 	buildManifestApp(t)
 	html := compileImageFixture(t, `src="/manifest-only.webp" alt="Only"`)
 
-	if strings.Contains(html, "<picture>") || strings.Contains(html, "<source") {
+	if strings.Contains(html, "<picture") || strings.Contains(html, "<source") {
 		t.Fatalf("expected a plain <img>, no <picture>/<source> wrapper for a WebP-native source, got %q", html)
 	}
 	for _, snippet := range []string{
@@ -244,10 +285,15 @@ func TestFileRendererImageWebPSourceSkipsPictureWrapper(t *testing.T) {
 // <picture> wrapping an empty <source type="image/webp">.
 func TestFileRendererImageNativeOnlySourceSkipsPictureWrapper(t *testing.T) {
 	buildManifestApp(t)
-	html := compileImageFixture(t, `src="/manifest-native-only.png" alt="Native only"`)
+	html := compileImageFixtureWithEnv(t, `src="/manifest-native-only.png" alt="Native only" pictureAttrs={data.pictureAttrs} class="native-image"`, ProgramRenderEnv{Values: map[string]any{
+		"data": map[string]any{"pictureAttrs": map[string]any{"class": "responsive-picture"}},
+	}})
 
-	if strings.Contains(html, "<picture>") || strings.Contains(html, "<source") {
+	if strings.Contains(html, "<picture") || strings.Contains(html, "<source") {
 		t.Fatalf("expected a plain <img>, no <picture>/<source> wrapper for a native-only source, got %q", html)
+	}
+	if strings.Contains(html, "responsive-picture") || strings.Contains(html, "pictureAttrs") {
+		t.Fatalf("expected wrapper-only attrs not to create or leak from a native-only manifest image, got %q", html)
 	}
 	for _, snippet := range []string{
 		`<img`,
@@ -255,6 +301,7 @@ func TestFileRendererImageNativeOnlySourceSkipsPictureWrapper(t *testing.T) {
 		`srcset="/gosx/assets/images/native-320w.22222221.png 320w, /gosx/assets/images/native-640w.22222222.png 640w"`,
 		`width="640"`,
 		`height="480"`,
+		`class="native-image"`,
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Fatalf("expected %q in %q", snippet, html)

--- a/route/image_picture_test.go
+++ b/route/image_picture_test.go
@@ -188,6 +188,34 @@ func TestFileRendererImagePictureExtraAttrsLandOnImgFallback(t *testing.T) {
 	}
 }
 
+func TestFileRendererManifestPictureOrdersAuthoredSourcesBeforeFormatSources(t *testing.T) {
+	buildManifestApp(t)
+	src := `package docs
+
+func Page() Node {
+	return <Image src="/manifest-hero.jpg" alt="Hero" sources={data.sources} />
+}
+`
+	prog, err := gosx.Compile([]byte(src))
+	if err != nil {
+		t.Fatalf("compile: %v", err)
+	}
+	html, err := RenderProgramComponent(prog, "Page", ProgramRenderEnv{Values: map[string]any{
+		"data": map[string]any{
+			"sources": []map[string]any{{"media": "(max-width: 600px)", "srcset": "/mobile-crop-800.jpg 800w"}},
+		},
+	}})
+	if err != nil {
+		t.Fatalf("render: %v", err)
+	}
+	authored := strings.Index(html, `/mobile-crop-800.jpg 800w`)
+	format := strings.Index(html, `type="image/webp"`)
+	img := strings.Index(html, "<img")
+	if authored < 0 || format < 0 || img < 0 || !(authored < format && format < img) {
+		t.Fatalf("expected authored art direction before generic format selection and fallback, got %q", html)
+	}
+}
+
 func TestFileRendererImageWebPSourceSkipsPictureWrapper(t *testing.T) {
 	buildManifestApp(t)
 	html := compileImageFixture(t, `src="/manifest-only.webp" alt="Only"`)

--- a/server/image.go
+++ b/server/image.go
@@ -36,12 +36,16 @@ type ImageTransform struct {
 // ImageSource describes one author-supplied <source> candidate for image art
 // direction. SrcSet is emitted as an HTML srcset value; GoSX does not fetch,
 // cache, or rewrite its candidates. Sources are evaluated in slice order, as
-// required by the browser's <picture> selection algorithm.
+// required by the browser's <picture> selection algorithm. Positive Width and
+// Height values declare that source crop's intrinsic dimensions; non-positive
+// values are omitted.
 type ImageSource struct {
 	SrcSet string `json:"srcset,omitempty"`
 	Media  string `json:"media,omitempty"`
 	Sizes  string `json:"sizes,omitempty"`
 	Type   string `json:"type,omitempty"`
+	Width  int    `json:"width,omitempty"`
+	Height int    `json:"height,omitempty"`
 }
 
 // ImageProps configures the server.Image helper.
@@ -61,6 +65,9 @@ type ImageProps struct {
 	Format        string
 	Resolver      string
 	Sources       []ImageSource
+	// PictureAttrs applies only when Image emits a <picture> wrapper. The
+	// variadic args passed to Image remain attributes on the fallback <img>.
+	PictureAttrs gosx.AttrList
 }
 
 // ImageURL builds an optimizer URL for a local public image source.
@@ -174,7 +181,7 @@ func Image(props ImageProps, args ...any) gosx.Node {
 		children = append(children, source)
 	}
 	children = append(children, img)
-	return gosx.El("picture", children...)
+	return gosx.El("picture", append([]any{props.PictureAttrs}, children...)...)
 }
 
 func imageSourceNodes(sources []ImageSource) []gosx.Node {
@@ -193,6 +200,12 @@ func imageSourceNodes(sources []ImageSource) []gosx.Node {
 		}
 		if typ := strings.TrimSpace(source.Type); typ != "" {
 			attrs = append(attrs, gosx.Attr("type", typ))
+		}
+		if source.Width > 0 {
+			attrs = append(attrs, gosx.Attr("width", source.Width))
+		}
+		if source.Height > 0 {
+			attrs = append(attrs, gosx.Attr("height", source.Height))
 		}
 		nodes = append(nodes, gosx.El("source", gosx.Attrs(attrs...)))
 	}

--- a/server/image.go
+++ b/server/image.go
@@ -33,6 +33,17 @@ type ImageTransform struct {
 	Format  string
 }
 
+// ImageSource describes one author-supplied <source> candidate for image art
+// direction. SrcSet is emitted as an HTML srcset value; GoSX does not fetch,
+// cache, or rewrite its candidates. Sources are evaluated in slice order, as
+// required by the browser's <picture> selection algorithm.
+type ImageSource struct {
+	SrcSet string `json:"srcset,omitempty"`
+	Media  string `json:"media,omitempty"`
+	Sizes  string `json:"sizes,omitempty"`
+	Type   string `json:"type,omitempty"`
+}
+
 // ImageProps configures the server.Image helper.
 type ImageProps struct {
 	Src           string
@@ -49,6 +60,7 @@ type ImageProps struct {
 	Quality       int
 	Format        string
 	Resolver      string
+	Sources       []ImageSource
 }
 
 // ImageURL builds an optimizer URL for a local public image source.
@@ -57,7 +69,8 @@ func ImageURL(src string, transform ImageTransform) string {
 }
 
 // Image renders an optimized image tag for local public assets and falls back
-// to a plain <img> for unsupported sources such as remote URLs or SVGs.
+// to an unoptimized <img> for sources such as remote URLs or SVGs. Non-empty
+// Sources wrap that fallback image in ordered native <picture> markup.
 func Image(props ImageProps, args ...any) gosx.Node {
 	// Fail closed at render time: a format the handler cannot produce would
 	// otherwise ship as a fmt= URL that 400s only when a browser requests it
@@ -151,7 +164,39 @@ func Image(props ImageProps, args ...any) gosx.Node {
 	}
 
 	baseAttrs = append(baseAttrs, args...)
-	return gosx.El("img", baseAttrs...)
+	img := gosx.El("img", baseAttrs...)
+	sources := imageSourceNodes(props.Sources)
+	if len(sources) == 0 {
+		return img
+	}
+	children := make([]any, 0, len(sources)+1)
+	for _, source := range sources {
+		children = append(children, source)
+	}
+	children = append(children, img)
+	return gosx.El("picture", children...)
+}
+
+func imageSourceNodes(sources []ImageSource) []gosx.Node {
+	nodes := make([]gosx.Node, 0, len(sources))
+	for _, source := range sources {
+		srcset := strings.TrimSpace(source.SrcSet)
+		if srcset == "" {
+			continue
+		}
+		attrs := []any{gosx.Attr("srcset", srcset)}
+		if media := strings.TrimSpace(source.Media); media != "" {
+			attrs = append(attrs, gosx.Attr("media", media))
+		}
+		if sizes := strings.TrimSpace(source.Sizes); sizes != "" {
+			attrs = append(attrs, gosx.Attr("sizes", sizes))
+		}
+		if typ := strings.TrimSpace(source.Type); typ != "" {
+			attrs = append(attrs, gosx.Attr("type", typ))
+		}
+		nodes = append(nodes, gosx.El("source", gosx.Attrs(attrs...)))
+	}
+	return nodes
 }
 
 // ImageHandler serves optimized local images from a source directory.

--- a/server/image_test.go
+++ b/server/image_test.go
@@ -50,6 +50,53 @@ func TestImageHelperBuildsResponsiveMarkup(t *testing.T) {
 	}
 }
 
+func TestImageHelperRendersOrderedArtDirectionSources(t *testing.T) {
+	node := Image(ImageProps{
+		Src:    "https://images.example.com/hero-1600.jpg",
+		Alt:    "Ceramic bowl on a worktable",
+		Width:  1600,
+		Height: 1200,
+		Sources: []ImageSource{
+			{Media: "(max-width: 600px)", SrcSet: "https://images.example.com/hero-mobile-480.jpg 480w, https://images.example.com/hero-mobile-800.jpg 800w", Sizes: "100vw", Type: "image/jpeg"},
+			{Media: "(max-width: 1000px)", SrcSet: "https://images.example.com/hero-tablet-1000.jpg 1000w"},
+		},
+	})
+
+	html := gosx.RenderHTML(node)
+	if !strings.HasPrefix(html, "<picture>") || !strings.HasSuffix(html, "</picture>") {
+		t.Fatalf("expected sources to opt into a picture wrapper, got %q", html)
+	}
+	mobile := strings.Index(html, `media="(max-width: 600px)"`)
+	tablet := strings.Index(html, `media="(max-width: 1000px)"`)
+	img := strings.Index(html, "<img")
+	if mobile < 0 || tablet < 0 || img < 0 || !(mobile < tablet && tablet < img) {
+		t.Fatalf("expected authored source order before the fallback img, got %q", html)
+	}
+	for _, snippet := range []string{
+		`srcset="https://images.example.com/hero-mobile-480.jpg 480w, https://images.example.com/hero-mobile-800.jpg 800w"`,
+		`sizes="100vw"`,
+		`type="image/jpeg"`,
+		`src="https://images.example.com/hero-1600.jpg"`,
+		`width="1600"`,
+		`height="1200"`,
+	} {
+		if !strings.Contains(html, snippet) {
+			t.Fatalf("expected %q in %q", snippet, html)
+		}
+	}
+}
+
+func TestImageHelperSkipsBlankArtDirectionSources(t *testing.T) {
+	html := gosx.RenderHTML(Image(ImageProps{
+		Src:     "/hero.png",
+		Alt:     "Hero",
+		Sources: []ImageSource{{Media: "(max-width: 600px)", SrcSet: "  "}},
+	}))
+	if strings.Contains(html, "<picture>") || strings.Contains(html, "<source") {
+		t.Fatalf("expected blank sources not to change the existing img-only contract, got %q", html)
+	}
+}
+
 func TestImageHelperBypassesOptimizerForSVG(t *testing.T) {
 	html := gosx.RenderHTML(Image(ImageProps{
 		Src: "/mark.svg",

--- a/server/image_test.go
+++ b/server/image_test.go
@@ -55,15 +55,19 @@ func TestImageHelperRendersOrderedArtDirectionSources(t *testing.T) {
 		Src:    "https://images.example.com/hero-1600.jpg",
 		Alt:    "Ceramic bowl on a worktable",
 		Width:  1600,
-		Height: 1200,
+		Height: 900,
 		Sources: []ImageSource{
-			{Media: "(max-width: 600px)", SrcSet: "https://images.example.com/hero-mobile-480.jpg 480w, https://images.example.com/hero-mobile-800.jpg 800w", Sizes: "100vw", Type: "image/jpeg"},
+			{Media: "(max-width: 600px)", SrcSet: "https://images.example.com/hero-mobile-480.jpg 480w, https://images.example.com/hero-mobile-800.jpg 800w", Sizes: "100vw", Type: "image/jpeg", Width: 800, Height: 1000},
 			{Media: "(max-width: 1000px)", SrcSet: "https://images.example.com/hero-tablet-1000.jpg 1000w"},
 		},
-	})
+		PictureAttrs: gosx.Attrs(
+			gosx.Attr("class", "responsive-picture"),
+			gosx.Attr("data-layout", "wide & narrow"),
+		),
+	}, gosx.Attrs(gosx.Attr("class", "hero-image")))
 
 	html := gosx.RenderHTML(node)
-	if !strings.HasPrefix(html, "<picture>") || !strings.HasSuffix(html, "</picture>") {
+	if !strings.HasPrefix(html, `<picture class="responsive-picture" data-layout="wide &amp; narrow">`) || !strings.HasSuffix(html, "</picture>") {
 		t.Fatalf("expected sources to opt into a picture wrapper, got %q", html)
 	}
 	mobile := strings.Index(html, `media="(max-width: 600px)"`)
@@ -76,9 +80,12 @@ func TestImageHelperRendersOrderedArtDirectionSources(t *testing.T) {
 		`srcset="https://images.example.com/hero-mobile-480.jpg 480w, https://images.example.com/hero-mobile-800.jpg 800w"`,
 		`sizes="100vw"`,
 		`type="image/jpeg"`,
+		`width="800"`,
+		`height="1000"`,
 		`src="https://images.example.com/hero-1600.jpg"`,
 		`width="1600"`,
-		`height="1200"`,
+		`height="900"`,
+		`class="hero-image"`,
 	} {
 		if !strings.Contains(html, snippet) {
 			t.Fatalf("expected %q in %q", snippet, html)
@@ -88,12 +95,30 @@ func TestImageHelperRendersOrderedArtDirectionSources(t *testing.T) {
 
 func TestImageHelperSkipsBlankArtDirectionSources(t *testing.T) {
 	html := gosx.RenderHTML(Image(ImageProps{
+		Src:          "/hero.png",
+		Alt:          "Hero",
+		Sources:      []ImageSource{{Media: "(max-width: 600px)", SrcSet: "  ", Width: 400, Height: 700}},
+		PictureAttrs: gosx.Attrs(gosx.Attr("class", "responsive-picture")),
+	}, gosx.Attrs(gosx.Attr("class", "hero-image"))))
+	if strings.Contains(html, "<picture") || strings.Contains(html, "<source") {
+		t.Fatalf("expected blank sources not to change the existing img-only contract, got %q", html)
+	}
+	if strings.Contains(html, "responsive-picture") || !strings.Contains(html, `class="hero-image"`) {
+		t.Fatalf("expected wrapper attrs to be ignored without a wrapper and ordinary attrs to remain on img, got %q", html)
+	}
+}
+
+func TestImageHelperOmitsNonPositiveSourceDimensions(t *testing.T) {
+	html := gosx.RenderHTML(Image(ImageProps{
 		Src:     "/hero.png",
 		Alt:     "Hero",
-		Sources: []ImageSource{{Media: "(max-width: 600px)", SrcSet: "  "}},
+		Sources: []ImageSource{{Media: "(max-width: 600px)", SrcSet: "/mobile.png 400w", Width: 0, Height: -1}},
 	}))
-	if strings.Contains(html, "<picture>") || strings.Contains(html, "<source") {
-		t.Fatalf("expected blank sources not to change the existing img-only contract, got %q", html)
+	sourceStart := strings.Index(html, "<source")
+	sourceEnd := strings.Index(html[sourceStart:], ">")
+	sourceTag := html[sourceStart : sourceStart+sourceEnd]
+	if strings.Contains(sourceTag, " width=") || strings.Contains(sourceTag, " height=") {
+		t.Fatalf("expected non-positive source dimensions to be omitted, got %q", sourceTag)
 	}
 }
 


### PR DESCRIPTION
## Summary

- add an ordered `server.ImageSource` art-direction contract and wrap `server.Image` in native `<picture>` markup only when a usable source is supplied
- add optional positive per-source `width`/`height`, so art-directed crops with distinct aspect ratios carry their own intrinsic dimensions
- add `server.ImageProps.PictureAttrs` as a distinct wrapper-only attribute channel; existing variadic attributes remain on the fallback `<img>`
- accept `sources={...}` and `pictureAttrs={...}` on file-routed `<Image>`, keeping authored media-specific sources ahead of the build manifest's generic WebP format source
- validate file-route wrapper attribute names, render through GoSX's normal escaping and boolean semantics, consume the builtin prop, and sort string-keyed map input deterministically

## Consumer evidence

This implements only the portion of #202 for which a concrete layout now exists. The released Muddy Noni storefront commit [343e157](https://github.com/odvcencio/muddy-noni-commerce/commit/343e1574ef5eba9e47ddc1e72e8f3fd9efa74dac) hand-authors five `<picture><source media="(max-width: 600px)">...</picture>` sites to serve mobile crops. Its attempted `<Image>` migration could carry the ordinary responsive ladder but not `imageMobileSrcset`, distinct mobile crop dimensions, or the `.responsive-picture { display: contents; }` wrapper class.

The other #202 ideas remain deferred: no current consumer justifies blur-placeholder encoding, `fill`, a separate `imageSizes` ladder, AVIF's encoder/blob cost, or remote asset ownership.

## Compatibility and cost

- calls without non-blank sources retain the existing `<img>` shape
- blank source entries are ignored; wrapper attributes alone do not create a wrapper
- ordinary and variadic attributes remain on the fallback `<img>`
- source dimensions render only when positive
- source candidates are escaped but otherwise author-owned
- no `client/` or runtime asset source changed
- host CLI: 60,110,083 -> 60,142,147 bytes (+32,064 bytes, +0.053342%)
- review-fix increment over the first PR head: +9,872 bytes (+0.016423% of main)
- shipped TinyGo budget at the first PR head: full 2,244,251 / 5,632,000 bytes; islands 837,518 / 3,276,800 bytes (review patch changes server/route/docs only)

## Verification

- `make fmt-check`
- `go test -count=1 ./server ./route ./strictcheck ./examples/gosx-docs/...`
- `go vet ./server ./route ./strictcheck`
- `make test-unit` (189-package non-CLI partition)
- focused `cmd/gosx` image staging/native-format/init-template tests
- 25-run deterministic file-route wrapper rendering test
- `git diff --check`
- first PR head: `make wasm-size-budget`, generated bootstrap `--check`, runtime TypeScript typecheck, and all hosted checks except the still-running browser job passed before this review patch
- bundled Windows Node from WSL ran 1,682 JS tests: 1,675 passed, 2 skipped, and 5 host-bound failures (`go` subprocess lookup and Windows symlink privileges). The seven directly relevant bootstrap/size-policy assertions passed; the one remaining test was another `spawnSync go ENOENT`. No client/runtime source changed in this PR.

Refs #202
