### PR TITLE
feat(islands): inline pure-view component composition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - The file-routed `<Image>` builtin accepts the source contract through `sources={...}`. Authored art-direction sources precede any generic format source generated from the build manifest, so a media-specific crop cannot be shadowed by an unconditional WebP source.
 - Source candidates remain author-owned: GoSX escapes them into HTML but does not fetch, cache, or rewrite remote media, and no client JavaScript is added. This slice follows the real Muddy Noni storefront layout that already had to hand-author mobile `<source media>` candidates.
 
+### Added: strict pure-view composition inside islands
+
+- A `//gosx:island` component may call same-file strict pure-view components. The compiler inlines each invocation into the parent island program, including direct typed scalar props, caller children, and named slots; the browser still hydrates one root with one VM and no component-call opcode.
+- The boundary fails closed for nested islands, engines, legacy or imported callees, callee-owned reactive behavior, handler-valued props, nested/slice props, spreads, cycles, more than 32 component frames, and programs beyond the VM's 65,535-node/expression limits.
+- Root island call-site children and slots now fail explicitly instead of being omitted from the per-component `.gxi` program. Put a slot-bearing pure-view component inside the island instead.
+
 ## v0.55.2 (2026-09-04)
 
 ### Fixed: comments inside GSX markup compile away

--- a/README.md
+++ b/README.md
@@ -114,6 +114,25 @@ Strict `//gosx:engine` declarations and automatic `.gsx` engine-surface
 discovery remain preview/post-v1. The v1 engine contract is the programmatic
 `engine.Config` / `ctx.Engine` surface described below.
 
+An island may compose same-file strict **pure-view** components. GoSX inlines
+each invocation into the parent island program at compile time, so composition
+adds no browser component runtime: the result still has one hydration root,
+one VM, and the same `.gxi` shape as equivalent hand-flattened markup. Direct
+typed scalar props, caller-owned children, and named slots are supported;
+projected children keep access to the parent island's signals and handlers.
+
+The v1 boundary is deliberately fail-closed. A composed callee cannot be an
+island, engine, legacy or imported component; own signals, computed values,
+handlers, or effects; accept handler-valued props; read nested/slice props; or
+use spreads. Recursion is rejected, composition depth is capped at 32, and the
+expanded island retains the VM's 65,535-node and expression limits. Put state
+and behavior in the parent island and pass scalar view data down.
+
+Root island call-site children and named slots are not supported: island
+program assets are compiled per component, before any individual server call
+site exists. Put the slot-bearing pure-view component *inside* the island when
+you need that composition shape.
+
 ### Legacy component syntax (deprecated)
 
 Earlier GoSX releases also accepted `func Name(props T) Node` as a

--- a/examples/gosx-docs/app/docs/components/page.gsx
+++ b/examples/gosx-docs/app/docs/components/page.gsx
@@ -264,6 +264,18 @@ func Page() Node {
 		<p>
 			A component that renders no children rejects child content with a diagnostic that names both remedies, rather than dropping the content silently.
 		</p>
+		<h2 id="island-composition">Composing inside an island</h2>
+		<p>
+			An island may call a same-file strict pure-view component. GoSX expands each call into the parent island program at compile time, so the browser still receives one hydration root and one VM—not a client component runtime. Direct typed scalar props, caller children, and named slots are supported. Projected child markup remains in the caller's scope, so it may read the parent island's signals and bind its handlers.
+		</p>
+		<p>
+			Keep state and behavior in the parent island. A v1 pure-view callee cannot be another island, an engine, a legacy or imported component; own signals, computed values, handlers, or effects; accept handler-valued props; read nested or slice props; or use spreads. Recursive composition fails with its cycle path, depth is capped at 32 components, and the expanded program keeps the VM's 65,535-node and expression limits.
+		</p>
+		<p>
+			Do not declare
+			<span class="inline-code">{"{children}"}</span>
+			or a named-slot hole on the root island itself. A root island program is compiled per component, before a server call site can supply content. Put a slot-bearing pure-view component inside the island instead.
+		</p>
 		<p>
 			Strict markup also accepts the familiar aliases
 			<span class="inline-code">className</span>

--- a/examples/gosx-docs/app/docs/components/page.server.go
+++ b/examples/gosx-docs/app/docs/components/page.server.go
@@ -123,6 +123,8 @@ func init() {
 					{"href": "#strict-loops-and-spread", "label": "Loops & Spread Props"},
 					{"href": "#legacy-components", "label": "Legacy Components"},
 					{"href": "#attributes", "label": "Elements & Attributes"},
+					{"href": "#children", "label": "Children"},
+					{"href": "#island-composition", "label": "Island Composition"},
 					{"href": "#tooling", "label": "Tooling"},
 					{"href": "#choosing", "label": "Choosing a Style"},
 				},

--- a/examples/gosx-docs/app/docs/islands/page.gsx
+++ b/examples/gosx-docs/app/docs/islands/page.gsx
@@ -58,6 +58,19 @@ func Page() Node {
 			<span class="inline-code">gosx dev</span>
 			to produce and serve application assets.
 		</p>
+		<h2 id="composition">Pure-view composition</h2>
+		<CodeBlock lang="gosx" source={data.compositionSample} />
+		<p>
+			A parent island may call a same-file strict pure-view component. The compiler inlines every invocation into the parent's program, including direct typed scalar props, caller-owned children, and named slots. Projected child markup can read the parent island's signals and bind its handlers. The browser still hydrates one root with one VM, and the encoded program has no component-call opcode.
+		</p>
+		<p>
+			Pure-view means the callee owns no signals, computed values, handlers, or effects. Nested islands, engines, legacy and imported callees, handler-valued props, nested or slice props, spreads, recursion, and more than 32 composed component frames fail closed. Expanded programs retain the 65,535-node and expression limits.
+		</p>
+		<p>
+			Caller children and named slots belong on an inner pure-view component, as in the sample. The root island itself cannot declare those holes because its
+			<span class="inline-code">.gxi</span>
+			asset is compiled before any individual server call site supplies content.
+		</p>
 		<h2 id="vm-subset">Expression VM subset</h2>
 		<p>
 			The island VM implements a constrained expression and statement language for signal reads and writes, literals, supported operators, property/index access, conditionals, and known handlers. The compiler rejects constructs it cannot encode.

--- a/examples/gosx-docs/app/docs/islands/page.server.go
+++ b/examples/gosx-docs/app/docs/islands/page.server.go
@@ -16,14 +16,16 @@ func init() {
 				"toc": []map[string]string{
 					{"href": "#island-model", "label": "Island Model"},
 					{"href": "#authoring", "label": "Authoring"},
+					{"href": "#composition", "label": "Composition"},
 					{"href": "#vm-subset", "label": "VM Subset"},
 					{"href": "#shared-signals", "label": "Shared Signals"},
 					{"href": "#program-assets", "label": "Program Assets"},
 					{"href": "#choosing", "label": "Choosing Islands"},
 				},
-				"counterSample": "package counter\n\n//gosx:island\ncomponent Counter() {\n\tcount := signal.New(0)\n\tincrement := func() { count.Set(count.Get() + 1) }\n\tdecrement := func() { count.Set(count.Get() - 1) }\n\treturn <div class=\"counter\">\n\t\t<button onClick={decrement}>-</button>\n\t\t<span>{count.Get()}</span>\n\t\t<button onClick={increment}>+</button>\n\t</div>\n}",
-				"sharedSample":  "//gosx:island\ncomponent ThemeSwitch() {\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\ttoggle := func() {\n\t\ttheme.Set(theme.Get() == \"dark\" ? \"light\" : \"dark\")\n\t}\n\treturn <button onClick={toggle}>{theme.Get()}</button>\n}",
-				"assetSample":   "node := ctx.Runtime().IslandWithProgramAsset(\n\tcounterProgram,\n\tmap[string]int{\"initial\": 2},\n\t\"/islands/Counter.bin\",\n\t\"bin\",\n\tcounterHash,\n)",
+				"counterSample":     "package counter\n\n//gosx:island\ncomponent Counter() {\n\tcount := signal.New(0)\n\tincrement := func() { count.Set(count.Get() + 1) }\n\tdecrement := func() { count.Set(count.Get() - 1) }\n\treturn <div class=\"counter\">\n\t\t<button onClick={decrement}>-</button>\n\t\t<span>{count.Get()}</span>\n\t\t<button onClick={increment}>+</button>\n\t</div>\n}",
+				"compositionSample": "type LabelProps struct { Text string }\n\ncomponent Label(props: LabelProps) {\n\treturn <span class=\"label\">{props.Text}{children}</span>\n}\n\n//gosx:island\ncomponent Counter() {\n\tcount := signal.New(0)\n\tincrement := func() { count.Set(count.Get() + 1) }\n\treturn <Label text=\"Count: \">\n\t\t<button onClick={increment}>{count.Get()}</button>\n\t</Label>\n}",
+				"sharedSample":      "//gosx:island\ncomponent ThemeSwitch() {\n\ttheme := signal.NewShared(\"theme\", \"dark\")\n\ttoggle := func() {\n\t\ttheme.Set(theme.Get() == \"dark\" ? \"light\" : \"dark\")\n\t}\n\treturn <button onClick={toggle}>{theme.Get()}</button>\n}",
+				"assetSample":       "node := ctx.Runtime().IslandWithProgramAsset(\n\tcounterProgram,\n\tmap[string]int{\"initial\": 2},\n\t\"/islands/Counter.bin\",\n\t\"bin\",\n\tcounterHash,\n)",
 			}, nil
 		},
 	})

