### PR TITLE
fix(ci): raise go-tests completion ceiling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,12 +55,14 @@ jobs:
   # desktop gates. The production-build CLI suite runs in go-cli-tests beside
   # this job, so its ~6 minute TinyGo integration tests no longer serialize all
   # other Go checks. The go-race-tests job now runs the race detector in
-  # parallel, so this lane needs neither TinyGo nor Node. A recent PR-path run
-  # measured 12m01s without its race step (run 31573355088, job 94042534187),
-  # so it keeps a 15-minute fail-safe.
+  # parallel, so this lane needs neither TinyGo nor Node. A main-path run
+  # measured 14m10s (run 33836750032, job 100910735401), and a PR run reached
+  # its final test gate at 14m59 before the 15-minute ceiling cancelled teardown
+  # (run 33853282910, job 100960713148). A 20-minute fail-safe stays bounded
+  # while allowing normal runner variance and post-step cleanup.
   go-tests:
     runs-on: ubuntu-latest
-    timeout-minutes: 15
+    timeout-minutes: 20
 
     steps:
       - name: Check out repository

--- a/internal/perfbrowserpin/validator.go
+++ b/internal/perfbrowserpin/validator.go
@@ -18,6 +18,7 @@ import (
 
 const (
 	browserJobName = "browser-tests"
+	goTestsJobName = "go-tests"
 	stableJobName  = "scene3d-v1-browser-renderer-proof"
 	adapterJobName = "scene3d-v1-adapter-proof"
 	testJobName    = "test"
@@ -153,6 +154,13 @@ func Validate(source []byte) error {
 	if err != nil {
 		return err
 	}
+	goTestsJob, ok := jobs[goTestsJobName]
+	if !ok {
+		return errors.New("workflow.jobs: go-tests job is missing")
+	}
+	if err := validateGoTestsTimeout(goTestsJob); err != nil {
+		return err
+	}
 
 	browserJob, ok := jobs[browserJobName]
 	if !ok {
@@ -184,6 +192,19 @@ func Validate(source []byte) error {
 		return err
 	}
 	return nil
+}
+
+func validateGoTestsTimeout(node *yaml.Node) error {
+	const label = "go-tests job"
+	job, err := mapping(node, label)
+	if err != nil {
+		return err
+	}
+	timeout, ok := job["timeout-minutes"]
+	if !ok {
+		return fmt.Errorf("%s: missing field %q", label, "timeout-minutes")
+	}
+	return exactInt(timeout, label+".timeout-minutes", "20")
 }
 
 func decode(source []byte) (*yaml.Node, error) {

--- a/internal/perfbrowserpin/validator_test.go
+++ b/internal/perfbrowserpin/validator_test.go
@@ -24,6 +24,14 @@ func TestStructuralMutationsFailClosed(t *testing.T) {
 		want   string
 	}{
 		{
+			name: "go-tests timeout regression",
+			mutate: replace(
+				"  go-tests:\n    runs-on: ubuntu-latest\n    timeout-minutes: 20",
+				"  go-tests:\n    runs-on: ubuntu-latest\n    timeout-minutes: 15",
+			),
+			want: "go-tests job.timeout-minutes",
+		},
+		{
 			name: "numeric pin drift",
 			mutate: replace(
 				"          chrome-version: '1688711'",


### PR DESCRIPTION
## What changed

- raise the bounded `go-tests` job ceiling from 15 to 20 minutes
- replace the stale 12m01 rationale with exact current evidence: main run 33836750032 / job 100910735401 completed in 14m10s, while PR run 33853282910 / job 100960713148 reached its final named gate at 14m59 and was cancelled at 15m01 during teardown
- extend the existing governed-workflow validator so a timeout regression is rejected

## Why

The lane is healthy but the old ceiling no longer leaves enough GitHub runner variance or teardown time. This keeps the job bounded without dropping, splitting, or weakening any gate.

## Verification

- `actionlint .github/workflows/ci.yml`
- `go test ./internal/perfbrowserpin`
- `sh scripts/check-perf-browser-pin-test.sh`
- `make fmt-check`
- `make release-gate`
- `git diff --check`

No product code or performance/size budgets changed.