### PR TITLE
Prepare GoSX v0.56.2 release metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## v0.56.2 (2026-09-09)
+
+### Changed: managed region polling and regenerated bundles
+
+- Periodic regions continue refreshing when their retained, non-editable root holds GoSX-managed hash-navigation focus; this fixes indefinitely paused updates after section redirects.
+- Focused descendants, editable/native-control roots, active pointers, hidden documents, and in-flight navigation still defer polling.
+- Checked-in runtime bundles and their generated compressed/map siblings were regenerated from the current source so published assets match the release.
+
 ## v0.56.1 (2026-09-09)
 
 ### Fixed: edge scrolling for fixed-target transfers

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Go-native web platform. Declare `.gsx` components with the strict, typed `component Name(props: Type)` form. GoSX compiles through a real compiler pipeline. It renders on the server by default and hydrates interactive islands with WebAssembly. It needs no app-side JavaScript toolchain and no CGo, and it keeps a small dependency budget.
 
-Current release: **v0.56.1**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
+Current release: **v0.56.2**. Pre-1.0; breaking changes are documented in [CHANGELOG.md](./CHANGELOG.md).
 
 ## Agent Skills
 
@@ -1062,7 +1062,7 @@ The same compiler infrastructure powers [Arbiter](https://github.com/odvcencio/a
 
 ## Status
 
-GoSX is pre-1.0. The current release is **v0.56.1**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
+GoSX is pre-1.0. The current release is **v0.56.2**. The five primitives (Server, Action, Island, Engine, Hub) are stable in shape — we do not expect their top-level API to change before 1.0. Subsystems like `ir`, `scene`, `desktop`, `field`, `sim`, `workspace`, and `semantic` are still under active development and may take breaking changes; each such change is called out explicitly in [CHANGELOG.md](./CHANGELOG.md) with a migration path.
 
 If you're evaluating GoSX for production work, the server + island + route + engine + scene stack has been used in production. The semantic, workspace, and sim layers have production users but are newer.
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,11 +1,11 @@
 package version
 
 // Current is the canonical GoSX release tag.
-const Current = "v0.56.1"
+const Current = "v0.56.2"
 
 // Number is Current without the leading tag prefix. Keep this constant in sync
 // with Current so packages that historically expose bare semver remain stable.
-const Number = "0.56.1"
+const Number = "0.56.2"
 
 // MinGo is the lowest Go toolchain release that can build GoSX. It must equal
 // the go directive in the repository go.mod.


### PR DESCRIPTION
Prepare the v0.56.2 source version and release notes for the managed-region hash-focus correction and regenerated runtime bundles. This changes only internal/version/version.go, README.md, and CHANGELOG.md. Local source release check, source-truth check, all ten release-gate stages, and all 1,796 JavaScript tests pass. No tag or deployment has been performed. Merge only after required checks pass; do not bypass protection.