### PR TITLE
Prepare GoSX v0.56.0 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
-## Unreleased
+## v0.56.0 (2026-09-08)
+
+### Added: fixed-target transfer gestures
+
+- `data-gosx-transfer` roots declare stable source and destination identities, optional source-specific eligibility, context fields, and a same-origin managed POST action for fixed-slot assignments.
+- Pointer, touch, and keyboard pickup/commit are supported with Space/Enter, arrow keys, Tab/Shift+Tab, and Escape. Touch handling is scoped to the source handle so surrounding board and list surfaces retain native scrolling.
+- Transfer submissions carry CSRF and context fields without optimistic DOM relocation. Authoritative action results, server rejection, unknown transport failures, and region replacement all clear pending gesture state and leave the rendered assignment under server control.
 
 ### Added: consumer-backed image art direction
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Declare `.gsx` components with the strict, typed `component Name(props: Type)` form. GoSX compiles through a real compiler pipeline. It renders on the server by default and hydrates interactive islands with WebAssembly. It needs no app-side JavaScript toolchain and no CGo, and it keeps a small dependency budget.
 
-Current release: **v0.55.2**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.56.0**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -1060,7 +1060,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.55.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.56.0**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.55.2"
+const Current = "v0.56.0"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.55.2"
+const Number = "0.56.0"
 
 // MinGo is the lowest Go toolchain release that can build GoSX. It must equal
 // the go directive in the repository go.mod.


### PR DESCRIPTION
Align version constants, README, and changelog for v0.56.0. Fixed-target transfer commit 69b73bc passed full hosted CI and three targeted Chromium acceptance runs. Metadata source-truth checks, release preflight, and focused Go tests pass. No tag or deployment is performed by this PR.