### PR TITLE
test(scene3d): own native proof diagnostics by phase

### DIFF
--- a/client/js/scene3d-browser-diagnostic-ownership.test.js
+++ b/client/js/scene3d-browser-diagnostic-ownership.test.js
@@ -1,0 +1,181 @@
+"use strict";
+
+const assert = require("node:assert/strict");
+const fs = require("node:fs");
+const path = require("node:path");
+const test = require("node:test");
+const vm = require("node:vm");
+
+const {
+  buildOwnedChromeStderrRanges,
+  chromeDiagnosticFailures,
+  normalizeOwnedRanges,
+  scanOwnedChromeDiagnostics,
+} = require("./testdata/scene3d-browser-diagnostics.cjs");
+
+const SWAP = ["non-existent mailbox"];
+const LIFECYCLE = ["device was destroyed"];
+
+function stderrFixture(gl, wg, startup = "startup noise\n") {
+  const capability = "capability: non-existent mailbox\n";
+  const glStart = Buffer.byteLength(startup + capability);
+  const glContent = gl + "\n";
+  const wgStart = glStart + Buffer.byteLength(glContent);
+  const wgContent = wg + "\n";
+  const teardown = "teardown: device was destroyed\n";
+  return {
+    raw: Buffer.from(startup + capability + glContent + wgContent + teardown),
+    capabilityRange: {
+      startByte: Buffer.byteLength(startup),
+      afterTargetCloseByte: glStart,
+    },
+    ranges: [
+      { name: "gl", startByte: glStart, beforeTargetCloseByte: wgStart },
+      {
+        name: "wg",
+        startByte: wgStart,
+        beforeTargetCloseByte: wgStart + Buffer.byteLength(wgContent),
+      },
+    ],
+  };
+}
+
+test("native proof diagnostics are governed only inside live renderer ranges", () => {
+  const outside = stderrFixture("clean gl", "clean wg");
+  const outsideRanges = buildOwnedChromeStderrRanges(
+    outside.capabilityRange, outside.ranges,
+  );
+  const excluded = scanOwnedChromeDiagnostics(
+    outside.raw, outsideRanges, SWAP, LIFECYCLE,
+  );
+  assert.deepEqual(excluded.swapFindings, []);
+  assert.deepEqual(excluded.preTeardownLifecycleFindings, []);
+  assert.deepEqual(excluded.ownedStderrRanges, [
+    { name: "chrome-startup", startByte: 0, beforeTargetCloseByte: 14 },
+    ...outside.ranges,
+  ]);
+  assert.equal(excluded.ownedStderrBytes,
+    Buffer.byteLength("startup noise\n") + Buffer.byteLength("clean gl\n") +
+      Buffer.byteLength("clean wg\n"));
+
+  const inside = stderrFixture(
+    "renderer: non-existent mailbox",
+    "renderer: device was destroyed",
+  );
+  const rejected = scanOwnedChromeDiagnostics(
+    inside.raw,
+    buildOwnedChromeStderrRanges(inside.capabilityRange, inside.ranges),
+    SWAP,
+    LIFECYCLE,
+  );
+  assert.deepEqual(rejected.swapFindings,
+    [{ needle: "non-existent mailbox", count: 1 }]);
+  assert.deepEqual(rejected.preTeardownLifecycleFindings,
+    [{ needle: "device was destroyed", count: 1 }]);
+
+  const startup = stderrFixture(
+    "clean gl", "clean wg", "startup: non-existent mailbox\n",
+  );
+  const startupRejected = scanOwnedChromeDiagnostics(
+    startup.raw,
+    buildOwnedChromeStderrRanges(startup.capabilityRange, startup.ranges),
+    SWAP,
+    LIFECYCLE,
+  );
+  assert.deepEqual(startupRejected.swapFindings,
+    [{ needle: "non-existent mailbox", count: 1 }]);
+});
+
+test("native proof range validation fails closed on missing, overlapping, or invalid ownership", () => {
+  assert.throws(() => normalizeOwnedRanges(10, []), /ranges are missing/);
+  assert.throws(() => normalizeOwnedRanges(10, [
+    { name: "gl", startByte: 2, beforeTargetCloseByte: 8 },
+    { name: "wg", startByte: 7, beforeTargetCloseByte: 9 },
+  ]), /overlaps/);
+  assert.throws(() => normalizeOwnedRanges(10, [
+    { name: "gl", startByte: 2, beforeTargetCloseByte: 11 },
+  ]), /invalid bounds/);
+  assert.throws(() => normalizeOwnedRanges(10, [
+    { name: "gl", startByte: 2, beforeTargetCloseByte: 3 },
+    { name: "gl", startByte: 4, beforeTargetCloseByte: 5 },
+  ]), /invalid name/);
+  assert.throws(() => buildOwnedChromeStderrRanges(
+    { startByte: 2, afterTargetCloseByte: 8 },
+    [{ name: "gl", startByte: 7, beforeTargetCloseByte: 9 }],
+  ), /overlaps capability teardown/);
+});
+
+test("capability teardown does not contaminate the no-submit causal error set", () => {
+  const expectedNoSubmitErrors = [
+    "[wg] baseline product queue submission was not forwarded",
+    "[wg] baseline mapped renderer target contains 0 non-background pixels, expected > 20",
+    "[wg] playing product queue submission was not forwarded",
+    "[wg] playing mapped renderer target contains 0 non-background pixels, expected > 20",
+    "[wg] playing frame changed 0 pixels, expected > 20",
+    "[wg] restored product queue submission was not forwarded",
+    "[wg] restored mapped renderer target contains 0 non-background pixels, expected > 20",
+  ];
+  const outside = stderrFixture("clean gl", "clean wg");
+  const excluded = scanOwnedChromeDiagnostics(
+    outside.raw,
+    buildOwnedChromeStderrRanges(outside.capabilityRange, outside.ranges),
+    SWAP,
+    LIFECYCLE,
+  );
+  assert.deepEqual(
+    expectedNoSubmitErrors.concat(chromeDiagnosticFailures({ ...excluded, scanError: "" })),
+    expectedNoSubmitErrors,
+  );
+
+  const inside = stderrFixture("clean gl", "renderer: non-existent mailbox");
+  const rejected = scanOwnedChromeDiagnostics(
+    inside.raw,
+    buildOwnedChromeStderrRanges(inside.capabilityRange, inside.ranges),
+    SWAP,
+    LIFECYCLE,
+  );
+  assert.deepEqual(chromeDiagnosticFailures({ ...rejected, scanError: "" }), [
+    "Chrome stderr contains forbidden swap/SharedImage diagnostics: " +
+      '[{"needle":"non-existent mailbox","count":1}]',
+  ]);
+});
+
+test("adapter proof drains capability teardown before renderer case ownership", async () => {
+  const source = fs.readFileSync(path.join(
+    __dirname, "testdata", "scene3d-adapter-hydrate-browser.cjs",
+  ), "utf8");
+  const start = source.indexOf("async function drainCapabilityPage(send) {");
+  const end = source.indexOf("\nasync function poll", start);
+  assert.ok(start >= 0 && end > start, "capability drain helper must remain extractable");
+
+  const events = [];
+  let loaded;
+  const context = {
+    CAPABILITY_TEARDOWN_DRAIN_MS: 100,
+    STEP_MS: 20000,
+    currentCaseName: "",
+    currentCasePhase: "",
+    waitForEvent(name, timeout) {
+      events.push(["wait", name, timeout]);
+      return new Promise((resolve) => { loaded = resolve; });
+    },
+    async sleep(ms) { events.push(["sleep", ms]); },
+  };
+  const drain = vm.runInNewContext(source.slice(start, end) + "; drainCapabilityPage", context);
+  await drain(async (method, params) => {
+    events.push(["send", method, params]);
+    loaded();
+  });
+  assert.equal(context.currentCaseName, "caps");
+  assert.equal(context.currentCasePhase, "capability-probe");
+  assert.deepEqual(JSON.parse(JSON.stringify(events)), [
+    ["wait", "Page.loadEventFired", 20000],
+    ["send", "Page.navigate", { url: "about:blank" }],
+    ["sleep", 100],
+  ]);
+
+  const drainCall = source.indexOf("await drainCapabilityPage(send);");
+  const firstCase = source.indexOf("for (const c of CASES) await runCase(send, c);");
+  assert.ok(drainCall > source.indexOf("nativeCaps = await evalSend"));
+  assert.ok(firstCase > drainCall);
+});

