### PR TITLE
chore(release): prepare v0.56.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.56.1 (2026-09-09)
+
+### Fixed: edge scrolling for fixed-target transfers
+
+- Declarative transfer gestures now scroll the nearest scrollable ancestor or document viewport while a pointer or touch is held near an edge, re-testing live targets at the held coordinates after each scroll increment.
+- Edge scrolling uses deterministic instant increments even when smooth scroll CSS is active and cleans up on release, cancellation, lost pointer capture, Escape, and navigation; no optimistic DOM relocation occurs.
+
 ## v0.56.0 (2026-09-08)
 
 ### Added: fixed-target transfer gestures

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Declare `.gsx` components with the strict, typed `component Name(props: Type)` form. GoSX compiles through a real compiler pipeline. It renders on the server by default and hydrates interactive islands with WebAssembly. It needs no app-side JavaScript toolchain and no CGo, and it keeps a small dependency budget.
 
-Current release: **v0.56.0**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.56.1**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -1062,7 +1062,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.56.0**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.56.1**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.56.0"
+const Current = "v0.56.1"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.56.0"
+const Number = "0.56.1"
 
 // MinGo is the lowest Go toolchain release that can build GoSX. It must equal
 // the go directive in the repository go.mod.


### PR DESCRIPTION
## Summary\n\n- Bump the canonical GoSX release to v0.56.1 in internal/version/version.go and both README current-release statements.\n- Add the dated v0.56.1 changelog entry for fixed-target transfer edge auto-scroll.\n- Prepared from merged main fac6ed016c604f7b3fe70d2f1d85316daa43620e; latest existing stable tag was v0.56.0 and v0.56.1 was unused.\n\n## Validation\n\n- PASS: scripts/check-release-source-truth.sh --root . --tag v0.56.1\n- PASS: gosx release check --root . --next v0.56.1\n- PASS: go test ./internal/version\n