--- a/ir/ir.go
+++ b/ir/ir.go
@@ -328,6 +328,13 @@ const (
 type Node struct {
 	Kind NodeKind
 
+	// syntheticConditional identifies the compiler-owned <If> shape used to
+	// lower JSX conditional expressions such as {ok && <span/>}. It is kept
+	// private so source authors cannot forge it: same-file component lookup
+	// applies only to authored component references, while this node always
+	// retains builtin conditional semantics.
+	syntheticConditional bool
+
 	// Tag is the element/component name (for NodeElement and NodeComponent).
 	Tag string
 
@@ -364,6 +371,13 @@ type Node struct {
 
 	// Span tracks source location.
 	Span Span
+}
+
+// IsSyntheticConditional reports whether this node is compiler-owned control
+// flow rather than an authored component reference. Consumers that resolve
+// same-file components must preserve builtin semantics for these nodes.
+func (n *Node) IsSyntheticConditional() bool {
+	return n != nil && n.syntheticConditional
 }
 
 // AttrKind discriminates attribute types.

--- a/ir/island.go
+++ b/ir/island.go
@@ -2,6 +2,7 @@ package ir
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -14,6 +15,9 @@ func LowerIsland(prog *Program, compIdx int) (*program.Program, error) {
 	comp, err := islandComponent(prog, compIdx)
 	if err != nil {
 		return nil, err
+	}
+	if comp.AcceptsChildren || len(comp.AcceptsSlots) > 0 {
+		return nil, fmt.Errorf("island component %s cannot declare caller children or named slots: root island call-site content is rendered outside the per-component .gxi program; compose children and slots through a same-file pure-view component inside the island instead", comp.Name)
 	}
 
 	scope := mergedIslandScope(prog, comp)
@@ -141,23 +145,70 @@ func cloneExprScope(scope *ExprScope) *ExprScope {
 type islandLowerer struct {
 	src                *Program
 	dst                *program.Program
-	nodeMap            map[NodeID]program.NodeID
 	srcIDs             []NodeID // tracks source node ID for each dst node
 	scope              *ExprScope
 	inlineHandlerIndex int
+	componentIndex     map[string]int
+	calleeErrors       map[int]error
+	compositionIndex   int
+	composed           bool
+}
+
+const maxIslandCompositionDepth = 32
+
+type islandInlineExpr struct {
+	source  string
+	context *islandInlineContext
+	scope   *ExprScope
+}
+
+type islandProjection struct {
+	nodes   []NodeID
+	context *islandInlineContext
+	scope   *ExprScope
+	// stack belongs to the projection's caller. A finite nested use such as
+	// <Wrapper><Wrapper /></Wrapper> is not a recursive component definition,
+	// even though the inner call is lowered while visiting Wrapper's hole.
+	stack []string
+}
+
+// islandInlineContext is compile-time-only. It specializes a same-file
+// pure-view component call into its owning island program; no component frame
+// or virtual-DOM abstraction survives into the browser artifact.
+type islandInlineContext struct {
+	component    string
+	props        map[string]islandInlineExpr
+	children     islandProjection
+	slots        map[string]islandProjection
+	identAliases map[string]string
+	activeNames  map[string]bool
+}
+
+func newIslandInlineContext() *islandInlineContext {
+	return &islandInlineContext{
+		props:        make(map[string]islandInlineExpr),
+		slots:        make(map[string]islandProjection),
+		identAliases: make(map[string]string),
+		activeNames:  make(map[string]bool),
+	}
 }
 
 func newIslandLowerer(src *Program, name string, scope *ExprScope) *islandLowerer {
+	componentIndex := make(map[string]int, len(src.Components))
+	for i := range src.Components {
+		componentIndex[src.Components[i].Name] = i
+	}
 	return &islandLowerer{
-		src:     src,
-		dst:     &program.Program{Name: name},
-		nodeMap: make(map[NodeID]program.NodeID),
-		scope:   scope,
+		src:            src,
+		dst:            &program.Program{Name: name},
+		scope:          scope,
+		componentIndex: componentIndex,
+		calleeErrors:   make(map[int]error),
 	}
 }
 
 func (l *islandLowerer) lowerComponent(comp Component) error {
-	rootID, err := l.lowerNode(comp.Root)
+	rootID, err := l.lowerNode(comp.Root, newIslandInlineContext(), []string{comp.Name})
 	if err != nil {
 		return fmt.Errorf("lower %s: %w", comp.Name, err)
 	}
@@ -273,6 +324,10 @@ func (l *islandLowerer) parseExprOrFallback(source string, scope *ExprScope, fal
 }
 
 func (l *islandLowerer) populateStaticMask() {
+	if l.composed {
+		l.populateComposedStaticMask()
+		return
+	}
 	l.dst.StaticMask = make([]bool, len(l.dst.Nodes))
 	for i, srcID := range l.srcIDs {
 		if int(srcID) < len(l.src.Nodes) {
@@ -281,23 +336,70 @@ func (l *islandLowerer) populateStaticMask() {
 	}
 }
 
-func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
-	if mapped, ok := l.nodeMap[srcID]; ok {
-		return mapped, nil
+func (l *islandLowerer) populateComposedStaticMask() {
+	l.dst.StaticMask = make([]bool, len(l.dst.Nodes))
+	known := make([]bool, len(l.dst.Nodes))
+	var isStatic func(program.NodeID) bool
+	isStatic = func(id program.NodeID) bool {
+		if int(id) >= len(l.dst.Nodes) {
+			return false
+		}
+		if known[id] {
+			return l.dst.StaticMask[id]
+		}
+		known[id] = true
+		node := l.dst.Nodes[id]
+		static := false
+		switch node.Kind {
+		case program.NodeText:
+			static = true
+		case program.NodeElement, program.NodeFragment:
+			static = true
+			for _, attr := range node.Attrs {
+				if attr.Kind == program.AttrExpr || attr.Kind == program.AttrEvent {
+					static = false
+					break
+				}
+			}
+			if static {
+				for _, child := range node.Children {
+					if !isStatic(child) {
+						static = false
+						break
+					}
+				}
+			}
+		}
+		l.dst.StaticMask[id] = static
+		return static
 	}
+	for id := range l.dst.Nodes {
+		isStatic(program.NodeID(id))
+	}
+}
 
+func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, stack []string) (program.NodeID, error) {
 	if int(srcID) >= len(l.src.Nodes) {
 		return 0, fmt.Errorf("node %d not found", srcID)
 	}
 	srcNode := l.src.NodeAt(srcID)
 
+	if srcNode.Kind == NodeComponent {
+		if targetIdx, ok := l.componentIndex[srcNode.Tag]; ok &&
+			!isEachComponent(srcNode.Tag) && !isConditionalComponent(srcNode.Tag) {
+			return l.lowerComposedCall(srcNode, targetIdx, context, stack)
+		}
+		if strings.Contains(srcNode.Tag, ".") {
+			return 0, fmt.Errorf("imported component <%s> cannot be composed inside island %s in v1; use a same-file strict pure-view component", srcNode.Tag, l.dst.Name)
+		}
+	}
+
 	// Check NodeID overflow (uint32 -> uint16)
 	if len(l.dst.Nodes) >= 65535 {
-		return 0, fmt.Errorf("island exceeds 65,535 node limit")
+		return 0, fmt.Errorf("island %s exceeds the 65,535 expanded-node limit while composing client-side components", l.dst.Name)
 	}
 
 	dstID := program.NodeID(len(l.dst.Nodes))
-	l.nodeMap[srcID] = dstID
 
 	// Pre-allocate the slot
 	l.dst.Nodes = append(l.dst.Nodes, program.Node{})
@@ -311,7 +413,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 		node.Tag = srcNode.Tag
 		// Lower attributes
 		for _, attr := range srcNode.Attrs {
-			dstAttr, err := l.lowerAttr(attr)
+			dstAttr, err := l.lowerAttr(attr, context)
 			if err != nil {
 				return 0, err
 			}
@@ -320,7 +422,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 	case NodeComponent:
 		if isEachComponent(srcNode.Tag) {
 			var err error
-			node, err = l.lowerEachNode(srcNode)
+			node, err = l.lowerEachNode(srcNode, context)
 			if err != nil {
 				return 0, err
 			}
@@ -328,7 +430,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 		}
 		if isConditionalComponent(srcNode.Tag) {
 			var err error
-			node, err = l.lowerConditionalNode(srcNode)
+			node, err = l.lowerConditionalNode(srcNode, context)
 			if err != nil {
 				return 0, err
 			}
@@ -341,7 +443,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 			node.Kind = program.NodeElement
 			node.Tag = tag
 			for _, attr := range srcNode.Attrs {
-				dstAttr, err := l.lowerAttr(attr)
+				dstAttr, err := l.lowerAttr(attr, context)
 				if err != nil {
 					return 0, err
 				}
@@ -355,9 +457,10 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 		node.Text = srcNode.Text
 	case NodeExpr:
 		node.Kind = program.NodeExpr
-		// For now, store expression text as a simple signal/prop reference
-		// Full expression parsing comes in Task 10
-		exprID := l.addExpr(srcNode.Text)
+		exprID, err := l.addExprWithContext(srcNode.Text, context, l.scope)
+		if err != nil {
+			return 0, err
+		}
 		node.Expr = exprID
 	case NodeFragment:
 		node.Kind = program.NodeFragment
@@ -368,37 +471,289 @@ func (l *islandLowerer) lowerNode(srcID NodeID) (program.NodeID, error) {
 
 	// Lower children
 	childScope := l.scope
+	childContext := context
 	if node.Kind == program.NodeForEach {
 		childScope = l.scopeForEach(node)
+		childContext, node = l.scopeInlineForEach(context, node)
 	}
-	for _, childSrcID := range srcNode.Children {
-		childDstID, err := l.lowerNodeWithScope(childSrcID, childScope)
-		if err != nil {
-			return 0, err
-		}
-		node.Children = append(node.Children, childDstID)
+	children, err := l.lowerChildren(srcNode.Children, childScope, childContext, stack)
+	if err != nil {
+		return 0, err
 	}
+	node.Children = append(node.Children, children...)
 
 	l.dst.Nodes[dstID] = node
 	return dstID, nil
 }
 
-func (l *islandLowerer) lowerNodeWithScope(srcID NodeID, scope *ExprScope) (program.NodeID, error) {
+func (l *islandLowerer) lowerNodeWithScope(srcID NodeID, scope *ExprScope, context *islandInlineContext, stack []string) (program.NodeID, error) {
 	prev := l.scope
 	l.scope = scope
 	defer func() {
 		l.scope = prev
 	}()
-	return l.lowerNode(srcID)
+	return l.lowerNode(srcID, context, stack)
 }
 
-func (l *islandLowerer) lowerEachNode(srcNode *Node) (program.Node, error) {
+func (l *islandLowerer) lowerChildren(srcIDs []NodeID, scope *ExprScope, context *islandInlineContext, stack []string) ([]program.NodeID, error) {
+	var out []program.NodeID
+	for _, srcID := range srcIDs {
+		if int(srcID) >= len(l.src.Nodes) {
+			return nil, fmt.Errorf("node %d not found", srcID)
+		}
+		srcNode := l.src.NodeAt(srcID)
+		if srcNode.Kind == NodeExpr && context != nil {
+			if name, projected := islandProjectionExpression(srcNode.Text); projected && name == "" {
+				projected, err := l.lowerProjection(context.children, stack)
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, projected...)
+				continue
+			} else if projected {
+				projected, err := l.lowerProjection(context.slots[name], stack)
+				if err != nil {
+					return nil, err
+				}
+				out = append(out, projected...)
+				continue
+			}
+		}
+		dstID, err := l.lowerNodeWithScope(srcID, scope, context, stack)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, dstID)
+	}
+	return out, nil
+}
+
+// islandProjectionExpression recognizes only the whole bare identifiers used
+// for children and named-slot holes. ParseExpr makes redundant parentheses
+// transparent while keeping this build-neutral; ir/island.go is compiled by
+// TinyGo, whereas the host strict-component validator depends on go/parser.
+// The empty returned name denotes the anonymous children projection.
+func islandProjectionExpression(source string) (name string, ok bool) {
+	exprs, root, err := ParseExpr(source, nil)
+	if err != nil || len(exprs) != 1 || int(root) >= len(exprs) {
+		return "", false
+	}
+	expr := exprs[root]
+	if expr.Op != program.OpPropGet {
+		return "", false
+	}
+	if expr.Value == "children" {
+		return "", true
+	}
+	if !strings.HasPrefix(expr.Value, "slot") || len(expr.Value) == len("slot") {
+		return "", false
+	}
+	rest := expr.Value[len("slot"):]
+	if rest[0] < 'A' || rest[0] > 'Z' {
+		return "", false
+	}
+	return rest, true
+}
+
+func (l *islandLowerer) lowerProjection(projection islandProjection, stack []string) ([]program.NodeID, error) {
+	if len(projection.nodes) == 0 {
+		return nil, nil
+	}
+	if projection.stack != nil {
+		stack = projection.stack
+	}
+	return l.lowerChildren(projection.nodes, projection.scope, projection.context, stack)
+}
+
+func (l *islandLowerer) lowerComposedCall(call *Node, targetIdx int, callerContext *islandInlineContext, stack []string) (program.NodeID, error) {
+	target := l.src.Components[targetIdx]
+	for _, name := range stack {
+		if name == target.Name {
+			path := append(append([]string(nil), stack...), target.Name)
+			return 0, fmt.Errorf("island component composition cycle: %s", strings.Join(path, " -> "))
+		}
+	}
+	if len(stack) >= maxIslandCompositionDepth {
+		return 0, fmt.Errorf("island component composition exceeds the %d-component depth limit at <%s>", maxIslandCompositionDepth, target.Name)
+	}
+	calleeErr, checked := l.calleeErrors[targetIdx]
+	if !checked {
+		calleeErr = l.composableCalleeError(&target)
+		l.calleeErrors[targetIdx] = calleeErr
+	}
+	if calleeErr != nil {
+		return 0, calleeErr
+	}
+	l.composed = true
+
+	callScope := cloneExprScope(l.scope)
+	context := newIslandInlineContext()
+	context.component = target.Name
+	if callerContext != nil {
+		for name, active := range callerContext.activeNames {
+			context.activeNames[name] = active
+		}
+	}
+	for _, attr := range call.Attrs {
+		var source string
+		switch attr.Kind {
+		case AttrStatic:
+			source = strconv.Quote(attr.Value)
+		case AttrBool:
+			source = "true"
+		case AttrExpr:
+			if attr.IsEvent || (l.scope != nil && l.scope.Handlers[strings.TrimSpace(attr.Expr)]) {
+				return 0, fmt.Errorf("component <%s> passes handler-valued prop %q inside island %s; v1 pure-view composition accepts typed scalar props only", target.Name, attr.Name, l.dst.Name)
+			}
+			source = attr.Expr
+		case AttrSpread:
+			return 0, fmt.Errorf("component <%s> uses a spread inside island %s; v1 pure-view composition requires explicit typed scalar props", target.Name, l.dst.Name)
+		default:
+			return 0, fmt.Errorf("component <%s> has unsupported prop %q inside island %s", target.Name, attr.Name, l.dst.Name)
+		}
+		context.props[attr.Name] = islandInlineExpr{source: source, context: callerContext, scope: callScope}
+	}
+	projectionStack := append([]string(nil), stack...)
+	context.children = islandProjection{nodes: call.Children, context: callerContext, scope: callScope, stack: projectionStack}
+	for name, nodeID := range call.Slots {
+		context.slots[name] = islandProjection{nodes: []NodeID{nodeID}, context: callerContext, scope: callScope, stack: projectionStack}
+	}
+
+	l.compositionIndex++
+	return l.lowerNodeWithScope(target.Root, l.scope, context, append(stack, target.Name))
+}
+
+func (l *islandLowerer) composableCalleeError(target *Component) error {
+	if target.IsIsland {
+		return fmt.Errorf("nested island <%s> is not allowed inside island %s; compose a non-island strict pure-view component so the subtree has one hydration root and one VM", target.Name, l.dst.Name)
+	}
+	if target.IsEngine || target.ServerOnly {
+		return fmt.Errorf("component <%s> is not a client pure-view component and cannot be composed inside island %s", target.Name, l.dst.Name)
+	}
+	if target.Syntax != ComponentSyntaxStrict {
+		return fmt.Errorf("component <%s> uses legacy component syntax; v1 island composition accepts same-file strict pure-view components only", target.Name)
+	}
+	if target.Scope != nil && (len(target.Scope.Signals) > 0 || len(target.Scope.Computeds) > 0 || len(target.Scope.Handlers) > 0 || len(target.Scope.Locals) > 0) {
+		return fmt.Errorf("component <%s> owns signals, computed values, handlers, or effects; v1 island composition requires a pure-view callee and keeps all state in the parent island", target.Name)
+	}
+	fields := make([]string, 0, len(target.PropsFields))
+	for field := range target.PropsFields {
+		fields = append(fields, field)
+	}
+	sort.Strings(fields)
+	for _, field := range fields {
+		typ := target.PropsFields[field]
+		if !strictRendererScalarType(typ) {
+			return fmt.Errorf("component <%s> reads non-scalar prop %s (%s); v1 island composition accepts typed string, bool, integer, and floating-point props only", target.Name, field, typ)
+		}
+	}
+	if len(target.PropsPaths) > 0 || len(target.PropsSlices) > 0 {
+		return fmt.Errorf("component <%s> reads nested or slice props; v1 island composition accepts direct typed scalar props only", target.Name)
+	}
+	if err := l.composableViewTreeError(target.Name, target.Root, make(map[NodeID]bool)); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (l *islandLowerer) composableViewTreeError(componentName string, id NodeID, seen map[NodeID]bool) error {
+	if int(id) >= len(l.src.Nodes) || seen[id] {
+		return nil
+	}
+	seen[id] = true
+	node := l.src.NodeAt(id)
+	for _, attr := range node.Attrs {
+		if attr.Kind == AttrSpread {
+			return fmt.Errorf("pure-view component <%s> contains a spread attribute; v1 island composition requires explicit attributes", componentName)
+		}
+		if attr.IsEvent || (attr.Kind == AttrStatic && strings.HasPrefix(strings.ToLower(strings.TrimSpace(attr.Name)), "data-on-")) {
+			return fmt.Errorf("pure-view component <%s> contains handler attribute %q; keep behavior in the parent island and pass only scalar view data", componentName, attr.Name)
+		}
+	}
+	for _, child := range node.Children {
+		if err := l.composableViewTreeError(componentName, child, seen); err != nil {
+			return err
+		}
+	}
+	for _, child := range node.Slots {
+		if err := l.composableViewTreeError(componentName, child, seen); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (l *islandLowerer) scopeInlineForEach(context *islandInlineContext, node program.Node) (*islandInlineContext, program.Node) {
+	if context == nil {
+		context = newIslandInlineContext()
+	}
+	next := &islandInlineContext{
+		component:    context.component,
+		props:        context.props,
+		children:     context.children,
+		slots:        context.slots,
+		identAliases: make(map[string]string, len(context.identAliases)+3),
+		activeNames:  make(map[string]bool, len(context.activeNames)+3),
+	}
+	for name, alias := range context.identAliases {
+		next.identAliases[name] = alias
+	}
+	for name, active := range context.activeNames {
+		next.activeNames[name] = active
+	}
+
+	itemName := forEachStaticAttr(node.Attrs, "as")
+	if itemName == "" {
+		itemName = "item"
+	}
+	actualItem := l.uniqueInlineBinding(itemName, next.activeNames)
+	next.identAliases[itemName] = actualItem
+	next.identAliases[itemName+"Key"] = actualItem + "Key"
+	next.activeNames[actualItem] = true
+	next.activeNames[actualItem+"Key"] = true
+	setForEachStaticAttr(node.Attrs, "as", actualItem)
+
+	if indexName := forEachStaticAttr(node.Attrs, "index"); indexName != "" {
+		actualIndex := l.uniqueInlineBinding(indexName, next.activeNames)
+		next.identAliases[indexName] = actualIndex
+		next.activeNames[actualIndex] = true
+		setForEachStaticAttr(node.Attrs, "index", actualIndex)
+	}
+	return next, node
+}
+
+func (l *islandLowerer) uniqueInlineBinding(name string, active map[string]bool) string {
+	if !active[name] {
+		return name
+	}
+	for {
+		l.compositionIndex++
+		candidate := "__gosx_inline_" + strconv.Itoa(l.compositionIndex) + "_" + name
+		if !active[candidate] {
+			return candidate
+		}
+	}
+}
+
+func setForEachStaticAttr(attrs []program.Attr, name, value string) {
+	for i := range attrs {
+		if attrs[i].Kind == program.AttrStatic && attrs[i].Name == name {
+			attrs[i].Value = value
+			return
+		}
+	}
+}
+
+func (l *islandLowerer) lowerEachNode(srcNode *Node, context *islandInlineContext) (program.Node, error) {
 	collectionExpr := eachAttrSource(srcNode.Attrs, "of", "each", "items")
 	if collectionExpr == "" {
 		return program.Node{}, fmt.Errorf("%s requires an of/each/items attribute", srcNode.Tag)
 	}
 
-	exprID := l.addExpr(collectionExpr)
+	exprID, err := l.addExprWithContext(collectionExpr, context, l.scope)
+	if err != nil {
+		return program.Node{}, err
+	}
 	node := program.Node{
 		Kind: program.NodeForEach,
 		Expr: exprID,
@@ -423,31 +778,43 @@ func (l *islandLowerer) lowerEachNode(srcNode *Node) (program.Node, error) {
 	}
 
 	if fallbackSource := eachAttrSource(srcNode.Attrs, "fallback", "empty"); fallbackSource != "" {
+		fallbackID, err := l.addExprWithContext(fallbackSource, context, l.scope)
+		if err != nil {
+			return program.Node{}, err
+		}
 		node.Attrs = append(node.Attrs, program.Attr{
 			Kind: program.AttrExpr,
 			Name: "fallback",
-			Expr: l.addExpr(fallbackSource),
+			Expr: fallbackID,
 		})
 	}
 
 	return node, nil
 }
 
-func (l *islandLowerer) lowerConditionalNode(srcNode *Node) (program.Node, error) {
+func (l *islandLowerer) lowerConditionalNode(srcNode *Node, context *islandInlineContext) (program.Node, error) {
 	conditionExpr := islandAttrSource(srcNode.Attrs, "when", "if", "cond", "test")
 	if conditionExpr == "" {
 		return program.Node{}, fmt.Errorf("%s requires a when/if/cond/test attribute", srcNode.Tag)
 	}
 
+	conditionID, err := l.addExprWithContext(conditionExpr, context, l.scope)
+	if err != nil {
+		return program.Node{}, err
+	}
 	node := program.Node{
 		Kind: program.NodeConditional,
-		Expr: l.addExpr(conditionExpr),
+		Expr: conditionID,
 	}
 	if fallbackSource := islandAttrSource(srcNode.Attrs, "fallback", "else"); fallbackSource != "" {
+		fallbackID, err := l.addExprWithContext(fallbackSource, context, l.scope)
+		if err != nil {
+			return program.Node{}, err
+		}
 		node.Attrs = append(node.Attrs, program.Attr{
 			Kind: program.AttrExpr,
 			Name: "fallback",
-			Expr: l.addExpr(fallbackSource),
+			Expr: fallbackID,
 		})
 	}
 	return node, nil
@@ -472,7 +839,7 @@ func (l *islandLowerer) scopeForEach(node program.Node) *ExprScope {
 	return scope
 }
 
-func (l *islandLowerer) lowerAttr(attr Attr) (program.Attr, error) {
+func (l *islandLowerer) lowerAttr(attr Attr, context *islandInlineContext) (program.Attr, error) {
 	switch attr.Kind {
 	case AttrStatic:
 		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(attr.Name)), "data-on-") {
@@ -500,8 +867,12 @@ func (l *islandLowerer) lowerAttr(attr Attr) (program.Attr, error) {
 				Event: attr.Expr, // handler name from expression
 			}, nil
 		}
-		// Expression attribute -- add to expr table
-		exprID := l.addExpr(attr.Expr)
+		// Expression attribute -- add to expr table, substituting any
+		// compile-time pure-view prop bindings before the opcode graph lands.
+		exprID, err := l.addExprWithContext(attr.Expr, context, l.scope)
+		if err != nil {
+			return program.Attr{}, err
+		}
 		return program.Attr{
 			Kind: program.AttrExpr,
 			Name: attr.Name,
@@ -673,6 +1044,83 @@ func forEachStaticAttr(attrs []program.Attr, name string) string {
 		}
 	}
 	return ""
+}
+
+// addExprWithContext parses one expression and rewrites direct props.Field
+// reads through the scalar expressions supplied at the component call site.
+// The rewrite happens on the opcode graph, not by source-text replacement, so
+// identifiers with matching substrings and string literals remain untouched.
+func (l *islandLowerer) addExprWithContext(source string, context *islandInlineContext, scope *ExprScope) (program.ExprID, error) {
+	exprs, rootID, err := ParseExpr(source, scope)
+	if err != nil {
+		return 0, fmt.Errorf("parse island expression %q: %w", source, err)
+	}
+	return l.appendInlineExpr(exprs, rootID, context, make(map[program.ExprID]program.ExprID))
+}
+
+func (l *islandLowerer) appendInlineExpr(exprs []program.Expr, id program.ExprID, context *islandInlineContext, memo map[program.ExprID]program.ExprID) (program.ExprID, error) {
+	if mapped, ok := memo[id]; ok {
+		return mapped, nil
+	}
+	if int(id) >= len(exprs) {
+		return 0, fmt.Errorf("island expression references invalid opcode %d", id)
+	}
+	if field, ok := directPropsField(exprs, id); ok && context != nil && context.component != "" {
+		binding, supplied := context.props[field]
+		if !supplied {
+			return 0, fmt.Errorf("composed component <%s> requires scalar prop %s, but the call does not supply it", context.component, field)
+		}
+		mapped, err := l.addExprWithContext(binding.source, binding.context, binding.scope)
+		if err != nil {
+			return 0, fmt.Errorf("compose <%s> prop %s: %w", context.component, field, err)
+		}
+		memo[id] = mapped
+		return mapped, nil
+	}
+
+	expr := exprs[id]
+	if expr.Op == program.OpPropGet && context != nil {
+		if alias := context.identAliases[expr.Value]; alias != "" {
+			expr.Value = alias
+		}
+	}
+	if len(expr.Operands) > 0 {
+		operands := make([]program.ExprID, len(expr.Operands))
+		for i, operand := range expr.Operands {
+			mapped, err := l.appendInlineExpr(exprs, operand, context, memo)
+			if err != nil {
+				return 0, err
+			}
+			operands[i] = mapped
+		}
+		expr.Operands = operands
+	}
+	if len(l.dst.Exprs) >= 65535 {
+		return 0, fmt.Errorf("island %s exceeds the 65,535 expression limit while composing client-side components", l.dst.Name)
+	}
+	mapped := program.ExprID(len(l.dst.Exprs))
+	l.dst.Exprs = append(l.dst.Exprs, expr)
+	memo[id] = mapped
+	return mapped, nil
+}
+
+func directPropsField(exprs []program.Expr, id program.ExprID) (string, bool) {
+	if int(id) >= len(exprs) {
+		return "", false
+	}
+	expr := exprs[id]
+	if expr.Op != program.OpIndex || len(expr.Operands) != 2 {
+		return "", false
+	}
+	receiverID, fieldID := expr.Operands[0], expr.Operands[1]
+	if int(receiverID) >= len(exprs) || int(fieldID) >= len(exprs) {
+		return "", false
+	}
+	receiver, field := exprs[receiverID], exprs[fieldID]
+	if receiver.Op != program.OpPropGet || receiver.Value != "props" || field.Op != program.OpLitString || field.Value == "" {
+		return "", false
+	}
+	return field.Value, true
 }
 
 // addExpr parses a Go expression source string into typed opcodes and appends

--- a/ir/island.go
+++ b/ir/island.go
@@ -539,7 +539,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, an
 	}
 	srcNode := l.src.NodeAt(srcID)
 
-	if srcNode.Kind == NodeComponent {
+	if srcNode.Kind == NodeComponent && !srcNode.IsSyntheticConditional() {
 		// A same-file declaration is authoritative even when its name shadows
 		// an island builtin or element alias. The strict front end applies the
 		// same precedence before this VM lowering stage.

--- a/ir/island.go
+++ b/ir/island.go
@@ -30,6 +30,9 @@ func LowerIsland(prog *Program, compIdx int) (*program.Program, error) {
 		return nil, err
 	}
 	l.populateStaticMask()
+	if err := l.validateProgramIntegrity(); err != nil {
+		return nil, err
+	}
 
 	return l.dst, nil
 }
@@ -155,6 +158,21 @@ type islandLowerer struct {
 }
 
 const maxIslandCompositionDepth = 32
+const maxIslandProgramEntries = 1<<16 - 1
+
+// islandExpansionError marks a lowering failure whose exact answer depends on
+// the physically expanded island program (composition depth, emitted-node
+// count, or expression-table capacity). Validation delegates those answers to
+// LowerIsland so compile-time diagnostics and direct lowering cannot drift.
+type islandExpansionError struct {
+	message string
+}
+
+func (e *islandExpansionError) Error() string { return e.message }
+
+func newIslandExpansionError(format string, args ...any) error {
+	return &islandExpansionError{message: fmt.Sprintf(format, args...)}
+}
 
 type islandInlineExpr struct {
 	source  string
@@ -166,10 +184,10 @@ type islandProjection struct {
 	nodes   []NodeID
 	context *islandInlineContext
 	scope   *ExprScope
-	// stack belongs to the projection's caller. A finite nested use such as
+	// ancestry belongs to the projection's caller. A finite nested use such as
 	// <Wrapper><Wrapper /></Wrapper> is not a recursive component definition,
 	// even though the inner call is lowered while visiting Wrapper's hole.
-	stack []string
+	ancestry []string
 }
 
 // islandInlineContext is compile-time-only. It specializes a same-file
@@ -208,7 +226,7 @@ func newIslandLowerer(src *Program, name string, scope *ExprScope) *islandLowere
 }
 
 func (l *islandLowerer) lowerComponent(comp Component) error {
-	rootID, err := l.lowerNode(comp.Root, newIslandInlineContext(), []string{comp.Name})
+	rootID, err := l.lowerNode(comp.Root, newIslandInlineContext(), []string{comp.Name}, 1)
 	if err != nil {
 		return fmt.Errorf("lower %s: %w", comp.Name, err)
 	}
@@ -220,26 +238,32 @@ func (l *islandLowerer) emitComponentScope(scope *ComponentScope) error {
 	if scope == nil {
 		return nil
 	}
-	l.emitSignalDefs(scope.Signals)
+	if err := l.emitSignalDefs(scope.Signals); err != nil {
+		return err
+	}
 	if err := l.emitComputedDefs(scope.Computeds); err != nil {
 		return err
 	}
 	return l.emitHandlerDefs(scope.Handlers)
 }
 
-func (l *islandLowerer) emitSignalDefs(signals []SignalInfo) {
+func (l *islandLowerer) emitSignalDefs(signals []SignalInfo) error {
 	for _, sig := range signals {
-		initID := l.parseExprOrFallback(sig.InitExpr, l.scope, program.Expr{
+		initID, err := l.parseExprOrFallback(sig.InitExpr, l.scope, program.Expr{
 			Op:    program.OpLitString,
 			Value: sig.InitExpr,
 			Type:  program.TypeAny,
 		})
+		if err != nil {
+			return fmt.Errorf("emit signal %s initializer: %w", sig.Name, err)
+		}
 		l.dst.Signals = append(l.dst.Signals, program.SignalDef{
 			Name: sig.Name,
 			Type: typeHintToExprType(sig.TypeHint),
 			Init: initID,
 		})
 	}
+	return nil
 }
 
 func (l *islandLowerer) emitComputedDefs(computeds []ComputedInfo) error {
@@ -263,7 +287,10 @@ func (l *islandLowerer) emitComputedDefs(computeds []ComputedInfo) error {
 		if err != nil {
 			return fmt.Errorf("parse computed %s expression %q: %w", computed.Name, bodySource, err)
 		}
-		bodyID := l.appendExprs(exprs, rootID)
+		bodyID, err := l.appendExprs(exprs, rootID)
+		if err != nil {
+			return fmt.Errorf("emit computed %s expression: %w", computed.Name, err)
+		}
 		l.dst.Computeds = append(l.dst.Computeds, program.ComputedDef{
 			Name: computed.Name,
 			Type: program.TypeAny,
@@ -283,7 +310,11 @@ func (l *islandLowerer) emitHandlerDefs(handlers []HandlerInfo) error {
 			if err != nil {
 				return fmt.Errorf("parse handler %s statement %q: %w", handler.Name, stmtSource, err)
 			}
-			h.Body = append(h.Body, l.appendExprs(stmtExprs, stmtID))
+			bodyID, err := l.appendExprs(stmtExprs, stmtID)
+			if err != nil {
+				return fmt.Errorf("emit handler %s statement: %w", handler.Name, err)
+			}
+			h.Body = append(h.Body, bodyID)
 		}
 		l.dst.Handlers = append(l.dst.Handlers, h)
 	}
@@ -315,7 +346,7 @@ var islandEventFields = []string{
 	"data", "eventData",
 }
 
-func (l *islandLowerer) parseExprOrFallback(source string, scope *ExprScope, fallback program.Expr) program.ExprID {
+func (l *islandLowerer) parseExprOrFallback(source string, scope *ExprScope, fallback program.Expr) (program.ExprID, error) {
 	exprs, rootID, err := ParseExpr(source, scope)
 	if err != nil {
 		return l.addExprDirect(fallback)
@@ -378,16 +409,142 @@ func (l *islandLowerer) populateComposedStaticMask() {
 	}
 }
 
-func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, stack []string) (program.NodeID, error) {
+// validateProgramIntegrity is the final fail-closed wire-contract gate. The
+// binary format encodes collection counts and node/expression references as
+// uint16; reaching this point must prove that no earlier append or offset can
+// be truncated by serialization.
+func (l *islandLowerer) validateProgramIntegrity() error {
+	p := l.dst
+	checkCount := func(label string, count int) error {
+		if count > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d %s; the program limit is 65,535", p.Name, count, label)
+		}
+		return nil
+	}
+	counts := []struct {
+		label string
+		count int
+	}{
+		{"props", len(p.Props)},
+		{"nodes", len(p.Nodes)},
+		{"expressions", len(p.Exprs)},
+		{"signals", len(p.Signals)},
+		{"computeds", len(p.Computeds)},
+		{"handlers", len(p.Handlers)},
+		{"functions", len(p.Funcs)},
+		{"engine nodes", len(p.EngineNodes)},
+		{"static flags", len(p.StaticMask)},
+	}
+	for _, entry := range counts {
+		if err := checkCount(entry.label, entry.count); err != nil {
+			return err
+		}
+	}
+	if len(p.Nodes) == 0 || int(p.Root) >= len(p.Nodes) {
+		return newIslandExpansionError("island %s has invalid root node %d for %d nodes", p.Name, p.Root, len(p.Nodes))
+	}
+	if len(p.StaticMask) != len(p.Nodes) {
+		return newIslandExpansionError("island %s has %d static flags for %d nodes", p.Name, len(p.StaticMask), len(p.Nodes))
+	}
+	validExpr := func(id program.ExprID) bool { return int(id) < len(p.Exprs) }
+	for i, expr := range p.Exprs {
+		if len(expr.Operands) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d operands on expression %d; the program limit is 65,535", p.Name, len(expr.Operands), i)
+		}
+		for _, operand := range expr.Operands {
+			if !validExpr(operand) {
+				return newIslandExpansionError("island %s expression %d references missing operand %d", p.Name, i, operand)
+			}
+		}
+	}
+	for i, node := range p.Nodes {
+		if len(node.Attrs) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d attributes on node %d; the program limit is 65,535", p.Name, len(node.Attrs), i)
+		}
+		if len(node.Children) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d children on node %d; the program limit is 65,535", p.Name, len(node.Children), i)
+		}
+		for _, child := range node.Children {
+			if int(child) >= len(p.Nodes) {
+				return newIslandExpansionError("island %s node %d references missing child %d", p.Name, i, child)
+			}
+		}
+		if (node.Kind == program.NodeExpr || node.Kind == program.NodeForEach || node.Kind == program.NodeConditional) && !validExpr(node.Expr) {
+			return newIslandExpansionError("island %s node %d references missing expression %d", p.Name, i, node.Expr)
+		}
+		for _, attr := range node.Attrs {
+			if attr.Kind == program.AttrExpr && !validExpr(attr.Expr) {
+				return newIslandExpansionError("island %s node %d attribute %q references missing expression %d", p.Name, i, attr.Name, attr.Expr)
+			}
+		}
+	}
+	for _, signal := range p.Signals {
+		if !validExpr(signal.Init) {
+			return newIslandExpansionError("island %s signal %s references missing initializer %d", p.Name, signal.Name, signal.Init)
+		}
+	}
+	for _, computed := range p.Computeds {
+		if !validExpr(computed.Expr) {
+			return newIslandExpansionError("island %s computed %s references missing expression %d", p.Name, computed.Name, computed.Expr)
+		}
+	}
+	for _, handler := range p.Handlers {
+		if len(handler.Body) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d expressions in handler %s; the program limit is 65,535", p.Name, len(handler.Body), handler.Name)
+		}
+		for _, id := range handler.Body {
+			if !validExpr(id) {
+				return newIslandExpansionError("island %s handler %s references missing expression %d", p.Name, handler.Name, id)
+			}
+		}
+	}
+	for _, fn := range p.Funcs {
+		if len(fn.Params) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d parameters in function %s; the program limit is 65,535", p.Name, len(fn.Params), fn.Name)
+		}
+		if len(fn.Body) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d expressions in function %s; the program limit is 65,535", p.Name, len(fn.Body), fn.Name)
+		}
+		for _, id := range fn.Body {
+			if !validExpr(id) {
+				return newIslandExpansionError("island %s function %s references missing expression %d", p.Name, fn.Name, id)
+			}
+		}
+	}
+	for i, node := range p.EngineNodes {
+		if len(node.Props) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d properties on engine node %d; the program limit is 65,535", p.Name, len(node.Props), i)
+		}
+		if len(node.Children) > maxIslandProgramEntries {
+			return newIslandExpansionError("island %s has %d children on engine node %d; the program limit is 65,535", p.Name, len(node.Children), i)
+		}
+		names := make([]string, 0, len(node.Props))
+		for name := range node.Props {
+			names = append(names, name)
+		}
+		sort.Strings(names)
+		for _, name := range names {
+			id := node.Props[name]
+			if !validExpr(id) {
+				return newIslandExpansionError("island %s engine node %d property %s references missing expression %d", p.Name, i, name, id)
+			}
+		}
+	}
+	return nil
+}
+
+func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, ancestry []string, physicalDepth int) (program.NodeID, error) {
 	if int(srcID) >= len(l.src.Nodes) {
 		return 0, fmt.Errorf("node %d not found", srcID)
 	}
 	srcNode := l.src.NodeAt(srcID)
 
 	if srcNode.Kind == NodeComponent {
-		if targetIdx, ok := l.componentIndex[srcNode.Tag]; ok &&
-			!isEachComponent(srcNode.Tag) && !isConditionalComponent(srcNode.Tag) {
-			return l.lowerComposedCall(srcNode, targetIdx, context, stack)
+		// A same-file declaration is authoritative even when its name shadows
+		// an island builtin or element alias. The strict front end applies the
+		// same precedence before this VM lowering stage.
+		if targetIdx, ok := l.componentIndex[srcNode.Tag]; ok {
+			return l.lowerComposedCall(srcNode, targetIdx, context, ancestry, physicalDepth)
 		}
 		if strings.Contains(srcNode.Tag, ".") {
 			return 0, fmt.Errorf("imported component <%s> cannot be composed inside island %s in v1; use a same-file strict pure-view component", srcNode.Tag, l.dst.Name)
@@ -395,8 +552,8 @@ func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, st
 	}
 
 	// Check NodeID overflow (uint32 -> uint16)
-	if len(l.dst.Nodes) >= 65535 {
-		return 0, fmt.Errorf("island %s exceeds the 65,535 expanded-node limit while composing client-side components", l.dst.Name)
+	if len(l.dst.Nodes) >= maxIslandProgramEntries {
+		return 0, newIslandExpansionError("island %s exceeds the 65,535 expanded-node limit while composing client-side components", l.dst.Name)
 	}
 
 	dstID := program.NodeID(len(l.dst.Nodes))
@@ -476,7 +633,7 @@ func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, st
 		childScope = l.scopeForEach(node)
 		childContext, node = l.scopeInlineForEach(context, node)
 	}
-	children, err := l.lowerChildren(srcNode.Children, childScope, childContext, stack)
+	children, err := l.lowerChildren(srcNode.Children, childScope, childContext, ancestry, physicalDepth)
 	if err != nil {
 		return 0, err
 	}
@@ -486,16 +643,16 @@ func (l *islandLowerer) lowerNode(srcID NodeID, context *islandInlineContext, st
 	return dstID, nil
 }
 
-func (l *islandLowerer) lowerNodeWithScope(srcID NodeID, scope *ExprScope, context *islandInlineContext, stack []string) (program.NodeID, error) {
+func (l *islandLowerer) lowerNodeWithScope(srcID NodeID, scope *ExprScope, context *islandInlineContext, ancestry []string, physicalDepth int) (program.NodeID, error) {
 	prev := l.scope
 	l.scope = scope
 	defer func() {
 		l.scope = prev
 	}()
-	return l.lowerNode(srcID, context, stack)
+	return l.lowerNode(srcID, context, ancestry, physicalDepth)
 }
 
-func (l *islandLowerer) lowerChildren(srcIDs []NodeID, scope *ExprScope, context *islandInlineContext, stack []string) ([]program.NodeID, error) {
+func (l *islandLowerer) lowerChildren(srcIDs []NodeID, scope *ExprScope, context *islandInlineContext, ancestry []string, physicalDepth int) ([]program.NodeID, error) {
 	var out []program.NodeID
 	for _, srcID := range srcIDs {
 		if int(srcID) >= len(l.src.Nodes) {
@@ -504,14 +661,14 @@ func (l *islandLowerer) lowerChildren(srcIDs []NodeID, scope *ExprScope, context
 		srcNode := l.src.NodeAt(srcID)
 		if srcNode.Kind == NodeExpr && context != nil {
 			if name, projected := islandProjectionExpression(srcNode.Text); projected && name == "" {
-				projected, err := l.lowerProjection(context.children, stack)
+				projected, err := l.lowerProjection(context.children, ancestry, physicalDepth)
 				if err != nil {
 					return nil, err
 				}
 				out = append(out, projected...)
 				continue
 			} else if projected {
-				projected, err := l.lowerProjection(context.slots[name], stack)
+				projected, err := l.lowerProjection(context.slots[name], ancestry, physicalDepth)
 				if err != nil {
 					return nil, err
 				}
@@ -519,7 +676,7 @@ func (l *islandLowerer) lowerChildren(srcIDs []NodeID, scope *ExprScope, context
 				continue
 			}
 		}
-		dstID, err := l.lowerNodeWithScope(srcID, scope, context, stack)
+		dstID, err := l.lowerNodeWithScope(srcID, scope, context, ancestry, physicalDepth)
 		if err != nil {
 			return nil, err
 		}
@@ -555,26 +712,26 @@ func islandProjectionExpression(source string) (name string, ok bool) {
 	return rest, true
 }
 
-func (l *islandLowerer) lowerProjection(projection islandProjection, stack []string) ([]program.NodeID, error) {
+func (l *islandLowerer) lowerProjection(projection islandProjection, ancestry []string, physicalDepth int) ([]program.NodeID, error) {
 	if len(projection.nodes) == 0 {
 		return nil, nil
 	}
-	if projection.stack != nil {
-		stack = projection.stack
+	if projection.ancestry != nil {
+		ancestry = projection.ancestry
 	}
-	return l.lowerChildren(projection.nodes, projection.scope, projection.context, stack)
+	return l.lowerChildren(projection.nodes, projection.scope, projection.context, ancestry, physicalDepth)
 }
 
-func (l *islandLowerer) lowerComposedCall(call *Node, targetIdx int, callerContext *islandInlineContext, stack []string) (program.NodeID, error) {
+func (l *islandLowerer) lowerComposedCall(call *Node, targetIdx int, callerContext *islandInlineContext, ancestry []string, physicalDepth int) (program.NodeID, error) {
 	target := l.src.Components[targetIdx]
-	for _, name := range stack {
+	for _, name := range ancestry {
 		if name == target.Name {
-			path := append(append([]string(nil), stack...), target.Name)
+			path := append(append([]string(nil), ancestry...), target.Name)
 			return 0, fmt.Errorf("island component composition cycle: %s", strings.Join(path, " -> "))
 		}
 	}
-	if len(stack) >= maxIslandCompositionDepth {
-		return 0, fmt.Errorf("island component composition exceeds the %d-component depth limit at <%s>", maxIslandCompositionDepth, target.Name)
+	if physicalDepth >= maxIslandCompositionDepth {
+		return 0, newIslandExpansionError("island component composition exceeds the %d-component depth limit at <%s>", maxIslandCompositionDepth, target.Name)
 	}
 	calleeErr, checked := l.calleeErrors[targetIdx]
 	if !checked {
@@ -613,14 +770,23 @@ func (l *islandLowerer) lowerComposedCall(call *Node, targetIdx int, callerConte
 		}
 		context.props[attr.Name] = islandInlineExpr{source: source, context: callerContext, scope: callScope}
 	}
-	projectionStack := append([]string(nil), stack...)
-	context.children = islandProjection{nodes: call.Children, context: callerContext, scope: callScope, stack: projectionStack}
-	for name, nodeID := range call.Slots {
-		context.slots[name] = islandProjection{nodes: []NodeID{nodeID}, context: callerContext, scope: callScope, stack: projectionStack}
+	projectionAncestry := append([]string(nil), ancestry...)
+	context.children = islandProjection{nodes: call.Children, context: callerContext, scope: callScope, ancestry: projectionAncestry}
+	// A single map key has no ordering ambiguity. Keep the overwhelmingly
+	// common one-slot path allocation-free while sorting multi-slot calls.
+	if len(call.Slots) == 1 {
+		for name, nodeID := range call.Slots {
+			context.slots[name] = islandProjection{nodes: []NodeID{nodeID}, context: callerContext, scope: callScope, ancestry: projectionAncestry}
+		}
+	} else {
+		for _, name := range sortedNodeSlotNames(call.Slots) {
+			nodeID := call.Slots[name]
+			context.slots[name] = islandProjection{nodes: []NodeID{nodeID}, context: callerContext, scope: callScope, ancestry: projectionAncestry}
+		}
 	}
 
 	l.compositionIndex++
-	return l.lowerNodeWithScope(target.Root, l.scope, context, append(stack, target.Name))
+	return l.lowerNodeWithScope(target.Root, l.scope, context, append(ancestry, target.Name), physicalDepth+1)
 }
 
 func (l *islandLowerer) composableCalleeError(target *Component) error {
@@ -675,12 +841,25 @@ func (l *islandLowerer) composableViewTreeError(componentName string, id NodeID,
 			return err
 		}
 	}
-	for _, child := range node.Slots {
+	for _, name := range sortedNodeSlotNames(node.Slots) {
+		child := node.Slots[name]
 		if err := l.composableViewTreeError(componentName, child, seen); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+func sortedNodeSlotNames(slots map[string]NodeID) []string {
+	if len(slots) == 0 {
+		return nil
+	}
+	names := make([]string, 0, len(slots))
+	for name := range slots {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 func (l *islandLowerer) scopeInlineForEach(context *islandInlineContext, node program.Node) (*islandInlineContext, program.Node) {
@@ -933,7 +1112,10 @@ func (l *islandLowerer) lowerInlineEvent(eventType, source string) (program.Attr
 	if err != nil {
 		return program.Attr{}, fmt.Errorf("parse data-on-%s expression %q: %w", eventType, expression, err)
 	}
-	bodyID := l.appendExprs(exprs, rootID)
+	bodyID, err := l.appendExprs(exprs, rootID)
+	if err != nil {
+		return program.Attr{}, fmt.Errorf("emit data-on-%s expression: %w", eventType, err)
+	}
 	l.dst.Handlers = append(l.dst.Handlers, program.Handler{
 		Name: handlerName,
 		Body: []program.ExprID{bodyID},
@@ -1095,11 +1277,10 @@ func (l *islandLowerer) appendInlineExpr(exprs []program.Expr, id program.ExprID
 		}
 		expr.Operands = operands
 	}
-	if len(l.dst.Exprs) >= 65535 {
-		return 0, fmt.Errorf("island %s exceeds the 65,535 expression limit while composing client-side components", l.dst.Name)
+	mapped, err := l.addExprDirect(expr)
+	if err != nil {
+		return 0, err
 	}
-	mapped := program.ExprID(len(l.dst.Exprs))
-	l.dst.Exprs = append(l.dst.Exprs, expr)
 	memo[id] = mapped
 	return mapped, nil
 }
@@ -1123,65 +1304,52 @@ func directPropsField(exprs []program.Expr, id program.ExprID) (string, bool) {
 	return field.Value, true
 }
 
-// addExpr parses a Go expression source string into typed opcodes and appends
-// them to the island program's expression table. Returns the root ExprID.
-func (l *islandLowerer) addExpr(source string) program.ExprID {
-	baseID := program.ExprID(len(l.dst.Exprs))
-
-	exprs, rootID, err := ParseExpr(source, l.scope)
-	if err != nil {
-		// If parsing fails, fall back to a simple prop/signal reference
-		id := program.ExprID(len(l.dst.Exprs))
-		l.dst.Exprs = append(l.dst.Exprs, program.Expr{
-			Op:    program.OpPropGet,
-			Value: source,
-			Type:  program.TypeAny,
-		})
-		return id
+// addExprDirect is the only expression-table allocator. Every caller receives
+// an error before len(Exprs) can overflow the uint16 count/ID wire contract.
+func (l *islandLowerer) addExprDirect(e program.Expr) (program.ExprID, error) {
+	if len(l.dst.Exprs) >= maxIslandProgramEntries {
+		return 0, newIslandExpansionError("island %s exceeds the 65,535 expression limit", l.dst.Name)
 	}
-
-	// Append all parsed expressions, adjusting IDs by the base offset
-	for _, e := range exprs {
-		adjusted := e
-		// Offset operand references by baseID
-		if len(adjusted.Operands) > 0 {
-			ops := make([]program.ExprID, len(adjusted.Operands))
-			for i, op := range adjusted.Operands {
-				ops[i] = op + baseID
-			}
-			adjusted.Operands = ops
-		}
-		l.dst.Exprs = append(l.dst.Exprs, adjusted)
-	}
-
-	return rootID + baseID
-}
-
-// addExprDirect appends a single expression to the program and returns its ID.
-func (l *islandLowerer) addExprDirect(e program.Expr) program.ExprID {
 	id := program.ExprID(len(l.dst.Exprs))
 	l.dst.Exprs = append(l.dst.Exprs, e)
-	return id
+	return id, nil
 }
 
 // appendExprs appends parsed expressions to the program, offsetting operand
 // references, and returns the adjusted root ID.
-func (l *islandLowerer) appendExprs(exprs []program.Expr, rootID program.ExprID) program.ExprID {
-	baseID := program.ExprID(len(l.dst.Exprs))
-
+func (l *islandLowerer) appendExprs(exprs []program.Expr, rootID program.ExprID) (program.ExprID, error) {
+	if len(exprs) == 0 || int(rootID) >= len(exprs) {
+		return 0, fmt.Errorf("island expression root %d is outside %d parsed opcodes", rootID, len(exprs))
+	}
+	base := len(l.dst.Exprs)
+	if len(exprs) > maxIslandProgramEntries-base {
+		return 0, newIslandExpansionError("island %s exceeds the 65,535 expression limit", l.dst.Name)
+	}
 	for _, e := range exprs {
 		adjusted := e
 		if len(adjusted.Operands) > 0 {
 			ops := make([]program.ExprID, len(adjusted.Operands))
 			for i, op := range adjusted.Operands {
-				ops[i] = op + baseID
+				if int(op) >= len(exprs) {
+					return 0, fmt.Errorf("island expression operand %d is outside %d parsed opcodes", op, len(exprs))
+				}
+				offset := base + int(op)
+				if offset >= maxIslandProgramEntries {
+					return 0, newIslandExpansionError("island %s exceeds the 65,535 expression limit", l.dst.Name)
+				}
+				ops[i] = program.ExprID(offset)
 			}
 			adjusted.Operands = ops
 		}
-		l.dst.Exprs = append(l.dst.Exprs, adjusted)
+		if _, err := l.addExprDirect(adjusted); err != nil {
+			return 0, err
+		}
 	}
-
-	return rootID + baseID
+	rootOffset := base + int(rootID)
+	if rootOffset >= maxIslandProgramEntries {
+		return 0, newIslandExpansionError("island %s exceeds the 65,535 expression limit", l.dst.Name)
+	}
+	return program.ExprID(rootOffset), nil
 }
 
 // typeHintToExprType converts a type hint string to an ExprType.

--- a/ir/island_composition_test.go
+++ b/ir/island_composition_test.go
@@ -106,6 +106,42 @@ func TestIslandSameFileComponentsShadowBuiltinsAndAliases(t *testing.T) {
 	}
 }
 
+func TestSyntheticConditionalBypassesImpureLocalIfShadow(t *testing.T) {
+	prog := &Program{
+		Nodes: []Node{
+			{
+				Kind:                 NodeComponent,
+				Tag:                  "If",
+				Attrs:                []Attr{{Kind: AttrExpr, Name: "when", Expr: "visible"}},
+				Children:             []NodeID{1},
+				syntheticConditional: true,
+			},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+			{Kind: NodeElement, Tag: "em", IsStatic: true},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{
+				Name:   "If",
+				Syntax: ComponentSyntaxStrict,
+				Root:   2,
+				Scope:  &ComponentScope{Signals: []SignalInfo{{Name: "owned", InitExpr: "0"}}},
+			},
+		},
+	}
+
+	lowered, err := LowerIsland(prog, 0)
+	if err != nil {
+		t.Fatalf("LowerIsland synthetic conditional: %v", err)
+	}
+	if lowered.Nodes[lowered.Root].Kind != program.NodeConditional {
+		t.Fatalf("lowered root = %#v, want compiler conditional", lowered.Nodes[lowered.Root])
+	}
+	if diags := Validate(prog); len(diags) != 0 {
+		t.Fatalf("Validate synthetic conditional = %#v, want no local-If purity diagnostics", diags)
+	}
+}
+
 func TestValidateIslandPureViewCompositionBoundaryErrors(t *testing.T) {
 	prog := basicComposedIslandProgram()
 	prog.Components[1].IsIsland = true

--- a/ir/island_composition_test.go
+++ b/ir/island_composition_test.go
@@ -1,0 +1,289 @@
+package ir
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestLowerIslandPureViewCompositionBoundaryErrors(t *testing.T) {
+	tests := map[string]struct {
+		mutate func(*Program)
+		want   string
+	}{
+		"nested island": {
+			mutate: func(prog *Program) { prog.Components[1].IsIsland = true },
+			want:   "nested island <Badge>",
+		},
+		"legacy callee": {
+			mutate: func(prog *Program) { prog.Components[1].Syntax = ComponentSyntaxLegacy },
+			want:   "uses legacy component syntax",
+		},
+		"callee state": {
+			mutate: func(prog *Program) {
+				prog.Components[1].Scope = &ComponentScope{Signals: []SignalInfo{{Name: "local"}}}
+			},
+			want: "owns signals, computed values, handlers, or effects",
+		},
+		"non scalar prop": {
+			mutate: func(prog *Program) { prog.Components[1].PropsFields["Label"] = "LabelModel" },
+			want:   "reads non-scalar prop Label",
+		},
+		"handler valued prop": {
+			mutate: func(prog *Program) {
+				prog.Nodes[1].Attrs[0] = Attr{Kind: AttrExpr, Name: "OnTap", Expr: "increment", IsEvent: true}
+			},
+			want: "passes handler-valued prop \"OnTap\"",
+		},
+		"handler reference as ordinary prop": {
+			mutate: func(prog *Program) {
+				prog.Components[0].Scope = &ComponentScope{
+					Handlers: []HandlerInfo{{Name: "increment"}},
+					Locals:   map[string]string{"increment": "handler"},
+				}
+				prog.Nodes[1].Attrs[0] = Attr{Kind: AttrExpr, Name: "Callback", Expr: "increment"}
+			},
+			want: "passes handler-valued prop \"Callback\"",
+		},
+		"spread call": {
+			mutate: func(prog *Program) {
+				prog.Nodes[1].Attrs = []Attr{{Kind: AttrSpread, Expr: "props"}}
+			},
+			want: "uses a spread",
+		},
+		"callee handler": {
+			mutate: func(prog *Program) {
+				prog.Nodes[2].Attrs = []Attr{{Kind: AttrExpr, Name: "onClick", Expr: "tap", IsEvent: true}}
+			},
+			want: "contains handler attribute \"onClick\"",
+		},
+		"callee spread": {
+			mutate: func(prog *Program) {
+				prog.Nodes[2].Attrs = []Attr{{Kind: AttrSpread, Expr: "props.Extra"}}
+			},
+			want: "contains a spread attribute",
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			prog := basicComposedIslandProgram()
+			tc.mutate(prog)
+			_, err := LowerIsland(prog, 0)
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("LowerIsland error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateIslandPureViewCompositionBoundaryErrors(t *testing.T) {
+	prog := basicComposedIslandProgram()
+	prog.Components[1].IsIsland = true
+	diags := Validate(prog)
+	if !diagnosticsContain(diags, "nested island <Badge>") {
+		t.Fatalf("Validate diagnostics = %#v, want nested-island boundary", diags)
+	}
+}
+
+func TestLowerIslandRejectsImportedComposition(t *testing.T) {
+	prog := basicComposedIslandProgram()
+	prog.Nodes[1].Tag = "ui.Badge"
+	prog.Components = prog.Components[:1]
+	_, err := LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "imported component <ui.Badge>") {
+		t.Fatalf("LowerIsland error = %v, want imported-component boundary", err)
+	}
+}
+
+func TestLowerIslandRejectsMissingScalarProp(t *testing.T) {
+	prog := basicComposedIslandProgram()
+	prog.Nodes[1].Attrs = nil
+	_, err := LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "requires scalar prop Label") {
+		t.Fatalf("LowerIsland error = %v, want missing-prop boundary", err)
+	}
+}
+
+func TestLowerIslandRejectsCompositionCycle(t *testing.T) {
+	prog := &Program{
+		Nodes: []Node{
+			{Kind: NodeComponent, Tag: "Child"},
+			{Kind: NodeComponent, Tag: "Root"},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Child", Syntax: ComponentSyntaxStrict, Root: 1},
+		},
+	}
+	_, err := LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "Root -> Child -> Root") {
+		t.Fatalf("LowerIsland error = %v, want explicit cycle path", err)
+	}
+}
+
+func TestLowerIslandRejectsCompositionDepthOverflow(t *testing.T) {
+	const componentCount = maxIslandCompositionDepth + 1
+	prog := &Program{}
+	for i := 0; i < componentCount; i++ {
+		name := "C" + decimal(i)
+		node := Node{Kind: NodeElement, Tag: "span"}
+		if i+1 < componentCount {
+			node = Node{Kind: NodeComponent, Tag: "C" + decimal(i+1)}
+		}
+		prog.Nodes = append(prog.Nodes, node)
+		prog.Components = append(prog.Components, Component{
+			Name:     name,
+			Syntax:   ComponentSyntaxStrict,
+			Root:     NodeID(i),
+			IsIsland: i == 0,
+		})
+	}
+	_, err := LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "32-component depth limit") {
+		t.Fatalf("LowerIsland error = %v, want depth boundary", err)
+	}
+}
+
+func TestLowerIslandRejectsExpandedNodeOverflow(t *testing.T) {
+	const callCount = 65535
+	prog := &Program{
+		Nodes: []Node{
+			{Kind: NodeFragment, Children: make([]NodeID, 0, callCount)},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Leaf", Syntax: ComponentSyntaxStrict, Root: 1},
+		},
+	}
+	for i := 0; i < callCount; i++ {
+		id := prog.AddNode(Node{Kind: NodeComponent, Tag: "Leaf"})
+		prog.Nodes[0].Children = append(prog.Nodes[0].Children, id)
+	}
+	_, err := LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "65,535 expanded-node limit") {
+		t.Fatalf("LowerIsland error = %v, want expanded-node boundary", err)
+	}
+}
+
+func TestLowerIslandAllowsOmittedProjectedChildrenAndSlots(t *testing.T) {
+	prog := basicComposedIslandProgram()
+	prog.Nodes[2] = Node{Kind: NodeElement, Tag: "article", Children: []NodeID{3, 4}}
+	prog.Nodes[3] = Node{Kind: NodeExpr, Text: "children"}
+	prog.Nodes = append(prog.Nodes, Node{Kind: NodeExpr, Text: "slotTitle"})
+	prog.Components[1].AcceptsChildren = true
+	prog.Components[1].AcceptsSlots = []string{"Title"}
+	prog.Components[1].PropsFields = nil
+	prog.Nodes[1].Attrs = nil
+
+	lowered, err := LowerIsland(prog, 0)
+	if err != nil {
+		t.Fatalf("LowerIsland: %v", err)
+	}
+	if len(lowered.Nodes) != 2 || len(lowered.Nodes[1].Children) != 0 {
+		t.Fatalf("lowered nodes = %#v, want empty article projection", lowered.Nodes)
+	}
+}
+
+func TestLowerIslandAllowsFiniteNestedInvocationThroughChildren(t *testing.T) {
+	prog := &Program{
+		Nodes: []Node{
+			{Kind: NodeComponent, Tag: "Wrapper", Children: []NodeID{1}},
+			{Kind: NodeComponent, Tag: "Wrapper", Children: []NodeID{2}},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+			{Kind: NodeElement, Tag: "div", Children: []NodeID{4}},
+			{Kind: NodeExpr, Text: "children"},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Wrapper", Syntax: ComponentSyntaxStrict, Root: 3, AcceptsChildren: true},
+		},
+	}
+
+	lowered, err := LowerIsland(prog, 0)
+	if err != nil {
+		t.Fatalf("LowerIsland: %v", err)
+	}
+	if len(lowered.Nodes) != 3 {
+		t.Fatalf("lowered nodes = %#v, want two div invocations and one span", lowered.Nodes)
+	}
+	outer := lowered.Nodes[lowered.Root]
+	inner := lowered.Nodes[outer.Children[0]]
+	if outer.Tag != "div" || inner.Tag != "div" || lowered.Nodes[inner.Children[0]].Tag != "span" {
+		t.Fatalf("lowered nested projection = %#v", lowered.Nodes)
+	}
+}
+
+func TestLowerIslandRejectsRootCallSiteChildrenAndSlots(t *testing.T) {
+	for _, mutate := range []func(*Component){
+		func(comp *Component) { comp.AcceptsChildren = true },
+		func(comp *Component) { comp.AcceptsSlots = []string{"Title"} },
+	} {
+		prog := basicComposedIslandProgram()
+		mutate(&prog.Components[0])
+		_, err := LowerIsland(prog, 0)
+		if err == nil || !strings.Contains(err.Error(), "root island call-site content") {
+			t.Fatalf("LowerIsland error = %v, want root projection boundary", err)
+		}
+	}
+}
+
+func TestIslandProjectionExpression(t *testing.T) {
+	tests := map[string]struct {
+		name string
+		ok   bool
+	}{
+		"children":       {ok: true},
+		"((children))":   {ok: true},
+		"slotTitle":      {name: "Title", ok: true},
+		"(slotTrailing)": {name: "Trailing", ok: true},
+		"slotlower":      {},
+		"props.children": {},
+		"children + 1":   {},
+		"(children":      {},
+	}
+	for source, want := range tests {
+		name, ok := islandProjectionExpression(source)
+		if name != want.name || ok != want.ok {
+			t.Errorf("islandProjectionExpression(%q) = (%q, %v), want (%q, %v)", source, name, ok, want.name, want.ok)
+		}
+	}
+}
+
+func basicComposedIslandProgram() *Program {
+	return &Program{
+		Nodes: []Node{
+			{Kind: NodeElement, Tag: "main", Children: []NodeID{1}},
+			{Kind: NodeComponent, Tag: "Badge", Attrs: []Attr{{Kind: AttrExpr, Name: "Label", Expr: "props.Label"}}},
+			{Kind: NodeElement, Tag: "span", Children: []NodeID{3}},
+			{Kind: NodeExpr, Text: "props.Label"},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Badge", Syntax: ComponentSyntaxStrict, Root: 2, PropsFields: map[string]string{"Label": "string"}},
+		},
+	}
+}
+
+func diagnosticsContain(diags []Diagnostic, want string) bool {
+	for _, diag := range diags {
+		if strings.Contains(diag.Message, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func decimal(value int) string {
+	if value == 0 {
+		return "0"
+	}
+	var digits [20]byte
+	i := len(digits)
+	for value > 0 {
+		i--
+		digits[i] = byte('0' + value%10)
+		value /= 10
+	}
+	return string(digits[i:])
+}

--- a/ir/island_composition_test.go
+++ b/ir/island_composition_test.go
@@ -3,6 +3,8 @@ package ir
 import (
 	"strings"
 	"testing"
+
+	"m31labs.dev/gosx/island/program"
 )
 
 func TestLowerIslandPureViewCompositionBoundaryErrors(t *testing.T) {
@@ -76,6 +78,34 @@ func TestLowerIslandPureViewCompositionBoundaryErrors(t *testing.T) {
 	}
 }
 
+func TestIslandSameFileComponentsShadowBuiltinsAndAliases(t *testing.T) {
+	for _, tag := range []string{"If", "Each", "For", "Show", "When", "Link", "Image"} {
+		t.Run(tag, func(t *testing.T) {
+			prog := shadowedIslandComponentProgram(tag)
+			lowered, err := LowerIsland(prog, 0)
+			if err != nil {
+				t.Fatalf("LowerIsland pure shadow: %v", err)
+			}
+			if len(lowered.Nodes) != 1 || lowered.Nodes[lowered.Root].Tag != "span" {
+				t.Fatalf("lowered %s shadow = %#v, want composed span", tag, lowered.Nodes)
+			}
+			if diags := Validate(prog); len(diags) != 0 {
+				t.Fatalf("Validate pure %s shadow = %#v", tag, diags)
+			}
+
+			prog = shadowedIslandComponentProgram(tag)
+			prog.Components[1].Scope = &ComponentScope{Signals: []SignalInfo{{Name: "owned", InitExpr: "0"}}}
+			_, err = LowerIsland(prog, 0)
+			if err == nil || !strings.Contains(err.Error(), "owns signals, computed values, handlers, or effects") {
+				t.Fatalf("LowerIsland impure %s shadow = %v, want callee-purity error", tag, err)
+			}
+			if diags := Validate(prog); !diagnosticsContain(diags, "owns signals, computed values, handlers, or effects") {
+				t.Fatalf("Validate impure %s shadow = %#v, want callee-purity diagnostic", tag, diags)
+			}
+		})
+	}
+}
+
 func TestValidateIslandPureViewCompositionBoundaryErrors(t *testing.T) {
 	prog := basicComposedIslandProgram()
 	prog.Components[1].IsIsland = true
@@ -144,6 +174,25 @@ func TestLowerIslandRejectsCompositionDepthOverflow(t *testing.T) {
 	}
 }
 
+func TestIslandCompositionPhysicalDepthThroughProjectedChildren(t *testing.T) {
+	allowed := nestedWrapperProjectionProgram(maxIslandCompositionDepth - 1)
+	if _, err := LowerIsland(allowed, 0); err != nil {
+		t.Fatalf("LowerIsland at physical depth limit: %v", err)
+	}
+	if diags := Validate(allowed); diagnosticsContain(diags, "depth limit") {
+		t.Fatalf("Validate at physical depth limit = %#v", diags)
+	}
+
+	overflow := nestedWrapperProjectionProgram(maxIslandCompositionDepth)
+	_, err := LowerIsland(overflow, 0)
+	if err == nil || !strings.Contains(err.Error(), "32-component depth limit") {
+		t.Fatalf("LowerIsland projected depth overflow = %v", err)
+	}
+	if diags := Validate(overflow); !diagnosticsContain(diags, "32-component depth limit") {
+		t.Fatalf("Validate projected depth overflow = %#v", diags)
+	}
+}
+
 func TestLowerIslandRejectsExpandedNodeOverflow(t *testing.T) {
 	const callCount = 65535
 	prog := &Program{
@@ -163,6 +212,107 @@ func TestLowerIslandRejectsExpandedNodeOverflow(t *testing.T) {
 	_, err := LowerIsland(prog, 0)
 	if err == nil || !strings.Contains(err.Error(), "65,535 expanded-node limit") {
 		t.Fatalf("LowerIsland error = %v, want expanded-node boundary", err)
+	}
+}
+
+func TestIslandCompositionNodeLimitMatchesExactEmittedTree(t *testing.T) {
+	tests := []struct {
+		name string
+		prog func(int) *Program
+	}{
+		{name: "leaf calls", prog: leafCallIslandProgram},
+		{name: "repeated children holes", prog: repeatedChildrenHoleIslandProgram},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name+" at limit", func(t *testing.T) {
+			prog := tc.prog(maxIslandProgramEntries - 1)
+			lowered, err := LowerIsland(prog, 0)
+			if err != nil {
+				t.Fatalf("LowerIsland: %v", err)
+			}
+			if got := len(lowered.Nodes); got != maxIslandProgramEntries {
+				t.Fatalf("emitted nodes = %d, want %d", got, maxIslandProgramEntries)
+			}
+			if diags := Validate(prog); diagnosticsContain(diags, "expanded-node limit") {
+				t.Fatalf("Validate rejected exact emitted-node limit: %#v", diags)
+			}
+		})
+		t.Run(tc.name+" overflow", func(t *testing.T) {
+			prog := tc.prog(maxIslandProgramEntries)
+			_, err := LowerIsland(prog, 0)
+			if err == nil || !strings.Contains(err.Error(), "65,535 expanded-node limit") {
+				t.Fatalf("LowerIsland error = %v", err)
+			}
+			if diags := Validate(prog); !diagnosticsContain(diags, "65,535 expanded-node limit") {
+				t.Fatalf("Validate overflow diagnostics = %#v", diags)
+			}
+		})
+	}
+}
+
+func TestLowerIslandRejectsScopeExpressionOverflowAfterNodeExpressions(t *testing.T) {
+	exprs, _, err := ParseExpr("props.Value", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	signalCount := maxIslandProgramEntries - len(exprs) + 1
+	signals := make([]SignalInfo, signalCount)
+	for i := range signals {
+		signals[i] = SignalInfo{Name: "filled", InitExpr: "0", TypeHint: "int"}
+	}
+	prog := &Program{
+		Nodes: []Node{{Kind: NodeExpr, Text: "props.Value"}},
+		Components: []Component{{
+			Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true,
+			Scope: &ComponentScope{Signals: signals},
+		}},
+	}
+	_, err = LowerIsland(prog, 0)
+	if err == nil || !strings.Contains(err.Error(), "65,535 expression limit") {
+		t.Fatalf("LowerIsland expression overflow = %v", err)
+	}
+	if diags := Validate(prog); !diagnosticsContain(diags, "65,535 expression limit") {
+		t.Fatalf("Validate expression overflow = %#v", diags)
+	}
+}
+
+func TestIslandExpressionAllocationsFailClosedAtCapacity(t *testing.T) {
+	newFullLowerer := func() *islandLowerer {
+		l := newIslandLowerer(&Program{}, "Root", cloneExprScope(nil))
+		l.dst.Exprs = make([]program.Expr, maxIslandProgramEntries)
+		return l
+	}
+	tests := map[string]func(*islandLowerer) error{
+		"signal": func(l *islandLowerer) error {
+			return l.emitSignalDefs([]SignalInfo{{Name: "value", InitExpr: "0"}})
+		},
+		"computed": func(l *islandLowerer) error {
+			return l.emitComputedDefs([]ComputedInfo{{Name: "value", BodyExpr: "0"}})
+		},
+		"handler": func(l *islandLowerer) error {
+			return l.emitHandlerDefs([]HandlerInfo{{Name: "tap", Statements: []string{"0"}}})
+		},
+		"inline event": func(l *islandLowerer) error {
+			_, err := l.lowerInlineEvent("click", "0")
+			return err
+		},
+	}
+	for name, run := range tests {
+		t.Run(name, func(t *testing.T) {
+			if err := run(newFullLowerer()); err == nil || !strings.Contains(err.Error(), "65,535 expression limit") {
+				t.Fatalf("allocation error = %v", err)
+			}
+		})
+	}
+}
+
+func TestIslandProgramIntegrityRejectsOverflowingExpressionCount(t *testing.T) {
+	l := newIslandLowerer(&Program{}, "Root", cloneExprScope(nil))
+	l.dst.Nodes = []program.Node{{Kind: program.NodeText}}
+	l.dst.StaticMask = []bool{true}
+	l.dst.Exprs = make([]program.Expr, maxIslandProgramEntries+1)
+	if err := l.validateProgramIntegrity(); err == nil || !strings.Contains(err.Error(), "65536 expressions; the program limit is 65,535") {
+		t.Fatalf("program integrity error = %v", err)
 	}
 }
 
@@ -247,6 +397,132 @@ func TestIslandProjectionExpression(t *testing.T) {
 		if name != want.name || ok != want.ok {
 			t.Errorf("islandProjectionExpression(%q) = (%q, %v), want (%q, %v)", source, name, ok, want.name, want.ok)
 		}
+	}
+}
+
+func TestIslandCompositionSlotDiagnosticOrderIsDeterministic(t *testing.T) {
+	purityProgram := &Program{
+		Nodes: []Node{
+			{Kind: NodeComponent, Tag: "View"},
+			{Kind: NodeElement, Tag: "div", Slots: map[string]NodeID{"Zulu": 2, "Alpha": 3}},
+			{Kind: NodeElement, Tag: "button", Attrs: []Attr{{Kind: AttrStatic, Name: "data-on-zulu", Value: "tap"}}},
+			{Kind: NodeElement, Tag: "button", Attrs: []Attr{{Kind: AttrStatic, Name: "data-on-alpha", Value: "tap"}}},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "View", Syntax: ComponentSyntaxStrict, Root: 1},
+		},
+	}
+	validatorProgram := &Program{
+		Nodes: []Node{
+			{Kind: NodeElement, Tag: "div", Slots: map[string]NodeID{"Zulu": 1, "Alpha": 2}},
+			{Kind: NodeExpr, Text: "zulu()"},
+			{Kind: NodeExpr, Text: "alpha()"},
+		},
+		Components: []Component{{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true}},
+	}
+	var first string
+	for i := 0; i < 100; i++ {
+		_, err := LowerIsland(purityProgram, 0)
+		if err == nil || !strings.Contains(err.Error(), `handler attribute "data-on-alpha"`) {
+			t.Fatalf("LowerIsland run %d = %v, want alphabetically first slot diagnostic", i, err)
+		}
+		diags := Validate(validatorProgram)
+		var messages []string
+		for _, diag := range diags {
+			messages = append(messages, diag.Message)
+		}
+		got := strings.Join(messages, "\n")
+		if i == 0 {
+			first = got
+		} else if got != first {
+			t.Fatalf("Validate diagnostic order changed on run %d:\nfirst=%q\n got=%q", i, first, got)
+		}
+		alpha := strings.Index(got, `"alpha"`)
+		zulu := strings.Index(got, `"zulu"`)
+		if alpha < 0 || zulu < 0 || alpha >= zulu {
+			t.Fatalf("Validate run %d = %q, want Alpha diagnostic before Zulu", i, got)
+		}
+	}
+}
+
+func shadowedIslandComponentProgram(tag string) *Program {
+	return &Program{
+		Nodes: []Node{
+			{Kind: NodeComponent, Tag: tag},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: tag, Syntax: ComponentSyntaxStrict, Root: 1},
+		},
+	}
+}
+
+func nestedWrapperProjectionProgram(callCount int) *Program {
+	nodes := make([]Node, callCount)
+	for i := range nodes {
+		nodes[i] = Node{Kind: NodeComponent, Tag: "Wrapper"}
+		if i+1 < callCount {
+			nodes[i].Children = []NodeID{NodeID(i + 1)}
+		}
+	}
+	leafID := NodeID(len(nodes))
+	nodes = append(nodes, Node{Kind: NodeElement, Tag: "span", IsStatic: true})
+	if callCount > 0 {
+		nodes[callCount-1].Children = []NodeID{leafID}
+	}
+	wrapperRoot := NodeID(len(nodes))
+	holeID := wrapperRoot + 1
+	nodes = append(nodes,
+		Node{Kind: NodeElement, Tag: "div", Children: []NodeID{holeID}},
+		Node{Kind: NodeExpr, Text: "children"},
+	)
+	return &Program{
+		Nodes: nodes,
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Wrapper", Syntax: ComponentSyntaxStrict, Root: wrapperRoot, AcceptsChildren: true},
+		},
+	}
+}
+
+func leafCallIslandProgram(callCount int) *Program {
+	prog := &Program{
+		Nodes: []Node{
+			{Kind: NodeFragment, Children: make([]NodeID, 0, callCount)},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Leaf", Syntax: ComponentSyntaxStrict, Root: 1},
+		},
+	}
+	for i := 0; i < callCount; i++ {
+		id := prog.AddNode(Node{Kind: NodeComponent, Tag: "Leaf"})
+		prog.Nodes[0].Children = append(prog.Nodes[0].Children, id)
+	}
+	return prog
+}
+
+func repeatedChildrenHoleIslandProgram(holeCount int) *Program {
+	holes := make([]NodeID, holeCount)
+	for i := range holes {
+		holes[i] = 4
+	}
+	return &Program{
+		Nodes: []Node{
+			{Kind: NodeComponent, Tag: "Repeater", Children: []NodeID{1}},
+			{Kind: NodeComponent, Tag: "Leaf"},
+			{Kind: NodeElement, Tag: "span", IsStatic: true},
+			{Kind: NodeFragment, Children: holes},
+			{Kind: NodeExpr, Text: "children"},
+		},
+		Components: []Component{
+			{Name: "Root", Syntax: ComponentSyntaxStrict, Root: 0, IsIsland: true},
+			{Name: "Repeater", Syntax: ComponentSyntaxStrict, Root: 3, AcceptsChildren: true},
+			{Name: "Leaf", Syntax: ComponentSyntaxStrict, Root: 2},
+		},
 	}
 }
 

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -1516,18 +1516,6 @@ func (l *lowerer) collectStructSchemas(n *gotreesitter.Node) {
 	walk(n)
 }
 
-func strictRendererScalarType(typeName string) bool {
-	switch strings.TrimSpace(typeName) {
-	case "string", "bool",
-		"int", "int8", "int16", "int32", "int64",
-		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
-		"byte", "rune", "float32", "float64":
-		return true
-	default:
-		return false
-	}
-}
-
 func (l *lowerer) validateStrictRenderedProps(n *gotreesitter.Node, componentName, propsType string) {
 	reads := l.strictReads[componentName]
 	if len(reads) == 0 {

--- a/ir/lower.go
+++ b/ir/lower.go
@@ -3020,7 +3020,7 @@ func (l *lowerer) validateStrictServerExpressions(root NodeID, componentName, pr
 			// positions admit different identifier sets.
 			l.validateStrictServerChildExpression(node.Span, node.Text, componentName, propsType, scope)
 		}
-		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && !ifShadowed
+		isBuiltinIf := node.Kind == NodeComponent && node.Tag == "If" && (node.IsSyntheticConditional() || !ifShadowed)
 		isBuiltinEach := node.Kind == NodeComponent && node.Tag == "Each" && !eachShadowed
 		if isBuiltinEach {
 			childScope, ok := l.enterStrictEach(node, componentName, propsType, scope, slices)
@@ -3881,11 +3881,12 @@ func (l *lowerer) buildIfComponent(whenExpr string, children []NodeID, fallbackE
 		attrs = append(attrs, Attr{Kind: AttrExpr, Name: "fallback", Expr: fallbackExpr})
 	}
 	return l.prog.AddNode(Node{
-		Kind:     NodeComponent,
-		Tag:      "If",
-		Attrs:    attrs,
-		Children: children,
-		Span:     span,
+		Kind:                 NodeComponent,
+		Tag:                  "If",
+		Attrs:                attrs,
+		Children:             children,
+		Span:                 span,
+		syntheticConditional: true,
 	})
 }
 

--- a/ir/strict_scalar.go
+++ b/ir/strict_scalar.go
@@ -1,0 +1,19 @@
+package ir
+
+import "strings"
+
+// strictRendererScalarType is shared by the host-only CST lowerer and the
+// TinyGo-clean island lowerer. Keep the renderer boundary in one build-neutral
+// file so production runtime builds compile the same scalar contract checked
+// while reading strict component schemas.
+func strictRendererScalarType(typeName string) bool {
+	switch strings.TrimSpace(typeName) {
+	case "string", "bool",
+		"int", "int8", "int16", "int32", "int64",
+		"uint", "uint8", "uint16", "uint32", "uint64", "uintptr",
+		"byte", "rune", "float32", "float64":
+		return true
+	default:
+		return false
+	}
+}

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -955,7 +955,7 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 		}
 
 		node := &prog.Nodes[id]
-		if node.Kind != NodeComponent {
+		if node.Kind != NodeComponent || node.IsSyntheticConditional() {
 			diags = append(diags, validateIslandNode(node, scope)...)
 			for _, child := range node.Children {
 				walk(child, stack)

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -937,13 +937,124 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 	}
 
 	var diags []Diagnostic
-	nodeIDs := collectComponentNodeIDs(prog, comp.Root)
 	scope := mergedIslandScope(prog, *comp)
-	for _, id := range nodeIDs {
-		node := &prog.Nodes[id]
-		diags = append(diags, validateIslandNode(node, scope)...)
+	checker := newIslandLowerer(prog, comp.Name, scope)
+	if comp.AcceptsChildren || len(comp.AcceptsSlots) > 0 {
+		diags = append(diags, Diagnostic{
+			Span:    comp.Span,
+			Message: fmt.Sprintf("island component %s cannot declare caller children or named slots", comp.Name),
+			Hint:    "root island call-site content is outside the per-component .gxi program; compose children and slots through a same-file pure-view component inside the island instead",
+		})
 	}
 
+	expandedNodes := 0
+	limitReported := false
+	var walk func(NodeID, []string)
+	walk = func(id NodeID, stack []string) {
+		if int(id) >= len(prog.Nodes) {
+			return
+		}
+		expandedNodes++
+		if expandedNodes > 65535 {
+			if !limitReported {
+				limitReported = true
+				diags = append(diags, Diagnostic{
+					Span:    prog.Nodes[id].Span,
+					Message: fmt.Sprintf("island %s exceeds the 65,535 expanded-node limit while composing client-side components", comp.Name),
+				})
+			}
+			return
+		}
+
+		node := &prog.Nodes[id]
+		if node.Kind != NodeComponent || isEachComponent(node.Tag) || isConditionalComponent(node.Tag) || node.Tag == "Link" || node.Tag == "Image" {
+			diags = append(diags, validateIslandNode(node, scope)...)
+			for _, child := range node.Children {
+				walk(child, stack)
+			}
+			for _, child := range node.Slots {
+				walk(child, stack)
+			}
+			return
+		}
+
+		targetIdx, local := checker.componentIndex[node.Tag]
+		if !local {
+			message := fmt.Sprintf("component <%s> is not supported inside island components", node.Tag)
+			hint := "use a same-file strict pure-view component or move the component outside the hydrated subtree"
+			if strings.Contains(node.Tag, ".") {
+				message = fmt.Sprintf("imported component <%s> cannot be composed inside island %s in v1", node.Tag, comp.Name)
+				hint = "use a same-file strict pure-view component; imported island callees require a future package-aware composition contract"
+			}
+			diags = append(diags, Diagnostic{Span: node.Span, Message: message, Hint: hint})
+			for _, child := range node.Children {
+				walk(child, stack)
+			}
+			for _, child := range node.Slots {
+				walk(child, stack)
+			}
+			return
+		}
+
+		callInvalid := false
+		for _, attr := range node.Attrs {
+			switch {
+			case attr.Kind == AttrSpread:
+				callInvalid = true
+				diags = append(diags, Diagnostic{
+					Span:    node.Span,
+					Message: fmt.Sprintf("component <%s> uses a spread inside island %s", node.Tag, comp.Name),
+					Hint:    "v1 pure-view composition requires explicit typed scalar props",
+				})
+			case attr.IsEvent || (attr.Kind == AttrExpr && scope.Handlers[strings.TrimSpace(attr.Expr)]):
+				callInvalid = true
+				diags = append(diags, Diagnostic{
+					Span:    node.Span,
+					Message: fmt.Sprintf("component <%s> passes handler-valued prop %q inside island %s", node.Tag, attr.Name, comp.Name),
+					Hint:    "keep behavior in the parent island and pass only typed scalar view data",
+				})
+			case attr.Kind == AttrExpr:
+				if diag, ok := validateIslandExprSource(node.Span, attr.Expr, scope); ok {
+					callInvalid = true
+					diags = append(diags, diag)
+				}
+			}
+		}
+
+		target := &prog.Components[targetIdx]
+		for _, name := range stack {
+			if name == target.Name {
+				path := append(append([]string(nil), stack...), target.Name)
+				diags = append(diags, Diagnostic{Span: node.Span, Message: "island component composition cycle: " + strings.Join(path, " -> ")})
+				return
+			}
+		}
+		if len(stack) >= maxIslandCompositionDepth {
+			diags = append(diags, Diagnostic{
+				Span:    node.Span,
+				Message: fmt.Sprintf("island component composition exceeds the %d-component depth limit at <%s>", maxIslandCompositionDepth, target.Name),
+			})
+			return
+		}
+		if err := checker.composableCalleeError(target); err != nil {
+			callInvalid = true
+			diags = append(diags, Diagnostic{Span: node.Span, Message: err.Error()})
+		}
+
+		// Caller-owned projections retain the parent island scope. Validate
+		// them even when the callee boundary itself is invalid so diagnostics
+		// never hide an independently malformed child expression.
+		for _, child := range node.Children {
+			walk(child, stack)
+		}
+		for _, child := range node.Slots {
+			walk(child, stack)
+		}
+		if !callInvalid {
+			walk(target.Root, append(stack, target.Name))
+		}
+	}
+	walk(comp.Root, []string{comp.Name})
 	return diags
 }
 

--- a/ir/validate.go
+++ b/ir/validate.go
@@ -1,6 +1,7 @@
 package ir
 
 import (
+	"errors"
 	"fmt"
 	"go/ast"
 	"go/parser"
@@ -947,39 +948,46 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 		})
 	}
 
-	expandedNodes := 0
-	limitReported := false
 	var walk func(NodeID, []string)
 	walk = func(id NodeID, stack []string) {
 		if int(id) >= len(prog.Nodes) {
 			return
 		}
-		expandedNodes++
-		if expandedNodes > 65535 {
-			if !limitReported {
-				limitReported = true
-				diags = append(diags, Diagnostic{
-					Span:    prog.Nodes[id].Span,
-					Message: fmt.Sprintf("island %s exceeds the 65,535 expanded-node limit while composing client-side components", comp.Name),
-				})
-			}
-			return
-		}
 
 		node := &prog.Nodes[id]
-		if node.Kind != NodeComponent || isEachComponent(node.Tag) || isConditionalComponent(node.Tag) || node.Tag == "Link" || node.Tag == "Image" {
+		if node.Kind != NodeComponent {
 			diags = append(diags, validateIslandNode(node, scope)...)
 			for _, child := range node.Children {
 				walk(child, stack)
 			}
-			for _, child := range node.Slots {
-				walk(child, stack)
+			for _, name := range sortedNodeSlotNames(node.Slots) {
+				walk(node.Slots[name], stack)
 			}
 			return
 		}
 
 		targetIdx, local := checker.componentIndex[node.Tag]
 		if !local {
+			if isEachComponent(node.Tag) || isConditionalComponent(node.Tag) || node.Tag == "Link" || node.Tag == "Image" {
+				diags = append(diags, validateIslandNode(node, scope)...)
+				for _, child := range node.Children {
+					walk(child, stack)
+				}
+				for _, name := range sortedNodeSlotNames(node.Slots) {
+					walk(node.Slots[name], stack)
+				}
+				return
+			}
+			if diag, unsupported := unsupportedIslandComponentDiagnostic(node); unsupported {
+				diags = append(diags, diag)
+				for _, child := range node.Children {
+					walk(child, stack)
+				}
+				for _, name := range sortedNodeSlotNames(node.Slots) {
+					walk(node.Slots[name], stack)
+				}
+				return
+			}
 			message := fmt.Sprintf("component <%s> is not supported inside island components", node.Tag)
 			hint := "use a same-file strict pure-view component or move the component outside the hydrated subtree"
 			if strings.Contains(node.Tag, ".") {
@@ -990,8 +998,8 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 			for _, child := range node.Children {
 				walk(child, stack)
 			}
-			for _, child := range node.Slots {
-				walk(child, stack)
+			for _, name := range sortedNodeSlotNames(node.Slots) {
+				walk(node.Slots[name], stack)
 			}
 			return
 		}
@@ -1030,10 +1038,9 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 			}
 		}
 		if len(stack) >= maxIslandCompositionDepth {
-			diags = append(diags, Diagnostic{
-				Span:    node.Span,
-				Message: fmt.Sprintf("island component composition exceeds the %d-component depth limit at <%s>", maxIslandCompositionDepth, target.Name),
-			})
+			// Physical composition depth can differ from definition ancestry
+			// when caller projections pass through multiple wrappers. The
+			// actual lowerer below is the sole exact authority for the cap.
 			return
 		}
 		if err := checker.composableCalleeError(target); err != nil {
@@ -1047,14 +1054,22 @@ func validateIslandExprs(prog *Program, comp *Component) []Diagnostic {
 		for _, child := range node.Children {
 			walk(child, stack)
 		}
-		for _, child := range node.Slots {
-			walk(child, stack)
+		for _, name := range sortedNodeSlotNames(node.Slots) {
+			walk(node.Slots[name], stack)
 		}
 		if !callInvalid {
 			walk(target.Root, append(stack, target.Name))
 		}
 	}
 	walk(comp.Root, []string{comp.Name})
+	if compIdx, ok := checker.componentIndex[comp.Name]; ok {
+		if _, err := LowerIsland(prog, compIdx); err != nil {
+			var expansionErr *islandExpansionError
+			if errors.As(err, &expansionErr) {
+				diags = append(diags, Diagnostic{Span: comp.Span, Message: expansionErr.Error()})
+			}
+		}
+	}
 	return diags
 }
 

--- a/island_component_composition_test.go
+++ b/island_component_composition_test.go
@@ -1,0 +1,274 @@
+package gosx_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"m31labs.dev/gosx"
+	clientvm "m31labs.dev/gosx/client/vm"
+	"m31labs.dev/gosx/ir"
+	"m31labs.dev/gosx/island"
+	islandprogram "m31labs.dev/gosx/island/program"
+	"m31labs.dev/gosx/route"
+)
+
+const composedIslandSource = `package app
+
+import "m31labs.dev/gosx/signal"
+
+type BadgeProps struct {
+	Label string
+	Count int
+	Active bool
+}
+
+type DashboardProps struct {
+	Label string
+	Start int
+}
+
+type ValueProps struct {
+	Text string
+}
+
+component Value(props: ValueProps) {
+	return <h2>{props.Text}</h2>
+}
+
+component Badge(props: BadgeProps) {
+	return <article data-active={props.Active}><header>{slotTitle}</header><Value text={props.Label} /><span>{props.Count}</span><div>{children}</div></article>
+}
+
+//gosx:island
+component Dashboard(props: DashboardProps) {
+	count := signal.New(props.Start)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <section><Badge label={props.Label} count={count.Get()} active><strong slot="Title">Primary</strong><button onClick={increment}>{count.Get()}</button></Badge><Badge label="Second" count={count.Get()} active={false}><em>{props.Label}</em></Badge></section>
+}
+
+component Page() {
+	return <main><Dashboard label="Inbox" start={4} /></main>
+}
+`
+
+const flattenedIslandSource = `package app
+
+import "m31labs.dev/gosx/signal"
+
+type DashboardProps struct {
+	Label string
+	Start int
+}
+
+//gosx:island
+component Dashboard(props: DashboardProps) {
+	count := signal.New(props.Start)
+	increment := func() { count.Set(count.Get() + 1) }
+	return <section><article data-active={true}><header><strong>Primary</strong></header><h2>{props.Label}</h2><span>{count.Get()}</span><div><button onClick={increment}>{count.Get()}</button></div></article><article data-active={false}><header></header><h2>{"Second"}</h2><span>{count.Get()}</span><div><em>{props.Label}</em></div></article></section>
+}
+`
+
+func TestIslandPureViewCompositionMatchesHandFlattenedProgram(t *testing.T) {
+	composed := compileIslandProgram(t, composedIslandSource, "Dashboard")
+	flattened := compileIslandProgram(t, flattenedIslandSource, "Dashboard")
+
+	composedBinary, err := islandprogram.EncodeBinary(composed)
+	if err != nil {
+		t.Fatalf("EncodeBinary(composed): %v", err)
+	}
+	flattenedBinary, err := islandprogram.EncodeBinary(flattened)
+	if err != nil {
+		t.Fatalf("EncodeBinary(flattened): %v", err)
+	}
+	if !bytes.Equal(composedBinary, flattenedBinary) {
+		t.Fatalf("composed program = %d bytes, flattened = %d bytes; want byte-identical .gxi output\ncomposed=%#v\nflattened=%#v", len(composedBinary), len(flattenedBinary), composed, flattened)
+	}
+	t.Logf("encoded island program: composed=%d bytes flattened=%d bytes", len(composedBinary), len(flattenedBinary))
+
+	const props = `{"Label":"Inbox","Start":4}`
+	composedTree := clientvm.ResolveInitialTree(composed, props)
+	flattenedTree := clientvm.ResolveInitialTree(flattened, props)
+	if got, want := renderTreeText(composedTree), renderTreeText(flattenedTree); got != want {
+		t.Fatalf("composed initial tree text = %q, flattened = %q", got, want)
+	}
+	if got := strings.Join(resolvedTags(composedTree), ","); strings.Count(got, "article") != 2 {
+		t.Fatalf("resolved tags = %q, want two independently inlined article invocations", got)
+	}
+	root := composed.Nodes[composed.Root]
+	if len(root.Children) != 2 || root.Children[0] == root.Children[1] {
+		t.Fatalf("root children = %#v, want two hygienically cloned component invocations", root.Children)
+	}
+
+	live := clientvm.NewIsland(composed, props)
+	if got := strings.TrimSpace(renderTreeText(live.CurrentTree())); !strings.Contains(got, "Inbox4") {
+		t.Fatalf("initial composed text = %q", got)
+	}
+	live.Dispatch("increment", `{}`)
+	if got := renderTreeText(live.CurrentTree()); strings.Count(got, "5") != 3 {
+		t.Fatalf("text after one parent handler dispatch = %q, want all three signal projections updated", got)
+	}
+}
+
+func TestIslandPureViewCompositionIsDeterministic(t *testing.T) {
+	first := compileIslandProgram(t, composedIslandSource, "Dashboard")
+	second := compileIslandProgram(t, composedIslandSource, "Dashboard")
+	firstBinary, err := islandprogram.EncodeBinary(first)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondBinary, err := islandprogram.EncodeBinary(second)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !bytes.Equal(firstBinary, secondBinary) {
+		t.Fatal("same source produced nondeterministic .gxi bytes")
+	}
+}
+
+func TestIslandPureViewCompositionRendersOneHydrationRoot(t *testing.T) {
+	prog, err := gosx.Compile([]byte(composedIslandSource))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	renderer := island.NewRenderer("composition-test")
+	html, err := route.RenderProgramComponent(prog, "Page", route.ProgramRenderEnv{
+		RenderIsland: renderer.RenderIslandFromProgram,
+	})
+	if err != nil {
+		t.Fatalf("RenderProgramComponent: %v", err)
+	}
+	if got := strings.Count(html, `data-gosx-island="Dashboard"`); got != 1 {
+		t.Fatalf("rendered HTML has %d Dashboard hydration roots, want exactly one:\n%s", got, html)
+	}
+	if strings.Contains(html, `data-gosx-island="Badge"`) {
+		t.Fatalf("pure-view callee became a second hydration root:\n%s", html)
+	}
+	if got := strings.Count(html, "<article"); got != 2 {
+		t.Fatalf("server render has %d composed articles, want two:\n%s", got, html)
+	}
+	if !strings.Contains(html, "<h2>Inbox</h2>") || !strings.Contains(html, "<strong>Primary</strong>") {
+		t.Fatalf("server render omitted composed props or named-slot content:\n%s", html)
+	}
+}
+
+func TestIslandCompositionFailsClosedDuringCompile(t *testing.T) {
+	tests := map[string]struct {
+		source string
+		want   string
+	}{
+		"root children": {
+			source: `package app
+//gosx:island
+component Root() {
+	return <div>{children}</div>
+}`,
+			want: "cannot declare caller children or named slots",
+		},
+		"nested island": {
+			source: `package app
+//gosx:island
+component Child() {
+	return <span>child</span>
+}
+//gosx:island
+component Root() {
+	return <div><Child /></div>
+}`,
+			want: "nested island <Child>",
+		},
+		"spread": {
+			source: `package app
+type ViewProps struct { Label string }
+component View(props: ViewProps) {
+	return <span>{props.Label}</span>
+}
+//gosx:island
+component Root(props: ViewProps) {
+	return <div><View {...props} /></div>
+}`,
+			want: "uses a spread inside island Root",
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			_, err := gosx.Compile([]byte(tc.source))
+			if err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Compile error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func BenchmarkIslandPureViewCompositionBaseline(b *testing.B) {
+	composedIR, err := gosx.Compile([]byte(composedIslandSource))
+	if err != nil {
+		b.Fatal(err)
+	}
+	flattenedIR, err := gosx.Compile([]byte(flattenedIslandSource))
+	if err != nil {
+		b.Fatal(err)
+	}
+	composedIndex := indexOf(composedIR, "Dashboard")
+	flattenedIndex := indexOf(flattenedIR, "Dashboard")
+
+	b.Run("lower/composed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := ir.LowerIsland(composedIR, composedIndex); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+	b.Run("lower/flattened", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			if _, err := ir.LowerIsland(flattenedIR, flattenedIndex); err != nil {
+				b.Fatal(err)
+			}
+		}
+	})
+
+	composed := compileIslandProgram(b, composedIslandSource, "Dashboard")
+	flattened := compileIslandProgram(b, flattenedIslandSource, "Dashboard")
+	const props = `{"Label":"Inbox","Start":4}`
+	b.Run("initial-resolve/composed", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = clientvm.ResolveInitialTree(composed, props)
+		}
+	})
+	b.Run("initial-resolve/flattened", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			_ = clientvm.ResolveInitialTree(flattened, props)
+		}
+	})
+}
+
+type testingTB interface {
+	Helper()
+	Fatalf(string, ...any)
+}
+
+func compileIslandProgram(t testingTB, source, name string) *islandprogram.Program {
+	t.Helper()
+	prog, err := gosx.Compile([]byte(source))
+	if err != nil {
+		t.Fatalf("Compile: %v", err)
+	}
+	lowered, err := ir.LowerIsland(prog, indexOf(prog, name))
+	if err != nil {
+		t.Fatalf("LowerIsland(%s): %v", name, err)
+	}
+	return lowered
+}
+
+func resolvedTags(tree *clientvm.ResolvedTree) []string {
+	if tree == nil {
+		return nil
+	}
+	var tags []string
+	for _, node := range tree.Nodes {
+		if node.Tag != "" {
+			tags = append(tags, node.Tag)
+		}
+	}
+	return tags
+}

--- a/island_component_composition_test.go
+++ b/island_component_composition_test.go
@@ -126,6 +126,29 @@ func TestIslandPureViewCompositionIsDeterministic(t *testing.T) {
 	}
 }
 
+func TestIslandPureViewCompositionHonorsSameFileBuiltinShadows(t *testing.T) {
+	const sourceTemplate = `package app
+
+component SHADOW() {
+	return <span>shadowed</span>
+}
+
+//gosx:island
+component Root() {
+	return <SHADOW />
+}
+`
+	for _, tag := range []string{"If", "Each", "For", "Show", "When", "Link", "Image"} {
+		t.Run(tag, func(t *testing.T) {
+			source := strings.ReplaceAll(sourceTemplate, "SHADOW", tag)
+			lowered := compileIslandProgram(t, source, "Root")
+			if lowered.Nodes[lowered.Root].Tag != "span" {
+				t.Fatalf("lowered same-file %s shadow = %#v, want composed span", tag, lowered.Nodes)
+			}
+		})
+	}
+}
+
 func TestIslandPureViewCompositionRendersOneHydrationRoot(t *testing.T) {
 	prog, err := gosx.Compile([]byte(composedIslandSource))
 	if err != nil {

--- a/island_component_composition_test.go
+++ b/island_component_composition_test.go
@@ -2,6 +2,7 @@ package gosx_test
 
 import (
 	"bytes"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -144,6 +145,98 @@ component Root() {
 			lowered := compileIslandProgram(t, source, "Root")
 			if lowered.Nodes[lowered.Root].Tag != "span" {
 				t.Fatalf("lowered same-file %s shadow = %#v, want composed span", tag, lowered.Nodes)
+			}
+		})
+	}
+}
+
+func TestSyntheticJSXConditionalsIgnoreLocalIfShadow(t *testing.T) {
+	tests := []struct {
+		name             string
+		body             string
+		wantConditionals int
+		wantTrueTags     string
+		wantFalseTags    string
+	}{
+		{
+			name:             "logical and",
+			body:             `{props.Show && <strong>shown</strong>}`,
+			wantConditionals: 1,
+			wantTrueTags:     "div,strong",
+			wantFalseTags:    "div",
+		},
+		{
+			name:             "jsx ternary",
+			body:             `{props.Show ? <strong>shown</strong> : <small>hidden</small>}`,
+			wantConditionals: 2,
+			wantTrueTags:     "div,strong",
+			wantFalseTags:    "div,small",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			source := fmt.Sprintf(`package app
+
+type RootProps struct { Show bool }
+
+component If() {
+	return <em>shadow</em>
+}
+
+//gosx:island
+component Root(props: RootProps) {
+	return <div>%s</div>
+}
+
+component ServerRoot(props: RootProps) {
+	return <div>{props.Show && <strong>shown</strong>}</div>
+}
+`, tc.body)
+			lowered := compileIslandProgram(t, source, "Root")
+			conditionals := 0
+			for _, node := range lowered.Nodes {
+				if node.Kind == islandprogram.NodeConditional {
+					conditionals++
+				}
+				if node.Tag == "em" || node.Text == "shadow" {
+					t.Fatalf("compiler-owned conditional resolved through local If shadow: %#v", lowered.Nodes)
+				}
+			}
+			if conditionals != tc.wantConditionals {
+				t.Fatalf("conditional node count = %d, want %d: %#v", conditionals, tc.wantConditionals, lowered.Nodes)
+			}
+
+			for _, state := range []struct {
+				show bool
+				want string
+			}{
+				{show: true, want: tc.wantTrueTags},
+				{show: false, want: tc.wantFalseTags},
+			} {
+				props := fmt.Sprintf(`{"Show":%t}`, state.show)
+				tree := clientvm.ResolveInitialTree(lowered, props)
+				if got := strings.Join(resolvedTags(tree), ","); got != state.want {
+					t.Fatalf("resolved tags for props %s = %q, want %q", props, got, state.want)
+				}
+
+				prog, err := gosx.Compile([]byte(source))
+				if err != nil {
+					t.Fatalf("Compile server branch: %v", err)
+				}
+				html, err := route.RenderProgramComponent(prog, "ServerRoot", route.ProgramRenderEnv{
+					Props: struct{ Show bool }{Show: state.show},
+				})
+				if err != nil {
+					t.Fatalf("RenderProgramComponent: %v", err)
+				}
+				wantHTML := "<div></div>"
+				if state.show {
+					wantHTML = "<div><strong>shown</strong></div>"
+				}
+				if html != wantHTML {
+					t.Fatalf("server HTML for Show=%t = %q, want %q", state.show, html, wantHTML)
+				}
 			}
 		})
 	}

--- a/route/fileprogram.go
+++ b/route/fileprogram.go
@@ -312,6 +312,14 @@ func (r *fileProgramRenderer) writeElement(b *strings.Builder, node *ir.Node, en
 }
 
 func (r *fileProgramRenderer) writeComponent(b *strings.Builder, node *ir.Node, env fileRenderEnv) {
+	// JSX conditional expressions lower to a compiler-owned <If> shape. The
+	// marker distinguishes that control flow from an authored <If/> reference,
+	// so a same-file component named If only shadows authored calls.
+	if node.IsSyntheticConditional() {
+		r.writeConditional(b, node, env)
+		return
+	}
+
 	// Strict calls are type-checked as calls to the same-file declaration. Keep
 	// that declaration authoritative even when its name collides with a layout
 	// replacement or one of the legacy renderer builtins; otherwise generated Go
@@ -3505,6 +3513,13 @@ func (r *fileProgramRenderer) textContentNode(nodeID ir.NodeID, env fileRenderEn
 	case ir.NodeFragment, ir.NodeElement:
 		return r.textContentChildren(node.Children, env)
 	case ir.NodeComponent:
+		if node.IsSyntheticConditional() {
+			condition := attrValue(node.Attrs, env, "when", "if", "cond", "test")
+			if truthy(condition) {
+				return r.textContentChildren(node.Children, env)
+			}
+			return plainTextFileEvaluatedExpr(attrValue(node.Attrs, env, "fallback", "else"))
+		}
 		comp, ok := r.components[node.Tag]
 		if !ok || comp.IsIsland || comp.IsEngine {
 			return ""

--- a/transpile/package.go
+++ b/transpile/package.go
@@ -304,7 +304,7 @@ func ValidateStrictPackageBoundaries(files []PackageFile) error {
 			continue
 		}
 		for _, node := range file.Program.Nodes {
-			if node.Kind != ir.NodeComponent {
+			if node.Kind != ir.NodeComponent || node.IsSyntheticConditional() {
 				continue
 			}
 			// The file renderer resolves a local definition first. A same-file

--- a/transpile/package_test.go
+++ b/transpile/package_test.go
@@ -162,3 +162,22 @@ func Page() Node {
 		t.Fatalf("TranspilePackage: %v", err)
 	}
 }
+
+func TestValidateStrictPackageBoundariesIgnoresSyntheticConditional(t *testing.T) {
+	files := []PackageFile{
+		packageTestFile(t, "/project/a_if.gsx", `package app
+component If() {
+	return <em>authored</em>
+}
+`),
+		packageTestFile(t, "/project/b_page.gsx", `package app
+type PageProps struct { Show bool }
+component Page(props: PageProps) {
+	return <main>{props.Show && <strong>shown</strong>}</main>
+}
+`),
+	}
+	if err := ValidateStrictPackageBoundaries(files); err != nil {
+		t.Fatalf("ValidateStrictPackageBoundaries treated compiler conditional as cross-file If call: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Inline same-file strict pure-view component calls into one parent island program with no client component runtime or extra hydration root.
- Support direct typed scalar props, caller-owned children, named slots, caller signal reads, and parent handlers in projected markup.
- Clone each invocation hygienically and structurally substitute prop opcode graphs; reject nested islands, engines, legacy/imported callees, callee state or behavior, handler-valued props, nested/slice props, spreads, cycles, depth overflow, and expanded node/expression overflow.
- Fail closed for root-island children/slot holes, whose call-site content cannot belong to a per-component asset, and document the exact v1 boundary.

## Verification

- `make test-unit` (189-package unit partition)
- `make test-cli` (full CLI/production-build suite)
- `go test -race . ./ir ./route ./island/... ./client/vm/...`
- `go vet . ./ir ./route ./client/vm ./island/...`
- `make fmt-check` and `git diff --check`
- CLI `check`, `compile`, and `render` against a composed sample
- JS/WASM test binary compilation and production TinyGo islands-only build

The dedicated `make test-wasm-islands` execution lane could not launch because this host has no Node runtime. Compilation succeeds: the Go WASM test binary is 23 MiB and the production TinyGo islands-only runtime is 837,518 B raw / 349,116 B gzip.

## Baseline

- Encoded composed program: 735 B, byte-identical to the hand-flattened equivalent (735 B).
- Median lowering: 16.98 us composed vs 10.83 us flattened; compile-time-only.
- Median initial resolve: 3.62 us composed vs 3.65 us flattened, both 7,480 B and 57 allocations.
- Production islands-only runtime vs `origin/main`: 837,518 vs 837,561 B raw; 349,116 vs 349,135 B gzip. No runtime size budget increase.