### PR TITLE
test: bound Chrome startup and join failed-launch cleanup

### DIFF
--- a/e2e/e2e_shared_test.go
+++ b/e2e/e2e_shared_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"syscall"
@@ -27,6 +28,7 @@ import (
 	cdppage "github.com/chromedp/cdproto/page"
 	cdpruntime "github.com/chromedp/cdproto/runtime"
 	"github.com/chromedp/chromedp"
+	"m31labs.dev/gosx/internal/chrometest"
 )
 
 // e2eChromePath resolves the browser binary: GOSX_E2E_CHROME first,
@@ -253,24 +255,33 @@ func (p *browserPage) anyRequest(match func(string) bool) bool {
 // before every document in the tab (playwright addInitScript equivalent).
 func newBrowserPage(t *testing.T, chrome string, extraFlags map[string]any, width, height int, initScript string, timeout time.Duration) *browserPage {
 	t.Helper()
-	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chrome),
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Headless,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.WindowSize(width, height),
-	)
-	for name, value := range extraFlags {
-		allocOpts = append(allocOpts, chromedp.Flag(name, value))
+	args := []string{"--no-sandbox", fmt.Sprintf("--window-size=%d,%d", width, height)}
+	names := make([]string, 0, len(extraFlags))
+	for name := range extraFlags {
+		names = append(names, name)
 	}
-	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
-	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
-	ctx, timeoutCancel := context.WithTimeout(browserCtx, timeout)
+	sort.Strings(names)
+	for _, name := range names {
+		switch value := extraFlags[name].(type) {
+		case string:
+			args = append(args, "--"+name+"="+value)
+		case bool:
+			if !value {
+				t.Fatalf("unsupported disabled Chrome flag %q", name)
+			}
+			args = append(args, "--"+name)
+		default:
+			t.Fatalf("unsupported Chrome flag %q", name)
+		}
+	}
+	browser, err := chrometest.Start(t.Context(), chrome, args...)
+	if err != nil {
+		t.Fatalf("start Chrome: %v", err)
+	}
+	ctx, timeoutCancel := context.WithTimeout(browser.Context, timeout)
 	t.Cleanup(func() {
 		timeoutCancel()
-		browserCancel()
-		allocCancel()
+		browser.Close()
 	})
 
 	page := &browserPage{ctx: ctx}

--- a/e2e/render_chromedp_test.go
+++ b/e2e/render_chromedp_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"m31labs.dev/gosx/internal/chrometest"
 )
 
 type renderSmokeResult struct {
@@ -124,22 +125,15 @@ func findChrome(t *testing.T) string {
 
 func newChromeContext(t *testing.T, chrome string) (context.Context, context.CancelFunc) {
 	t.Helper()
-	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chrome),
-		chromedp.Headless,
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.Flag("use-angle", "swiftshader"),
-		chromedp.Flag("enable-webgl", true),
-	)
-	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
-	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
-	ctx, timeoutCancel := context.WithTimeout(browserCtx, 15*time.Second)
+	browser, err := chrometest.Start(t.Context(), chrome,
+		"--no-sandbox", "--use-angle=swiftshader", "--enable-webgl")
+	if err != nil {
+		t.Fatalf("start Chrome for render smoke: %v", err)
+	}
+	ctx, timeoutCancel := context.WithTimeout(browser.Context, 15*time.Second)
 	return ctx, func() {
 		timeoutCancel()
-		browserCancel()
-		allocCancel()
+		browser.Close()
 	}
 }
 

--- a/e2e/selena_material_overdraw_e2e_test.go
+++ b/e2e/selena_material_overdraw_e2e_test.go
@@ -39,6 +39,7 @@ import (
 
 	"github.com/chromedp/cdproto/page"
 	"github.com/chromedp/chromedp"
+	"m31labs.dev/gosx/internal/chrometest"
 )
 
 const selenaOverdrawPageTemplate = `<!doctype html>
@@ -183,21 +184,13 @@ func TestSelenaMaterialOwnsItsPixelsBesideALinesMesh(t *testing.T) {
 	// SwiftShader gives headless Chrome a real WebGL implementation. Without it
 	// the runtime downgrades to Canvas2D, runs no shaders, and every pixel
 	// assertion below would be meaningless -- the backend check guards that.
-	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chrome),
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Headless,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.Flag("use-angle", "swiftshader"),
-		chromedp.Flag("enable-unsafe-swiftshader", true),
-		chromedp.WindowSize(640, 480),
-	)
-	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
-	defer allocCancel()
-	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
-	defer browserCancel()
-	ctx, cancel := context.WithTimeout(browserCtx, 120*time.Second)
+	browser, err := chrometest.Start(t.Context(), chrome,
+		"--no-sandbox", "--use-angle=swiftshader", "--enable-unsafe-swiftshader", "--window-size=640,480")
+	if err != nil {
+		t.Fatalf("start Chrome for material overdraw: %v", err)
+	}
+	defer browser.Close()
+	ctx, cancel := context.WithTimeout(browser.Context, 120*time.Second)
 	defer cancel()
 
 	if err := chromedp.Run(ctx,

--- a/examples/gosx-docs/app/demos/water/water_diag_security_test.go
+++ b/examples/gosx-docs/app/demos/water/water_diag_security_test.go
@@ -10,159 +10,12 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
-	"sync"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
+	"m31labs.dev/gosx/internal/chrometest"
 )
-
-type chromeStartupState int
-
-const (
-	chromeStartupPending chromeStartupState = iota
-	chromeStartupBound
-	chromeStartupFailed
-	chromeStartupTimedOut
-)
-
-type chromeStartupDeadline struct {
-	mu              sync.Mutex
-	state           chromeStartupState
-	cancelBrowser   context.CancelFunc
-	timer           *time.Timer
-	timerDone       chan struct{}
-	stopOnce        sync.Once
-	beforeTimerWins func()
-	beforeTimerJoin func()
-}
-
-func newChromeStartupDeadline(timeout time.Duration, cancelBrowser context.CancelFunc) *chromeStartupDeadline {
-	return newChromeStartupDeadlineForTest(timeout, cancelBrowser, nil, nil)
-}
-
-func newChromeStartupDeadlineForTest(timeout time.Duration, cancelBrowser context.CancelFunc, beforeTimerWins func(), beforeTimerJoin func()) *chromeStartupDeadline {
-	deadline := &chromeStartupDeadline{
-		state:           chromeStartupPending,
-		cancelBrowser:   cancelBrowser,
-		timerDone:       make(chan struct{}),
-		beforeTimerWins: beforeTimerWins,
-		beforeTimerJoin: beforeTimerJoin,
-	}
-	deadline.timer = time.AfterFunc(timeout, func() {
-		defer close(deadline.timerDone)
-		if deadline.beforeTimerWins != nil {
-			deadline.beforeTimerWins()
-		}
-		deadline.mu.Lock()
-		defer deadline.mu.Unlock()
-		if deadline.state != chromeStartupPending {
-			return
-		}
-		deadline.state = chromeStartupTimedOut
-		deadline.cancelBrowser()
-	})
-	return deadline
-}
-
-func (deadline *chromeStartupDeadline) finish(success bool) chromeStartupState {
-	deadline.stopOnce.Do(func() {
-		if !deadline.timer.Stop() {
-			if deadline.beforeTimerJoin != nil {
-				deadline.beforeTimerJoin()
-			}
-			<-deadline.timerDone
-		}
-	})
-	deadline.mu.Lock()
-	defer deadline.mu.Unlock()
-	if deadline.state == chromeStartupPending {
-		if success {
-			deadline.state = chromeStartupBound
-		} else {
-			deadline.state = chromeStartupFailed
-		}
-	}
-	return deadline.state
-}
-
-func requireChromeStartupTestSignal(t *testing.T, ch <-chan struct{}, name string) {
-	t.Helper()
-	select {
-	case <-ch:
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for chrome startup test signal %q", name)
-	}
-}
-
-func requireChromeStartupTestState(t *testing.T, ch <-chan chromeStartupState, name string) chromeStartupState {
-	t.Helper()
-	select {
-	case state := <-ch:
-		return state
-	case <-time.After(2 * time.Second):
-		t.Fatalf("timed out waiting for chrome startup test state %q", name)
-		return chromeStartupPending
-	}
-}
-
-func TestChromeStartupDeadlineJoinsTimerBeforeSuccess(t *testing.T) {
-	cancelled := make(chan struct{})
-	cancelBrowser := func() {
-		close(cancelled)
-	}
-	timerEntered := make(chan struct{})
-	joinStarted := make(chan struct{})
-	releaseTimer := make(chan struct{})
-	var releaseOnce sync.Once
-	release := func() {
-		releaseOnce.Do(func() {
-			close(releaseTimer)
-		})
-	}
-	defer release()
-	deadline := newChromeStartupDeadlineForTest(0, cancelBrowser, func() {
-		close(timerEntered)
-		<-releaseTimer
-	}, func() {
-		close(joinStarted)
-	})
-	requireChromeStartupTestSignal(t, timerEntered, "timer callback entered")
-
-	finished := make(chan chromeStartupState, 1)
-	go func() {
-		finished <- deadline.finish(true)
-	}()
-
-	requireChromeStartupTestSignal(t, joinStarted, "finish reached timer callback join")
-	select {
-	case state := <-finished:
-		t.Fatalf("startup finish returned %v before joining in-flight timer callback", state)
-	default:
-	}
-
-	release()
-	if state := requireChromeStartupTestState(t, finished, "finish after timer release"); state != chromeStartupTimedOut {
-		t.Fatalf("startup boundary did not fail closed after timer won; state=%v", state)
-	}
-	requireChromeStartupTestSignal(t, cancelled, "browser canceled by startup timeout")
-	if state := deadline.finish(true); state != chromeStartupTimedOut {
-		t.Fatalf("startup timeout state was not terminal; got %v", state)
-	}
-}
-
-func TestChromeStartupDeadlineSuccessIsTerminal(t *testing.T) {
-	cancelBrowser := func() {
-		t.Fatal("startup timer canceled browser after successful bind")
-	}
-	deadline := newChromeStartupDeadline(time.Hour, cancelBrowser)
-	if state := deadline.finish(true); state != chromeStartupBound {
-		t.Fatalf("startup success was not recorded; state=%v", state)
-	}
-	if state := deadline.finish(false); state != chromeStartupBound {
-		t.Fatalf("startup success state was not terminal; got %v", state)
-	}
-}
 
 func waterDiagSource(t *testing.T) []byte {
 	t.Helper()
@@ -192,10 +45,7 @@ func TestWaterDiagAvoidsHTMLParsingSinks(t *testing.T) {
 }
 
 func TestWaterDiagRendersQueryAndAttributeValuesAsText(t *testing.T) {
-	const (
-		chromeStartupTimeout = 30 * time.Second
-		assertionTimeout     = 15 * time.Second
-	)
+	const assertionTimeout = 15 * time.Second
 
 	chromePath := ""
 	for _, name := range []string{"google-chrome", "google-chrome-stable", "chromium", "chromium-browser", "chrome"} {
@@ -231,37 +81,18 @@ func TestWaterDiagRendersQueryAndAttributeValuesAsText(t *testing.T) {
 	server := httptest.NewServer(mux)
 	defer server.Close()
 
-	allocOptions := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chromePath),
-		chromedp.Headless,
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.Flag("disable-gpu", true),
+	browser, err := chrometest.Start(t.Context(), chromePath,
+		"--no-sandbox",
+		"--disable-gpu",
 	)
-	allocContext, cancelAlloc := chromedp.NewExecAllocator(context.Background(), allocOptions...)
-	defer cancelAlloc()
-	browserContext, cancelBrowser := chromedp.NewContext(allocContext)
-	defer cancelBrowser()
-
-	// Bind the browser under a separate startup deadline. The deadline protocol
-	// joins any in-flight timeout callback before the test proceeds, so startup
-	// success cannot be canceled later by a timer that already began firing. The
-	// security assertion below keeps its own fixed deadline, so a slow CI Chrome
-	// launch cannot spend the entire payload-rendering/XSS assertion budget
-	// before navigation starts.
-	startupDeadline := newChromeStartupDeadline(chromeStartupTimeout, cancelBrowser)
-	if err := chromedp.Run(browserContext); err != nil {
-		if startupDeadline.finish(false) == chromeStartupTimedOut {
-			t.Fatalf("start Chrome for water diagnostics within %s: %v", chromeStartupTimeout, err)
-		}
+	if err != nil {
 		t.Fatalf("start Chrome for water diagnostics: %v", err)
 	}
-	if startupDeadline.finish(true) == chromeStartupTimedOut {
-		t.Fatalf("start Chrome for water diagnostics within %s: startup timer fired while binding browser", chromeStartupTimeout)
-	}
+	defer browser.Close()
 
-	ctx, cancelAssertion := context.WithTimeout(browserContext, assertionTimeout)
+	// Startup and the payload-rendering/XSS assertion have independent hard
+	// bounds, so a recovered transient launch cannot consume assertion time.
+	ctx, cancelAssertion := context.WithTimeout(browser.Context, assertionTimeout)
 	defer cancelAssertion()
 
 	var got struct {
@@ -273,7 +104,7 @@ func TestWaterDiagRendersQueryAndAttributeValuesAsText(t *testing.T) {
 		UnexpectedNodes int    `json:"unexpectedNodes"`
 	}
 	target := server.URL + "/?diag=1&meshRes=" + url.QueryEscape(queryAttack)
-	err := chromedp.Run(ctx,
+	err = chromedp.Run(ctx,
 		chromedp.Navigate(target),
 		chromedp.WaitReady(`[data-water-diag]`, chromedp.ByQuery),
 		chromedp.Evaluate(`(() => {

--- a/examples/ouroboros-corpus/main_test.go
+++ b/examples/ouroboros-corpus/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/gorilla/websocket"
 	"m31labs.dev/gosx/hydrate"
+	"m31labs.dev/gosx/internal/chrometest"
 	"m31labs.dev/gosx/island/program"
 	ouroboros "m31labs.dev/gosx/perf/ouroboros"
 )
@@ -244,19 +245,13 @@ func TestFixtureMP4BrowserLoadsMetadata(t *testing.T) {
 	}))
 	defer server.Close()
 