--- a/client/js/testdata/scene3d-adapter-hydrate-browser.cjs
+++ b/client/js/testdata/scene3d-adapter-hydrate-browser.cjs
@@ -61,6 +61,7 @@ const MOUNT_MS = 40000;
 const OVERALL_MS = 420000;
 const BUILD_MS = 240000;
 const DIAGNOSTIC_CAPTURE_MS = 2000;
+const CAPABILITY_TEARDOWN_DRAIN_MS = 100;
 const CHROME_BIN = process.env.GOSX_CHROME_BIN || '/usr/bin/google-chrome';
 const EXPECTED_VERSION_ENV = 'GOSX_EXPECTED_CHROME_VERSION';
 const FOUR_PART_VERSION = /^\d+\.\d+\.\d+\.\d+$/;
@@ -717,6 +718,15 @@ function dispatch(raw) {
 async function evalSend(send, expression, extra) {
   const response = await send('Runtime.evaluate', Object.assign({ expression, returnByValue: true }, extra || {}));
   return response && response.result && response.result.value;
+}
+
+async function drainCapabilityPage(send) {
+  currentCaseName = 'caps';
+  currentCasePhase = 'capability-probe';
+  const loaded = waitForEvent('Page.loadEventFired', STEP_MS);
+  await send('Page.navigate', { url: 'about:blank' });
+  await loaded;
+  await sleep(CAPABILITY_TEARDOWN_DRAIN_MS);
 }
 
 async function poll(send, expression, label, timeoutMs) {
@@ -2420,6 +2430,10 @@ const watchdog = setTimeout(() => {
     throw new Error('native WebGL2 is required; WebGPU capability is recorded but not required; got ' +
       JSON.stringify(nativeCaps));
   }
+  // Destroy and drain the capability document while capability ownership is
+  // still active. Otherwise Page.navigate for the first renderer case can
+  // report the old probe canvas/context teardown under that new case.
+  await drainCapabilityPage(send);
 
   for (const c of CASES) await runCase(send, c);
   for (const c of CASES) {

--- a/client/js/testdata/scene3d-browser-diagnostics.cjs
+++ b/client/js/testdata/scene3d-browser-diagnostics.cjs
@@ -1,0 +1,115 @@
+'use strict';
+
+function countDiagnostic(content, needle) {
+  let count = 0;
+  let offset = 0;
+  for (;;) {
+    const found = content.indexOf(needle, offset);
+    if (found < 0) return count;
+    count += 1;
+    offset = found + Math.max(1, needle.length);
+  }
+}
+
+function normalizeOwnedRanges(rawLength, ranges) {
+  if (!Number.isInteger(rawLength) || rawLength < 0) {
+    throw new Error('Chrome stderr length must be a non-negative integer');
+  }
+  if (!Array.isArray(ranges) || ranges.length === 0) {
+    throw new Error('live renderer stderr ranges are missing');
+  }
+  const names = new Set();
+  let previousEnd = 0;
+  return ranges.map((entry, index) => {
+    const name = entry && typeof entry.name === 'string' ? entry.name : '';
+    const startByte = entry && entry.startByte;
+    const beforeTargetCloseByte = entry && entry.beforeTargetCloseByte;
+    if (!name || names.has(name)) {
+      throw new Error('live renderer stderr range ' + index + ' has an invalid name');
+    }
+    if (!Number.isInteger(startByte) || !Number.isInteger(beforeTargetCloseByte) ||
+        startByte < 0 || beforeTargetCloseByte < startByte ||
+        beforeTargetCloseByte > rawLength) {
+      throw new Error('live renderer stderr range ' + name + ' has invalid bounds');
+    }
+    if (index > 0 && startByte < previousEnd) {
+      throw new Error('live renderer stderr range ' + name + ' overlaps its predecessor');
+    }
+    names.add(name);
+    previousEnd = beforeTargetCloseByte;
+    return { name, startByte, beforeTargetCloseByte };
+  });
+}
+
+function buildOwnedChromeStderrRanges(capabilityRange, caseRanges) {
+  const startByte = capabilityRange && capabilityRange.startByte;
+  const afterTargetCloseByte = capabilityRange && capabilityRange.afterTargetCloseByte;
+  if (!Number.isInteger(startByte) || !Number.isInteger(afterTargetCloseByte) ||
+      startByte < 0 || afterTargetCloseByte < startByte) {
+    throw new Error('capability stderr range has invalid bounds');
+  }
+  if (!Array.isArray(caseRanges) || caseRanges.length === 0) {
+    throw new Error('live renderer stderr ranges are missing');
+  }
+  if (!caseRanges[0] || caseRanges[0].startByte < afterTargetCloseByte) {
+    throw new Error('first live renderer stderr range overlaps capability teardown');
+  }
+  return [
+    { name: 'chrome-startup', startByte: 0, beforeTargetCloseByte: startByte },
+    ...caseRanges,
+  ];
+}
+
+function diagnosticFindings(raw, ranges, needles) {
+  return needles.map((needle) => {
+    let count = 0;
+    for (const range of ranges) {
+      const content = raw.subarray(range.startByte, range.beforeTargetCloseByte)
+        .toString('utf8').toLowerCase();
+      count += countDiagnostic(content, needle);
+    }
+    return { needle, count };
+  }).filter((entry) => entry.count > 0);
+}
+
+function scanOwnedChromeDiagnostics(raw, ranges, swapDiagnostics, lifecycleDiagnostics) {
+  if (!Buffer.isBuffer(raw)) throw new Error('Chrome stderr must be a Buffer');
+  const ownedStderrRanges = normalizeOwnedRanges(raw.length, ranges);
+  const swapNeedles = Array.isArray(swapDiagnostics) ? swapDiagnostics : [];
+  const lifecycleNeedles = Array.isArray(lifecycleDiagnostics) ? lifecycleDiagnostics : [];
+  return {
+    ownedStderrBytes: ownedStderrRanges.reduce((total, range) =>
+      total + range.beforeTargetCloseByte - range.startByte, 0),
+    ownedStderrRanges,
+    swapFindings: diagnosticFindings(raw, ownedStderrRanges, swapNeedles),
+    preTeardownLifecycleFindings:
+      diagnosticFindings(raw, ownedStderrRanges, lifecycleNeedles),
+  };
+}
+
+function chromeDiagnosticFailures(diagnostics) {
+  if (!diagnostics || typeof diagnostics !== 'object') {
+    return ['Chrome stderr diagnostic scan failed: missing diagnostics'];
+  }
+  const failures = [];
+  if (diagnostics.scanError) {
+    failures.push('Chrome stderr diagnostic scan failed: ' + diagnostics.scanError);
+  }
+  if (Array.isArray(diagnostics.swapFindings) && diagnostics.swapFindings.length > 0) {
+    failures.push('Chrome stderr contains forbidden swap/SharedImage diagnostics: ' +
+      JSON.stringify(diagnostics.swapFindings));
+  }
+  if (Array.isArray(diagnostics.preTeardownLifecycleFindings) &&
+      diagnostics.preTeardownLifecycleFindings.length > 0) {
+    failures.push('Chrome stderr contains pre-teardown WebGPU lifecycle diagnostics: ' +
+      JSON.stringify(diagnostics.preTeardownLifecycleFindings));
+  }
+  return failures;
+}
+
+module.exports = {
+  buildOwnedChromeStderrRanges,
+  chromeDiagnosticFailures,
+  normalizeOwnedRanges,
+  scanOwnedChromeDiagnostics,
+};

--- a/client/js/testdata/scene3d-cubic-spline-browser-matrix.cjs
+++ b/client/js/testdata/scene3d-cubic-spline-browser-matrix.cjs
@@ -16,6 +16,8 @@ const fs = require('fs');
 const path = require('path');
 const util = require('util');
 const { spawn, spawnSync } = require('child_process');
+const { buildOwnedChromeStderrRanges, scanOwnedChromeDiagnostics } =
+  require('./scene3d-browser-diagnostics.cjs');
 
 const REPO = process.argv[2] ? path.resolve(process.argv[2]) : '';
 const ART = process.argv[3] ? path.resolve(process.argv[3]) : '';
@@ -121,6 +123,8 @@ function verifyHostedClaimSources() {
   const files = {
     harness: HARNESS,
     matrix: __filename,
+    diagnostics: path.join(REPO, 'client', 'js', 'testdata',
+      'scene3d-browser-diagnostics.cjs'),
     workflow: path.join(REPO, '.github', 'workflows', 'ci.yml'),
     corpus: path.join(REPO, 'scene', 'harness', 'testdata', 'v1-corpus.json'),
     readme: path.join(REPO, 'README.md'),
@@ -247,34 +251,36 @@ function containsSwiftShader(value) {
   catch (_error) { return false; }
 }
 
-function countDiagnostic(content, needle) {
-  let count = 0;
-  let offset = 0;
-  for (;;) {
-    const found = content.indexOf(needle, offset);
-    if (found < 0) return count;
-    count += 1;
-    offset = found + Math.max(1, needle.length);
-  }
-}
-
-function scanChromeDiagnostics(raw, boundary) {
-  const all = raw.toString('utf8').toLowerCase();
+function scanChromeDiagnostics(raw, boundary, capabilityRange, caseRanges) {
   const bounded = Number.isInteger(boundary)
     ? Math.max(0, Math.min(raw.length, boundary)) : raw.length;
-  const beforeTeardown = raw.subarray(0, bounded).toString('utf8').toLowerCase();
-  return {
-    scannedBytes: raw.length,
-    webgpuIntentionalTeardownStderrByte: bounded,
-    swapFindings: CHROME_SWAP_DIAGNOSTICS.map((needle) => ({
-      needle, count: countDiagnostic(all, needle),
-    })).filter((entry) => entry.count > 0),
-    preTeardownLifecycleFindings:
-      CHROME_PRE_TEARDOWN_LIFECYCLE_DIAGNOSTICS.map((needle) => ({
-        needle, count: countDiagnostic(beforeTeardown, needle),
-      })).filter((entry) => entry.count > 0),
-    scanError: '',
-  };
+  try {
+    const owned = scanOwnedChromeDiagnostics(
+      raw,
+      buildOwnedChromeStderrRanges(capabilityRange, caseRanges),
+      CHROME_SWAP_DIAGNOSTICS,
+      CHROME_PRE_TEARDOWN_LIFECYCLE_DIAGNOSTICS,
+    );
+    return {
+      scannedBytes: raw.length,
+      webgpuIntentionalTeardownStderrByte: bounded,
+      ownedStderrBytes: owned.ownedStderrBytes,
+      ownedStderrRanges: owned.ownedStderrRanges,
+      swapFindings: owned.swapFindings,
+      preTeardownLifecycleFindings: owned.preTeardownLifecycleFindings,
+      scanError: '',
+    };
+  } catch (error) {
+    return {
+      scannedBytes: raw.length,
+      webgpuIntentionalTeardownStderrByte: bounded,
+      ownedStderrBytes: null,
+      ownedStderrRanges: [],
+      swapFindings: [],
+      preTeardownLifecycleFindings: [],
+      scanError: String(error && error.message || error),
+    };
+  }
 }
 
 function checkCDPBrowserIdentity(failures, value, browser, label) {
@@ -941,6 +947,25 @@ function checkTopLevel(failures, report, mode, browser) {
           entry.beforeTargetCloseByte <= maxByte,
         'report.caseStderrRanges[' + index + '] is invalid');
       }
+      const expectedOwnedRanges = [
+        {
+          name: 'chrome-startup',
+          startByte: 0,
+          beforeTargetCloseByte: report.capabilityStderrRange &&
+            report.capabilityStderrRange.startByte,
+        },
+        ...report.caseStderrRanges.map((entry) => ({
+          name: entry && entry.name,
+          startByte: entry && entry.startByte,
+          beforeTargetCloseByte: entry && entry.beforeTargetCloseByte,
+        })),
+      ];
+      exact(failures, report.chromeDiagnostics.ownedStderrRanges,
+        expectedOwnedRanges, 'report.chromeDiagnostics.ownedStderrRanges');
+      exact(failures, report.chromeDiagnostics.ownedStderrBytes,
+        expectedOwnedRanges.reduce((total, entry) =>
+          total + entry.beforeTargetCloseByte - entry.startByte, 0),
+      'report.chromeDiagnostics.ownedStderrBytes');
     }
   }
   check(failures, report.browserGPU && typeof report.browserGPU === 'object',
@@ -1177,7 +1202,15 @@ function runMode(mode, browser) {
         }
         const boundary = report && report.chromeDiagnostics &&
           report.chromeDiagnostics.webgpuIntentionalTeardownStderrByte;
-        chromeDiagnostics = scanChromeDiagnostics(chromeStderrRaw, boundary);
+        const capabilityRange = report && report.capabilityStderrRange;
+        const caseRanges = report && report.caseStderrRanges;
+        chromeDiagnostics = scanChromeDiagnostics(
+          chromeStderrRaw, boundary, capabilityRange, caseRanges,
+        );
+        if (chromeDiagnostics.scanError) {
+          verificationFailures.push('raw Chrome stderr diagnostic scan failed: ' +
+            chromeDiagnostics.scanError);
+        }
         if (chromeDiagnostics.swapFindings.length > 0) {
           verificationFailures.push('raw Chrome stderr contains forbidden swap/SharedImage ' +
             'diagnostics: ' + JSON.stringify(chromeDiagnostics.swapFindings));

--- a/client/js/testdata/scene3d-cubic-spline-browser.cjs
+++ b/client/js/testdata/scene3d-cubic-spline-browser.cjs
@@ -49,6 +49,11 @@ const os = require('os');
 const path = require('path');
 const http = require('http');
 const { spawn, spawnSync } = require('child_process');
+const {
+  buildOwnedChromeStderrRanges,
+  chromeDiagnosticFailures,
+  scanOwnedChromeDiagnostics,
+} = require('./scene3d-browser-diagnostics.cjs');
 
 const REPO = process.argv[2];
 const ART = process.argv[3];
@@ -2189,44 +2194,34 @@ let finished = false;
 let exitCode = 0;
 let reportWriteFailed = false;
 
-function countDiagnostic(content, needle) {
-  let count = 0;
-  let offset = 0;
-  for (;;) {
-    const found = content.indexOf(needle, offset);
-    if (found < 0) return count;
-    count += 1;
-    offset = found + Math.max(1, needle.length);
-  }
-}
-
 function scanChromeDiagnostics() {
   const stderrPath = path.join(ART, 'chrome-stderr.log');
   try {
     const raw = fs.readFileSync(stderrPath);
-    const all = raw.toString('utf8').toLowerCase();
     const boundary = Number.isInteger(webGPUIntentionalTeardownStderrByte)
       ? Math.max(0, Math.min(raw.length, webGPUIntentionalTeardownStderrByte))
       : raw.length;
-    const beforeTeardown = raw.subarray(0, boundary).toString('utf8').toLowerCase();
-    const swapFindings = CHROME_SWAP_DIAGNOSTICS.map((needle) => ({
-      needle, count: countDiagnostic(all, needle),
-    })).filter((entry) => entry.count > 0);
-    const preTeardownLifecycleFindings =
-      CHROME_PRE_TEARDOWN_LIFECYCLE_DIAGNOSTICS.map((needle) => ({
-        needle, count: countDiagnostic(beforeTeardown, needle),
-      })).filter((entry) => entry.count > 0);
+    const owned = scanOwnedChromeDiagnostics(
+      raw,
+      buildOwnedChromeStderrRanges(CAPABILITY_STDERR_RANGE, CASE_STDERR_RANGES),
+      CHROME_SWAP_DIAGNOSTICS,
+      CHROME_PRE_TEARDOWN_LIFECYCLE_DIAGNOSTICS,
+    );
     return {
       scannedBytes: raw.length,
       webgpuIntentionalTeardownStderrByte: boundary,
-      swapFindings,
-      preTeardownLifecycleFindings,
+      ownedStderrBytes: owned.ownedStderrBytes,
+      ownedStderrRanges: owned.ownedStderrRanges,
+      swapFindings: owned.swapFindings,
+      preTeardownLifecycleFindings: owned.preTeardownLifecycleFindings,
       scanError: '',
     };
   } catch (error) {
     return {
       scannedBytes: null,
       webgpuIntentionalTeardownStderrByte,
+      ownedStderrBytes: null,
+      ownedStderrRanges: [],
       swapFindings: [],
       preTeardownLifecycleFindings: [],
       scanError: String(error && error.message || error),
@@ -2513,16 +2508,8 @@ const watchdog = setTimeout(() => {
   }
   await cleanup();
   chromeDiagnostics = scanChromeDiagnostics();
-  if (chromeDiagnostics.scanError) {
-    fail('Chrome stderr diagnostic scan failed: ' + chromeDiagnostics.scanError);
-  }
-  if (chromeDiagnostics.swapFindings.length > 0) {
-    fail('Chrome stderr contains forbidden swap/SharedImage diagnostics: ' +
-      JSON.stringify(chromeDiagnostics.swapFindings));
-  }
-  if (chromeDiagnostics.preTeardownLifecycleFindings.length > 0) {
-    fail('Chrome stderr contains pre-teardown WebGPU lifecycle diagnostics: ' +
-      JSON.stringify(chromeDiagnostics.preTeardownLifecycleFindings));
+  for (const diagnosticFailure of chromeDiagnosticFailures(chromeDiagnostics)) {
+    fail(diagnosticFailure);
   }
   writeReport({});
   exitCode = (errors.length || warnings.length || notFound.length || unexpectedRequests.length ||


### PR DESCRIPTION
## What changed

- drain the adapter capability document under `caps/capability-probe` ownership before the first renderer case begins
- scan cubic renderer Chrome diagnostics only across explicit proof-owned byte ranges: Chrome startup plus each live case before target close
- exclude the separate capability probe and target-close teardown gaps without expanding any message allowlist
- fail closed on missing, duplicate, overlapping, or out-of-bounds ownership ranges
- record the governed ranges/byte count and independently recompute them from the raw Chrome stderr artifact in the matrix verifier
- hash the shared diagnostic scanner in the hosted proof source receipt

## Evidence

Two independent artifacts place `SharedImageManager::ProduceSkia ... non-existent mailbox` at byte 3894 inside capability range 3709..3916 and outside every live case range:

- PR #321 run 33856825453, `gap100`
- PR #319 run 33857630520, `no-submit`

The #319 no-submit product proof otherwise produced exactly its seven expected causal failures. PR #318 artifact 9930749928 recorded `CONTEXT_LOST_WEBGL` one millisecond after the GL phase label changed to `navigate`, while navigating away from the reused capability document; every actual renderer, disposal, network, and typed device-loss receipt passed.

Regression tests inject the exact mailbox and device-loss diagnostics outside and inside owned ranges. Capability/teardown diagnostics are excluded; the same diagnostics remain fatal during Chrome startup or any live GL/WG case. The no-submit expected error set stays exact.

## Verification

- focused ownership and adapter suites: 28/28 pass
- full direct Node runtime suite: 1686/1686 pass
- strict TypeScript contract typecheck: pass
- buildbootstrap tests and generated bundle freshness check: pass
- `make fmt-check`: pass (81 files)
- local four-mode native renderer matrix: positive/gap100 pass; no-draw/no-submit exit 1 with exact expected causal failures; matrix verified all four modes
- exact #321/#319 failed artifact replay: zero governed diagnostic findings; both mailbox bytes remain proven inside the excluded capability range

The local adapter proof could not pass its pre-existing native WebGL2 capability gate under this host Chrome/Mesa llvmpipe configuration (`webgl2=false`); hosted SwiftShader CI is the authoritative verification for that path.

No product renderer semantics, generated client bundles, dependencies, or size/performance budgets changed.