-	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chrome),
-		chromedp.Headless,
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.Flag("autoplay-policy", "no-user-gesture-required"),
-	)
-	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
-	defer allocCancel()
-	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
-	defer browserCancel()
-	ctx, cancel := context.WithTimeout(browserCtx, 30*time.Second)
+	browser, err := chrometest.Start(t.Context(), chrome,
+		"--no-sandbox", "--autoplay-policy=no-user-gesture-required")
+	if err != nil {
+		t.Fatalf("start Chrome for media metadata: %v", err)
+	}
+	defer browser.Close()
+	ctx, cancel := context.WithTimeout(browser.Context, 30*time.Second)
 	defer cancel()
 
 	mediaURL := server.URL + "/media/ouroboros-placeholder.mp4"
@@ -1022,17 +1017,12 @@ func newChromeContext(t *testing.T, chrome string, timeout time.Duration) (conte
 func newAuditedChromeContext(t *testing.T, chrome string, timeout time.Duration) (context.Context, context.CancelFunc, *chromeAudit) {
 	t.Helper()
 	audit := &chromeAudit{}
-	allocOpts := append(chromedp.DefaultExecAllocatorOptions[:],
-		chromedp.ExecPath(chrome),
-		chromedp.Headless,
-		chromedp.NoFirstRun,
-		chromedp.NoDefaultBrowserCheck,
-		chromedp.Flag("no-sandbox", true),
-		chromedp.Flag("autoplay-policy", "no-user-gesture-required"),
-	)
-	allocCtx, allocCancel := chromedp.NewExecAllocator(context.Background(), allocOpts...)
-	browserCtx, browserCancel := chromedp.NewContext(allocCtx)
-	chromedp.ListenTarget(browserCtx, func(ev any) {
+	browser, err := chrometest.Start(t.Context(), chrome,
+		"--no-sandbox", "--autoplay-policy=no-user-gesture-required")
+	if err != nil {
+		t.Fatalf("start Chrome for fixture: %v", err)
+	}
+	chromedp.ListenTarget(browser.Context, func(ev any) {
 		switch ev := ev.(type) {
 		case *cdpRuntime.EventConsoleAPICalled:
 			var parts []string
@@ -1051,11 +1041,10 @@ func newAuditedChromeContext(t *testing.T, chrome string, timeout time.Duration)
 			audit.Add("exception: " + message)
 		}
 	})
-	ctx, cancel := context.WithTimeout(browserCtx, timeout)
+	ctx, cancel := context.WithTimeout(browser.Context, timeout)
 	return ctx, func() {
 		cancel()
-		browserCancel()
-		allocCancel()
+		browser.Close()
 	}, audit
 }
 

--- a/internal/chrometest/README.md
+++ b/internal/chrometest/README.md
@@ -4,9 +4,11 @@
 already bound and active. Create navigation/assertion deadlines from `browser.Context`
 afterward, and call `browser.Close()` in cleanup. Startup gets at most two
 30-second attempts within a 65-second overall budget, reserving time for process,
-pipe, and CDP cleanup. Only a live process that reaches the startup deadline can
-retry. Process exits, invalid endpoints, and concrete CDP errors fail immediately;
-assertions and page navigation are never retried.
+pipe, and CDP cleanup. The WebSocket handshake uses the remaining attempt/overall
+allowance. Startup deadlines and typed handshake timeouts can retry only while the
+process is alive and the caller is not canceled. Process exits, invalid endpoints,
+and non-timeout CDP errors fail immediately; assertions and page navigation are
+never retried.
 
 This package launches Chrome directly and uses chromedp's remote allocator for
 the bound connection because chromedp v0.15.1's exec allocator has three relevant

--- a/internal/chrometest/README.md
+++ b/internal/chrometest/README.md
@@ -1,0 +1,48 @@
+# Chrome startup for tests
+
+`Start(t.Context(), chromePath, flags...)` returns a browser whose empty tab is
+already bound and active. Create navigation/assertion deadlines from `browser.Context`
+afterward, and call `browser.Close()` in cleanup. Startup gets at most two
+30-second attempts within a 65-second overall budget, reserving time for process,
+pipe, and CDP cleanup. Only a live process that reaches the startup deadline can
+retry. Process exits, invalid endpoints, and concrete CDP errors fail immediately;
+assertions and page navigation are never retried.
+
+This package launches Chrome directly and uses chromedp's remote allocator for
+the bound connection because chromedp v0.15.1's exec allocator has three relevant
+behaviors that an option-only wrapper cannot fix:
+
+- `WSURLReadTimeout` changes the default 20-second limit, but that endpoint wait
+  does not select on caller cancellation.
+- `readOutput` accumulates all pre-endpoint output in an unbounded buffer, even
+  when `CombinedOutput` points to a bounded writer.
+- The tail copy starts only after the endpoint is found, making output-drain
+  ownership and failed-startup cleanup hard to join from a wrapper.
+
+The helper continuously drains an owned pipe into an 8 KiB tail and parses only
+bounded endpoint lines. It observes process exit independently of pipe draining,
+so a descendant holding stdout open cannot turn an immediate fatal exit into a
+retryable timeout. Failed attempts join the initial CDP run, allocator, process,
+and drain before removing the fresh profile. On Linux, cancellation kills the
+owned process group, including launcher/Chrome descendants. Other platforms use
+the standard process kill and a bounded pipe-drain close; descendant-group cleanup
+is Linux-specific. The flags preserve chromedp v0.15.1's defaults and each caller's
+rendering/codec settings. Product, visual, and performance launchers do not use
+this test helper.
+
+The remote allocator opens a new test tab beside Chrome's initial blank tab.
+Startup activates that tab before returning, preserving the exec allocator's
+visible-page behavior for requestAnimationFrame and chromedp's default polling.
+
+Diagnostics remove terminal controls, URLs, profile paths, endpoint addresses,
+and common credential fields. A truncated first line is discarded so redaction
+does not start in the middle of a secret value. This is diagnostic hygiene for
+local test processes, not a general-purpose arbitrary-log sanitizer.
+
+Fake executable and CDP peer tests cover fatal exits, inherited descendant pipes,
+timeout-only retries, fresh profiles, complete pipe floods, prompt cancellation
+before and during CDP bind, overall budgets, and successful browser lifetime after
+startup. These run in the ordinary and focused race CI partitions. POSIX process
+fixtures run on Linux/macOS; portable endpoint/diagnostic tests also compile and
+run on Windows. Set `GOSX_CHROME_BIN` to run the three-launch real Chrome smoke,
+including visible-page and animation-frame polling checks.

--- a/internal/chrometest/handshake_test.go
+++ b/internal/chrometest/handshake_test.go
@@ -1,0 +1,216 @@
+package chrometest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestRetryableStartupTimeoutRequiresTypedTimeoutLiveProcessAndCaller(t *testing.T) {
+	live := make(chan struct{})
+	exited := make(chan struct{})
+	close(exited)
+	canceled, cancel := context.WithCancel(context.Background())
+	cancel()
+	for _, tc := range []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"deadline", context.DeadlineExceeded, true},
+		{"wrapped deadline", fmt.Errorf("dial: %w", context.DeadlineExceeded), true},
+		{"wrapped network timeout", fmt.Errorf("dial: %w", &net.OpError{Op: "read", Net: "tcp", Err: os.ErrDeadlineExceeded}), true},
+		{"plain deadline text", errors.New("context deadline exceeded"), false},
+		{"plain timeout text", errors.New("dial timeout"), false},
+		{"network failure", &net.OpError{Op: "dial", Net: "tcp", Err: errors.New("connection refused")}, false},
+		{"cancellation", fmt.Errorf("dial: %w", context.Canceled), false},
+		{"nil", nil, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := retryableStartupTimeout(context.Background(), tc.err, live); got != tc.want {
+				t.Fatalf("live startup retry=%v, want %v", got, tc.want)
+			}
+			if retryableStartupTimeout(context.Background(), tc.err, exited) {
+				t.Fatal("process exit became retryable")
+			}
+			if retryableStartupTimeout(canceled, tc.err, live) {
+				t.Fatal("caller cancellation became retryable")
+			}
+		})
+	}
+}
+
+func TestStartRetriesHandshakeTimeoutWithFreshProcess(t *testing.T) {
+	requirePOSIXShell(t)
+	var handshakes atomic.Int32
+	firstCanceled := make(chan struct{})
+	endpoint, _, _ := fakeCDPBeforeUpgrade(t, false, func(w http.ResponseWriter, r *http.Request) bool {
+		if handshakes.Add(1) == 1 {
+			<-r.Context().Done()
+			close(firstCanceled)
+			return false
+		}
+		return true
+	})
+	executable, logPath := handshakeChrome(t, endpoint)
+	browser, err := startWithPolicy(t.Context(), executable, fastPolicy(2))
+	if err != nil {
+		t.Fatalf("handshake retry failed: %v", err)
+	}
+	defer browser.Close()
+	if handshakes.Load() != 2 {
+		t.Fatalf("handshakes=%d, want 2", handshakes.Load())
+	}
+	select {
+	case <-firstCanceled:
+	case <-time.After(time.Second):
+		t.Fatal("first handshake connection survived retry")
+	}
+	profiles := strings.Fields(readFile(t, logPath))
+	if len(profiles) != 2 || profiles[0] == profiles[1] {
+		t.Fatalf("retry profiles=%v, want two fresh profiles", profiles)
+	}
+	pids := strings.Fields(readFile(t, logPath+".pids"))
+	if len(pids) != 2 || pids[0] == pids[1] {
+		t.Fatalf("retry process IDs=%v, want two fresh processes", pids)
+	}
+	if _, err := os.Stat(profiles[0]); !os.IsNotExist(err) {
+		t.Fatalf("failed-attempt profile survived retry: %v", err)
+	}
+	if profiles[1] != browser.process.profileDir {
+		t.Fatal("returned browser did not belong to the second process")
+	}
+	browser.Close()
+	if _, err := os.Stat(profiles[1]); !os.IsNotExist(err) {
+		t.Fatalf("successful-attempt profile survived close: %v", err)
+	}
+}
+
+func TestStartDoesNotRetryPermanentHandshakeFailure(t *testing.T) {
+	requirePOSIXShell(t)
+	var handshakes atomic.Int32
+	endpoint, _, _ := fakeCDPBeforeUpgrade(t, false, func(w http.ResponseWriter, r *http.Request) bool {
+		handshakes.Add(1)
+		http.Error(w, "invalid protocol", http.StatusBadRequest)
+		return false
+	})
+	executable, logPath := handshakeChrome(t, endpoint)
+	_, err := startWithPolicy(t.Context(), executable, fastPolicy(2))
+	if err == nil || handshakes.Load() != 1 || countLogLines(t, logPath) != 1 {
+		t.Fatalf("permanent handshake failure err=%v handshakes=%d", err, handshakes.Load())
+	}
+}
+
+func TestStartHandshakeUsesRemainingAggregateBudget(t *testing.T) {
+	requirePOSIXShell(t)
+	var handshakes atomic.Int32
+	canceled := make(chan struct{}, 2)
+	endpoint, _, _ := fakeCDPBeforeUpgrade(t, false, func(w http.ResponseWriter, r *http.Request) bool {
+		attempt := handshakes.Add(1)
+		if attempt == 1 {
+			<-r.Context().Done()
+			canceled <- struct{}{}
+			return false
+		}
+		// This response fits a fresh one-second attempt but cannot fit the
+		// ~350ms remaining after the first attempt consumes its full second.
+		select {
+		case <-time.After(650 * time.Millisecond):
+			return true
+		case <-r.Context().Done():
+			canceled <- struct{}{}
+			return false
+		}
+	})
+	executable, logPath := handshakeChrome(t, endpoint)
+	policy := fastPolicy(2)
+	policy.attemptTimeout = time.Second
+	policy.overallTimeout = cleanupAllowance + 1350*time.Millisecond
+	browser, err := startWithPolicy(t.Context(), executable, policy)
+	if browser != nil {
+		browser.Close()
+		t.Fatal("second handshake incorrectly received a fresh attempt budget")
+	}
+	if err == nil || handshakes.Load() != 2 || countLogLines(t, logPath) != 2 {
+		t.Fatalf("aggregate deadline err=%v handshakes=%d", err, handshakes.Load())
+	}
+	for range 2 {
+		select {
+		case <-canceled:
+		case <-time.After(time.Second):
+			t.Fatal("expired aggregate budget left a handshake connected")
+		}
+	}
+	for _, profile := range strings.Fields(readFile(t, logPath)) {
+		if _, err := os.Stat(profile); !os.IsNotExist(err) {
+			t.Fatalf("expired aggregate budget left profile %q: %v", profile, err)
+		}
+	}
+}
+
+func TestStartCancellationDuringHandshakeDoesNotRetry(t *testing.T) {
+	requirePOSIXShell(t)
+	started := make(chan struct{})
+	closed := make(chan struct{})
+	endpoint, _, _ := fakeCDPBeforeUpgrade(t, false, func(w http.ResponseWriter, r *http.Request) bool {
+		close(started)
+		<-r.Context().Done()
+		close(closed)
+		return false
+	})
+	executable, logPath := handshakeChrome(t, endpoint)
+	ctx, cancel := context.WithCancel(t.Context())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := Start(ctx, executable)
+		result <- err
+	}()
+	select {
+	case <-started:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not reach handshake")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("canceled handshake error=%v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("caller cancellation did not interrupt handshake")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("canceled handshake connection remained open")
+	}
+	if countLogLines(t, logPath) != 1 {
+		t.Fatal("caller cancellation retried")
+	}
+}
+
+func handshakeChrome(t *testing.T, endpoint string) (string, string) {
+	t.Helper()
+	logPath := filepath.Join(t.TempDir(), "profiles.log")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	t.Setenv("GOSX_FAKE_PIDS", logPath+".pids")
+	t.Setenv("GOSX_FAKE_ENDPOINT", endpoint)
+	executable := writeFakeChrome(t, `
+printf '%s\n' "$$" >> "$GOSX_FAKE_PIDS"
+for arg in "$@"; do
+  case "$arg" in --user-data-dir=*) printf '%s\n' "${arg#--user-data-dir=}" >> "$GOSX_FAKE_LOG";; esac
+done
+printf 'DevTools listening on %s\n' "$GOSX_FAKE_ENDPOINT" >&2
+exec tail -f /dev/null
+`)
+	return executable, logPath
+}

--- a/internal/chrometest/process_linux.go
+++ b/internal/chrometest/process_linux.go
@@ -1,0 +1,26 @@
+//go:build linux
+
+package chrometest
+
+import (
+	"os"
+	"os/exec"
+	"syscall"
+)
+
+func configureProcess(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	if _, lambda := os.LookupEnv("LAMBDA_TASK_ROOT"); !lambda {
+		cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+	}
+	// Chrome and launch scripts can leave children holding output pipes or
+	// writing into the profile. Kill the owned process group before Wait and
+	// profile removal; killing only the direct parent is insufficient on CI.
+	cmd.Cancel = func() error {
+		err := syscall.Kill(-cmd.Process.Pid, syscall.SIGKILL)
+		if err == syscall.ESRCH {
+			return os.ErrProcessDone
+		}
+		return err
+	}
+}

--- a/internal/chrometest/process_linux_test.go
+++ b/internal/chrometest/process_linux_test.go
@@ -1,0 +1,75 @@
+//go:build linux
+
+package chrometest
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestStartupCleanupKillsDescendantHoldingOutputPipe(t *testing.T) {
+	testDescendantCleanup(t, false)
+}
+
+func TestEarlyExitWithDescendantPipeIsFatalWithoutRetry(t *testing.T) {
+	testDescendantCleanup(t, true)
+}
+
+func testDescendantCleanup(t *testing.T, earlyExit bool) {
+	t.Helper()
+	requirePOSIXShell(t)
+	root := t.TempDir()
+	pidPath := filepath.Join(root, "child.pid")
+	logPath := filepath.Join(root, "attempts.log")
+	t.Setenv("GOSX_FAKE_CHILD_PID", pidPath)
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	body := `
+printf 'attempt\n' >> "$GOSX_FAKE_LOG"
+tail -f /dev/null &
+printf '%s' "$!" > "$GOSX_FAKE_CHILD_PID"
+`
+	if earlyExit {
+		body += "exit 23\n"
+	} else {
+		body += "wait\n"
+	}
+	executable := writeFakeChrome(t, body)
+	policy := fastPolicy(1)
+	if earlyExit {
+		policy.attempts = 2
+	}
+	_, err := startWithPolicy(context.Background(), executable, policy)
+	if err == nil {
+		t.Fatal("expected launcher to fail")
+	}
+	if earlyExit && (!strings.Contains(err.Error(), "exit status 23") || countLogLines(t, logPath) != 1) {
+		t.Fatalf("early process exit was not fatal: %v", err)
+	}
+	pid, parseErr := strconv.Atoi(strings.TrimSpace(readFile(t, pidPath)))
+	if parseErr != nil || pid <= 1 {
+		t.Fatalf("invalid child PID: %d %v", pid, parseErr)
+	}
+	// A killed orphan can briefly remain as a zombie until the host reaps it;
+	// either missing or zombie proves it cannot keep pipes/profile files open.
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		stat, statErr := os.ReadFile(fmt.Sprintf("/proc/%d/stat", pid))
+		if os.IsNotExist(statErr) {
+			return
+		}
+		if statErr == nil {
+			parts := strings.SplitN(string(stat), ") ", 2)
+			if len(parts) == 2 && strings.HasPrefix(parts[1], "Z ") {
+				return
+			}
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("descendant %d survived startup cleanup", pid)
+}

--- a/internal/chrometest/process_other.go
+++ b/internal/chrometest/process_other.go
@@ -1,0 +1,7 @@
+//go:build !linux
+
+package chrometest
+
+import "os/exec"
+
+func configureProcess(*exec.Cmd) {}

--- a/internal/chrometest/startup.go
+++ b/internal/chrometest/startup.go
@@ -30,7 +30,6 @@ var defaultStartupPolicy = startupPolicy{
 	attempts:       2,
 	attemptTimeout: 30 * time.Second,
 	overallTimeout: 65 * time.Second,
-	dialTimeout:    3 * time.Second,
 	retryDelay:     100 * time.Millisecond,
 }
 
@@ -68,7 +67,6 @@ type startupPolicy struct {
 	attempts       int
 	attemptTimeout time.Duration
 	overallTimeout time.Duration
-	dialTimeout    time.Duration
 	retryDelay     time.Duration
 }
 
@@ -142,7 +140,7 @@ func startWithPolicy(ctx context.Context, executable string, policy startupPolic
 		if !time.Now().Before(deadline) {
 			return nil, fmt.Errorf("chrome startup exhausted overall budget: %s", strings.Join(failures, "; "))
 		}
-		browser, failure := launchAttempt(ctx, executable, policy, deadline, extraArgs)
+		browser, failure := launchAttempt(ctx, executable, deadline, extraArgs)
 		if failure == nil {
 			return browser, nil
 		}
@@ -172,7 +170,7 @@ func startWithPolicy(ctx context.Context, executable string, policy startupPolic
 func validatePolicy(policy startupPolicy) error {
 	if policy.attempts < 1 || policy.attempts > 3 || policy.attemptTimeout <= 0 || policy.attemptTimeout > 30*time.Second ||
 		policy.overallTimeout <= cleanupAllowance || policy.overallTimeout > 65*time.Second ||
-		policy.dialTimeout <= 0 || policy.dialTimeout > policy.attemptTimeout || policy.retryDelay < 0 || policy.retryDelay > time.Second {
+		policy.retryDelay < 0 || policy.retryDelay > time.Second {
 		return errors.New("chrome startup: invalid bounded startup policy")
 	}
 	return nil
@@ -205,7 +203,7 @@ type attemptFailure struct {
 func (failure *attemptFailure) summary(timeout time.Duration) string {
 	var reason string
 	if failure.timedOut {
-		reason = fmt.Sprintf("Chrome startup exceeded its deadline (attempt limit %s)", timeout)
+		reason = fmt.Sprintf("Chrome startup timed out (attempt limit %s)", timeout)
 	} else {
 		reason = redactDiagnostics(failure.err.Error())
 	}
@@ -215,7 +213,7 @@ func (failure *attemptFailure) summary(timeout time.Duration) string {
 	return reason
 }
 
-func launchAttempt(ctx context.Context, executable string, policy startupPolicy, deadline time.Time, extraArgs []string) (*Browser, *attemptFailure) {
+func launchAttempt(ctx context.Context, executable string, deadline time.Time, extraArgs []string) (*Browser, *attemptFailure) {
 	diagnostics := &tailWriter{limit: diagnosticsLimit}
 	profileDir, err := os.MkdirTemp("", "gosx-chrome-startup-")
 	if err != nil {
@@ -247,10 +245,17 @@ func launchAttempt(ctx context.Context, executable string, policy startupPolicy,
 		if err := validateDevToolsEndpoint(endpoint); err != nil {
 			return fail(err, false)
 		}
+		// Endpoint publication does not imply the WebSocket handshake is ready.
+		// Share the remaining attempt/aggregate budget; a separate short dial
+		// cap can reject a healthy Chrome while ample startup time remains.
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			return fail(context.DeadlineExceeded, true)
+		}
 		allocatorContext, cancelAllocator := chromedp.NewRemoteAllocator(ctx, endpoint, chromedp.NoModifyURL)
 		browserContext, cancelBrowser := chromedp.NewContext(
 			allocatorContext,
-			chromedp.WithBrowserOption(chromedp.WithDialTimeout(policy.dialTimeout)),
+			chromedp.WithBrowserOption(chromedp.WithDialTimeout(remaining)),
 		)
 		result := make(chan error, 1)
 		go func() {
@@ -289,12 +294,15 @@ func launchAttempt(ctx context.Context, executable string, policy startupPolicy,
 					diagnostics:     diagnostics,
 				}, nil
 			}
-			// CDP protocol/dial failures are concrete errors and are not retried.
 			if err == nil {
 				err = context.DeadlineExceeded
 			}
+			// A typed dial timeout can race the outer attempt timer. Both
+			// paths permit a fresh attempt only while Chrome remains alive.
+			transient := retryableStartupTimeout(ctx, err, process.done)
 			cleanup(false)
-			return nil, &attemptFailure{err: err, diagnostics: redactDiagnostics(diagnostics.String())}
+			return nil, &attemptFailure{err: err, transient: transient, timedOut: transient,
+				diagnostics: redactDiagnostics(diagnostics.String())}
 		case <-process.done:
 			cleanup(true)
 			return nil, &attemptFailure{
@@ -333,6 +341,19 @@ func launchAttempt(ctx context.Context, executable string, policy startupPolicy,
 	case <-ctx.Done():
 		return fail(ctx.Err(), false)
 	}
+}
+
+func retryableStartupTimeout(ctx context.Context, err error, processExited <-chan struct{}) bool {
+	if ctx.Err() != nil || errors.Is(err, context.Canceled) {
+		return false
+	}
+	select {
+	case <-processExited:
+		return false
+	default:
+	}
+	var timeout net.Error
+	return errors.Is(err, context.DeadlineExceeded) || errors.As(err, &timeout) && timeout.Timeout()
 }
 
 const (

--- a/internal/chrometest/startup.go
+++ b/internal/chrometest/startup.go
@@ -1,0 +1,623 @@
+// Package chrometest provides bounded Chrome startup for browser tests.
+// It is internal test infrastructure and is not part of the GoSX product
+// runtime or browser asset surface.
+package chrometest
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/url"
+	"os"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+	"unicode"
+
+	"github.com/chromedp/cdproto/cdp"
+	"github.com/chromedp/cdproto/target"
+	"github.com/chromedp/chromedp"
+)
+
+const diagnosticsLimit = 8 << 10
+
+var defaultStartupPolicy = startupPolicy{
+	attempts:       2,
+	attemptTimeout: 30 * time.Second,
+	overallTimeout: 65 * time.Second,
+	dialTimeout:    3 * time.Second,
+	retryDelay:     100 * time.Millisecond,
+}
+
+var defaultChromeArgs = []string{
+	"--no-first-run",
+	"--no-default-browser-check",
+	"--headless",
+	"--hide-scrollbars",
+	"--mute-audio",
+	"--disable-background-networking",
+	"--enable-features=NetworkService,NetworkServiceInProcess",
+	"--disable-background-timer-throttling",
+	"--disable-backgrounding-occluded-windows",
+	"--disable-breakpad",
+	"--disable-client-side-phishing-detection",
+	"--disable-default-apps",
+	"--disable-dev-shm-usage",
+	"--disable-extensions",
+	"--disable-features=site-per-process,Translate,BlinkGenPropertyTrees",
+	"--disable-hang-monitor",
+	"--disable-ipc-flooding-protection",
+	"--disable-popup-blocking",
+	"--disable-prompt-on-repost",
+	"--disable-renderer-backgrounding",
+	"--disable-sync",
+	"--force-color-profile=srgb",
+	"--metrics-recording-only",
+	"--safebrowsing-disable-auto-update",
+	"--enable-automation",
+	"--password-store=basic",
+	"--use-mock-keychain",
+}
+
+type startupPolicy struct {
+	attempts       int
+	attemptTimeout time.Duration
+	overallTimeout time.Duration
+	dialTimeout    time.Duration
+	retryDelay     time.Duration
+}
+
+// Browser is a bound Chrome process and its first tab. Close is idempotent.
+type Browser struct {
+	Context         context.Context
+	cancelBrowser   context.CancelFunc
+	cancelAllocator context.CancelFunc
+	process         *chromeProcess
+	diagnostics     *tailWriter
+	closeOnce       sync.Once
+}
+
+// Close releases the tab, remote allocator, Chrome process, and temporary
+// profile. Chrome output is drained before the profile is removed.
+func (browser *Browser) Close() {
+	if browser == nil {
+		return
+	}
+	browser.closeOnce.Do(func() {
+		browser.cancelAllocator()
+		browser.process.stop()
+		browser.cancelBrowser()
+		chromedp.FromContext(browser.Context).Allocator.Wait()
+	})
+}
+
+// Diagnostics returns bounded, redacted Chrome output captured since launch.
+func (browser *Browser) Diagnostics() string {
+	if browser == nil || browser.diagnostics == nil {
+		return ""
+	}
+	return redactDiagnostics(browser.diagnostics.String())
+}
+
+// Start launches Chrome with a fresh profile and an ephemeral loopback CDP
+// port. If Chrome remains alive but does not finish binding its empty tab within
+// the attempt deadline, the helper stops and drains it before one retry with a
+// new process/profile/port. Process exits and invalid endpoints fail without a
+// retry. Each attempt has a 30-second startup limit; the overall startup budget
+// is 65 seconds, including a process/pipe/CDP cleanup allowance. Caller
+// cancellation interrupts the attempt and synchronously joins cleanup.
+//
+// Extra arguments must be Chrome flags. The profile and debugging address/port
+// are owned by this helper and cannot be overridden.
+func Start(ctx context.Context, executable string, extraArgs ...string) (*Browser, error) {
+	return startWithPolicy(ctx, executable, defaultStartupPolicy, extraArgs...)
+}
+
+func startWithPolicy(ctx context.Context, executable string, policy startupPolicy, extraArgs ...string) (*Browser, error) {
+	if ctx == nil || strings.TrimSpace(executable) == "" {
+		return nil, errors.New("chrome startup: missing context or executable")
+	}
+	if err := validatePolicy(policy); err != nil {
+		return nil, err
+	}
+	if err := validateExtraArgs(extraArgs); err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	overallDeadline := time.Now().Add(policy.overallTimeout)
+	failures := make([]string, 0, policy.attempts)
+	for attempt := 1; attempt <= policy.attempts; attempt++ {
+		deadline := time.Now().Add(policy.attemptTimeout)
+		if latest := overallDeadline.Add(-cleanupAllowance); deadline.After(latest) {
+			deadline = latest
+		}
+		if !time.Now().Before(deadline) {
+			return nil, fmt.Errorf("chrome startup exhausted overall budget: %s", strings.Join(failures, "; "))
+		}
+		browser, failure := launchAttempt(ctx, executable, policy, deadline, extraArgs)
+		if failure == nil {
+			return browser, nil
+		}
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return nil, ctxErr
+		}
+
+		failures = append(failures, fmt.Sprintf("attempt %d: %s", attempt, failure.summary(policy.attemptTimeout)))
+		if !failure.transient || attempt == policy.attempts {
+			return nil, fmt.Errorf("chrome startup failed after %d attempt(s): %s", attempt, strings.Join(failures, "; "))
+		}
+		if !time.Now().Add(policy.retryDelay).Before(overallDeadline.Add(-cleanupAllowance)) {
+			return nil, fmt.Errorf("chrome startup exhausted overall budget: %s", strings.Join(failures, "; "))
+		}
+
+		timer := time.NewTimer(policy.retryDelay)
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return nil, ctx.Err()
+		case <-timer.C:
+		}
+	}
+	return nil, errors.New("chrome startup: exhausted bounded attempts")
+}
+
+func validatePolicy(policy startupPolicy) error {
+	if policy.attempts < 1 || policy.attempts > 3 || policy.attemptTimeout <= 0 || policy.attemptTimeout > 30*time.Second ||
+		policy.overallTimeout <= cleanupAllowance || policy.overallTimeout > 65*time.Second ||
+		policy.dialTimeout <= 0 || policy.dialTimeout > policy.attemptTimeout || policy.retryDelay < 0 || policy.retryDelay > time.Second {
+		return errors.New("chrome startup: invalid bounded startup policy")
+	}
+	return nil
+}
+
+func validateExtraArgs(extraArgs []string) error {
+	if len(extraArgs) > 32 {
+		return errors.New("chrome startup: too many extra flags")
+	}
+	for index, arg := range extraArgs {
+		if len(arg) < 3 || len(arg) > 512 || !strings.HasPrefix(arg, "--") || hasControl(arg) {
+			return fmt.Errorf("chrome startup: invalid extra flag at index %d", index)
+		}
+		name := strings.TrimPrefix(strings.SplitN(arg, "=", 2)[0], "--")
+		switch name {
+		case "remote-debugging-address", "remote-debugging-port", "remote-debugging-pipe", "user-data-dir":
+			return fmt.Errorf("chrome startup: reserved extra flag at index %d", index)
+		}
+	}
+	return nil
+}
+
+type attemptFailure struct {
+	err         error
+	diagnostics string
+	transient   bool
+	timedOut    bool
+}
+
+func (failure *attemptFailure) summary(timeout time.Duration) string {
+	var reason string
+	if failure.timedOut {
+		reason = fmt.Sprintf("Chrome startup exceeded its deadline (attempt limit %s)", timeout)
+	} else {
+		reason = redactDiagnostics(failure.err.Error())
+	}
+	if failure.diagnostics != "" {
+		reason += "; Chrome output: " + failure.diagnostics
+	}
+	return reason
+}
+
+func launchAttempt(ctx context.Context, executable string, policy startupPolicy, deadline time.Time, extraArgs []string) (*Browser, *attemptFailure) {
+	diagnostics := &tailWriter{limit: diagnosticsLimit}
+	profileDir, err := os.MkdirTemp("", "gosx-chrome-startup-")
+	if err != nil {
+		return nil, &attemptFailure{err: errors.New("create temporary Chrome profile")}
+	}
+	process, err := startChromeProcess(ctx, executable, profileDir, diagnostics, extraArgs)
+	if err != nil {
+		_ = os.RemoveAll(profileDir)
+		return nil, &attemptFailure{err: fmt.Errorf("start Chrome process: %s", redactDiagnostics(err.Error()))}
+	}
+
+	timer := time.NewTimer(time.Until(deadline))
+	defer stopTimer(timer)
+	fail := func(err error, timedOut bool) (*Browser, *attemptFailure) {
+		// An exited process is not a startup hang, even if its exit races the
+		// timer. Never hide a concrete launch failure behind a retry.
+		select {
+		case <-process.done:
+			err = process.exitError("Chrome exited during startup")
+			timedOut = false
+		default:
+		}
+		process.stop()
+		return nil, &attemptFailure{err: err, timedOut: timedOut, transient: timedOut,
+			diagnostics: redactDiagnostics(diagnostics.String())}
+	}
+	select {
+	case endpoint := <-process.endpoint:
+		if err := validateDevToolsEndpoint(endpoint); err != nil {
+			return fail(err, false)
+		}
+		allocatorContext, cancelAllocator := chromedp.NewRemoteAllocator(ctx, endpoint, chromedp.NoModifyURL)
+		browserContext, cancelBrowser := chromedp.NewContext(
+			allocatorContext,
+			chromedp.WithBrowserOption(chromedp.WithDialTimeout(policy.dialTimeout)),
+		)
+		result := make(chan error, 1)
+		go func() {
+			result <- chromedp.Run(browserContext, chromedp.ActionFunc(func(ctx context.Context) error {
+				// RemoteAllocator creates a new tab beside Chrome's initial
+				// about:blank. Activate it before returning: an inactive tab
+				// suppresses requestAnimationFrame (including chromedp.Poll).
+				state := chromedp.FromContext(ctx)
+				return target.ActivateTarget(state.Target.TargetID).Do(cdp.WithExecutor(ctx, state.Browser))
+			}))
+		}()
+		cleanup := func(join bool) {
+			// Cancel and kill before waiting: RemoteAllocator's socket has its
+			// own context, and a half-open CDP connection must not hold cleanup.
+			cancelAllocator()
+			process.stop()
+			if join {
+				<-result
+			}
+			cancelBrowser()
+			chromedp.FromContext(browserContext).Allocator.Wait()
+		}
+		select {
+		case err := <-result:
+			select {
+			case <-process.done:
+				err = process.exitError("Chrome exited during CDP bind")
+			default:
+			}
+			if err == nil && ctx.Err() == nil && time.Now().Before(deadline) {
+				return &Browser{
+					Context:         browserContext,
+					cancelBrowser:   cancelBrowser,
+					cancelAllocator: cancelAllocator,
+					process:         process,
+					diagnostics:     diagnostics,
+				}, nil
+			}
+			// CDP protocol/dial failures are concrete errors and are not retried.
+			if err == nil {
+				err = context.DeadlineExceeded
+			}
+			cleanup(false)
+			return nil, &attemptFailure{err: err, diagnostics: redactDiagnostics(diagnostics.String())}
+		case <-process.done:
+			cleanup(true)
+			return nil, &attemptFailure{
+				err:         process.exitError("Chrome exited after publishing DevTools endpoint but before CDP bind"),
+				diagnostics: redactDiagnostics(diagnostics.String()),
+			}
+		case <-timer.C:
+			// Capture process state before cleanup kills it, preserving concrete
+			// exits even when exit and timeout become ready together.
+			transient := true
+			startupErr := error(context.DeadlineExceeded)
+			select {
+			case <-process.done:
+				transient = false
+				startupErr = process.exitError("Chrome exited during CDP bind")
+			default:
+			}
+			cleanup(true)
+			return nil, &attemptFailure{
+				err:         startupErr,
+				diagnostics: redactDiagnostics(diagnostics.String()),
+				transient:   transient,
+				timedOut:    transient,
+			}
+		case <-ctx.Done():
+			cleanup(true)
+			return nil, &attemptFailure{err: ctx.Err(), diagnostics: redactDiagnostics(diagnostics.String())}
+		}
+
+	case <-process.done:
+		return fail(process.exitError("Chrome exited before publishing DevTools endpoint"), false)
+
+	case <-timer.C:
+		return fail(context.DeadlineExceeded, true)
+
+	case <-ctx.Done():
+		return fail(ctx.Err(), false)
+	}
+}
+
+const (
+	processWaitDelay = 2 * time.Second
+	cleanupAllowance = processWaitDelay + time.Second
+)
+
+type chromeProcess struct {
+	cancel     context.CancelFunc
+	terminate  func() error
+	done       chan struct{}
+	drained    chan struct{}
+	output     *os.File
+	endpoint   chan string
+	profileDir string
+
+	mu       sync.Mutex
+	waitErr  error
+	stopOnce sync.Once
+}
+
+func startChromeProcess(ctx context.Context, executable, profileDir string, diagnostics *tailWriter, extraArgs []string) (*chromeProcess, error) {
+	processContext, cancel := context.WithCancel(ctx)
+	args := make([]string, 0, len(defaultChromeArgs)+len(extraArgs)+4)
+	args = append(args, defaultChromeArgs...)
+	args = append(args, extraArgs...)
+	args = append(args,
+		"--remote-debugging-address=127.0.0.1",
+		"--remote-debugging-port=0",
+		"--user-data-dir="+profileDir,
+		"about:blank",
+	)
+	cmd := exec.CommandContext(processContext, executable, args...)
+	configureProcess(cmd)
+	cmd.WaitDelay = processWaitDelay
+	endpoint := make(chan string, 1)
+	output, childOutput, err := os.Pipe()
+	if err != nil {
+		cancel()
+		return nil, err
+	}
+	// Own the pipe drain separately from cmd.Wait. Otherwise exec.Cmd waits
+	// for copy goroutines before reporting exit, and a descendant holding the
+	// pipe open can turn an immediate fatal process exit into a timeout/retry.
+	cmd.Stdout = childOutput
+	cmd.Stderr = childOutput
+	if err := cmd.Start(); err != nil {
+		_ = childOutput.Close()
+		_ = output.Close()
+		cancel()
+		return nil, err
+	}
+	_ = childOutput.Close()
+
+	process := &chromeProcess{
+		cancel:     cancel,
+		terminate:  cmd.Cancel,
+		done:       make(chan struct{}),
+		drained:    make(chan struct{}),
+		output:     output,
+		endpoint:   endpoint,
+		profileDir: profileDir,
+	}
+	go func() {
+		writer := &endpointWriter{diagnostics: diagnostics, endpoint: endpoint, endpointOnce: new(sync.Once)}
+		_, _ = io.Copy(writer, output)
+		writer.Flush()
+		close(process.drained)
+	}()
+	go func() {
+		waitErr := cmd.Wait()
+		process.mu.Lock()
+		process.waitErr = waitErr
+		process.mu.Unlock()
+		close(process.done)
+	}()
+	return process, nil
+}
+
+func (process *chromeProcess) stop() {
+	if process == nil {
+		return
+	}
+	process.stopOnce.Do(func() {
+		// Also terminate after an early parent exit: CommandContext may have
+		// already stopped watching while descendants still own the pipes.
+		_ = process.terminate()
+		process.cancel()
+		<-process.done
+		timer := time.NewTimer(processWaitDelay)
+		select {
+		case <-process.drained:
+		case <-timer.C:
+			// Non-Linux platforms may not kill descendant processes as a
+			// group. Closing our read end still bounds the pipe-drain wait.
+		}
+		stopTimer(timer)
+		_ = process.output.Close()
+		<-process.drained
+		_ = os.RemoveAll(process.profileDir)
+	})
+}
+
+func (process *chromeProcess) exitError(prefix string) error {
+	process.mu.Lock()
+	defer process.mu.Unlock()
+	if process.waitErr == nil {
+		return errors.New(prefix)
+	}
+	return fmt.Errorf("%s: %s", prefix, redactDiagnostics(process.waitErr.Error()))
+}
+
+type endpointWriter struct {
+	mu           sync.Mutex
+	partial      []byte
+	diagnostics  *tailWriter
+	endpoint     chan<- string
+	endpointOnce *sync.Once
+}
+
+var endpointPattern = regexp.MustCompile(`DevTools listening on\s+(wss?://[^\s]+)`)
+
+func (writer *endpointWriter) Write(data []byte) (int, error) {
+	_, _ = writer.diagnostics.Write(data)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	writer.partial = append(writer.partial, data...)
+	for {
+		newline := strings.IndexByte(string(writer.partial), '\n')
+		if newline < 0 {
+			if len(writer.partial) > 4096 {
+				writer.scan(writer.partial)
+				writer.partial = append(writer.partial[:0], writer.partial[len(writer.partial)-2048:]...)
+			}
+			break
+		}
+		writer.scan(writer.partial[:newline])
+		writer.partial = writer.partial[newline+1:]
+	}
+	return len(data), nil
+}
+
+func (writer *endpointWriter) Flush() {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	writer.scan(writer.partial)
+	writer.partial = nil
+}
+
+func (writer *endpointWriter) scan(line []byte) {
+	match := endpointPattern.FindSubmatch(line)
+	if len(match) != 2 {
+		return
+	}
+	endpoint := string(match[1])
+	writer.endpointOnce.Do(func() {
+		writer.endpoint <- endpoint
+	})
+}
+
+func validateDevToolsEndpoint(raw string) error {
+	if raw == "" || len(raw) > 2048 || hasControl(raw) {
+		return errors.New("Chrome published an invalid DevTools endpoint")
+	}
+	endpoint, err := url.Parse(raw)
+	if err != nil || endpoint.Scheme != "ws" || endpoint.User != nil || endpoint.Hostname() == "" || endpoint.Port() == "" || endpoint.RawQuery != "" || endpoint.ForceQuery || endpoint.Fragment != "" || endpoint.Opaque != "" {
+		return errors.New("Chrome published an invalid DevTools endpoint")
+	}
+	ip := net.ParseIP(endpoint.Hostname())
+	if ip == nil || !ip.IsLoopback() {
+		return errors.New("Chrome published a non-loopback DevTools endpoint")
+	}
+	port, err := strconv.ParseUint(endpoint.Port(), 10, 16)
+	if err != nil || port == 0 {
+		return errors.New("Chrome published an invalid DevTools endpoint port")
+	}
+	const browserPath = "/devtools/browser/"
+	if !strings.HasPrefix(endpoint.EscapedPath(), browserPath) || len(endpoint.EscapedPath()) == len(browserPath) {
+		return errors.New("Chrome published an invalid DevTools browser path")
+	}
+	return nil
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil || timer.Stop() {
+		return
+	}
+	select {
+	case <-timer.C:
+	default:
+	}
+}
+
+type tailWriter struct {
+	mu        sync.Mutex
+	limit     int
+	buffer    []byte
+	truncated bool
+}
+
+func (writer *tailWriter) Write(data []byte) (int, error) {
+	written := len(data)
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	if writer.limit <= 0 {
+		writer.truncated = writer.truncated || len(data) > 0
+		return written, nil
+	}
+	if len(data) >= writer.limit {
+		writer.buffer = append(writer.buffer[:0], data[len(data)-writer.limit:]...)
+		writer.truncated = true
+		return written, nil
+	}
+	if overflow := len(writer.buffer) + len(data) - writer.limit; overflow > 0 {
+		copy(writer.buffer, writer.buffer[overflow:])
+		writer.buffer = writer.buffer[:len(writer.buffer)-overflow]
+		writer.truncated = true
+	}
+	writer.buffer = append(writer.buffer, data...)
+	return written, nil
+}
+
+func (writer *tailWriter) String() string {
+	writer.mu.Lock()
+	defer writer.mu.Unlock()
+	output := string(writer.buffer)
+	if writer.truncated {
+		// A byte-tail may begin inside a URL or secret value. Discard the
+		// incomplete first line so redaction always has the key/prefix.
+		if newline := strings.IndexByte(output, '\n'); newline >= 0 {
+			output = output[newline+1:]
+		} else {
+			output = ""
+		}
+		output = "[earlier output truncated]\n" + output
+	}
+	return output
+}
+
+var (
+	ansiDiagnosticPattern    = regexp.MustCompile(`\x1b\[[0-?]*[ -/]*[@-~]`)
+	urlDiagnosticPattern     = regexp.MustCompile(`(?i)\b(?:wss?|https?)://[^\s"'<>]+`)
+	secretDiagnosticPattern  = regexp.MustCompile(`(?i)\b(token|secret|password|authorization)["']?\s*[:=]\s*(?:"[^"]*"|'[^']*'|[^\n]+)`)
+	profileDiagnosticPattern = regexp.MustCompile(`(?i)(?:[A-Za-z]:)?[/\\][^\s"']*(?:chromedp-runner|gosx-chrome-startup-)[^\s"']*`)
+	socketDiagnosticPattern  = regexp.MustCompile(`\b(?:[0-9]{1,3}\.){3}[0-9]{1,3}:[0-9]+\b`)
+)
+
+func redactDiagnostics(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	raw = ansiDiagnosticPattern.ReplaceAllString(raw, "")
+	safe := strings.Map(func(r rune) rune {
+		switch r {
+		case '\n', '\t':
+			return r
+		case '\r':
+			return '\n'
+		default:
+			if unicode.IsControl(r) || unicode.Is(unicode.Cf, r) {
+				return '�'
+			}
+			return r
+		}
+	}, raw)
+	safe = urlDiagnosticPattern.ReplaceAllStringFunc(safe, func(value string) string {
+		if index := strings.Index(value, "://"); index >= 0 {
+			return value[:index] + "://<redacted>"
+		}
+		return "<redacted-url>"
+	})
+	safe = secretDiagnosticPattern.ReplaceAllString(safe, "$1=<redacted>")
+	safe = profileDiagnosticPattern.ReplaceAllString(safe, "<chrome-profile>")
+	safe = socketDiagnosticPattern.ReplaceAllString(safe, "<chrome-endpoint>")
+	if len(safe) > diagnosticsLimit {
+		safe = safe[:diagnosticsLimit] + " [output truncated]"
+	}
+	return strings.TrimSpace(safe)
+}
+
+func hasControl(value string) bool {
+	for _, r := range value {
+		if unicode.IsControl(r) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/chrometest/startup_test.go
+++ b/internal/chrometest/startup_test.go
@@ -274,10 +274,17 @@ func TestEndpointParsingAndDiagnosticsAreBounded(t *testing.T) {
 // This small CDP peer only supplies the responses needed to bind an empty tab.
 // Tests observe real websocket lifetimes; they do not stub chromedp.Run or cleanup.
 func fakeCDP(t *testing.T, stall bool) (string, <-chan struct{}, <-chan struct{}) {
+	return fakeCDPBeforeUpgrade(t, stall, nil)
+}
+
+func fakeCDPBeforeUpgrade(t *testing.T, stall bool, beforeUpgrade func(http.ResponseWriter, *http.Request) bool) (string, <-chan struct{}, <-chan struct{}) {
 	t.Helper()
 	calls := make(chan struct{}, 1)
 	closed := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if beforeUpgrade != nil && !beforeUpgrade(w, r) {
+			return
+		}
 		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
 		if err != nil {
 			return
@@ -323,6 +330,30 @@ func fakeCDP(t *testing.T, stall bool) (string, <-chan struct{}, <-chan struct{}
 	return "ws" + strings.TrimPrefix(server.URL, "http") + "/devtools/browser/test", calls, closed
 }
 
+func TestStartAllowsDelayedWebSocketHandshakeWithinAttempt(t *testing.T) {
+	requirePOSIXShell(t)
+	endpoint, _, _ := fakeCDPBeforeUpgrade(t, false, func(w http.ResponseWriter, r *http.Request) bool {
+		select {
+		case <-time.After(150 * time.Millisecond):
+			return true
+		case <-r.Context().Done():
+			return false
+		}
+	})
+	t.Setenv("GOSX_FAKE_ENDPOINT", endpoint)
+	executable := writeFakeChrome(t, `
+printf 'DevTools listening on %s\n' "$GOSX_FAKE_ENDPOINT" >&2
+exec tail -f /dev/null
+`)
+	policy := fastPolicy(1)
+	policy.attemptTimeout = time.Second
+	browser, err := startWithPolicy(t.Context(), executable, policy)
+	if err != nil {
+		t.Fatalf("handshake within the startup budget failed: %v", err)
+	}
+	defer browser.Close()
+}
+
 func TestStartCancellationIsImmediateAndDoesNotRetry(t *testing.T) {
 	requirePOSIXShell(t)
 	tempRoot := t.TempDir()
@@ -342,7 +373,6 @@ exec tail -f /dev/null
 			attempts:       3,
 			attemptTimeout: 2 * time.Second,
 			overallTimeout: 10 * time.Second,
-			dialTimeout:    time.Second,
 			retryDelay:     time.Millisecond,
 		})
 		result <- err
@@ -377,7 +407,6 @@ exec tail -f /dev/null
 		attempts:       1,
 		attemptTimeout: time.Second,
 		overallTimeout: 5 * time.Second,
-		dialTimeout:    100 * time.Millisecond,
 	})
 	if err == nil {
 		t.Fatal("expected fake CDP dial failure")
@@ -427,7 +456,6 @@ func fastPolicy(attempts int) startupPolicy {
 		attempts:       attempts,
 		attemptTimeout: 250 * time.Millisecond,
 		overallTimeout: 5 * time.Second,
-		dialTimeout:    40 * time.Millisecond,
 		retryDelay:     time.Millisecond,
 	}
 }

--- a/internal/chrometest/startup_test.go
+++ b/internal/chrometest/startup_test.go
@@ -1,0 +1,483 @@
+package chrometest
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/gorilla/websocket"
+)
+
+func TestStartDoesNotRetryEarlyProcessExitAndRedactsDiagnostics(t *testing.T) {
+	requirePOSIXShell(t)
+	logPath := filepath.Join(t.TempDir(), "attempts.log")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	executable := writeFakeChrome(t, `
+printf 'attempt\n' >> "$GOSX_FAKE_LOG"
+printf 'fatal token=hunter2 url=https://user:password@example.test/path?q=secret\n' >&2
+exit 23
+`)
+	started := time.Now()
+	_, err := startWithPolicy(context.Background(), executable, fastPolicy(3))
+	if err == nil {
+		t.Fatal("expected early process exit")
+	}
+	if elapsed := time.Since(started); elapsed > time.Second {
+		t.Fatalf("early exit took %s", elapsed)
+	}
+	if got := countLogLines(t, logPath); got != 1 {
+		t.Fatalf("early exit attempts = %d, want 1", got)
+	}
+	message := err.Error()
+	for _, secret := range []string{"hunter2", "user:password", "q=secret"} {
+		if strings.Contains(message, secret) {
+			t.Fatalf("startup error leaked %q: %s", secret, message)
+		}
+	}
+	if !strings.Contains(message, "token=<redacted>") || !strings.Contains(message, "exit status 23") {
+		t.Fatalf("startup error lacks actionable redaction: %s", message)
+	}
+}
+
+func TestStartRetriesOnlyEndpointTimeoutWithFreshProfilesAndCleanup(t *testing.T) {
+	requirePOSIXShell(t)
+	tempRoot := t.TempDir()
+	logPath := filepath.Join(tempRoot, "attempts.log")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	executable := writeFakeChrome(t, `
+printf 'pid=%s' "$$" >> "$GOSX_FAKE_LOG"
+for arg in "$@"; do printf ' %s' "$arg" >> "$GOSX_FAKE_LOG"; done
+printf '\nstartup secret=private-attempt\n' >> "$GOSX_FAKE_LOG"
+printf 'startup secret=private-attempt\n' >&2
+exec tail -f /dev/null
+`)
+	policy := fastPolicy(2)
+	_, err := startWithPolicy(context.Background(), executable, policy)
+	if err == nil {
+		t.Fatal("expected bounded endpoint timeout")
+	}
+	lines := strings.Split(strings.TrimSpace(readFile(t, logPath)), "\n")
+	var profiles []string
+	var attempts int
+	for _, line := range lines {
+		if !strings.HasPrefix(line, "pid=") {
+			continue
+		}
+		attempts++
+		fields := strings.Fields(line)
+		for _, field := range fields {
+			if strings.HasPrefix(field, "--user-data-dir=") {
+				profiles = append(profiles, strings.TrimPrefix(field, "--user-data-dir="))
+			}
+		}
+		if !strings.Contains(line, "--remote-debugging-port=0") {
+			t.Fatalf("attempt did not use an ephemeral debugging port: %s", line)
+		}
+	}
+	if attempts != 2 || len(profiles) != 2 || profiles[0] == profiles[1] {
+		t.Fatalf("attempts=%d profiles=%v, want two fresh profiles", attempts, profiles)
+	}
+	for _, profile := range profiles {
+		if _, statErr := os.Stat(profile); !os.IsNotExist(statErr) {
+			t.Fatalf("profile was not removed after failed attempt: %q err=%v", profile, statErr)
+		}
+	}
+	if strings.Contains(err.Error(), "private-attempt") || !strings.Contains(err.Error(), "secret=<redacted>") {
+		t.Fatalf("retry diagnostics were not redacted: %v", err)
+	}
+}
+
+func TestStartContinuouslyDrainsLargeProcessOutput(t *testing.T) {
+	requirePOSIXShell(t)
+	executable := writeFakeChrome(t, `
+i=0
+while [ "$i" -lt 12000 ]; do
+  printf 'pipe-noise-%s password=do-not-print\n' "$i" >&2
+  i=$((i + 1))
+done
+printf 'FLOOD_COMPLETE\n' >&2
+exit 27
+`)
+	policy := fastPolicy(1)
+	policy.attemptTimeout = 5 * time.Second
+	policy.overallTimeout = 10 * time.Second
+	started := time.Now()
+	_, err := startWithPolicy(context.Background(), executable, policy)
+	if err == nil {
+		t.Fatal("expected process exit after pipe flood")
+	}
+	if elapsed := time.Since(started); elapsed > 5*time.Second {
+		t.Fatalf("large pipe output blocked startup cleanup for %s", elapsed)
+	}
+	if strings.Contains(err.Error(), "do-not-print") {
+		t.Fatalf("pipe diagnostics leaked secret: %v", err)
+	}
+	if !strings.Contains(err.Error(), "earlier output truncated") || len(err.Error()) > diagnosticsLimit+1024 {
+		t.Fatalf("pipe diagnostics were not bounded: bytes=%d error=%v", len(err.Error()), err)
+	}
+	if !strings.Contains(err.Error(), "FLOOD_COMPLETE") || !strings.Contains(err.Error(), "exit status 27") {
+		t.Fatalf("process did not finish writing the full pipe flood: %v", err)
+	}
+}
+
+func TestStartRetriesBeforeActionsAndSuccessStopsStartupTimer(t *testing.T) {
+	requirePOSIXShell(t)
+	endpoint, calls, _ := fakeCDP(t, false)
+	t.Setenv("GOSX_FAKE_ENDPOINT", endpoint)
+	logPath := filepath.Join(t.TempDir(), "attempts.log")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	executable := writeFakeChrome(t, `
+if [ ! -e "$GOSX_FAKE_LOG" ]; then
+  printf 'first\n' > "$GOSX_FAKE_LOG"
+  exec tail -f /dev/null
+fi
+printf 'second\n' >> "$GOSX_FAKE_LOG"
+printf 'DevTools listening on %s\n' "$GOSX_FAKE_ENDPOINT" >&2
+exec tail -f /dev/null
+`)
+	policy := fastPolicy(2)
+	policy.attemptTimeout = 500 * time.Millisecond
+	browser, err := startWithPolicy(context.Background(), executable, policy)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer browser.Close()
+	if got := countLogLines(t, logPath); got != 2 {
+		t.Fatalf("attempts = %d, want 2", got)
+	}
+	select {
+	case <-calls:
+	default:
+		t.Fatal("successful startup did not bind a CDP target")
+	}
+	// A recovered browser must outlive its startup timer and remain usable.
+	time.Sleep(2 * policy.attemptTimeout)
+	var got int
+	if err := chromedp.Run(browser.Context, chromedp.Evaluate(`1 + 1`, &got)); err != nil || got != 2 {
+		t.Fatalf("bound browser did not survive startup deadline: got=%d err=%v", got, err)
+	}
+	browser.Close()
+	browser.Close()
+	if _, err := os.Stat(browser.process.profileDir); !os.IsNotExist(err) {
+		t.Fatalf("successful browser profile not removed: %v", err)
+	}
+}
+
+func TestStartCancellationDuringCDPBindJoinsConnection(t *testing.T) {
+	requirePOSIXShell(t)
+	endpoint, calls, closed := fakeCDP(t, true)
+	t.Setenv("GOSX_FAKE_ENDPOINT", endpoint)
+	executable := writeFakeChrome(t, `
+printf 'DevTools listening on %s\n' "$GOSX_FAKE_ENDPOINT" >&2
+exec tail -f /dev/null
+`)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	result := make(chan error, 1)
+	go func() {
+		_, err := Start(ctx, executable)
+		result <- err
+	}()
+	select {
+	case <-calls:
+	case <-time.After(2 * time.Second):
+		t.Fatal("did not reach stalled CDP bind")
+	}
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startup cancellation = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("cancellation blocked in CDP bind")
+	}
+	select {
+	case <-closed:
+	case <-time.After(time.Second):
+		t.Fatal("CDP connection survived canceled startup")
+	}
+}
+
+func TestStartOverallBudgetBoundsRetries(t *testing.T) {
+	requirePOSIXShell(t)
+	logPath := filepath.Join(t.TempDir(), "attempts.log")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	executable := writeFakeChrome(t, `
+printf 'attempt\n' >> "$GOSX_FAKE_LOG"
+exec tail -f /dev/null
+`)
+	policy := fastPolicy(3)
+	policy.attemptTimeout = time.Second
+	policy.overallTimeout = cleanupAllowance + 50*time.Millisecond
+	started := time.Now()
+	_, err := startWithPolicy(context.Background(), executable, policy)
+	if err == nil || !strings.Contains(err.Error(), "overall budget") {
+		t.Fatalf("overall startup deadline = %v", err)
+	}
+	if time.Since(started) >= time.Second || countLogLines(t, logPath) != 1 {
+		t.Fatal("overall budget allowed an additional attempt")
+	}
+}
+
+func TestEndpointParsingAndDiagnosticsAreBounded(t *testing.T) {
+	for _, invalid := range []string{
+		"ws://example.test:1234/devtools/browser/id", "ws://127.0.0.1:0/devtools/browser/id",
+		"ws://user@127.0.0.1:1234/devtools/browser/id", "ws://127.0.0.1:1234/devtools/browser/id?",
+		"ws://127.0.0.1:1234/devtools/browser/", "wss://127.0.0.1:1234/devtools/browser/id",
+	} {
+		if err := validateDevToolsEndpoint(invalid); err == nil {
+			t.Errorf("accepted invalid endpoint %q", invalid)
+		}
+	}
+	for _, endpoint := range []string{"ws://127.0.0.1:1234/devtools/browser/id", "ws://[::1]:1234/devtools/browser/id"} {
+		if err := validateDevToolsEndpoint(endpoint); err != nil {
+			t.Errorf("rejected loopback endpoint: %v", err)
+		}
+	}
+	tail := &tailWriter{limit: 256}
+	endpoint := make(chan string, 1)
+	writer := &endpointWriter{diagnostics: tail, endpoint: endpoint, endpointOnce: new(sync.Once)}
+	for _, chunk := range []string{"noise\r\nDevTools listen", "ing on ws://127.0.0.1:1234/devtools/", "browser/id\r\n"} {
+		_, _ = writer.Write([]byte(chunk))
+	}
+	select {
+	case got := <-endpoint:
+		if got != "ws://127.0.0.1:1234/devtools/browser/id" {
+			t.Fatalf("chunked endpoint = %q", got)
+		}
+	default:
+		t.Fatal("chunked CRLF endpoint was not parsed")
+	}
+	_, _ = tail.Write([]byte("token=" + strings.Repeat("private", 300) + "\nuseful error\n"))
+	if got := redactDiagnostics(tail.String()); strings.Contains(got, "private") || !strings.Contains(got, "useful error") {
+		t.Fatalf("tail cut leaked a partial secret or lost complete lines: %q", got)
+	}
+	for _, input := range []string{"authorization: Bearer private", `password="two words"`, "https://user:pass@host/path?q=private", "\x1b[31msecret=private", "secret: private\rnext line"} {
+		if got := redactDiagnostics(input); strings.Contains(got, "private") || strings.Contains(got, "\x1b") || strings.Contains(got, "two words") {
+			t.Errorf("diagnostic was not redacted: %q", got)
+		}
+	}
+}
+
+// This small CDP peer only supplies the responses needed to bind an empty tab.
+// Tests observe real websocket lifetimes; they do not stub chromedp.Run or cleanup.
+func fakeCDP(t *testing.T, stall bool) (string, <-chan struct{}, <-chan struct{}) {
+	t.Helper()
+	calls := make(chan struct{}, 1)
+	closed := make(chan struct{})
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		defer close(closed)
+		for {
+			var request struct {
+				ID        int             `json:"id"`
+				Method    string          `json:"method"`
+				SessionID string          `json:"sessionId,omitempty"`
+				Params    json.RawMessage `json:"params"`
+			}
+			if err := conn.ReadJSON(&request); err != nil {
+				return
+			}
+			select {
+			case calls <- struct{}{}:
+			default:
+			}
+			if stall {
+				continue
+			}
+			result := any(map[string]any{})
+			switch request.Method {
+			case "Target.createTarget":
+				result = map[string]any{"targetId": "page"}
+			case "Target.attachToTarget":
+				result = map[string]any{"sessionId": "session"}
+			case "Runtime.evaluate":
+				if strings.Contains(string(request.Params), "1 + 1") {
+					result = map[string]any{"result": map[string]any{"type": "number", "value": 2}}
+				} else {
+					result = map[string]any{"result": map[string]any{"type": "object", "className": "Window"}}
+				}
+			}
+			if err := conn.WriteJSON(map[string]any{"id": request.ID, "sessionId": request.SessionID, "result": result}); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+	return "ws" + strings.TrimPrefix(server.URL, "http") + "/devtools/browser/test", calls, closed
+}
+
+func TestStartCancellationIsImmediateAndDoesNotRetry(t *testing.T) {
+	requirePOSIXShell(t)
+	tempRoot := t.TempDir()
+	logPath := filepath.Join(tempRoot, "attempts.log")
+	readyPath := filepath.Join(tempRoot, "ready")
+	t.Setenv("GOSX_FAKE_LOG", logPath)
+	t.Setenv("GOSX_FAKE_READY", readyPath)
+	executable := writeFakeChrome(t, `
+printf 'attempt\n' >> "$GOSX_FAKE_LOG"
+: > "$GOSX_FAKE_READY"
+exec tail -f /dev/null
+`)
+	ctx, cancel := context.WithCancel(context.Background())
+	result := make(chan error, 1)
+	go func() {
+		_, err := startWithPolicy(ctx, executable, startupPolicy{
+			attempts:       3,
+			attemptTimeout: 2 * time.Second,
+			overallTimeout: 10 * time.Second,
+			dialTimeout:    time.Second,
+			retryDelay:     time.Millisecond,
+		})
+		result <- err
+	}()
+	waitForFile(t, readyPath)
+	started := time.Now()
+	cancel()
+	select {
+	case err := <-result:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Start() error = %v, want context cancellation", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("startup did not stop promptly after cancellation")
+	}
+	if elapsed := time.Since(started); elapsed > 500*time.Millisecond {
+		t.Fatalf("cancellation cleanup took %s", elapsed)
+	}
+	if got := countLogLines(t, logPath); got != 1 {
+		t.Fatalf("canceled startup attempts = %d, want 1", got)
+	}
+}
+
+func TestStartParsesStandardDevToolsEndpointWithoutWaitingForTimeout(t *testing.T) {
+	requirePOSIXShell(t)
+	executable := writeFakeChrome(t, `
+printf 'DevTools listening on ws://127.0.0.1:1/devtools/browser/private-id\n' >&2
+exec tail -f /dev/null
+`)
+	started := time.Now()
+	_, err := startWithPolicy(context.Background(), executable, startupPolicy{
+		attempts:       1,
+		attemptTimeout: time.Second,
+		overallTimeout: 5 * time.Second,
+		dialTimeout:    100 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected fake CDP dial failure")
+	}
+	if elapsed := time.Since(started); elapsed > 750*time.Millisecond {
+		t.Fatalf("standard endpoint was not parsed promptly: %s", elapsed)
+	}
+	if strings.Contains(err.Error(), "private-id") || strings.Contains(err.Error(), "127.0.0.1:1") {
+		t.Fatalf("endpoint diagnostic was not redacted: %v", err)
+	}
+}
+
+func TestStartChromeSmoke(t *testing.T) {
+	chrome := strings.TrimSpace(os.Getenv("GOSX_CHROME_BIN"))
+	if chrome == "" {
+		t.Skip("set GOSX_CHROME_BIN to run the bounded Chrome startup smoke")
+	}
+	for attempt := 0; attempt < 3; attempt++ {
+		browser, err := Start(t.Context(), chrome, "--no-sandbox", "--disable-gpu")
+		if err != nil {
+			t.Fatalf("start Chrome iteration %d: %v", attempt+1, err)
+		}
+		var value int
+		var visibility string
+		var painted bool
+		ctx, cancel := context.WithTimeout(browser.Context, 10*time.Second)
+		runErr := chromedp.Run(ctx,
+			chromedp.Navigate("data:text/html,<!doctype html><body>Chrome startup smoke</body>"),
+			chromedp.Evaluate(`1 + 1`, &value),
+			chromedp.Evaluate(`document.visibilityState`, &visibility),
+			chromedp.Evaluate(`window.painted = false; requestAnimationFrame(() => { window.painted = true; })`, nil),
+			chromedp.Poll(`window.painted`, &painted, chromedp.WithPollingTimeout(5*time.Second)),
+		)
+		cancel()
+		browser.Close()
+		if runErr != nil || value != 2 || visibility != "visible" || !painted {
+			t.Fatalf("Chrome iteration %d: value=%d visibility=%s painted=%v err=%v diagnostics=%s", attempt+1, value, visibility, painted, runErr, browser.Diagnostics())
+		}
+		if _, err := os.Stat(browser.process.profileDir); !os.IsNotExist(err) {
+			t.Fatalf("Chrome iteration %d left its profile: %v", attempt+1, err)
+		}
+	}
+}
+
+func fastPolicy(attempts int) startupPolicy {
+	return startupPolicy{
+		attempts:       attempts,
+		attemptTimeout: 250 * time.Millisecond,
+		overallTimeout: 5 * time.Second,
+		dialTimeout:    40 * time.Millisecond,
+		retryDelay:     time.Millisecond,
+	}
+}
+
+func requirePOSIXShell(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("fake Chrome process tests require a POSIX shell")
+	}
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("fake Chrome process tests require /bin/sh")
+	}
+}
+
+func writeFakeChrome(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-chrome")
+	script := "#!/bin/sh\nset -eu\n" + body
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatalf("write fake Chrome: %v", err)
+	}
+	return path
+}
+
+func countLogLines(t *testing.T, path string) int {
+	t.Helper()
+	content := strings.TrimSpace(readFile(t, path))
+	if content == "" {
+		return 0
+	}
+	return len(strings.Split(content, "\n"))
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(content)
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal(fmt.Sprintf("timed out waiting for %s", path))
+}

--- a/internal/citest/main.go
+++ b/internal/citest/main.go
@@ -54,6 +54,7 @@ var prRaceTargets = []raceTarget{
 	{"field", "parallel volumetric field work"},
 	{"hub", "websocket client pumps and shared connection state"},
 	{"hub/scene3d", "authoritative shared Scene3D state"},
+	{"internal/chrometest", "Chrome startup, pipe draining, cancellation, and cleanup goroutines"},
 	{"physics", "shared physics acceleration data"},
 	{"render/bundle", "parallel render-bundle assembly"},
 	{"route", "shared parser, source, and metadata caches"},


### PR DESCRIPTION
Browser tests can fail at chromedp's internal 20-second endpoint wait even when their outer startup deadline allows more time. The duplicated allocators also obscure process output and make failed-launch cleanup difficult to join.

Add an internal Chrome test harness and migrate all six test allocator sites. Startup allows two 30-second attempts within a 65-second total budget, with a fresh profile and ephemeral loopback port each time. The WebSocket handshake shares the remaining attempt and overall allowance. Startup deadlines and typed handshake timeouts can retry only while the process is alive and the caller remains active. Process exits, invalid endpoints, and non-timeout CDP failures fail immediately. Navigation and assertions keep their own deadlines and are never retried.

The harness drains output continuously into a bounded, redacted tail, observes process exit separately from pipe completion, joins process/CDP cleanup, and activates the test tab before returning so animation-frame polling keeps working. Caller rendering and codec flags are preserved. Product, performance, and visual launchers are outside this change.

Validation:

- Internal harness and CI partition tests passed; harness race tests passed five consecutive runs.
- Nine real Chrome startup, visible-page, and animation-frame smoke launches passed.
- Water diagnostic security and media metadata browser tests passed three runs; both targeted WebGL pixel tests passed.
- Focused vet and CI partition checks passed. Windows amd64 and macOS arm64 test binaries cross-compiled.
- Delayed-handshake regression failed under the old separate dial cap and passed with the shared startup allowance. Real-server tests cover timeout recovery with a fresh process/profile, permanent HTTP 400 failure, cancellation, and the clipped second-attempt overall budget. The updated harness passed five race runs and unchanged Water/media browser tests passed three runs.
- Independent review approved final commit `0235bc0be0518b29bf517af033a96576223d4ea1`, including the correction relative to `22534fddf6fcac7125a85bc5670f8db9b8519133`, on base `283ae8e03a6402f74fad7f63210036a198f8aa7f`.

The initial CI run exposed a harness regression: Water diagnostics received a typed WebSocket handshake timeout because the helper reduced chromedp's normal 10-second dial allowance to 3 seconds. The final implementation removes that separate cap and shares the bounded startup allowance. Captured diagnostics established the dial timeout; they do not establish how much time endpoint publication consumed. The corrected commit requires a fresh full CI run.

Linux process-group cleanup has direct descendant-process tests. Other platforms use direct-process termination and bounded pipe closure; native Windows/macOS browser behavior has not been tested. Full GitHub CI is required before merge.
